### PR TITLE
ad9084: add stub pages, pull-request: extend template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,3 +18,4 @@
   * https://analogdevicesinc.github.io/documentation/contributing/creating_new_pages.html#adding-images-and-other-binary-files
 - [ ] I have built the pages I edited or created, using either `make html` or `adoc serve`:
   * https://analogdevicesinc.github.io/doctools/cli.html#serve
+- [ ] I have signed-off my commits and believe my contribution improves the repository.

--- a/docs/eval/user-guide/adc/ad9084-ebz/index.rst
+++ b/docs/eval/user-guide/adc/ad9084-ebz/index.rst
@@ -1,0 +1,25 @@
+.. _eval-ad9084-ebz:
+
+EVAL-AD9084-EBZ
+===============
+
+.. attention::
+
+   This is a stub page, content will be updated shortly.
+
+Overview
+--------
+
+User Guides
+-----------
+
+Developers
+----------
+
+Help and Support
+----------------
+
+For questions and more information, please visit the
+:ez:`EngineerZone Support Community <reference-designs>`.
+
+.. esd-warning::

--- a/docs/linux/drivers/iio-adc/ad9084/index.rst
+++ b/docs/linux/drivers/iio-adc/ad9084/index.rst
@@ -1,0 +1,36 @@
+.. _linux ad9084:
+
+AD9084/AD9088
+=============
+
+.. attention::
+
+   This is a stub page, content will be updated shortly.
+
+Supported Devices
+-----------------
+
+* :adi:`AD9084`
+* :adi:`AD9088`
+
+Evaluation Boards
+-----------------
+
+Source Code
+-----------
+
+Status
+------
+
+Files
+-----
+
+Description
+-----------
+
+Devicetree
+----------
+
+Usage
+-----
+

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,3 @@
 sphinx
+snowballstemmer<3
 https://github.com/analogdevicesinc/doctools/releases/download/latest/adi-doctools.tar.gz


### PR DESCRIPTION
## Type
- [x] Documentation
- [ ] Bug fix
- [ ] New feature
- [ ] Continuous integration

## Checklist
- [x] I have performed a self-review of changes
- [ ] I have followed the guidelines:
  * https://analogdevicesinc.github.io/documentation/contributing/docs_guidelines.html
  * https://analogdevicesinc.github.io/doctools/docs_guidelines/index.html
  * https://analogdevicesinc.github.io/documentation/contributing/creating_new_pages.html#documentation-structure
- [ ] I have used the appropriate roles and directives:
  * https://analogdevicesinc.github.io/doctools/docs_guidelines/roles.html
  * https://analogdevicesinc.github.io/doctools/docs_guidelines/directives.html
- [ ] I ensured that binary data was committed to git lfs:
  * https://analogdevicesinc.github.io/documentation/contributing/creating_new_pages.html#adding-images-and-other-binary-files
- [ ] I have built the pages I edited or created, using either `make html` or `adoc serve`:
  * https://analogdevicesinc.github.io/doctools/cli.html#serve
