### PR TITLE
docs: Makefile: Default parallel to nproc

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,5 +1,5 @@
 SHELL         = /bin/bash
-SPHINXOPTS   ?=
+SPHINXOPTS   ?= -j auto
 SPHINXBUILD  ?= sphinx-build
 SOURCEDIR     = .
 BUILDDIR      = _build


### PR DESCRIPTION
Make's -j flag is not passed to sphinx, instead, needs to be added to SPHINXOPTS. To not complicate things, just default to auto.


## Type
- [ ] Documentation
- [ ] Bug fix
- [ ] New feature
- [ ] Continuous integration

## Checklist
- [ ] I have performed a self-review of changes
- [ ] I have followed the guidelines:
  * https://analogdevicesinc.github.io/documentation/contributing/docs_guidelines.html
  * https://analogdevicesinc.github.io/doctools/docs_guidelines/index.html
  * https://analogdevicesinc.github.io/documentation/contributing/creating_new_pages.html#documentation-structure
- [ ] I have used the appropriate roles and directives:
  * https://analogdevicesinc.github.io/doctools/docs_guidelines/roles.html
  * https://analogdevicesinc.github.io/doctools/docs_guidelines/directives.html
- [ ] I ensured that binary data was committed to git lfs:
  * https://analogdevicesinc.github.io/documentation/contributing/creating_new_pages.html#adding-images-and-other-binary-files
- [ ] I have built the pages I edited or created, using either `make html` or `adoc serve`:
  * https://analogdevicesinc.github.io/doctools/cli.html#serve
- [ ] I have signed-off my commits and believe my contribution improves the repository.
