### PR TITLE
ad-gmslcamrpi-adp: raspberry-pi-user-guide: Fix EVKIT name typo

### DIFF
--- a/docs/solutions/reference-designs/ad-gmslcamrpi-adp/raspberry-pi-user-guide/index.rst
+++ b/docs/solutions/reference-designs/ad-gmslcamrpi-adp/raspberry-pi-user-guide/index.rst
@@ -50,8 +50,8 @@ CFG1      **7** – Coax, 6 Gbps, Pixel   **0** – Coax, GMSL2, 6Gbps
 For more information about the default CFG configuration of each evaluation
 board, please visit the respective datasheet documentation:
 
-- :adi:`MAX98717EVKIT Data Sheet <media/en/technical-documentation/data-sheets/max96717ev.pdf>`
-- :adi:`MAX98724EVKIT Data Sheet <media/en/technical-documentation/data-sheets/max96724-bak-evk-max96724r-bak-evk.pdf>`
+- :adi:`MAX96717EVKIT Data Sheet <media/en/technical-documentation/data-sheets/max96717ev.pdf>`
+- :adi:`MAX96724EVKIT Data Sheet <media/en/technical-documentation/data-sheets/max96724-bak-evk-max96724r-bak-evk.pdf>`
 
 **GMSL Deserializer Evaluation Kit**
 


### PR DESCRIPTION
## Type
- [x] Documentation
- [ ] Bug fix
- [ ] New feature
- [ ] Continuous integration

## Checklist
- [x] I have performed a self-review of changes
- [x] I have followed the guidelines:
  * https://analogdevicesinc.github.io/documentation/contributing/docs_guidelines.html
  * https://analogdevicesinc.github.io/doctools/docs_guidelines/index.html
  * https://analogdevicesinc.github.io/documentation/contributing/creating_new_pages.html#documentation-structure
- [ ] I have used the appropriate roles and directives:
  * https://analogdevicesinc.github.io/doctools/docs_guidelines/roles.html
  * https://analogdevicesinc.github.io/doctools/docs_guidelines/directives.html
- [ ] I ensured that binary data was committed to git lfs:
  * https://analogdevicesinc.github.io/documentation/contributing/creating_new_pages.html#adding-images-and-other-binary-files
- [x] I have built the pages I edited or created, using either `make html` or `adoc serve`:
  * https://analogdevicesinc.github.io/doctools/cli.html#serve
- [x] I have signed-off my commits and believe my contribution improves the repository.
