### PR TITLE
.github: check doc with vale

### DIFF
--- a/.github/styles/config/vocabularies/Base/accept.txt
+++ b/.github/styles/config/vocabularies/Base/accept.txt
@@ -1,0 +1,4 @@
+ADI|adi
+[Dd]octools
+toctree
+docname

--- a/.github/workflows/top-level.yml
+++ b/.github/workflows/top-level.yml
@@ -35,6 +35,25 @@ jobs:
         name: html
         path: docs/_build/html
 
+  check-doc:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        lfs: 'false'
+
+    - name: Install pip packages
+      run: |
+        pip install docutils
+
+    - uses: errata-ai/vale-action@v2.1.1
+      with:
+        files: docs
+        fail_on_error: ${{ github.event_name == 'pull_request' }}
+        reporter: ${{ github.event_name == 'pull_request' && 'github-pr-check' || 'github-check' }}
+        filter_mode: ${{ github.event_name == 'pull_request' && 'added' || 'nofilter' }}
+
   deploy:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'

--- a/.vale.ini
+++ b/.vale.ini
@@ -1,0 +1,10 @@
+StylesPath = .github/styles
+
+Vocab = Base
+
+Packages = write-good
+
+[*.rst]
+BasedOnStyles = Vale, write-good
+
+write-good.So = warning

--- a/docs/contributing/template/example/eval.rst
+++ b/docs/contributing/template/example/eval.rst
@@ -152,7 +152,7 @@ The drivers source code are available at:
      - Documentation
    * - no-OS
      - :git-no-OS:`drivers/adc/ad405x`
-     - :external+no-OS:doc:`doc <drivers/ad405x>`
+     - :external+no-OS:doc:`doc <drivers/adc/ad405x>`
    * - Linux
      - :git-linux:`staging/ad4052:drivers/iio/adc/ad4052.c`
      - :ref:`doc <linux ad4052>`

--- a/docs/eval/user-guide/adc/ad4052-ardz/index.rst
+++ b/docs/eval/user-guide/adc/ad4052-ardz/index.rst
@@ -127,7 +127,7 @@ The drivers source code are available at:
      - Documentation
    * - no-OS
      - :git-no-OS:`drivers/adc/ad405x`
-     - :external+no-OS:doc:`doc <drivers/ad405x>`
+     - :external+no-OS:doc:`doc <drivers/adc/ad405x>`
    * - Linux
      - :git-linux:`staging/ad4052:drivers/iio/adc/ad4052.c`
      - :ref:`doc <linux ad4052>`


### PR DESCRIPTION
## Type
- [ ] Documentation
- [ ] Bug fix
- [ ] New feature
- [ ] Continuous integration

## Checklist
- [ ] I have performed a self-review of changes
- [ ] I have followed the guidelines:
  * https://analogdevicesinc.github.io/documentation/contributing/docs_guidelines.html
  * https://analogdevicesinc.github.io/doctools/docs_guidelines/index.html
  * https://analogdevicesinc.github.io/documentation/contributing/creating_new_pages.html#documentation-structure
- [ ] I have used the appropriate roles and directives:
  * https://analogdevicesinc.github.io/doctools/docs_guidelines/roles.html
  * https://analogdevicesinc.github.io/doctools/docs_guidelines/directives.html
- [ ] I ensured that binary data was committed to git lfs:
  * https://analogdevicesinc.github.io/documentation/contributing/creating_new_pages.html#adding-images-and-other-binary-files
- [ ] I have built the pages I edited or created, using either `make html` or `adoc serve`:
  * https://analogdevicesinc.github.io/doctools/cli.html#serve
- [ ] I have signed-off my commits and believe my contribution improves the repository.
