### PR TITLE
.vale: Do not use action, match JSON output

### DIFF
--- a/.github/workflows/top-level.yml
+++ b/.github/workflows/top-level.yml
@@ -44,26 +44,25 @@ jobs:
     - uses: actions/checkout@v4
       with:
         lfs: 'false'
-
-    - name: Install pip package
+    - name: Check writing
       run: |
-        pip install docutils
+        pip install docutils vale
+        vale sync
 
-    - uses: errata-ai/vale-action@v2.1.1
-      with:
-        files: docs
-        reporter: github-pr-check
-        filter_mode: added
-        fail_on_error: false
-        vale_flags: "--config=.github/styles/vale-spelling.ini"
+        check_vale() {
+          files=$(git diff --diff-filter=ACM --no-renames --name-only $base_sha..$head_sha -- docs/*.rst docs/**/*.rst)
 
-    - uses: errata-ai/vale-action@v2.1.1
-      with:
-        files: docs
-        reporter: github-pr-check
-        filter_mode: added
-        fail_on_error: false
-        vale_flags: "--config=.github/styles/vale-enforcement.ini"
+          [[ -z "$files" ]] && return
+          while read file; do
+            echo $file
+            vale $file --config=.github/styles/$1 --output=JSON | \
+              jq -r 'to_entries[] | .key as $file | .value[] |
+              "::\(.Severity) file=\($file),line=\(.Line),col=\(.Span[0])::vale:\(.Check):\($file):\(.Line):\(.Span[0]) \(.Message)"'
+          done <<< "$files"
+        }
+
+        check_vale vale-spelling.ini
+        check_vale vale-enforcement.ini
 
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Due to fail_on_error==false not applying and unmaintained. https://github.com/errata-ai/vale-action/issues/150


## Type
- [ ] Documentation
- [ ] Bug fix
- [ ] New feature
- [ ] Continuous integration

## Checklist
- [ ] I have performed a self-review of changes
- [ ] I have followed the guidelines:
  * https://analogdevicesinc.github.io/documentation/contributing/docs_guidelines.html
  * https://analogdevicesinc.github.io/doctools/docs_guidelines/index.html
  * https://analogdevicesinc.github.io/documentation/contributing/creating_new_pages.html#documentation-structure
- [ ] I have used the appropriate roles and directives:
  * https://analogdevicesinc.github.io/doctools/docs_guidelines/roles.html
  * https://analogdevicesinc.github.io/doctools/docs_guidelines/directives.html
- [ ] I ensured that binary data was committed to git lfs:
  * https://analogdevicesinc.github.io/documentation/contributing/creating_new_pages.html#adding-images-and-other-binary-files
- [ ] I have built the pages I edited or created, using either `make html` or `adoc serve`:
  * https://analogdevicesinc.github.io/doctools/cli.html#serve
- [ ] I have signed-off my commits and believe my contribution improves the repository.
