### PR TITLE
reference-designs/cn0579: Add CN0579 landing page

### DIFF
--- a/docs/solutions/reference-designs/cn0579/images/579_coraz7_setup.png
+++ b/docs/solutions/reference-designs/cn0579/images/579_coraz7_setup.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c741de596e11707a1cc8bcfb5a05141752ee1b4196a01cacc0fe36c908256cbd
+size 277527

--- a/docs/solutions/reference-designs/cn0579/images/579_de10_setup.png
+++ b/docs/solutions/reference-designs/cn0579/images/579_de10_setup.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3e463dc0a94e53d1b275f7f7dac71b90181cd95d380d1ccdfb45415850928278
+size 264224

--- a/docs/solutions/reference-designs/cn0579/images/579_debug0.png
+++ b/docs/solutions/reference-designs/cn0579/images/579_debug0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f7a4657d4ddc255999d7f1d42d8734f8f88ee5c3b5013a800db4b28fcbfb4619
+size 21185

--- a/docs/solutions/reference-designs/cn0579/images/579_dmm.png
+++ b/docs/solutions/reference-designs/cn0579/images/579_dmm.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8ab9e3edbf3b57edea996e84197f469e5d67c36245e3a226a767971cf0e03cb8
+size 35987

--- a/docs/solutions/reference-designs/cn0579/images/579_ex_ch0_input.png
+++ b/docs/solutions/reference-designs/cn0579/images/579_ex_ch0_input.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2404ada1250a2d59d6c5761732b499f1afc7334b515ee2bb1ee74ef244d58e43
+size 333266

--- a/docs/solutions/reference-designs/cn0579/images/579_ex_no_input.png
+++ b/docs/solutions/reference-designs/cn0579/images/579_ex_no_input.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3751097b129a6de040235e8df2fab19ad6c555c54fea26f834f8a0c6668c86b4
+size 83995

--- a/docs/solutions/reference-designs/cn0579/images/579_osc.png
+++ b/docs/solutions/reference-designs/cn0579/images/579_osc.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7c12b34cd05e981a408748247c87630d6d6bc17d2e22f29ba069c566478d7e77
+size 37009

--- a/docs/solutions/reference-designs/cn0579/images/cn0579_simplified_block_diagram.png
+++ b/docs/solutions/reference-designs/cn0579/images/cn0579_simplified_block_diagram.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:242b92a600e847016d653208acae07f5cc37849cbe787f314b38748154f9ad8e
+size 46203

--- a/docs/solutions/reference-designs/cn0579/images/eval-cn0579-ardz_bottom-web.gif
+++ b/docs/solutions/reference-designs/cn0579/images/eval-cn0579-ardz_bottom-web.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f7cf323df750d0187529101280f135da8b95dfdb5a5b16b3015af293dd2534f1
+size 203017

--- a/docs/solutions/reference-designs/cn0579/images/eval-cn0579-ardz_top-web.gif
+++ b/docs/solutions/reference-designs/cn0579/images/eval-cn0579-ardz_top-web.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:128648f7b8ca71ac1c1b93080def50fa1095c46213cc401295ce45d9fa9a8d70
+size 243923

--- a/docs/solutions/reference-designs/cn0579/images/kuiper.png
+++ b/docs/solutions/reference-designs/cn0579/images/kuiper.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9552161853678a23cf118aa91a0645d45d11290062667a41e1a6246a3481b3ac
+size 1702507

--- a/docs/solutions/reference-designs/cn0579/index.rst
+++ b/docs/solutions/reference-designs/cn0579/index.rst
@@ -65,8 +65,10 @@ LED Indicators
 | **SHUTDOWN LED (DS7)**      | left side of U19        | indicates status of shutdown logic/buffer, FDA, SW disable |
 +-----------------------------+-------------------------+------------------------------------------------------------+
 
-| 
-| ===== Secondary Side ===== |image1|
+Secondary Side
+--------------
+
+|image1|
 
 Current Source Jumper
 ---------------------
@@ -191,7 +193,7 @@ Hardware
 Software
 ~~~~~~~~
 
--  `ADI Kuiper Image <https://wiki.analog.com/resources/tools-software/linux-software/kuiper-linux>`_
+-  :external+kuiper:doc:`ADI Kuiper Image <index>`
 -  `IIO-Oscilloscope <https://github.com/analogdevicesinc/iio-oscilloscope/releases>`_
 
 Hardware Setup
@@ -221,7 +223,7 @@ Preparing the SD Card
 
 To prepare the SD card for the DE10-Nano board:
 
--  `Download ADI Kuiper Image <https://wiki.analog.com/resources/tools-software/linux-software/kuiper-linux>`_
+-  :external+kuiper:doc:`Download ADI Kuiper Image <index>`
 -  Validate, format, and flash the SD Card
 
    -  `Format and flash the SD Card using Windows <https://wiki.analog.com/resources/tools-software/linux-software/zynq_images/windows_hosts>`_
@@ -269,12 +271,10 @@ Hardware Setup
    :align: center
    :width: 600
 
-::
-
-   -Mount the EVAL-CN0579-ARDZ on the Cora Z7.
-   -Connect ethernet cable on the Cora Z7 and on your PC.
-   -Power up Cora Z7 by plugging its power supply or connecting microUSB.
-   -Wait for the system to boot up. Upon boot up, open command terminal or any similar applications like PuTTy to communicate with the board.
+-  Mount the EVAL-CN0579-ARDZ on the Cora Z7.
+-  Connect ethernet cable on the Cora Z7 and on your PC.
+-  Power up Cora Z7 by plugging its power supply or connecting microUSB.
+-  Wait for the system to boot up. Upon boot up, open command terminal or any similar applications like PuTTy to communicate with the board.
 
 Software Setup
 --------------
@@ -284,7 +284,7 @@ Preparing the SD Card
 
 To prepare the SD card for the DE10-Nano board:
 
--  `Download ADI Kuiper Image <https://wiki.analog.com/resources/tools-software/linux-software/kuiper-linux>`_
+-  :external+kuiper:doc:`Download ADI Kuiper Image <index>`
 -  Validate, format, and flash the SD Card
 
    -  `Format and flash the SD Card using Windows <https://wiki.analog.com/resources/tools-software/linux-software/zynq_images/windows_hosts>`_
@@ -294,7 +294,7 @@ To prepare the SD card for the DE10-Nano board:
 Download and Install IIO Oscilloscope
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
--  Down the latest `IIO-Oscilloscope release <https://github.com/analogdevicesinc/iio-oscilloscope/releases>`_ from Github, and install it on your PC. (You may need to right-click the installer, and run as "Elevated" in order to get it to install.)
+-  Download the latest `IIO-Oscilloscope release <https://github.com/analogdevicesinc/iio-oscilloscope/releases>`_ from GitHub, and install it on your PC. (You may need to right-click the installer, and run as "Elevated" in order to get it to install.)
 -  Once the microSD card has been imaged, safely remove the hardware from the SD
    card writer, and insert the card directly into the microSD card slot on the
    DE10-Nano.
@@ -447,10 +447,10 @@ With input from :adi:`ADALM2000` (1 Vp-p, 1 kHz) on Channel 0:
 Reference Demos & Software
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
--  `pyADI-IIO <https://github.com/analogdevicesinc/pyadi-iio>`_
+-  `pyADI-IIO <https://github.com/analogdevicesinc/pyadi-iio>`__
 -  `PyADI-IIO Installation Guide <https://wiki.analog.com/resources/tools-software/linux-software/pyadi-iio>`_
 -  `IIO Oscilloscope Installation Guide <https://wiki.analog.com/resources/tools-software/linux-software/iio_oscilloscope>`_
--  `Kuiper Images <https://wiki.analog.com/resources/tools-software/linux-software/kuiper-linux>`_
+-  :external+kuiper:doc:`Kuiper Images <index>`
 -  :git-hdl:`CN0579 HDL Reference Design <projects/cn0579>`
 
 More Information and Useful Links

--- a/docs/solutions/reference-designs/cn0579/index.rst
+++ b/docs/solutions/reference-designs/cn0579/index.rst
@@ -1,0 +1,504 @@
+EVAL-CN0579-ARDZ User Guide
+===========================
+
+.. important::
+
+   Notice: This page has been fully migrated to GitHub.io and is no longer
+   maintained on the Wiki. Please refer to the GitHub link below for the most
+   current and accurate information.
+
+   
+   https://analogdevicesinc.github.io/documentation/solutions/reference-designs/eval-cn0579-ardz/index.html
+   
+   If you would like to contribute updates to this document, please submit your
+   suggestions via a Pull Request on the GitHub page.
+   
+   Thank you for your understanding, and we apologize for any inconvenience this
+   transition may cause.
+   
+
+Overview
+========
+
+Condition-based monitoring (CbM) enables early detection and diagnosis of
+machine and system abnormalities. Identifying and isolating these issues creates
+opportunities for optimizing replacement part inventories, scheduling downtime
+for planned maintenance, and making run-time process adjustments that can extend
+the life of equipment.
+
+The :adi:`EVAL-CN0579-ARDZ <CN0579>` is a 4-channel, high resolution, wide bandwidth, high dynamic range, IEPE-compatible interface data acquisition (DAQ) system that interfaces with IC piezoelectric (ICP®)/IEPE sensors. While most solutions that interface with piezoelectric sensors in the market are AC-coupled and lack DC and subhertz measurement capabilities, this solution is DC-coupled. By looking at the complete data set from an IEPE vibration sensor in the frequency domain (DC to 50 kHz), the type and source of a machine fault can be better predicted using the position, amplitude, and number of harmonics found in the fast Fourier transform (FFT) spectrum.
+
+Simplified Block Diagram
+------------------------
+
+.. image:: images/cn0579_simplified_block_diagram.png
+   :align: center
+   :width: 600
+
+--------------
+
+Hardware Configuration
+======================
+
+Primary Side
+------------
+
+.. image:: images/eval-cn0579-ardz_top-web.gif
+   :align: center
+   :width: 600
+
+Sensor Input
+------------
+
+The main input on the :adi:`EVAL-CN0579-ARDZ <CN0579>` are right-angle SMA connectors on the primary side of the board, as such it is highly recommended to connect the sensor using an SMA cable. If this is not possible, due to the type of sensor or otherwise, use the headers to connect the board with other standard wires.
+
+LED Indicators
+--------------
+
++-----------------------------+-------------------------+------------------------------------------------------------+
+| LED                         | Location                | Function                                                   |
++=============================+=========================+============================================================+
+| **PWR LEDs (DS1 to DS2)**   | bottom-left corner      | indicates board power                                      |
++-----------------------------+-------------------------+------------------------------------------------------------+
+| **FAULT LEDs (DS3 to DS6)** | near each SMA connector | indicates the status of switch's fault flag                |
++-----------------------------+-------------------------+------------------------------------------------------------+
+| **SHUTDOWN LED (DS7)**      | left side of U19        | indicates status of shutdown logic/buffer, FDA, SW disable |
++-----------------------------+-------------------------+------------------------------------------------------------+
+
+| 
+| ===== Secondary Side ===== |image1|
+
+Current Source Jumper
+---------------------
+
+The :adi:`EVAL-CN0579-ARDZ <CN0579>` includes solder jumpers (P17 to P20) to control current source. The jumpers connect the current source to the circuit and may be removed for testing without a current source.
+
+Arduino Interface
+-----------------
+
+All connector pinouts for the :adi:`EVAL-CN0579-ARDZ <CN0579>` are described in the table below.
+
+==================== ======= =============== ===================
+Connector            Pin No. Pin Name        CN0579 Pin Function
+==================== ======= =============== ===================
+Arduino DIO 1 (P12)  1       SCL             SCL
+                     2       SDA             SDA
+                     3       AREF            NC (Not connected)
+                     4       GND             GND
+                     5       13 / SCLK       SCLK
+                     6       12 / MISO       MISO
+                     7       11 / PWM / MOSI MOSI
+                     8       10 / PWM / CS   CS_ADC
+                     9       9 / PWM         DRDY_N
+                     10      8               DCLK
+Arduino DIO 0 (P14)  1       7               DOUT0
+                     2       6 / PWM         DOUT1
+                     3       5 / PWM         DOUT2
+                     4       4               DOUT3
+                     5       3 / PWM         SHUTDOWN_N
+                     6       2               RESET_N
+                     7       TX              NC
+                     8       RX              NC
+Arduino Analog (P13) 1       AIN0            NC
+                     2       AIN1            NC
+                     3       AIN2            NC
+                     4       AIN3            NC
+                     5       AIN4            NC
+                     6       AIN5            NC
+Arduino Power (P11)  1       NC              NC
+                     2       IOREF           IOREF
+                     3       RESET           NC
+                     4       3.3 V           3V3
+                     5       5V              5V
+                     6       GND             GND
+                     7       GND             GND
+                     8       Vin             NC
+==================== ======= =============== ===================
+
+.. tip::
+
+   To achieve reasonable noise measurements, the piezo vibration sensor must be stabilized using either an active shaker table, which cancels environmental vibrations; or anchored to a massive object, which makes sensor still. For noise measurements done on :adi:`EVAL-CN0579-ARDZ <CN0579>`, the piezo vibration sensor was anchored to a massive object, where it is also connected directly to the input of the signal chain.
+
+Test Points
+-----------
+
+The board also has many test points, most of which are labeled and are fairly
+self-explanatory. The table below describes some of the most significant test
+points and their connections.
+
++---------------------------+----------------------------------------------------------------------------+
+| Test Point                | Description                                                                |
++===========================+============================================================================+
+| 26V8                      | Connects to the 26.8 V rail before it's reduced to 26 V.                   |
++---------------------------+----------------------------------------------------------------------------+
+| 26V0                      | Connects to the 26 V rail.                                                 |
++---------------------------+----------------------------------------------------------------------------+
+| 5V5                       | Connects to the 5.5 V rail before it's reduced to 5 V.                     |
++---------------------------+----------------------------------------------------------------------------+
+| 5V0                       | Connects to the 5 V rail.                                                  |
++---------------------------+----------------------------------------------------------------------------+
+| TP1                       | Connects to the voltage reference of the DAC for IEPE sensor.              |
++---------------------------+----------------------------------------------------------------------------+
+| TP6 / TP11 / TP16 / TP21  | Connects to signal chain after passing through the fault protection switch |
++---------------------------+----------------------------------------------------------------------------+
+| TP7 / TP12 / TP17 / TP22  | Connects to VOCM.                                                          |
++---------------------------+----------------------------------------------------------------------------+
+| TP8 / TP13 / TP18 / TP23  | Connects to signal chain that is level shifted.                            |
++---------------------------+----------------------------------------------------------------------------+
+| TP9 / TP14 / TP19 / TP24  | Connects to FDA_OUT_N0 of the ADC driver.                                  |
++---------------------------+----------------------------------------------------------------------------+
+| TP10 / TP15 / TP20 / TP25 | Connects to FDA_OUT_P0 of the ADC driver.                                  |
++---------------------------+----------------------------------------------------------------------------+
+| TP27 / TP29 / TP31 / TP33 | Connects to output from the bias voltage correction.                       |
++---------------------------+----------------------------------------------------------------------------+
+| TP34                      | Connects to ADC reference buffer.                                          |
++---------------------------+----------------------------------------------------------------------------+
+| TP35                      | Connects to differential conversion reference buffer output / VOCM.        |
++---------------------------+----------------------------------------------------------------------------+
+| TP36                      | Connects to 32.768 MEGHz clock output.                                     |
++---------------------------+----------------------------------------------------------------------------+
+| TP37                      | Connects to VCM of ADC.                                                    |
++---------------------------+----------------------------------------------------------------------------+
+
+| 
+
+--------------
+
+System Setup
+============
+
+General Setup Using DE10-Nano
+-----------------------------
+
+Demo Requirements
+-----------------
+
+The following is the list of items needed in order to replicate this demo.
+
+Hardware
+~~~~~~~~
+
+-  :adi:`EVAL-CN0579-ARDZ <CN0579>`
+-  `DE10-Nano FPGA Board <https://www.terasic.com.tw/cgi-bin/page/archive.pl?Language=English&No=1046>`_
+
+   -  5V/2A wall power supply with barrel jack (comes with DE10-Nano)
+   -  mini USB to USB Type A (comes with DE10-Nano)
+
+-  `Class 10 16 GB SD Card <https://www.amazon.com/gp/product/B073K14CVB/ref=ppx_yo_dt_b_asin_title_o03_s00?ie=UTF8&psc=1>`_ with boot files in `cn0579_boot_files.zip <resources/cn0579_boot_files.zip>`_
+-  Ethernet cable
+-  IEPE-compatible sensor
+
+Software
+~~~~~~~~
+
+-  `ADI Kuiper Image <https://wiki.analog.com/resources/tools-software/linux-software/kuiper-linux>`_
+-  `IIO-Oscilloscope <https://github.com/analogdevicesinc/iio-oscilloscope/releases>`_
+
+Hardware Setup
+--------------
+
+.. image:: images/579_de10_setup.png
+   :align: center
+   :width: 700
+
+-  Mount the EVAL-CN0579-ARDZ on the DE10-Nano.
+-  Connect the monitor to the DE10-Nano using HDMI cable.
+-  Connect a OTG to USB connector to- USB OTG of DE10-Nano. If necessary, connect the USB hub to the USB-OTG connector.
+-  Connect the keyboard and mouse USB dongle to the USB OTG adapter/USB hub.
+-  Plug the power cable of the DE10 Nano.
+-  Wait for the system to boot up. Upon boot up, screen like image below will
+   appear.
+
+.. image:: images/kuiper.png
+   :align: center
+   :width: 600
+
+Software Setup
+--------------
+
+Preparing the SD Card
+~~~~~~~~~~~~~~~~~~~~~
+
+To prepare the SD card for the DE10-Nano board:
+
+-  `Download ADI Kuiper Image <https://wiki.analog.com/resources/tools-software/linux-software/kuiper-linux>`_
+-  Validate, format, and flash the SD Card
+
+   -  `Format and flash the SD Card using Windows <https://wiki.analog.com/resources/tools-software/linux-software/zynq_images/windows_hosts>`_
+
+      -  `Format and flash the SD Card using Linux <https://wiki.analog.com/resources/tools-software/linux-software/zynq_images/linux_hosts>`_
+
+Download and Install IIO Oscilloscope
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+-  Download the latest `IIO-Oscilloscope release <https://github.com/analogdevicesinc/iio-oscilloscope/releases>`_ from GitHub and install it on your PC. (You may need to right-click the installer and run as "Elevated" in order to get it to install.)
+-  Once microSD card has been imaged, safely remove the hardware from the SD
+   card writer, and insert the card directly into the microSD card slot on the
+   DE10-Nano.
+
+--------------
+
+General Setup Using Cora Z7
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Demo Requirements
+-----------------
+
+The following is the list of items needed in order to replicate this demo.
+
+Hardware
+~~~~~~~~
+
+-  :adi:`EVAL-CN0579-ARDZ <en/design-center/reference-designs/circuits-from-the-lab/CN0579.html>`
+-  `CoraZ7-07s FPGA Board <https://store.digilentinc.com/cora-z7-zynq-7000-single-core-and-dual-core-options-for-arm-fpga-soc-development/>`_
+-  `Class 10 16 GB SD Card <https://www.amazon.com/gp/product/B073K14CVB/ref=ppx_yo_dt_b_asin_title_o03_s00?ie=UTF8&psc=1>`_
+-  Ethernet cable
+-  Micro USB to USB Type A cable
+-  IEPE-compatible sensor
+
+Software
+~~~~~~~~
+
+-  `ADI Kuiper Image for CN0579 <https://swdownloads.analog.com/cse/kuiper/cn0540.tar.gz>`_
+-  `IIO-Oscilloscope <https://github.com/analogdevicesinc/iio-oscilloscope/releases>`_
+
+Hardware Setup
+--------------
+
+.. image:: images/579_coraz7_setup.png
+   :align: center
+   :width: 600
+
+::
+
+   -Mount the EVAL-CN0579-ARDZ on the Cora Z7.
+   -Connect ethernet cable on the Cora Z7 and on your PC.
+   -Power up Cora Z7 by plugging its power supply or connecting microUSB.
+   -Wait for the system to boot up. Upon boot up, open command terminal or any similar applications like PuTTy to communicate with the board.
+
+Software Setup
+--------------
+
+Preparing the SD Card
+~~~~~~~~~~~~~~~~~~~~~
+
+To prepare the SD card for the DE10-Nano board:
+
+-  `Download ADI Kuiper Image <https://wiki.analog.com/resources/tools-software/linux-software/kuiper-linux>`_
+-  Validate, format, and flash the SD Card
+
+   -  `Format and flash the SD Card using Windows <https://wiki.analog.com/resources/tools-software/linux-software/zynq_images/windows_hosts>`_
+
+      -  `Format and flash the SD Card using Linux <https://wiki.analog.com/resources/tools-software/linux-software/zynq_images/linux_hosts>`_
+
+Download and Install IIO Oscilloscope
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+-  Down the latest `IIO-Oscilloscope release <https://github.com/analogdevicesinc/iio-oscilloscope/releases>`_ from Github, and install it on your PC. (You may need to right-click the installer, and run as "Elevated" in order to get it to install.)
+-  Once the microSD card has been imaged, safely remove the hardware from the SD
+   card writer, and insert the card directly into the microSD card slot on the
+   DE10-Nano.
+
+--------------
+
+Application Software
+~~~~~~~~~~~~~~~~~~~~
+
+The :adi:`EVAL-CN0579-ARDZ <CN0579>` is supported by the Libiio library. This library is cross-platform (Windows, Linux, Mac) with language bindings for C, C#, Python, MATLAB, and others. Two easy examples that can be used with the :adi:`EVAL-CN0579-ARDZ` are:
+
+-  `IIO Oscilloscope <https://wiki.analog.com/resources/tools-software/linux-software/iio_oscilloscope>`_
+-  `Python (via Pyadi-iio) <https://wiki.analog.com/resources/tools-software/linux-software/pyadi-iio>`_
+
+Connection
+----------
+
+To be able to connect your device, the software must be able to create a context. The context creation in the software depends on the backend used to connect to the device, as well as the platform where the EVAL-CN0579-ARDZ is attached. The platforms currently supported for the :adi:`EVAL-CN0579-ARDZ <CN0579>` are Cora Z7 and DE10-Nano using the ADI Kuiper Linux. The user needs to supply a URI, which will be used in the context creation. The Libiio is a library for interfacing with IIO devices.
+
+.. admonition:: Download
+   :class: download
+
+   Install the `Libiio package <https://github.com/analogdevicesinc/libiio/releases>`_ on your machine.
+
+The `iio_info <https://wiki.analog.com/resources/tools-software/linux-software/libiio/iio_info>`_ command is a part of the libIIO package that reports all IIO attributes.
+
+Upon installation, simply enter the command on the terminal command line to
+access it.
+
+For Windows machine connected to ZedBoard via Ethernet cable:
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Using SSH Terminal Software
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Open SSH Terminal Software (PuTTY, TeraTerm, or similar). The user should now
+start the PuTTY application and enter certain values in the configuration
+window. In the terminal, run:
+
+::
+
+   analog@analog:~$ iio_info -u ip:<ip_address>
+
+Using Command Terminal
+^^^^^^^^^^^^^^^^^^^^^^
+
+::
+
+   iio_info -s
+
+Prompting this on the command terminal in your Windows PC will give you the IP
+address to access the EVAL-CN0579-ARDZ.
+
+::
+
+   ssh analog@<ip_address>
+
+::
+
+   analog@analog:~$ iio_info -u ip:<ip_address>
+
+IIO Commands
+------------
+
+There are different commands that can be used to manage the device being used. The `iio_attr <https://wiki.analog.com/resources/tools-software/linux-software/libiio/iio_attr>`_ command reads and writes IIO attributes.
+
+::
+
+   analog@analog:~$ iio_attr [OPTION]...
+
+Example:
+
+-  To look at the context attributes, enter this code on the terminal:
+
+::
+
+   analog@analog:~$ iio_attr -a -C
+
+IIO Oscilloscope
+----------------
+
+.. admonition:: Download
+   :class: download
+
+   Make sure to download/update to the latest version of IIO Oscilloscope.
+
+   
+   https://github.com/analogdevicesinc/iio-oscilloscope/releases
+
+-  Once done with the installation or an update of the latest IIO Oscilloscope, open the application. The user needs to supply a URI, which will be used in the context creation of the IIO Oscilloscope and the instructions can be seen in the previous section.
+-  Press refresh to display available IIO Devices, once cn0579 appeared, press **connect**.
+
+.. image:: images/579_osc.png
+   :alt: osc.exe
+   :align: center
+   :width: 600
+
+Debug Panel
+~~~~~~~~~~~
+
+Below is the Debug panel wherein you can directly access the attributes of the
+device.
+
+|Debug Panel|
+
+DMM Panel
+~~~~~~~~~
+
+Access the DMM panel to see the instantaneous reading of the ADC voltages.
+
+|DMM Panel|
+
+Pyadi-IIO
+---------
+
+`PyADI-IIO <https://wiki.analog.com/resources/tools-software/linux-software/pyadi-iio>`_ is a Python abstraction module for ADI hardware with IIO drivers to make them easier to use. This module provides device-specific APIs built on top of the current libIIO Python bindings. These interfaces try to match the driver naming as much as possible without the need to understand the complexities of libIIO and IIO.
+
+Running the Example
+~~~~~~~~~~~~~~~~~~~
+
+After installing and configuring PYADI-IIO on your machine, you are now ready to run Python script examples. In our case, run the :git-pyadi-iio:`examples/cn0579/cn0579_example.py`.
+
+-  Connect the :adi:`EVAL-CN0579-ARDZ <CN0579>` to the DE10-Nano or Cora Z7.
+-  Open command prompt or terminal and navigate through the examples folder inside the downloaded or cloned *pyadi-iio* directory.
+-  Run the example script using the command.
+
+::
+
+   .../pyadi-iio/examples $ python3 cn0579_example.py
+
+The expected output should look like this:
+
+Without input signal:
+
+.. image:: images/579_ex_no_input.png
+   :align: center
+   :width: 600
+
+With input from :adi:`ADALM2000` (1 Vp-p, 1 kHz) on Channel 0:
+
+|image2|
+
+.. admonition:: Download
+   :class: download
+
+   GitHub link for the Python sample script: :git-pyadi-iio:`CN0579 Python Example <examples/cn0579/cn0579_example.py>`
+
+--------------
+
+Reference Demos & Software
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+-  `pyADI-IIO <https://github.com/analogdevicesinc/pyadi-iio>`_
+-  `PyADI-IIO Installation Guide <https://wiki.analog.com/resources/tools-software/linux-software/pyadi-iio>`_
+-  `IIO Oscilloscope Installation Guide <https://wiki.analog.com/resources/tools-software/linux-software/iio_oscilloscope>`_
+-  `Kuiper Images <https://wiki.analog.com/resources/tools-software/linux-software/kuiper-linux>`_
+-  :git-hdl:`CN0579 HDL Reference Design <projects/cn0579>`
+
+More Information and Useful Links
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+-  :adi:`CN0579 Circuit Note Page <CN0579>`
+-  :adi:`AD7768-4 Product Page <AD7768-4>`
+-  :adi:`AD5696R Product Page <AD5696R>`
+-  :adi:`ADA4807-2 Product Page <ADA4807-2>`
+-  :adi:`AD8605 Product Page <AD8605>`
+-  :adi:`ADA4945-1 Product Page <ADA4945-1>`
+-  :adi:`ADR4540 Product Page <ADR4540>`
+-  :adi:`ADP1613 Product Page <ADP1613>`
+-  :adi:`ADP7142 Product Page <ADP7142>`
+-  :adi:`ADG5421F Product Page <ADG5421F>`
+-  :adi:`ADP7118 Product Page <ADP7118>`
+-  :adi:`LT3092 Product Page <LT3092>`
+-  :adi:`LT8333 Product Page <LT8333>`
+
+Schematic, PCB Layout, Bill of Materials
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. admonition:: Download
+   :class: download
+
+   
+   :adi:`EVAL-CN0579-ARDZ Design & Integration Files <cn0579-designsupport>`
+   
+   -  Schematics
+   -  PCB Layout
+   -  Bill of Materials
+   -  Allegro Project
+   
+
+Registration
+~~~~~~~~~~~~
+
+.. tip::
+
+   Receive software update notifications, documentation updates, view the latest videos, and more when you register your hardware. `Register <https://form.analog.com/Form_Pages/FeedBack/EVAL-CN0579-ARDZ?&v=RevC>`_ to receive all these great benefits and more!
+
+*End of Document*
+
+.. |image1| image:: images/eval-cn0579-ardz_bottom-web.gif
+   :width: 600
+.. |Debug Panel| image:: images/579_debug0.png
+   :width: 600
+.. |DMM Panel| image:: images/579_dmm.png
+   :width: 600
+.. |image2| image:: images/579_ex_ch0_input.png
+   :width: 600

--- a/docs/solutions/reference-designs/cn0579/resources/cn0579_boot_files.zip
+++ b/docs/solutions/reference-designs/cn0579/resources/cn0579_boot_files.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dccd0d3345ac2000631398673091db56e30d39dab571ff7ff02c26db685b5d7f
+size 17506436


### PR DESCRIPTION
## Summary
- Move CN0579 landing page from `wiki-migration/resources/eval/user-guides/circuits-from-the-lab/cn0579` to `solutions/reference-designs/cn0579/`
- 1 RST files (1 landing + 0 subpages)
- 11 images localized, 1 binary artifacts localized
- Updated `:doc:` cross-references and includes

Source: [wiki.analog.com/resources/eval/user-guides/circuits-from-the-lab/cn0579](https://wiki.analog.com/resources/eval/user-guides/circuits-from-the-lab/cn0579)

## Test plan
- [ ] Sphinx build passes without new warnings
- [ ] Landing page renders correctly
- [ ] Internal links resolve
- [ ] Images display properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)