### PR TITLE
reference-designs/jupiter_sdr: Add Jupiter SDR landing page

### DIFF
--- a/docs/solutions/reference-designs/jupiter_sdr/hardware-overview.rst
+++ b/docs/solutions/reference-designs/jupiter_sdr/hardware-overview.rst
@@ -1,0 +1,411 @@
+Jupiter-SDR Hardware Overview
+=============================
+
+.. image:: images/jupitersdr_blockdiagram.png
+
+--------------
+
+Processing System
+-----------------
+
+Zynq Ultrascale+ MPSOC XCZU3EG
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+-  Application Processing Unit - Quad ARM Cortex-A53 (1.5 GHz each)
+
+   -  L1 Cache 32KB I / D per core
+   -  L2 Cache 1MB
+   -  256kB on-chip Memory
+
+-  Real time Processing Unit - Dual ARM Cortex-R5 (600 MHz each)
+
+   -  L1 Cache 32KB I / D per core
+   -  128kB/core memory
+
+-  Graphics Processing Unit - ARM Mali-400 MP2
+
+   -  L2 Cache 64KB
+
+-  Programmable logic
+
+   -  154k Logic cells
+   -  360 DSP slices
+   -  7.6Mb block RAM
+
+DDR
+~~~
+
+2GB DDR4 with 32 bit data bus connected to the PS of XCZU3EG are shared by the
+OS, video (optional) and RF data streaming. XCZU3EG DDR memory controller has
+the maximum data rate limited to 2133Mbps.
+
+Configuration and boot
+~~~~~~~~~~~~~~~~~~~~~~
+
+The following boot options are supported:
+
+-  Quad-SPI - 2 x 64MB Flash memory
+
+   -  dual parallel configuration with 8-bit data bus width
+   -  32 bits addressing
+   -  ZU3EG boot mode configuration MODE[3:0] = 0010
+
+-  SD1 LS (3.0)
+
+   -  Supports FAT 16/32 filesystem
+   -  ZU3EG boot mode configuration MODE[3:0] = 1110
+
+MODE pins are automatically configured in hardware so that the SD card boot
+option has higher priority than Quad-SPI Flash.
+
+The ZU3EG on-chip SD Controller is compatible with SD memory card specification
+version 3.01, supporting UHS-I speeds and SDXC capacity format. The front panel
+includes a micro SD card connector.
+
+Multi Gigabit Transceiver (MGTR)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+XCZU3EG Zynq Ultrascale+ has 4 GTR channels up to 6Gb/s. The following table
+shows the GTR channels usage on Jupiter SDR.
+
+===================== ========= =================
+MGTR Channel          Interface Data Rate
+===================== ========= =================
+RX0                   USB3      USB 3, 5Gb/s
+TX0                   USB3      USB 3, 5Gb/s
+RX1                   SATA      SATA III, 6Gb/s
+TX1                   SATA      SATA III, 6Gb/s
+RX2          -
+TX2                   DP        DP1 v1.2, 5.4Gb/s
+RX3          -
+TX3                   DP        DP0 v1.2, 5.4Gb/s
+CLK0                  USB3      26 MHz
+CLK1                  DP        108 MHz
+CLK2                  SATA      150 MHz
+CLK3         not used
+===================== ========= =================
+
+:adi:`AD9542` provides a flexible solution for generating the required MGTR clocks. It integrates a dual PLL with 5 pairs of clock output pins. AD9542 is capable to load its configuration from EEPROM making it suitable for stand alone use.
+
+--------------
+
+User Interfaces
+---------------
+
+USB
+~~~
+
+USB Type-C data connector exposes a DRP (Dual Role Port) USB 3.1 Gen1 interface
+which operate as either a DFP (Downstream Facing Port) or a UFP (Upstream Facing
+Port):
+
+-  UFP – it is used to connect Jupiter-SDR (device) to a computer (host) for data streaming
+-  DFP – it is used to connect different USB3 devices to Jupiter-SDR (keyboard, mouse, wi-fi, etc.);
+-  backward compatibility with USB2 interface is supported by USB3320
+   transceiver connected over ULPI interface to the PS side of XCZU3EG.
+
+Ethernet
+~~~~~~~~
+
+:adi:`ADIN1300` is a 10BASE-Te/100BASE-TX/1000BASE-T IEEE 802.3 compliant Ethernet PHY interfaced to the PS of XCZU3EG through RGMII interface.
+
+SATA
+~~~~
+
+XCZU3EG supports SATA III – 6Gb/s or 600MB/s. SATA interface is exposed to the user through an eSATA connector which supports 2.5K mating cycles and shielded cable.
+
+Display Port
+~~~~~~~~~~~~
+
+XCZU3EG supports Display Port 1.2 source-only controller with two lanes having
+link data rate of 1.62Gb/s, 2.7Gb/s or 5.4Gbps. Most of the monitors will
+achieve 1080p at 60 FPS. It also supports AUX channel for audio digital signal
+transfer (720 Mb/s).
+
+.. warning::
+
+   Xilinx provide a list of `monitors <https://support.xilinx.com/s/article/68671?language=en_US>`_ that were tested and work with the Ultrascale+ Display Port controller.
+
+Debug interfaces
+~~~~~~~~~~~~~~~~
+
+-  Micro USB connector exposes an UART interface that gives the possibility to communicate with Linux running on the XCZU3EG. The FT230XQ transceiver is used for USB to UART interfacing.
+-  Optionally the user could populate 14 pins JTAG header inside the enclosure
+   that allows to do deeper development debug.
+
+GPIOs
+~~~~~
+
+We are exposing XCZU3EG IO lines of Bank 26 to a 20 pins (1.27mm pitch) header
+on the front panel. The GPIO connector also provide 3.3V supply rail to the user
+which is also used to supply the FPGA IO Bank.
+
+-  16 lines independently configurable as inputs or outputs
+-  3V3 TTL levels
+-  ESD protection
+-  I2C0, SPI0, UART0 could be exposed using EMIO
+
+LEDs and Button
+~~~~~~~~~~~~~~~
+
+Status LED (bi-color red and blue)
+
+-  red - at least one of the power sources is present and the board was not turned on
+-  purple (both red and blue turned on) - after turn on it will indicate that bitstream was loaded into FPGA
+-  this LED is hardware controlled
+
+User LED (blue)
+
+-  by default it blinks once per second after boot up
+-  it could be programmed to desired functionality
+
+User button (S1)
+
+-  it could be used to enter DFU mode (it makes sense only for FLASH boot)
+
+--------------
+
+RF Front-end
+------------
+
+The Main Board RF front end block diagram is presented in the following picture.
+
+|image1|
+
+ADRV9002 clock
+~~~~~~~~~~~~~~
+
+Jupiter SDR supports two ADRV9002 clock sources:
+
+-  on-board 38.4MHz oscillator - `GTXO-74V/JI <https://www.golledge.com/products/gtxo-74v-low-phase-noise-sm-tcxo-with-voltage-control-and-clipped-sine-output/c-26/p-327>`_ made by Golledge
+-  external clock input exposed to the dedicated SMA connector
+
+   -  50 ohm input
+
+      -  input level range from -8dBm to 15.8 dBm
+
+adrv9002_clksrc signal selects ADRV9002 clock source:
+
+-  LOW - on-board oscillator (default)
+-  HIGH - external clock
+
+The adrv9002_clksrc control is implemented in the device tree.
+
+The on-board oscillator GTXO-74V is coming with voltage tune feature that allows
+frequency adjustment in the range of +/-8 to +/-14 ppm. The oscillator has
+frequency tuning pin connected to AUXDAC3 of ADRV9002 which allows frequency
+correction algorithms to tune the LO frequency. The following formula could be
+used to find required DAC voltage for desired tune voltage:
+
+VAUXDAC3 = (2.47V-VTUNE)/1.47
+
+For example if we want VTUNE = 1.5V then we need VAUXDAC3 = 0.659V.
+
+RF FE Main Board
+~~~~~~~~~~~~~~~~
+
+The main board expose to the front panel two wide band receive channels RX1A and RX2A which are connected to the ADRV9002 transceiver RX A channels. The receive path consist of a by-passable LNA :adi:`HMC8414`, a non-reflective SPDT switch :adi:`HMC8038` that allows to terminate with 50 ohms the RX input during internal calibration and a `TCM1-83X+ <https://www.minicircuits.com/WebStore/dashboard.html?model=TCM1-83X%2B>`_ MiniCircuits balun. The control of calibration switch is done by the driver and is not exposed to the user. The frequency range of the main board RX1A and RX2A paths is 100 MHz to 6 GHz.
+
+On the main board we have another two receive channels RX1B and RX2B which are
+connected to RX B channels of ADRV9002. These receive channels are connected to
+the RF add-on board through uFL cables and also have the same SPDT switch and
+balun as on the RX A channels.
+
+The main board also expose to the front panel two transmit channels TX1A and TX2A which consists of a TCM1-83X+ balun and a three way non-reflective switch :adi:`ADRF5040` which allows disconnecting the TX output during internal calibration or connecting the transmit path to the RF Add-on board. There are some attributes exposed to the user that allows selecting between TX1A and TX1B respective TX2A and TX2B. (:doc:`link to command example </solutions/reference-designs/jupiter_sdr/quickstart>`)
+
+RF FE Add-on board
+~~~~~~~~~~~~~~~~~~
+
+The picture below show the block diagram of the RF Add-on board.
+
+.. image:: images/jupitersdr_rf_fe_add-on.png
+
+The RF Add-on board expose B receive channels RX1B and RX2B to the front pannel. The receive path has a by-passable `LNA TSY-13LNB+ <https://www.minicircuits.com/WebStore/dashboard.html?model=TSY-13LNB%2B>`_ with frequency range 10MHz to 1GHz.
+
+TX1B and TX2B channels include just an amplifier :adi:`HMC8413` that boosts by 20 dB the transmit signal.
+
+RF FE Add-on interface
+~~~~~~~~~~~~~~~~~~~~~~
+
+Main Board expose a control interface for the RF Add-on board to a 40 pin
+connector. The table below show the pinout of the interface connector.
+
+====================== == == =================
+VAGPIO_1P8             1  2  ADV9002_AUXADC_0
+ADV9002_AUXADC_1       3  4  ADV9002_AUXADC_2
+ADV9002_AUXADC_3       5  6  ADV9002_AUXDAC_0
+ADV9002_AUXDAC_1       7  8  ADV9002_AUXDAC_2
+ADV9002_AUXDAC_3       9  10 GND
+ADV9002_AGPIO_5        11 12 ADV9002_AGPIO_7
+ADV9002_AGPIO_8        13 14 ADV9002_AGPIO_9
+ADV9002_AGPIO_10       15 16 ADV9002_AGPIO_11
+3V3                    17 18 GND
+IO_L9P_AD3P_26         19 20 IO_L10P_AD2P_26
+IO_L9N_AD3N_26         21 22 IO_L10N_AD2N_26
+IO_L11P_AD1P_26        23 24 IO_L12P_AD0P_26
+IO_L11N_AD1N_26        25 26 IO_L12N_AD0N_26
+1V8_VCCO               27 28 GND
+IO_L1P_T0L_N0_DBC_64   29 30 IO_L2P_T0L_N2_64
+IO_L1N_T0L_N1_DBC_64   31 32 IO_L2N_T0L_N3_64
+IO_L21P_T3L_N4_AD8P_64 33 34 IO_L23P_T3U_N8_64
+IO_L21P_T3L_N5_AD8N_64 35 36 IO_L23N_T3U_N9_64
+VIN_PWR                37 38 GND
+VIN_PWR                39 40 GND
+====================== == == =================
+
+Transceiver Resources
+
+-  4 AUX ADC channels
+-  4 AUX DAC channels
+-  6/10 AGPIO lines (AUX DAC channels could also be used as AGPIOs)
+
+FPGA Resources
+
+-  8 FPGA IO LVTTL 3V3 (HD bank)
+-  8 FPGA IO LVTTL 1V8 (HP bank)
+
+Power Budget
+
+-  VAGPIO_1P8 - 1V8/100 mA
+-  3V3/100 mA
+-  VIN_PWR - 5V - 20V/TBD A
+
+The user could build their own RF Add-on board to suit their specific needs.
+
+RX gain control
+~~~~~~~~~~~~~~~
+
+ADRV9002 external gain control functionality allows AGPIO pins configured as output to automatically set required front end gain. The software exposes required attributes that allows to manually control the AGPIO state.(:doc:`link to command example </solutions/reference-designs/jupiter_sdr/quickstart>`)
+
+=========== ==============================
+LNA control ADRV9002 external gain control
+=========== ==============================
+RX1A        agpio4
+RX1B        agpio5
+RX2A        agpio6
+RX2B        agpio7
+=========== ==============================
+
+AGPIO driven LOW bypass the LNA while driven HIGH turns on the LNA.
+
+--------------
+
+Power
+-----
+
+The picture below show the power supply high level block diagram.
+
+|image2|
+
+Power Sources
+~~~~~~~~~~~~~
+
+The board has three power sources:
+
+-  USB Type-C (power only) - priority 1
+
+   -  power sink - PDO1 9V/3A (default), PDO2 5V/3A
+
+-  USB Type-C (data and power) - priority 3
+
+   -  power sink - PDO1 5V/3A
+   -  power source - PDO1 5V/0.9A
+
+-  POE - priority 2
+
+   -  :adi:`LT4276A` - IEEE 802.3at 25.5W Compliant
+
+:adi:`LTC4417` power selector turns on the highest priority valid power source. The switchover from one power source to another should not cause the board to reset when total power consumption of the system does not exceed 15W.
+
+.. warning::
+
+   When you want to use Jupiter SDR by just connecting one cable to the USB
+   Type-C data and power port make sure that your computer's USB port (or
+   docking station) supports 5V and 3A PDO. Jupiter SDR will not boot up with 5V
+   and 1.5A PDO.
+
+.. warning::
+
+   The board is not going to power up if your PSE (Power Source Equipment) does
+   not support POE+ (IEEE 802.3at).
+
+System Power on/off
+~~~~~~~~~~~~~~~~~~~
+
+:adi:`LTC2955` is a push button on/off controller that manages the power supply enable/disable when the push button is pressed. A short button press will generate an enable signal to the power selector which is enabling the appropriate path and the board powers up. Once the board has booted up a short press of the button will notify the operating system that power off is desired then when operating system is ready it will send the shutdwon signal to the push button controller which in turn will disable the power selector cutting off the power of the board. When things are not working as expected it is possible to force a shutdown by pressing the button more than 5s.
+
+System Monitoring
+~~~~~~~~~~~~~~~~~
+
+:adi:`LTC2945` measures the input voltage and current consumption of the entire board giving the board's total power consumption.
+
+ZU3EG and ADRV9002 integrated temperature sensors offers the possibility to
+monitor system's hottest parts.
+
+Fan control
+~~~~~~~~~~~
+
+The fan could be controlled to be in three states: off, low speed and high
+speed. There are two lines that control the fan speed:
+
+-  fan_en - enables the fan to spin
+-  fan_ctl - when the fan is enabled the signal controls the fan speed to low
+   speed or high speed.
+
+====== ======= ==========
+fan_en fan_ctl fan state
+====== ======= ==========
+LOW    LOW     off
+LOW    HIGH    off
+HIGH   LOW     low speed
+HIGH   HIGH    high speed
+====== ======= ==========
+
+By default the fan is set to low speed. For higher power applications the fan
+can be set to high speed by changing the device tree configuration.
+
+--------------
+
+Mechanical
+----------
+
+Jupiter SDR temperature storage and operating range is 0 to 50 degC.
+
+Panels Map
+~~~~~~~~~~
+
+The early samples doesn't have the panels printed. We are presenting in the next
+pictures the meaning of each connector exposed on the two sides of the
+enclosure.
+
+|jupitersdr_front_panel.png| |jupitersdr_back_panel.png|
+
+--------------
+
+Jupiter-SDR Schematics, BOM
+---------------------------
+
+Main Board
+
+.. admonition:: Download
+   :class: download
+
+   
+   -  `Rev C Schematics <resources/02-048139-01-c.pdf>`_
+   -  `Rev C BOM <resources/05-048139-01-c.zip>`_
+   
+
+RF Add-on
+
+.. admonition:: Download
+   :class: download
+
+   
+   -  `Rev B Schematics <resources/02-071103-01-b.pdf>`_
+   -  `Rev B BOM <resources/05-071103-01-b.zip>`_
+   
+
+.. |image1| image:: images/jupitersdr_rf_fe_main.png
+.. |image2| image:: images/jupitersdr_powermap.png
+.. |jupitersdr_front_panel.png| image:: images/jupitersdr_front_panel.png
+.. |jupitersdr_back_panel.png| image:: images/jupitersdr_back_panel.png

--- a/docs/solutions/reference-designs/jupiter_sdr/images/jupitersdr_back1.png
+++ b/docs/solutions/reference-designs/jupiter_sdr/images/jupitersdr_back1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b7b8439bded10411dc0e41364255075262fe42be6fe353ebeb35259e5a5b1cad
+size 59527

--- a/docs/solutions/reference-designs/jupiter_sdr/images/jupitersdr_back_panel.png
+++ b/docs/solutions/reference-designs/jupiter_sdr/images/jupitersdr_back_panel.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f7f16b15567001b29f4b17b6299f4a11a7306da1dfc0f5cbb20fa7bf00b2cc90
+size 51895

--- a/docs/solutions/reference-designs/jupiter_sdr/images/jupitersdr_blockdiagram.png
+++ b/docs/solutions/reference-designs/jupiter_sdr/images/jupitersdr_blockdiagram.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:328a13f77a79da6493f60a4635b31e15234367a765c3def9464b3022784fe1c1
+size 189802

--- a/docs/solutions/reference-designs/jupiter_sdr/images/jupitersdr_front1.png
+++ b/docs/solutions/reference-designs/jupiter_sdr/images/jupitersdr_front1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4b39fafd416cb45126bffb3b316b0d9a2dce10fa60bafdef31485ff3ceb44e10
+size 82005

--- a/docs/solutions/reference-designs/jupiter_sdr/images/jupitersdr_front_explained.png
+++ b/docs/solutions/reference-designs/jupiter_sdr/images/jupitersdr_front_explained.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ca57b4d1c3355dcf0c6c7b0469a242b79e62f0500a0c223b30eeb6dc19e4309a
+size 52336

--- a/docs/solutions/reference-designs/jupiter_sdr/images/jupitersdr_front_panel.png
+++ b/docs/solutions/reference-designs/jupiter_sdr/images/jupitersdr_front_panel.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ab325dc717d191fb12c202a1d65a3efff978d9995407757e18eb8227f5ae4f01
+size 61159

--- a/docs/solutions/reference-designs/jupiter_sdr/images/jupitersdr_powermap.png
+++ b/docs/solutions/reference-designs/jupiter_sdr/images/jupitersdr_powermap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:116ba918035f94b0bc85dfc7ff16785aec15f91ef386ba9831400ad13ebb5436
+size 198653

--- a/docs/solutions/reference-designs/jupiter_sdr/images/jupitersdr_rf_fe_add-on.png
+++ b/docs/solutions/reference-designs/jupiter_sdr/images/jupitersdr_rf_fe_add-on.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0a4b2c6a3246f25467dfc4921334e47fa9f38bb6e164771991fda99319b49c9c
+size 34384

--- a/docs/solutions/reference-designs/jupiter_sdr/images/jupitersdr_rf_fe_main.png
+++ b/docs/solutions/reference-designs/jupiter_sdr/images/jupitersdr_rf_fe_main.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:172d2d65a1015a5f82a347389a20ed95dbf2e53957e5e0cadbba3ceef9f98936
+size 158743

--- a/docs/solutions/reference-designs/jupiter_sdr/images/tes_diversity_settings_2.png
+++ b/docs/solutions/reference-designs/jupiter_sdr/images/tes_diversity_settings_2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3da18523542f40a94497a0ae4cc30a286d001507297d99b88b80889ee88da891
+size 71219

--- a/docs/solutions/reference-designs/jupiter_sdr/images/tes_enable_nco_correction_2.png
+++ b/docs/solutions/reference-designs/jupiter_sdr/images/tes_enable_nco_correction_2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ac607d6c0356030b818e71f8d5780df9ff7ba8b1f83fa1f6e10aa971dc6b80c3
+size 82805

--- a/docs/solutions/reference-designs/jupiter_sdr/images/tes_main_configuration_4.png
+++ b/docs/solutions/reference-designs/jupiter_sdr/images/tes_main_configuration_4.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:04bfb889d87a0d187100b57b4f21c81a7ec243670d1317f0a012a0e22725c558
+size 65818

--- a/docs/solutions/reference-designs/jupiter_sdr/images/tes_save_profile_and_stream_2.png
+++ b/docs/solutions/reference-designs/jupiter_sdr/images/tes_save_profile_and_stream_2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:454a5a781c6f7c289c8bbd1840b8371df09a74ad7b41b85ea22f854ac3251013
+size 68946

--- a/docs/solutions/reference-designs/jupiter_sdr/images/test_fh_enablement_2.png
+++ b/docs/solutions/reference-designs/jupiter_sdr/images/test_fh_enablement_2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a5826ab3f548745487a24fde06b4ad5d865d4bcb26a6832b9f5f76f7b766ff69
+size 75681

--- a/docs/solutions/reference-designs/jupiter_sdr/index.rst
+++ b/docs/solutions/reference-designs/jupiter_sdr/index.rst
@@ -1,0 +1,236 @@
+Jupiter SDR
+===========
+
+Overview
+--------
+
+Jupiter is a versatile software-defined platform based on Analog Devices :adi:`ADRV9002` and Xilinx `Zynq UltraScale+ MPSoC <https://www.xilinx.com/products/silicon-devices/soc/zynq-ultrascale-mpsoc.html>`_. ADRV9002 is a new generation RF transceiver that has dual-channel transmitters, dual-channel receivers covering 30 MHz to 6 GHz frequency range with very good RF linearity performance and a set of advanced features like fast profiles switching, flexible power vs performance configuration, fast frequency hopping, multi-chip synchronization and DPD for narrow and wide band waveform. The evaluation platform includes XCZU3EG processing device that has a wide range of interfaces making the system capable of local processing or streaming to a remote host. It comes integrated in a self-contained ruggedised aluminum case which gives flexibility in evaluating and prototyping across different environments.
+
+|jupitersdr_back1.png| |jupitersdr_front1.png|
+
+The platform comes with open-source software that includes:
+
+-  Linux and no-OS
+-  HDL reference design
+-  IIO
+-  MATLAB
+-  GNU Radio
+-  Python
+
+--------------
+
+Key Features
+------------
+
+-  RF/SDR
+
+   -  ADRV9002 transceiver
+
+      -  2 x RX, 2 x TX
+      -  LO Frequency range 30 MHz to 6 GHz
+      -  12 KHz to 40 MHz frequency bandwidth
+      -  Sampling rate 12 KS/s to 61.44 MS/s
+
+   -  External device clock input
+   -  External MCS input
+   -  RF Front-end
+
+-  Processing system
+
+   -  Zynq UltraScale+ MPSoC XCZU3EG
+
+      -  ARM CORTEX-A53 1.5GHz
+      -  ARM CORTEX-R5 500 MHz
+      -  Mali-400 MP2 graphic processor
+      -  Programmable logic 154k
+
+   -  DDR4 – 2 GB (x32)
+   -  Boot source
+
+      -  SD CARD 3.0
+      -  FLASH memory 128MB
+
+-  User Interfaces
+
+   -  USB 3.1 Gen 1 – Type C
+
+      -  Upstream Facing Port (UFP)
+      -  Downstream Facing Port (DFP)
+      -  USB 2.0 compatible
+
+   -  Ethernet 1000BASE-T RGMII
+   -  Display Port v1.2 (2 lanes 5.4Gb/s)
+   -  SATA 3
+   -  USB (micro) debug interface
+   -  16 GPIOs (3V3 LVCMOS)
+
+-  Power Sources
+
+   -  USB Type-C (power only)
+
+      -  Power Sink 5V, 9V/3A
+
+   -  USB Type-C (data)
+
+      -  Power Sink 5V/3A
+      -  Power Source 5V/0.9A
+
+   -  802.3at POE compliant, 25.5W Type2 (POE+)
+
+--------------
+
+User Resources
+--------------
+
+People who follow the flow that is outlined, have a much better experience with things. However, like many things, documentation is never as complete as it should be. If you have any questions, feel free to `ask <https://wiki.analog.com/resources/eval/user-guides/ad-fmcomms2-ebz/help_and_support>`_.
+
+-  Getting Started
+
+   -  `What you need to get started <https://wiki.analog.com/.jupiter-sdr/quickstart>`_
+   -  Quick Start Guides
+
+      -  `Generate a custom device profile using TES <https://wiki.analog.com/.jupiter-sdr/profile_generation_using_tes>`_
+      -  `Configure a pre-existing SD-Card <https://wiki.analog.com/resources/tools-software/linux-software/kuiper-linux>`_
+      -  `Update the old card you received with your hardware <https://wiki.analog.com/resources/tools-software/linux-software/kuiper-linux>`_
+
+-  Software Solutions
+
+   -  `IIO Scope <https://wiki.analog.com/resources/tools-software/linux-software/iio_oscilloscope>`_
+
+      -  `ADRV9001/2 IIO Scope View <https://wiki.analog.com/resources/tools-software/linux-software/adrv9002_osc_main>`_
+
+         -  `ADRV9001/2 Control IIO Scope Plugin <https://wiki.analog.com/resources/tools-software/linux-software/adrv9002_plugin>`_
+         -  `ADRV9001/2 Profile Generator Plugin <https://wiki.analog.com/resources/tools-software/linux-software/adrv9002_profile_generator_plugin>`_
+
+      -  `Transceiver Toolbox for MATLAB and Simulink <https://wiki.analog.com/resources/tools-software/transceiver-toolbox>`_
+      -  `GNU Radio <https://wiki.analog.com/resources/tools-software/linux-software/gnuradio>`_
+      -  `Python Interfaces <https://wiki.analog.com/resources/tools-software/linux-software/pyadi-iio>`_
+      -  `IIO Command Line Tools <https://wiki.analog.com/resources/tools-software/linux-software/libiio/cmd_line>`_
+
+-  Embedded Resources
+
+   -  `ADRV9001/2 Linux Device Driver <https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9002>`_
+
+      -  `ADRV9001/2 Device Driver Customization <https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9002-customization>`_
+      -  `AXI-DMAC DMA Controller Linux Driver <https://wiki.analog.com/resources/tools-software/linux-drivers/axi-dmac>`_
+      -  `AXI ADC HDL Linux Driver <https://wiki.analog.com/resources/tools-software/linux-drivers/iio-adc/axi-adc-hdl>`_
+      -  `AXI DAC HDL Linux Driver <https://wiki.analog.com/resources/tools-software/linux-drivers/iio-dds/axi-dac-dds-hdl>`_
+      -  `Customizing the devicetree on the target <https://wiki.analog.com/resources/eval/user-guides/ad-fmcomms2-ebz/software/linux/zynq_tips_tricks>`_
+      -  `ADRV9001/2 No-OS System Level Design Setup <https://wiki.analog.com/resources/eval/user-guides/adrv9002/no-os-setup>`_
+      -  `Building the ZynqMP / MPSoC Linux kernel and devicetrees from source <https://wiki.analog.com/resources/tools-software/linux-build/generic/zynqmp>`_
+
+-  FPGA Resources
+
+   -  `HDL Reference Design <https://wiki.analog.com/resources/eval/user-guides/jupiter_sdr/reference_hdl>`_ which you must use in your FPGA.
+
+      -  `AXI_ADRV9002 Interface Core <https://wiki.analog.com/resources/eval/user-guides/adrv9002/axi_adrv9002>`_
+      -  `ADI Reference Designs HDL User Guide <https://wiki.analog.com/resources/fpga/docs/hdl>`_
+      -  `HDL Targeting From MATLAB and Simulink <https://wiki.analog.com/resources/tools-software/transceiver-toolbox>`_
+
+-  Hardware Resources
+
+   -  `Jupiter SDR Hardware Overview <https://wiki.analog.com/.jupiter-sdr/hardware-overview>`_
+
+      -  :adi:`ADRV9002 Product page <ADRV9002>`
+      -  :adi:`Full Datasheet and chip design package <en/design-center/landing-pages/001/integrated-rf-agile-transceiver-design-resources.html>`
+
+-  `Multi-chip synchronization support <https://wiki.analog.com/resources/eval/user-guides/jupiter_sdr/mcs>`_
+
+-  `Help and Support <https://wiki.analog.com/resources/eval/user-guides/ad-fmcomms2-ebz/help_and_support>`_
+
+   -  `Known issues <https://wiki.analog.com/.jupiter-sdr/known-issues>`_
+   -  For Hardware technical support go to:
+
+      -   :ez:`Design Support Community ADRV9001-ADRV9007 <wide-band-rf-transceivers/design-support-adrv9001-adrv9007>`
+
+   -  For Evaluation System Software support (TES GUI, ADRV9001 API driver,
+      etc.) go to:
+
+      -  :ez:`TES GUI Software Support Community ADRV9001-ADRV9007 <wide-band-rf-transceivers/tes-gui-software-support-adrv9001-adrv9007>`
+
+   -  For questions regarding the HDL reference design please use the
+
+      -  :ez:`FPGA Reference Designs <community/fpga>` sub-community.
+
+   -  For questions regarding the the ADI Linux distribution, the Linux drivers,
+      or the device trees for the ADRV9001/2 based platforms, please use the
+
+      -  :ez:`Linux Software Drivers <community/linux-device-drivers/linux-software-drivers>` sub-community.
+
+   -  For questions regarding the no-OS drivers for ADRV9001/2, please use the
+
+      -  :ez:`Microcontroller and No-OS Driver <community/linux-device-drivers/microcontroller-no-os-drivers>` sub-community.
+
+   -  `Additional Documentation about SDR Signal Chains - The math behind the RF <https://wiki.analog.com/resources/eval/user-guides/ad-fmcomms1-ebz/math>`_
+
+--------------
+
+Downloads
+---------
+
+Binaries:
+
+Osc for windows can be downloaded directly from Github. Go to to the following
+link and download the latest release.
+
+-  `IIO-Scope <https://github.com/analogdevicesinc/iio-oscilloscope/releases>`_
+
+The latest boot files for adrv9002 (for all supported carriers) can be found in
+the latest Kuiper Image release (note one can choose between downloading the
+full image or just the boot partition):
+
+-  `Kuiper Image <https://wiki.analog.com/resources/tools-software/linux-software/adi-kuiper_images/release_notes>`_
+
+Below it's an **experimental** pre-release which enables DMA Coherency on the AXI DMA core. That means the IP core can snoop the caches and so samples can actually live in them. This gave some promising throughput improvements when using libiio IP and USB backends:
+
+-  `Jupiter DMA Coeherent <resources/jupiter-dma-coeherent.tar.gz>`_
+
+--------------
+
+Reference Material
+------------------
+
+-  :adi:`ADRV9002: Narrow to Wide Band Integrated RF Transceiver <en/education/education-library/videos/6170462863001.html>`
+
+Software Defined Radio using the Linux IIO Framework
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+`iiosdr.mp4 <http://ftp.fau.de/fosdem/2015/devroom-software_defined_radio/iiosdr.mp4>`_
+
+ADI Articles
+~~~~~~~~~~~~
+
+-   Four Quick Steps to Production: Using Model-Based Design for
+    Software-Defined Radio
+
+   -  :adi:`Part 1—the Analog Devices/Xilinx SDR Rapid Prototyping Platform: Its Capabilities, Benefits, and Tools <library/analogDialogue/archives/49-09/four-step-sdr-01.html>`
+   -  :adi:`Part 2—Mode S Detection and Decoding Using MATLAB and Simulink <library/analogDialogue/archives/49-10/four-step-sdr-02.html>`
+   -  :adi:`Part 3—Mode S Signals Decoding Algorithm Validation Using Hardware in the Loop <library/analogDialogue/archives/49-11/four-step-sdr-03.html>`
+   -  :adi:`Part 4 - Rapid Prototyping Using the Zynq SDR Kit and Simulink Code Generation Workflow <library/analogDialogue/archives/49-12/four-step-sdr-04.html>`
+
+MathWorks Webinars
+~~~~~~~~~~~~~~~~~~
+
+-  `Modelling and Simulating Analog Devices’ RF Transceivers with MATLAB and SimRF <https://www.mathworks.com/videos/modelling-and-simulating-analog-devices-rf-transceivers-with-matlab-and-simrf-89934.html>`_
+-  `Getting Started with Software-Defined Radio using MATLAB and Simulink <https://www.mathworks.com/videos/getting-started-with-software-defined-radio-using-matlab-and-simulink-108646.html>`_
+
+Warning
+-------
+
+.. esd-warning::
+
+.. |jupitersdr_back1.png| image:: images/jupitersdr_back1.png
+   :width: 550
+   :height: 300px
+.. |jupitersdr_front1.png| image:: images/jupitersdr_front1.png
+   :width: 550
+   :height: 300px
+
+
+.. toctree::
+   :hidden:
+
+   hardware-overview
+   known-issues
+   profile_generation_using_tes
+   quickstart

--- a/docs/solutions/reference-designs/jupiter_sdr/known-issues.rst
+++ b/docs/solutions/reference-designs/jupiter_sdr/known-issues.rst
@@ -1,0 +1,10 @@
+Jupiter SDR - known issues
+==========================
+
+Jupiter SDR known issues when used with `2023_r2 Patch1 Kuiper image: <https://wiki.analog.com/resources/tools-software/linux-software/adi-kuiper_images/release_notes>`_
+
+-  IIO buffer size limited to 131072 samples when USB 3 interface is used to stream data to a host
+-  USB 3 and Gigabit Ethernet interfaces throughput is currently limited by `libiio v0.26 <https://wiki.analog.com/resources/eval/user-guides/ad-fmcdaq2-ebz/software/linux/applications/libiio>`_ implementation. The throughputs will significantly improve once libiio v1.0 will be realeaed.
+-  IIO Oscilloscope profile generator (latest libadrv9002-iio) supports v68.10.1 API while 2023_r3 Patch1 comes with v68.14.10 API; `Generate a custom device profile using TES <https://wiki.analog.com/..jupiter-sdr/profile_generation_using_tes>`_
+-  Multi chip synchronization support is not included in the 2023_r2 Patch1 Kuiper release. Please visit `multi-chip synchronization page <https://wiki.analog.com/resources/eval/user-guides/jupiter_sdr/mcs>`_ to check available support.
+-  ADRV9002 CMOS interface not implemented

--- a/docs/solutions/reference-designs/jupiter_sdr/profile_generation_using_tes.rst
+++ b/docs/solutions/reference-designs/jupiter_sdr/profile_generation_using_tes.rst
@@ -1,0 +1,94 @@
+Profile generation flow using TES
+=================================
+
+Profiles
+--------
+
+ADRV9002 uses profiles to designate different device configuration settings for the Tx/Rx channels. The profile dictates how the digital filters, analog filters, clock rates, and clock dividers are configured in the device. Some specific parameters set by profiles include the IQ data rate, ADC clock rate, analog filter corners, FIR filter coefficients, and interpolation/decimation factors in the half-band filters. Several profiles can be examined in the ADRV9002 Transceiver Evaluation Software for given device clock frequencies. If the desired profile exists in the software, it is recommended to set up the desired profile in and use the generated JSON file by pressing the ``Generate Profile File`` button. Custom profiles can be generated using other ADI software tools not described here :adi:`ADRV9002 transceiver evaluation software (TES) <en/design-center/landing-pages/001/transceiver-evaluation-software.html>`.
+
+.. warning::
+
+   Profiles are specific to the versions of ADRV9001/2 API that the driver uses. Therefore, they must be generated from the :adi:`TES software <en/design-center/landing-pages/001/transceiver-evaluation-software.html>` that coincides with that API version. Unfortunately, profiles themselves are not versioned so it is recommended to note the API version in the generated profile filenames when created. The driver will print the API version during boot for reference.
+
+For more information about profiles and how to load please see here: `Profile section on the ADRV9002 Linux driver documentation <https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9002>`_
+
+.. note::
+
+   We are about to release a library which allows device profile generation outside of TES. This library can be used in applications such as the `IIO Oscilloscope <https://wiki.analog.com/resources/tools-software/linux-software/iio_oscilloscope>`_, or other SDR software.
+
+Installation and Configuration
+------------------------------
+
+Detailed installation and configuration instructions can be found under section ``TRANSCEIVER EVALUATION SOFTWARE (TES)`` in the :adi:`UG-1828: ADRV9001 system development user guide <media/en/technical-documentation/user-guides/adrv9001-system-development-user-guide-ug-1828.pdf>`
+
+Download:
+
+-  :adi:`TRANSCEIVER EVALUATION SOFTWARE (TES) <en/license/licensing-agreement/transceiver-evaluation-software.html>`
+
+Worked example
+--------------
+
+In the following picture we can see the base controls for the profile:
+
+.. image:: images/tes_main_configuration_4.png
+   :align: center
+   :width: 800
+
+In here, one can change the main profile type (LTE, DMR, etc), interface rate,
+disabling ports and so on...
+
+.. important::
+
+   Special care for the fields highlighted in channel 2 (also applies for
+   channel 1) that must be set like in the image. The LVDS enforcement is
+   specific to jupiter.
+
+Once we are done with the settings, time to generate the stream and the profiles
+files:
+
+.. image:: images/tes_save_profile_and_stream_2.png
+   :align: center
+   :width: 800
+
+In the next subsections, we can see some extra and useful settings that one
+might want to set before generating the stream and the profile files.
+
+Enable NCO Frequency offset
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. image:: images/tes_enable_nco_correction_2.png
+   :align: center
+   :width: 800
+
+.. note::
+
+   Enabling this setting, enables the IIO attribute '`in_voltage0_nco_frequency <https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9002>`_'. These settings are on by default on jupiter default profile.
+
+Enable Antenna Diversity
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. image:: images/tes_diversity_settings_2.png
+   :align: center
+   :width: 800
+
+.. note::
+
+   This setting affects the LO mapping (which ports each LO drives). Basically
+   having this on, means that all ports are mapped into the same LO.
+
+.. warning::
+
+   This settings is obviously only available if TDD is set in the Device
+   Configuration tab
+
+Enable Frequency hopping
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. image:: images/test_fh_enablement_2.png
+   :align: center
+   :width: 800
+
+.. note::
+
+   The only thing needed to do in TES is just to enable Frequency hopping as
+   highlighted. All the other settings does not map in any profile setting...

--- a/docs/solutions/reference-designs/jupiter_sdr/quickstart.rst
+++ b/docs/solutions/reference-designs/jupiter_sdr/quickstart.rst
@@ -1,0 +1,852 @@
+Jupiter SDR Quick Start Guide
+=============================
+
+.. image:: images/jupitersdr_front_explained.png
+   :alt: jupitersdr_front_explained.png
+
+This guide provides some quick instructions on how to setup Jupiter SDR.
+
+Required Software
+-----------------
+
+-  SD Card 16GB image using the instructions here: `Kuiper Linux image <https://wiki.analog.com/resources/tools-software/linux-software/kuiper-linux>`_
+-  Instructions on how to build the ZynqMP / MPSoC Linux kernel and devicetrees
+   from source can be found here:
+
+   -  `Building the ZynqMP / MPSoC Linux kernel and devicetrees from source <https://wiki.analog.com/resources/eval/user-guides/ad-fmcomms2-ebz/software/linux/zynqmp>`_
+   -  `How to build the ZynqMP boot image BOOT.BIN <https://wiki.analog.com/resources/tools-software/linux-software/build-the-zynqmp-boot-image>`_
+
+-  When streaming data over USB3 interface is desired `USB driver <https://github.com/analogdevicesinc/plutosdr-m2k-drivers-win/releases>`_ need to be installed on the host computer
+-  UART terminal (Putty/Tera Term/Minicom, etc.), Baud rate 115200 (8N1).
+-  `IIO Osciloscope <https://wiki.analog.com/resources/tools-software/linux-software/iio_oscilloscope]>`_
+
+Please use the `release Image 2021_R2 or later <https://wiki.analog.com/resources/tools-software/linux-software/kuiper-linux>`_
+
+Hardware Setup
+--------------
+
+What's in the box
+~~~~~~~~~~~~~~~~~
+
+-  Jupiter SDR
+-  2 x USB Type-C cables
+-  150mm RF loopback cable
+-  micro SD Card with pre-programmed image
+-  USB Type-C power supply (one USB Type-C cable is used to supply the board)
+
+Use case 1 - data streaming to a host computer
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+-  Jupiter SDR
+-  Micro-USB cable
+-  USB Type-C cable (or Ethernet cable)
+-  USB Type-C Power Supply
+
+Use case 2 - stand alone use
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+-  Jupiter SDR
+-  Display Port compatible Monitor
+-  USB Type-C multiport hub, mouse and keyboard
+-  USB Type-C Power Supply
+
+Testing
+-------
+
+-  Insert SD card into the socket.
+-  Connect USB UART (Micro USB) to your host PC and connect your terminal application to the corresponding port.
+-  Connect the Power Supply to USB Type-C power only connector - after this the Status LED turns on red.
+-  Press Power Button to boot up - short time after button press Status LED becomes purple (both red and blue LEDs are on)
+-  Observe kernel and serial console messages on your terminal.
+-  Optionally connect test and measurement equipment to SMA ports or just
+   connect the loopback cable included and use IIO Osciloscope to control the
+   ADRV9002 settings.
+
+Messages
+~~~~~~~~
+
+.. container:: box bggreen
+
+   This specifies any shell prompt running on the target
+
+   
+
+   .. collapsible:: Boot log (click to expand)
+
+         ::
+   
+            Xilinx Zynq MP First Stage Boot Loader
+            Release 2022.2   Jun 27 2023  -  07:04:57
+            NOTICE:  BL31: Non secure code at 0x8000000
+            NOTICE:  BL31: v2.8(release):4683880e5
+            NOTICE:  BL31: Built : 06:39:41, Jun 27 2023
+   
+   
+            U-Boot 2022.01-40843-ga16a6a9cb3 (Jun 26 2023 - 15:37:16 +0300)
+   
+            CPU:   ZynqMP
+            Silicon: v3
+            Model: Analog Devices, Inc. Jupiter SDR
+            Board: Xilinx ZynqMP
+            DRAM:  2 GiB
+            PMUFW:  v1.1
+            PMUFW:  No permission to change config object
+            EL Level:       EL2
+            Chip ID:        zu3eg
+            NAND:  0 MiB
+            MMC:   mmc@ff170000: 0
+            Loading Environment from FAT... ** Error - No Valid Environment Area found
+            ** Warning - bad env area, using default environment
+   
+            In:    serial
+            Out:   serial
+            Err:   serial
+            Bootmode: LVL_SHFT_SD_MODE1
+            Reset reason:   EXTERNAL
+            Net:   FEC: can't find phy-handle
+   
+            ZYNQ GEM: ff0e0000, mdio bus ff0e0000, phyaddr 15, interface rgmii-id
+   
+            Error: ethernet@ff0e0000 address not set.
+            No ethernet found.
+   
+            scanning bus for devices...
+            SATA link 0 timeout.
+            SATA link 1 timeout.
+            AHCI 0001.0301 32 slots 2 ports 6 Gbps 0x3 impl SATA mode
+            flags: 64bit ncq pm clo only pmp fbss pio slum part ccc apst
+            starting USB...
+            No working controllers found
+            Hit any key to stop autoboot:  0
+            switch to partitions #0, OK
+            mmc0 is current device
+            Scanning mmc 0:1...
+            Found U-Boot script /boot.scr
+            242 bytes read in 20 ms (11.7 KiB/s)
+            ## Executing script at 20000000
+            33378 bytes read in 29 ms (1.1 MiB/s)
+            33384960 bytes read in 2251 ms (14.1 MiB/s)
+            ## Flattened Device Tree blob at 00100000
+               Booting using the fdt blob at 0x100000
+            FEC: can't find phy-handle
+   
+            ZYNQ GEM: ff0e0000, mdio bus ff0e0000, phyaddr 15, interface rgmii-id
+   
+            Error: ethernet@ff0e0000 address not set.
+            FEC: can't find phy-handle
+   
+            ZYNQ GEM: ff0e0000, mdio bus ff0e0000, phyaddr 15, interface rgmii-id
+   
+            Error: ethernet@ff0e0000 address not set.
+               Loading Device Tree to 000000007bdf8000, end 000000007be03261 ... OK
+   
+            Starting kernel ...
+   
+            [    0.000000] Booting Linux on physical CPU 0x0000000000 [0x410fd034]
+            [    0.000000] Linux version 5.15.0-175797-g9379dba5c06d (dragos@debian) (aarch64-none-linux-gnu-gcc (GNU Toolchain for the A-profile Architecture 10.3-2021.07 (arm-10.29)) 10.3.1 20210621, GNU ld (GNU Toolchain for the A-profile Architecture 10.3-2021.07 (arm-10.29)) 2.36.1.20210621) #6 SMP Fri Jun 23 12:59:00 EEST 2023
+            [    0.000000] Machine model: Analog Devices, Inc. Jupiter SDR
+            [    0.000000] earlycon: cdns0 at MMIO 0x00000000ff010000 (options '115200n8')
+            [    0.000000] printk: bootconsole [cdns0] enabled
+            [    0.000000] efi: UEFI not found.
+            [    0.000000] Zone ranges:
+            [    0.000000]   DMA      [mem 0x0000000000000000-0x000000007fffffff]
+            [    0.000000]   DMA32    empty
+            [    0.000000]   Normal   empty
+            [    0.000000] Movable zone start for each node
+            [    0.000000] Early memory node ranges
+            [    0.000000]   node   0: [mem 0x0000000000000000-0x000000007fffffff]
+            [    0.000000] Initmem setup node 0 [mem 0x0000000000000000-0x000000007fffffff]
+            [    0.000000] cma: Reserved 256 MiB at 0x000000006bc00000
+            [    0.000000] psci: probing for conduit method from DT.
+            [    0.000000] psci: PSCIv1.1 detected in firmware.
+            [    0.000000] psci: Using standard PSCI v0.2 function IDs
+            [    0.000000] psci: MIGRATE_INFO_TYPE not supported.
+            [    0.000000] psci: SMC Calling Convention v1.2
+            [    0.000000] percpu: Embedded 18 pages/cpu s34008 r8192 d31528 u73728
+            [    0.000000] Detected VIPT I-cache on CPU0
+            [    0.000000] CPU features: detected: ARM erratum 845719
+            [    0.000000] Built 1 zonelists, mobility grouping on.  Total pages: 517120
+            [    0.000000] Kernel command line: earlycon clk_ignore_unused root=/dev/mmcblk0p2 rw rootwait
+            [    0.000000] Dentry cache hash table entries: 262144 (order: 9, 2097152 bytes, linear)
+            [    0.000000] Inode-cache hash table entries: 131072 (order: 8, 1048576 bytes, linear)
+            [    0.000000] mem auto-init: stack:off, heap alloc:off, heap free:off
+            [    0.000000] Memory: 1765380K/2097152K available (16000K kernel code, 1690K rwdata, 12252K rodata, 2560K init, 615K bss, 69628K reserved, 262144K cma-reserved)
+            [    0.000000] rcu: Hierarchical RCU implementation.
+            [    0.000000] rcu:     RCU event tracing is enabled.
+            [    0.000000] rcu:     RCU restricting CPUs from NR_CPUS=8 to nr_cpu_ids=4.
+            [    0.000000] rcu: RCU calculated value of scheduler-enlistment delay is 25 jiffies.
+            [    0.000000] rcu: Adjusting geometry for rcu_fanout_leaf=16, nr_cpu_ids=4
+            [    0.000000] NR_IRQS: 64, nr_irqs: 64, preallocated irqs: 0
+            [    0.000000] GIC: Adjusting CPU interface base to 0x00000000f902f000
+            [    0.000000] Root IRQ handler: gic_handle_irq
+            [    0.000000] GIC: Using split EOI/Deactivate mode
+            [    0.000000] random: get_random_bytes called from start_kernel+0x470/0x6fc with crng_init=0
+            [    0.000000] arch_timer: cp15 timer(s) running at 33.33MHz (phys).
+            [    0.000000] clocksource: arch_sys_counter: mask: 0xffffffffffffff max_cycles: 0x7b0074340, max_idle_ns: 440795202884 ns
+            [    0.000000] sched_clock: 56 bits at 33MHz, resolution 30ns, wraps every 2199023255543ns
+            [    0.008302] Console: colour dummy device 80x25
+            [    0.012374] printk: console [tty0] enabled
+            [    0.016436] printk: bootconsole [cdns0] disabled
+            [    0.000000] Booting Linux on physical CPU 0x0000000000 [0x410fd034]
+            [    0.000000] Linux version 5.15.0-175797-g9379dba5c06d (dragos@debian) (aarch64-none-linux-gnu-gcc (GNU Toolchain for the A-profile Architecture 10.3-2021.07 (arm-10.29)) 10.3.1 20210621, GNU ld (GNU Toolchain for the A-profile Architecture 10.3-2021.07 (arm-10.29)) 2.36.1.20210621) #6 SMP Fri Jun 23 12:59:00 EEST 2023
+            [    0.000000] Machine model: Analog Devices, Inc. Jupiter SDR
+            [    0.000000] earlycon: cdns0 at MMIO 0x00000000ff010000 (options '115200n8')
+            [    0.000000] printk: bootconsole [cdns0] enabled
+            [    0.000000] efi: UEFI not found.
+            [    0.000000] Zone ranges:
+            [    0.000000]   DMA      [mem 0x0000000000000000-0x000000007fffffff]
+            [    0.000000]   DMA32    empty
+            [    0.000000]   Normal   empty
+            [    0.000000] Movable zone start for each node
+            [    0.000000] Early memory node ranges
+            [    0.000000]   node   0: [mem 0x0000000000000000-0x000000007fffffff]
+            [    0.000000] Initmem setup node 0 [mem 0x0000000000000000-0x000000007fffffff]
+            [    0.000000] cma: Reserved 256 MiB at 0x000000006bc00000
+            [    0.000000] psci: probing for conduit method from DT.
+            [    0.000000] psci: PSCIv1.1 detected in firmware.
+            [    0.000000] psci: Using standard PSCI v0.2 function IDs
+            [    0.000000] psci: MIGRATE_INFO_TYPE not supported.
+            [    0.000000] psci: SMC Calling Convention v1.2
+            [    0.000000] percpu: Embedded 18 pages/cpu s34008 r8192 d31528 u73728
+            [    0.000000] Detected VIPT I-cache on CPU0
+            [    0.000000] CPU features: detected: ARM erratum 845719
+            [    0.000000] Built 1 zonelists, mobility grouping on.  Total pages: 517120
+            [    0.000000] Kernel command line: earlycon clk_ignore_unused root=/dev/mmcblk0p2 rw rootwait
+            [    0.000000] Dentry cache hash table entries: 262144 (order: 9, 2097152 bytes, linear)
+            [    0.000000] Inode-cache hash table entries: 131072 (order: 8, 1048576 bytes, linear)
+            [    0.000000] mem auto-init: stack:off, heap alloc:off, heap free:off
+            [    0.000000] Memory: 1765380K/2097152K available (16000K kernel code, 1690K rwdata, 12252K rodata, 2560K init, 615K bss, 69628K reserved, 262144K cma-reserved)
+            [    0.000000] rcu: Hierarchical RCU implementation.
+            [    0.000000] rcu:     RCU event tracing is enabled.
+            [    0.000000] rcu:     RCU restricting CPUs from NR_CPUS=8 to nr_cpu_ids=4.
+            [    0.000000] rcu: RCU calculated value of scheduler-enlistment delay is 25 jiffies.
+            [    0.000000] rcu: Adjusting geometry for rcu_fanout_leaf=16, nr_cpu_ids=4
+            [    0.000000] NR_IRQS: 64, nr_irqs: 64, preallocated irqs: 0
+            [    0.000000] GIC: Adjusting CPU interface base to 0x00000000f902f000
+            [    0.000000] Root IRQ handler: gic_handle_irq
+            [    0.000000] GIC: Using split EOI/Deactivate mode
+            [    0.000000] random: get_random_bytes called from start_kernel+0x470/0x6fc with crng_init=0
+            [    0.000000] arch_timer: cp15 timer(s) running at 33.33MHz (phys).
+            [    0.000000] clocksource: arch_sys_counter: mask: 0xffffffffffffff max_cycles: 0x7b0074340, max_idle_ns: 440795202884 ns
+            [    0.000000] sched_clock: 56 bits at 33MHz, resolution 30ns, wraps every 2199023255543ns
+            [    0.008302] Console: colour dummy device 80x25
+            [    0.012374] printk: console [tty0] enabled
+            [    0.016436] printk: bootconsole [cdns0] disabled
+            [    0.021040] Calibrating delay loop (skipped), value calculated using timer frequency.. 66.66 BogoMIPS (lpj=133332)
+            [    0.021057] pid_max: default: 32768 minimum: 301
+            [    0.021183] Mount-cache hash table entries: 4096 (order: 3, 32768 bytes, linear)
+            [    0.021203] Mountpoint-cache hash table entries: 4096 (order: 3, 32768 bytes, linear)
+            [    0.022116] rcu: Hierarchical SRCU implementation.
+            [    0.022306] EFI services will not be available.
+            [    0.022442] smp: Bringing up secondary CPUs ...
+            [    0.022805] Detected VIPT I-cache on CPU1
+            [    0.022842] CPU1: Booted secondary processor 0x0000000001 [0x410fd034]
+            [    0.023222] Detected VIPT I-cache on CPU2
+            [    0.023246] CPU2: Booted secondary processor 0x0000000002 [0x410fd034]
+            [    0.023598] Detected VIPT I-cache on CPU3
+            [    0.023621] CPU3: Booted secondary processor 0x0000000003 [0x410fd034]
+            [    0.023663] smp: Brought up 1 node, 4 CPUs
+            [    0.023699] SMP: Total of 4 processors activated.
+            [    0.023708] CPU features: detected: 32-bit EL0 Support
+            [    0.023716] CPU features: detected: CRC32 instructions
+            [    0.023757] CPU: All CPU(s) started at EL2
+            [    0.023776] alternatives: patching kernel code
+            [    0.024818] devtmpfs: initialized
+            [    0.028759] Registered cp15_barrier emulation handler
+            [    0.028776] Registered setend emulation handler
+            [    0.028888] clocksource: jiffies: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 7645041785100000 ns
+            [    0.028911] futex hash table entries: 1024 (order: 4, 65536 bytes, linear)
+            [    0.037569] pinctrl core: initialized pinctrl subsystem
+            [    0.038315] NET: Registered PF_NETLINK/PF_ROUTE protocol family
+            [    0.039513] DMA: preallocated 256 KiB GFP_KERNEL pool for atomic allocations
+            [    0.039662] DMA: preallocated 256 KiB GFP_KERNEL|GFP_DMA pool for atomic allocations
+            [    0.039792] DMA: preallocated 256 KiB GFP_KERNEL|GFP_DMA32 pool for atomic allocations
+            [    0.039846] audit: initializing netlink subsys (disabled)
+            [    0.039937] audit: type=2000 audit(0.032:1): state=initialized audit_enabled=0 res=1
+            [    0.040223] cpuidle: using governor menu
+            [    0.040299] hw-breakpoint: found 6 breakpoint and 4 watchpoint registers.
+            [    0.040362] ASID allocator initialised with 65536 entries
+            [    0.054625] HugeTLB registered 1.00 GiB page size, pre-allocated 0 pages
+            [    0.054646] HugeTLB registered 32.0 MiB page size, pre-allocated 0 pages
+            [    0.054657] HugeTLB registered 2.00 MiB page size, pre-allocated 0 pages
+            [    0.054668] HugeTLB registered 64.0 KiB page size, pre-allocated 0 pages
+            [    1.114544] DRBG: Continuing without Jitter RNG
+            [    1.217848] raid6: neonx8   gen()  2133 MB/s
+            [    1.285908] raid6: neonx8   xor()  1582 MB/s
+            [    1.353965] raid6: neonx4   gen()  2184 MB/s
+            [    1.422013] raid6: neonx4   xor()  1556 MB/s
+            [    1.490086] raid6: neonx2   gen()  2071 MB/s
+            [    1.558128] raid6: neonx2   xor()  1429 MB/s
+            [    1.626187] raid6: neonx1   gen()  1769 MB/s
+            [    1.694248] raid6: neonx1   xor()  1212 MB/s
+            [    1.762293] raid6: int64x8  gen()  1437 MB/s
+            [    1.830358] raid6: int64x8  xor()   771 MB/s
+            [    1.898414] raid6: int64x4  gen()  1602 MB/s
+            [    1.966471] raid6: int64x4  xor()   818 MB/s
+            [    2.034540] raid6: int64x2  gen()  1398 MB/s
+            [    2.102591] raid6: int64x2  xor()   749 MB/s
+            [    2.170653] raid6: int64x1  gen()  1033 MB/s
+            [    2.238705] raid6: int64x1  xor()   517 MB/s
+            [    2.238715] raid6: using algorithm neonx4 gen() 2184 MB/s
+            [    2.238724] raid6: .... xor() 1556 MB/s, rmw enabled
+            [    2.238733] raid6: using neon recovery algorithm
+            [    2.239067] iommu: Default domain type: Translated
+            [    2.239078] iommu: DMA domain TLB invalidation policy: strict mode
+            [    2.239294] SCSI subsystem initialized
+            [    2.239462] usbcore: registered new interface driver usbfs
+            [    2.239498] usbcore: registered new interface driver hub
+            [    2.239527] usbcore: registered new device driver usb
+            [    2.239654] mc: Linux media interface: v0.10
+            [    2.239678] videodev: Linux video capture interface: v2.00
+            [    2.239742] pps_core: LinuxPPS API ver. 1 registered
+            [    2.239752] pps_core: Software ver. 5.3.6 - Copyright 2005-2007 Rodolfo Giometti <giometti@linux.it>
+            [    2.239772] PTP clock support registered
+            [    2.239805] EDAC MC: Ver: 3.0.0
+            [    2.240099] zynqmp-ipi-mbox mailbox@ff990400: Registered ZynqMP IPI mbox with TX/RX channels.
+            [    2.240421] jesd204: found 0 devices and 0 topologies
+            [    2.240461] FPGA manager framework
+            [    2.240589] Advanced Linux Sound Architecture Driver Initialized.
+            [    2.241014] Bluetooth: Core ver 2.22
+            [    2.241041] NET: Registered PF_BLUETOOTH protocol family
+            [    2.241050] Bluetooth: HCI device and connection manager initialized
+            [    2.241064] Bluetooth: HCI socket layer initialized
+            [    2.241075] Bluetooth: L2CAP socket layer initialized
+            [    2.241091] Bluetooth: SCO socket layer initialized
+            [    2.241506] clocksource: Switched to clocksource arch_sys_counter
+            [    2.241624] VFS: Disk quotas dquot_6.6.0
+            [    2.241669] VFS: Dquot-cache hash table entries: 512 (order 0, 4096 bytes)
+            [    2.245768] NET: Registered PF_INET protocol family
+            [    2.245886] IP idents hash table entries: 32768 (order: 6, 262144 bytes, linear)
+            [    2.246780] tcp_listen_portaddr_hash hash table entries: 1024 (order: 2, 16384 bytes, linear)
+            [    2.246818] TCP established hash table entries: 16384 (order: 5, 131072 bytes, linear)
+            [    2.246933] TCP bind hash table entries: 16384 (order: 6, 262144 bytes, linear)
+            [    2.247145] TCP: Hash tables configured (established 16384 bind 16384)
+            [    2.247225] UDP hash table entries: 1024 (order: 3, 32768 bytes, linear)
+            [    2.247275] UDP-Lite hash table entries: 1024 (order: 3, 32768 bytes, linear)
+            [    2.247406] NET: Registered PF_UNIX/PF_LOCAL protocol family
+            [    2.247787] RPC: Registered named UNIX socket transport module.
+            [    2.247799] RPC: Registered udp transport module.
+            [    2.247808] RPC: Registered tcp transport module.
+            [    2.247816] RPC: Registered tcp NFSv4.1 backchannel transport module.
+            [    2.248419] PCI: CLS 0 bytes, default 64
+            [    2.248814] armv8-pmu pmu: hw perfevents: no interrupt-affinity property, guessing.
+            [    2.248987] hw perfevents: enabled with armv8_pmuv3 PMU driver, 7 counters available
+            [    2.249729] Initialise system trusted keyrings
+            [    2.249810] workingset: timestamp_bits=62 max_order=19 bucket_order=0
+            [    2.250372] NFS: Registering the id_resolver key type
+            [    2.250391] Key type id_resolver registered
+            [    2.250401] Key type id_legacy registered
+            [    2.250421] nfs4filelayout_init: NFSv4 File Layout Driver Registering...
+            [    2.250432] nfs4flexfilelayout_init: NFSv4 Flexfile Layout Driver Registering...
+            [    2.250458] jffs2: version 2.2. (NAND) (SUMMARY)  © 2001-2006 Red Hat, Inc.
+            [    2.250637] fuse: init (API version 7.34)
+            [    2.286700] NET: Registered PF_ALG protocol family
+            [    2.286714] xor: measuring software checksum speed
+            [    2.290896]    8regs           :  2363 MB/sec
+            [    2.294427]    32regs          :  2799 MB/sec
+            [    2.298740]    arm64_neon      :  2287 MB/sec
+            [    2.298749] xor: using function: 32regs (2799 MB/sec)
+            [    2.298762] Key type asymmetric registered
+            [    2.298770] Asymmetric key parser 'x509' registered
+            [    2.298812] Block layer SCSI generic (bsg) driver version 0.4 loaded (major 246)
+            [    2.298826] io scheduler mq-deadline registered
+            [    2.298835] io scheduler kyber registered
+            [    2.324628] Serial: 8250/16550 driver, 4 ports, IRQ sharing disabled
+            [    2.326446] cacheinfo: Unable to detect cache hierarchy for CPU 0
+            [    2.330645] brd: module loaded
+            [    2.334122] loop: module loaded
+            [    2.334341] Registered mathworks_ip class
+            [    2.336103] libphy: Fixed MDIO Bus: probed
+            [    2.337258] tun: Universal TUN/TAP device driver, 1.6
+            [    2.337350] CAN device driver interface
+            [    2.337928] usbcore: registered new interface driver asix
+            [    2.337974] usbcore: registered new interface driver ax88179_178a
+            [    2.338005] usbcore: registered new interface driver cdc_ether
+            [    2.338033] usbcore: registered new interface driver net1080
+            [    2.338061] usbcore: registered new interface driver cdc_subset
+            [    2.338088] usbcore: registered new interface driver zaurus
+            [    2.338125] usbcore: registered new interface driver cdc_ncm
+            [    2.338566] ehci_hcd: USB 2.0 'Enhanced' Host Controller (EHCI) Driver
+            [    2.338577] ehci-pci: EHCI PCI platform driver
+            [    2.338893] usbcore: registered new interface driver uas
+            [    2.338930] usbcore: registered new interface driver usb-storage
+            [    2.338998] usbcore: registered new interface driver usbserial_generic
+            [    2.339021] usbserial: USB Serial support registered for generic
+            [    2.339047] usbcore: registered new interface driver ftdi_sio
+            [    2.339068] usbserial: USB Serial support registered for FTDI USB Serial Device
+            [    2.339095] usbcore: registered new interface driver upd78f0730
+            [    2.339115] usbserial: USB Serial support registered for upd78f0730
+            [    2.339928] i2c_dev: i2c /dev entries driver
+            [    2.341249] usbcore: registered new interface driver uvcvideo
+            [    2.342168] Bluetooth: HCI UART driver ver 2.3
+            [    2.342180] Bluetooth: HCI UART protocol H4 registered
+            [    2.342190] Bluetooth: HCI UART protocol BCSP registered
+            [    2.342213] Bluetooth: HCI UART protocol LL registered
+            [    2.342223] Bluetooth: HCI UART protocol ATH3K registered
+            [    2.342244] Bluetooth: HCI UART protocol Three-wire (H5) registered
+            [    2.342285] Bluetooth: HCI UART protocol Intel registered
+            [    2.342307] Bluetooth: HCI UART protocol QCA registered
+            [    2.342341] usbcore: registered new interface driver bcm203x
+            [    2.342374] usbcore: registered new interface driver bpa10x
+            [    2.342405] usbcore: registered new interface driver bfusb
+            [    2.342436] usbcore: registered new interface driver btusb
+            [    2.342480] usbcore: registered new interface driver ath3k
+            [    2.342569] EDAC MC: ECC not enabled
+            [    2.342710] EDAC DEVICE0: Giving out device to module zynqmp-ocm-edac controller zynqmp_ocm: DEV ff960000.memory-controller (INTERRUPT)
+            [    2.343077] sdhci: Secure Digital Host Controller Interface driver
+            [    2.343088] sdhci: Copyright(c) Pierre Ossman
+            [    2.343096] sdhci-pltfm: SDHCI platform and OF driver helper
+            [    2.343390] ledtrig-cpu: registered to indicate activity on CPUs
+            [    2.343546] SMCCC: SOC_ID: ID = jep106:0049:0000 Revision = 0x14710093
+            [    2.343622] zynqmp_firmware_probe Platform Management API v1.1
+            [    2.343636] zynqmp_firmware_probe Trustzone version v1.0
+            [    2.373414] zynqmp-aes firmware:zynqmp-firmware:zynqmp-aes: will run requests pump with realtime priority
+            [    2.385413] zynqmp-keccak-384 firmware:zynqmp-firmware:sha384: The zynqmp-sha-deprecated driver shall be deprecated in 2022.2 and removed in 2023.1 release
+            [    2.385509] alg: No test for xilinx-keccak-384 (zynqmp-keccak-384)
+            [    2.385689] alg: No test for xilinx-zynqmp-rsa (zynqmp-rsa)
+            [    2.385844] usbcore: registered new interface driver usbhid
+            [    2.385856] usbhid: USB HID core driver
+            [    2.391942] axi_sysid 85000000.axi-sysid-0: AXI System ID core version (1.01.a) found
+            [    2.392138] axi_sysid 85000000.axi-sysid-0: [jupiter] on [sdr] git branch <dev_pluto_ng_revb> git <38d58dc604ac06fe2912b1420a2963b46dd28984> dirty [2023-06-26 13:37:34] UTC
+            [    2.392686] fpga_manager fpga0: Xilinx ZynqMP FPGA Manager registered
+            [    2.393093] usbcore: registered new interface driver snd-usb-audio
+            [    2.394630] pktgen: Packet Generator for packet performance testing. Version: 2.75
+            [    2.395046] Initializing XFRM netlink socket
+            [    2.395132] NET: Registered PF_INET6 protocol family
+            [    2.395583] Segment Routing with IPv6
+            [    2.395607] In-situ OAM (IOAM) with IPv6
+            [    2.395662] sit: IPv6, IPv4 and MPLS over IPv4 tunneling driver
+            [    2.396003] NET: Registered PF_PACKET protocol family
+            [    2.396023] NET: Registered PF_KEY protocol family
+            [    2.396112] can: controller area network core
+            [    2.396146] NET: Registered PF_CAN protocol family
+            [    2.396156] can: raw protocol
+            [    2.396166] can: broadcast manager protocol
+            [    2.396177] can: netlink gateway - max_hops=1
+            [    2.396251] Bluetooth: RFCOMM TTY layer initialized
+            [    2.396266] Bluetooth: RFCOMM socket layer initialized
+            [    2.396286] Bluetooth: RFCOMM ver 1.11
+            [    2.396299] Bluetooth: BNEP (Ethernet Emulation) ver 1.3
+            [    2.396308] Bluetooth: BNEP filters: protocol multicast
+            [    2.396319] Bluetooth: BNEP socket layer initialized
+            [    2.396327] Bluetooth: HIDP (Human Interface Emulation) ver 1.2
+            [    2.396339] Bluetooth: HIDP socket layer initialized
+            [    2.396454] 9pnet: Installing 9P2000 support
+            [    2.396474] NET: Registered PF_IEEE802154 protocol family
+            [    2.396498] Key type dns_resolver registered
+            [    2.396686] registered taskstats version 1
+            [    2.396697] Loading compiled-in X.509 certificates
+            [    2.397183] Btrfs loaded, crc32c=crc32c-generic, zoned=no, fsverity=no
+            [    2.405842]  domain0: domain0 request failed for node 33: -13
+            [    2.405882] xuartps ff000000.serial: failed to add to PM domain domain0: -13
+            [    2.405896] xuartps: probe of ff000000.serial failed with error -13
+            [    2.406984] ff010000.serial: ttyPS0 at MMIO 0xff010000 (irq = 30, base_baud = 6249999) is a xuartps
+            [    3.845140] printk: console [ttyPS0] enabled
+            [    3.849794] of-fpga-region fpga-full: FPGA Region probed
+            [    3.855292] gpio-347 (usb-reset): hogged as output/high
+            [    3.860522] gpio-413 (adrv9002-clksrc): hogged as output/high
+            [    3.866275] gpio-478 (fan-en): hogged as output/high
+            [    3.871246] gpio-479 (fan-ctl): hogged as output/low
+            [    3.877645] xilinx-zynqmp-dpdma fd4c0000.dma-controller: Xilinx DPDMA engine is probed
+            [    3.886533] zynqmp-display fd4a0000.display: vtc bridge property not present
+            [    3.900973] zynqmp_clk_divider_set_rate() set divider failed for adma_ref_div1, ret = -13
+            [    3.911337] xilinx-dp-snd-codec fd4a0000.display:zynqmp_dp_snd_codec0: Xilinx DisplayPort Sound Codec probed
+            [    3.921442] xilinx-dp-snd-pcm zynqmp_dp_snd_pcm0: Xilinx DisplayPort Sound PCM probed
+            [    3.929531] xilinx-dp-snd-pcm zynqmp_dp_snd_pcm1: Xilinx DisplayPort Sound PCM probed
+            [    3.938458] xilinx-dp-snd-card fd4a0000.display:zynqmp_dp_snd_card: Xilinx DisplayPort Sound Card probed
+            [    3.948039] OF: graph: no port node found in /axi/display@fd4a0000
+            [    3.954570] xlnx-drm xlnx-drm.0: bound fd4a0000.display (ops 0xffffffc0110729d0)
+            [    5.041526] zynqmp-display fd4a0000.display: [drm] Cannot find any crtc or sizes
+            [    5.049170] [drm] Initialized xlnx 1.0.0 20130509 for fd4a0000.display on minor 0
+            [    5.056685] zynqmp-display fd4a0000.display: ZynqMP DisplayPort Subsystem driver probed
+            [    5.064899] ahci-ceva fd0c0000.ahci: supply ahci not found, using dummy regulator
+            [    5.072458] ahci-ceva fd0c0000.ahci: supply phy not found, using dummy regulator
+            [    5.079928] ahci-ceva fd0c0000.ahci: supply target not found, using dummy regulator
+            [    5.087778] ahci-ceva fd0c0000.ahci: AHCI 0001.0301 32 slots 2 ports 6 Gbps 0x3 impl platform mode
+            [    5.096744] ahci-ceva fd0c0000.ahci: flags: 64bit ncq sntf pm clo only pmp fbs pio slum part ccc sds apst
+            [    5.107274] scsi host0: ahci-ceva
+            [    5.110866] scsi host1: ahci-ceva
+            [    5.114287] ata1: SATA max UDMA/133 mmio [mem 0xfd0c0000-0xfd0c1fff] port 0x100 irq 26
+            [    5.122215] ata2: SATA max UDMA/133 mmio [mem 0xfd0c0000-0xfd0c1fff] port 0x180 irq 26
+            [    5.131641] xilinx-axipmon ffa00000.perf-monitor: Probed Xilinx APM
+            [    5.138184] xilinx-axipmon fd0b0000.perf-monitor: Probed Xilinx APM
+            [    5.144669] xilinx-axipmon fd490000.perf-monitor: Probed Xilinx APM
+            [    5.151160] xilinx-axipmon ffa10000.perf-monitor: Probed Xilinx APM
+            [    5.181487] at24 0-0050: supply vcc not found, using dummy regulator
+            [    5.185596] xhci-hcd xhci-hcd.0.auto: xHCI Host Controller
+            [    5.193350] xhci-hcd xhci-hcd.0.auto: new USB bus registered, assigned bus number 1
+            [    5.201022] at24 0-0050: 2048 byte 24c16 EEPROM, writable, 16 bytes/write
+            [    5.201116] xhci-hcd xhci-hcd.0.auto: hcc params 0x0238f625 hci version 0x100 quirks 0x0000000002010090
+            [    5.217223] xhci-hcd xhci-hcd.0.auto: irq 40, io mem 0xfe200000
+            [    5.223251] xhci-hcd xhci-hcd.0.auto: xHCI Host Controller
+            [    5.228754] xhci-hcd xhci-hcd.0.auto: new USB bus registered, assigned bus number 2
+            [    5.236436] xhci-hcd xhci-hcd.0.auto: Host supports USB 3.0 SuperSpeed
+            [    5.243101] usb usb1: New USB device found, idVendor=1d6b, idProduct=0002, bcdDevice= 5.15
+            [    5.251393] usb usb1: New USB device strings: Mfr=3, Product=2, SerialNumber=1
+            [    5.258635] usb usb1: Product: xHCI Host Controller
+            [    5.263521] usb usb1: Manufacturer: Linux 5.15.0-175797-g9379dba5c06d xhci-hcd
+            [    5.270753] usb usb1: SerialNumber: xhci-hcd.0.auto
+            [    5.275960] hub 1-0:1.0: USB hub found
+            [    5.279749] hub 1-0:1.0: 1 port detected
+            [    5.283904] usb usb2: We don't know the algorithms for LPM for this host, disabling LPM.
+            [    5.292074] usb usb2: New USB device found, idVendor=1d6b, idProduct=0003, bcdDevice= 5.15
+            [    5.300357] usb usb2: New USB device strings: Mfr=3, Product=2, SerialNumber=1
+            [    5.307594] usb usb2: Product: xHCI Host Controller
+            [    5.312494] usb usb2: Manufacturer: Linux 5.15.0-175797-g9379dba5c06d xhci-hcd
+            [    5.319721] usb usb2: SerialNumber: xhci-hcd.0.auto
+            [    5.324875] hub 2-0:1.0: USB hub found
+            [    5.328646] hub 2-0:1.0: 1 port detected
+            [    5.396777] cdns-i2c ff030000.i2c: 400 kHz mmio ff030000 irq 22
+            [    5.403171] cdns-wdt fd4d0000.watchdog: Xilinx Watchdog Timer with timeout 60s
+            [    5.440693] random: fast init done
+            [    5.445064] ata1: SATA link down (SStatus 0 SControl 330)
+            [    5.449552] mmc0: SDHCI controller on ff170000.mmc [ff170000.mmc] using ADMA 64-bit
+            [    5.450501] ata2: SATA link down (SStatus 0 SControl 330)
+            [    5.550685] mmc0: new ultra high speed SDR104 SDHC card at address 5048
+            [    5.557732] mmcblk0: mmc0:5048 SD32G 28.8 GiB
+            [    5.564178]  mmcblk0: p1 p2 p3
+            [    6.125532] zynqmp-display fd4a0000.display: [drm] Cannot find any crtc or sizes
+            [    6.477135] random: crng init done
+            [   13.058846] adrv9002 spi0.0: adrv9002-phy Rev 12.0, Firmware 0.22.0.0,  Stream 0.7.9.0,  API version: 68.5.0 successfully initialized
+            [   13.072050] cf_axi_adc 84a00000.axi-adrv9002-rx-lpc: ADI AIM (10.02.b) at 0x84A00000 mapped to 0x000000008edaa943 probed ADC ADRV9002 as MASTER
+            [   13.105827] cf_axi_dds 84a0a000.axi-adrv9002-tx-lpc: Analog Devices CF_AXI_DDS_DDS MASTER (9.01.b) at 0x84A0A000 mapped to 0x00000000fbe94996, probed DDS ADRV9002
+            [   13.137822] cf_axi_dds 84a0c000.axi-adrv9002-tx2-lpc: Analog Devices CF_AXI_DDS_DDS MASTER (9.01.b) at 0x84A0C000 mapped to 0x000000002101aee5, probed DDS ADRV9002
+            [   13.153803] macb ff0e0000.ethernet: Not enabling partial store and forward
+            [   13.161811] libphy: MACB_mii_bus: probed
+            [   13.166237] macb ff0e0000.ethernet eth0: Cadence GEM rev 0x50070106 at 0xff0e0000 irq 20 (00:05:f7:80:74:3e)
+            [   13.178792] input: gpio-keys-power as /devices/platform/gpio-keys-power/input/input0
+            [   13.186908] of_cfs_init
+            [   13.189367] of_cfs_init: OK
+            [   13.192291] cfg80211: Loading compiled-in X.509 certificates for regulatory database
+            [   13.326959] cfg80211: Loaded X.509 cert 'sforshee: 00b28ddf47aef9cea7'
+            [   13.333490] clk: Not disabling unused clocks
+            [   13.338021] ALSA device list:
+            [   13.340984]   #0: DisplayPort monitor
+            [   13.344946] platform regulatory.0: Direct firmware load for regulatory.db failed with error -2
+            [   13.353572] cfg80211: failed to load regulatory.db
+            [   13.364112] EXT4-fs (mmcblk0p2): mounted filesystem with ordered data mode. Opts: (null). Quota mode: none.
+            [   13.373893] VFS: Mounted root (ext4 filesystem) on device 179:2.
+            [   13.383115] devtmpfs: mounted
+            [   13.387102] Freeing unused kernel memory: 2560K
+            [   13.405563] Run /sbin/init as init process
+            [   13.617964] systemd[1]: System time before build time, advancing clock.
+            [   13.637584] systemd[1]: systemd 247.3-7+rpi1+deb11u1 running in system mode. (+PAM +AUDIT +SELINUX +IMA +APPARMOR +SMACK +SYSVINIT +UTMP +LIBCRYPTSETUP +GCRYPT +GNUTLS +ACL +XZ +LZ4 +ZSTD +SECCOMP +BLKID +ELFUTILS +KMOD +IDN2 -IDN +PCRE2 default-hierarchy=unified)
+            [   13.661587] systemd[1]: Detected architecture arm64.
+   
+            Welcome to Kuiper GNU/Linux 11.2 (bullseye)!
+   
+            [   13.682526] systemd[1]: Set hostname to <analog>.
+            [   14.436264] systemd[1]: /lib/systemd/system/plymouth-start.service:16: Unit configured to use KillMode=none. This is unsafe, as it disables systemd's process lifecycle management for the service. Please update your service to use a safer KillMode=, such as 'mixed' or 'control-group'. Support for KillMode=none is deprecated and will eventually be removed.
+            [   14.636253] systemd[1]: Queued start job for default target Graphical Interface.
+            [   14.645081] systemd[1]: system-getty.slice: unit configures an IP firewall, but the local system does not support BPF/cgroup firewalling.
+            [   14.657451] systemd[1]: (This warning is only shown for the first unit using IP firewalling.)
+            [   14.666547] systemd[1]: Created slice system-getty.slice.
+            [  OK  ] Created slice system-getty.slice.
+            [   14.690008] systemd[1]: Created slice system-modprobe.slice.
+            [  OK  ] Created slice system-modprobe.slice.
+            [   14.709928] systemd[1]: Created slice system-serial\x2dgetty.slice.
+            [  OK  ] Created slice system-serial\x2dgetty.slice.
+            [   14.733910] systemd[1]: Created slice system-systemd\x2dfsck.slice.
+            [  OK  ] Created slice system-systemd\x2dfsck.slice.
+            [   14.757807] systemd[1]: Created slice User and Session Slice.
+            [  OK  ] Created slice User and Session Slice.
+            [   14.777865] systemd[1]: Started Forward Password Requests to Wall Directory Watch.
+            [  OK  ] Started Forward Password R…uests to Wall Directory Watch.
+            [   14.801843] systemd[1]: Condition check resulted in Arbitrary Executable File Formats File System Automount Point being skipped.
+            [   14.814148] systemd[1]: Reached target Slices.
+            [  OK  ] Reached target Slices.
+            [   14.829696] systemd[1]: Reached target Swap.
+            [  OK  ] Reached target Swap.
+            [   14.846351] systemd[1]: Listening on Syslog Socket.
+            [  OK  ] Listening on Syslog Socket.
+            [   14.861920] systemd[1]: Listening on fsck to fsckd communication Socket.
+            [  OK  ] Listening on fsck to fsckd communication Socket.
+            [   14.885747] systemd[1]: Listening on initctl Compatibility Named Pipe.
+            [  OK  ] Listening on initctl Compatibility Named Pipe.
+            [   14.910252] systemd[1]: Listening on Journal Audit Socket.
+            [  OK  ] Listening on Journal Audit Socket.
+            [   14.929933] systemd[1]: Listening on Journal Socket (/dev/log).
+            [  OK  ] Listening on Journal Socket (/dev/log).
+            [   14.953990] systemd[1]: Listening on Journal Socket.
+            [  OK  ] Listening on Journal Socket.
+            [   14.970994] systemd[1]: Listening on udev Control Socket.
+            [  OK  ] Listening on udev Control Socket.
+            [   14.993934] systemd[1]: Listening on udev Kernel Socket.
+            [  OK  ] Listening on udev Kernel Socket.
+            [   15.015596] systemd[1]: Mounting Huge Pages File System...
+                     Mounting Huge Pages File System...
+            [   15.035385] systemd[1]: Mounting POSIX Message Queue File System...
+                     Mounting POSIX Message Queue File System...
+            [   15.059209] systemd[1]: Mounting RPC Pipe File System...
+                     Mounting RPC Pipe File System...
+            [   15.075541] systemd[1]: Mounting Kernel Debug File System...
+                     Mounting Kernel Debug File System...
+            [   15.094063] systemd[1]: Condition check resulted in Kernel Trace File System being skipped.
+            [   15.102800] systemd[1]: Condition check resulted in Kernel Module supporting RPCSEC_GSS being skipped.
+            [   15.115549] systemd[1]: Starting Restore / save the current clock...
+                     Starting Restore / save the current clock...
+            [   15.142746] systemd[1]: Starting Set the console keyboard layout...
+                     Starting Set the console keyboard layout...
+            [   15.170869] systemd[1]: Condition check resulted in Create list of static device nodes for the current kernel being skipped.
+            [   15.184556] systemd[1]: Starting Load Kernel Module configfs...
+                     Starting Load Kernel Module configfs...
+            [   15.203983] systemd[1]: Starting Load Kernel Module drm...
+                     Starting Load Kernel Module drm...
+            [   15.223826] systemd[1]: Starting Load Kernel Module fuse...
+                     Starting Load Kernel Module fuse...
+            [   15.244489] systemd[1]: Condition check resulted in Set Up Additional Binary Formats being skipped.
+            [   15.253802] systemd[1]: Condition check resulted in File System Check on Root Device being skipped.
+            [   15.264835] systemd[1]: Starting Journal Service...
+                     Starting Journal Service...
+            [   15.285903] systemd[1]: Starting Load Kernel Modules...
+                     Starting Load Kernel Modules...
+            [   15.303738] systemd[1]: Starting Remount Root and Kernel File Systems...
+                     Starting Remount Root and Kernel File Systems...
+            [   15.327623] systemd[1]: Starting Coldplug All udev Devices...
+                     Starting Coldplug All udev Devices...
+            [   15.352792] systemd[1]: Mounted Huge Pages File System.
+            [  OK  ] Mounted Huge Pages File System.
+            [   15.386242] systemd[1]: Mounted POSIX Message Queue File System.
+            [  OK  ] Mounted POSIX Message Queue File System.
+            [   15.410207] systemd[1]: Started Journal Service.
+            [  OK  ] Started Journal Service.
+            [  OK  ] Mounted RPC Pipe File System.
+            [  OK  ] Mounted Kernel Debug File System.
+            [  OK  ] Finished Restore / save the current clock.
+            [  OK  ] Finished Set the console keyboard layout.
+            [  OK  ] Finished Load Kernel Module configfs[   15.493163] EXT4-fs (mmcblk0p2): re-mounted. Opts: (null). Quota mode: none.
+            .
+            [  OK  ] Finished Load Kernel Module drm.
+            [  OK  ] Finished Load Kernel Module fuse.
+            [FAILED] Failed to start Load Kernel Modules.
+            See 'systemctl status systemd-modules-load.service' for details.
+            [  OK  ] Finished Remount Root and Kernel File Systems.
+                     Mounting FUSE Control File System...
+                     Mounting Kernel Configuration File System...
+                     Starting Flush Journal to Persistent Storage...
+            [   15.660144] systemd-journald[184]: Received client request to flush runtime journal.
+                     Starting Load/Save Random Seed...
+                     Starting Apply Kernel Variables...
+            [   15.686650] systemd-journald[184]: File /var/log/journal/ada1ca10884b40d5a842c3234f7b495f/system.journal corrupted or uncleanly shut down, renaming and replacing.
+                     Starting Create System Users...
+            [  OK  ] Mounted FUSE Control File System.
+            [  OK  ] Mounted Kernel Configuration File System.
+            [  OK  ] Finished Load/Save Random Seed.
+            [  OK  ] Finished Apply Kernel Variables.
+            [  OK  ] Finished Create System Users.
+                     Starting Create Static Device Nodes in /dev...
+            [  OK  ] Finished Coldplug All udev Devices.
+                     Starting Helper to synchronize boot up for ifupdown...
+                     Starting Wait for udev To …plete Device Initialization...
+            [  OK  ] Finished Helper to synchronize boot up for ifupdown.
+            [  OK  ] Finished Create Static Device Nodes in /dev.
+            [  OK  ] Reached target Local File Systems (Pre).
+                     Starting Rule-based Manage…for Device Events and Files...
+            [  OK  ] Finished Flush Journal to Persistent Storage.
+            [  OK  ] Started Rule-based Manager for Device Events and Files.
+                     Starting Show Plymouth Boot Screen...
+            [  OK  ] Started Show Plymouth Boot Screen.
+            [  OK  ] Started Forward Password R…s to Plymouth Directory Watch.
+            [  OK  ] Reached target Local Encrypted Volumes.
+            [  OK  ] Found device /dev/ttyPS0.
+            [  OK  ] Found device /dev/disk/by-partuuid/9785213e-01.
+            [  OK  ] Found device /dev/ttyS0.
+            [  OK  ] Listening on Load/Save RF …itch Status /dev/rfkill Watch.
+                     Starting File System Check…isk/by-partuuid/9785213e-01...
+                     Starting Load Kernel Modules...
+            [FAILED] Failed to start Load Kernel Modules.
+            See 'systemctl status systemd-modules-load.service' for details.
+            [  OK  ] Finished Wait for udev To Complete Device Initialization.
+            [  OK  ] Finished File System Check…/disk/by-partuuid/9785213e-01.
+                     Mounting /boot...
+            [  OK  ] Started File System Check Daemon to report status.
+            [  OK  ] Mounted /boot.
+            [  OK  ] Reached target Local File Systems.
+                     Starting Set console font and keymap...
+                     Starting Raise network interfaces...
+                     Starting Preprocess NFS configuration...
+                     Starting Tell Plymouth To Write Out Runtime Data...
+                     Starting Create Volatile Files and Directories...
+            [  OK  ] Finished Set console font and keymap.
+            [  OK  ] Finished Preprocess NFS configuration.
+            [  OK  ] Reached target NFS client services.
+            [  OK  ] Reached target Remote File Systems (Pre).
+            [  OK  ] Reached target Remote File Systems.
+            [  OK  ] Finished Tell Plymouth To Write Out Runtime Data.
+            [  OK  ] Finished Create Volatile Files and Directories.
+                     Starting Update UTMP about System Boot/Shutdown...
+            [  OK  ] Finished Update UTMP about System Boot/Shutdown.
+            [  OK  ] Reached target System Initialization.
+            [  OK  ] Started CUPS Scheduler.
+            [  OK  ] Started Daily apt download activities.
+            [  OK  ] Started Daily apt upgrade and clean activities.
+            [  OK  ] Started Periodic ext4 Onli…ata Check for All Filesystems.
+            [  OK  ] Started Discard unused blocks once a week.
+            [  OK  ] Started Daily rotation of log files.
+            [  OK  ] Started Daily man-db regeneration.
+            [  OK  ] Started Daily Cleanup of Temporary Directories.
+            [  OK  ] Reached target Paths.
+            [  OK  ] Reached target Timers.
+            [  OK  ] Listening on Avahi mDNS/DNS-SD Stack Activation Socket.
+            [  OK  ] Listening on CUPS Scheduler.
+            [  OK  ] Listening on D-Bus System Message Bus Socket.
+            [  OK  ] Listening on Erlang Port Mapper Daemon Activation Socket.
+            [  OK  ] Listening on GPS (Global P…ioning System) Daemon Sockets.
+            [  OK  ] Listening on triggerhappy.socket.
+            [  OK  ] Reached target Sockets.
+            [  OK  ] Reached target Basic System.
+                     Starting Analog Devices power up/down sequence...
+                     Starting Save/Restore Sound Card State...
+                     Starting Avahi mDNS/DNS-SD Stack...
+            [  OK  ] Started Regular background program processing daemon.
+            [  OK  ] Started D-Bus System Message Bus.
+                     Starting dphys-swapfile - …unt, and delete a swap file...
+                     Starting Remove Stale Onli…t4 Metadata Check Snapshots...
+                     Starting Creating IIOD Context Attributes......
+                     Starting Analog Devices Jupiter User LED...
+                     Starting Initialize hardware monitoring sensors...
+                     Starting Authorization Manager...
+                     Starting DHCP Client Daemon...
+                     Starting LSB: Switch to on…nless shift key is pressed)...
+                     Starting LSB: rng-tools (Debian variant)...
+                     Starting System Logging Service...
+                     Starting User Login Management...
+                     Starting triggerhappy global hotkey daemon...
+                     Starting Disk Manager...
+                     Starting WPA supplicant...
+            [  OK  ] Finished Save/Restore Sound Card State.
+            [  OK  ] Reached target Sound Card.
+            [  OK  ] Started triggerhappy global hotkey daemon.
+            [  OK  ] Finished Raise network interfaces.
+            [  OK  ] Finished Initialize hardware monitoring sensors.
+            [  OK  ] Started System Logging Service.
+            [  OK  ] Started DHCP Client Daemon.
+            [  OK  ] Finished Remove Stale Onli…ext4 Metadata Check Snapshots.
+            [  OK  ] Started LSB: rng-tools (Debian variant).
+            [  OK  ] Started Avahi mDNS/DNS-SD Stack.
+            [  OK  ] Started User Login Management.
+            [  OK  ] Started WPA supplicant.
+            [  OK  ] Reached target Network.
+            [  OK  ] Reached target Network is Online.
+                     Starting CUPS Scheduler...
+            [  OK  ] Started Erlang Port Mapper Daemon.
+                     Starting HTTP based time synchronization tool...
+                     Starting Internet superserver...
+                     Starting /etc/rc.local Compatibility...
+                     Starting OpenBSD Secure Shell server...
+                     Starting Permit User Sessions...
+            [  OK  ] Started Unattended Upgrades Shutdown.
+            [  OK  ] Finished dphys-swapfile - …mount, and delete a swap file.
+            [  OK  ] Started Internet superserver.
+            [  OK  ] Started /etc/rc.local Compatibility.
+            [  OK  ] Started Authorization Manager.
+                     Starting Modem Manager...
+            [  OK  ] Finished Permit User Sessions.
+                     Starting Light Display Manager...
+                     Starting Hold until boot process finishes up...
+            [  OK  ] Started HTTP based time synchronization tool.
+            [  OK  ] Started OpenBSD Secure Shell server.
+                     Starting Manage, Install and Generate Color Profiles...
+            [  OK  ] Finished Analog Devices power up/down sequence.
+            [FAILED] Failed to start VNC Server for X11.
+   
+            Raspbian GNU/Linux 11 analog ttyPS0
+   
+            analog login: root (automatic login)
+   
+            Linux analog 5.15.0-175797-g9379dba5c06d #6 SMP Fri Jun 23 12:59:00 EEST 2023 aarch64
+   
+            The programs included with the Debian GNU/Linux system are free software;
+            the exact distribution terms for each program are described in the
+            individual files in /usr/share/doc/*/copyright.
+   
+            Debian GNU/Linux comes with ABSOLUTELY NO WARRANTY, to the extent
+            permitted by applicable law.
+            Last login: Thu Jun 29 14:36:16 BST 2023 on ttyPS0
+            root@analog:~#
+   
+
+Make sure all devices are present
+---------------------------------
+
+.. container:: box bggreen
+
+   This specifies any shell prompt running on the target
+
+   
+   ::
+   
+      root@analog:~# iio_info | grep iio:device
+              iio:device0: ams
+              iio:device1: adrv9002-phy
+              iio:device2: axi-adrv9002-rx-lpc (buffer capable)
+              iio:device3: axi-adrv9002-rx2-lpc (buffer capable)
+              iio:device4: axi-adrv9002-tx-lpc (buffer capable)
+              iio:device5: axi-adrv9002-tx2-lpc (buffer capable)
+   
+
+RX gain control
+---------------
+
+The following commands enable the LNA on RX1A channel.
+
+.. container:: box bggreen
+
+   This specifies any shell prompt running on the target
+
+   
+   ::
+   
+      root@analog:~# cd /sys/kernel/debug/iio/iio:device1
+      root@analog:/sys/kernel/debug/iio/iio:device1# echo 1 > agpio4_direction
+      root@analog:/sys/kernel/debug/iio/iio:device1# echo 1 > agpio4_value
+   
+
+RF Add-on power enable
+----------------------
+
+When RXB or TXB channels need to be used the RF Add-on board could be powered on
+with the following commands. Once the RF Add-on is powered up the TX amplifieres
+will be turned on.
+
+.. container:: box bggreen
+
+   This specifies any shell prompt running on the target
+
+   
+   ::
+   
+      root@analog:/# cd /sys/class/gpio
+      root@analog:/sys/class/gpio# echo 475 > export
+      root@analog:/sys/class/gpio# cd gpio475
+      root@analog:/sys/class/gpio/gpio475# echo out > direction
+      root@analog:/sys/class/gpio/gpio475# echo 1 > value
+   
+
+TX channel selection
+--------------------
+
+The transceiver TX could be routed to the main board output connector (TXA) or to the RF Add-on board (TXB). The *out_voltage0_port_select* and *out_voltage1_port_select* attributes allows us to select the desired TX1 respective TX2 outputs. Below is a command example showing how to configure TX1 channel to TX1B (RF Add-on output).
+
+.. container:: box bggreen
+
+   This specifies any shell prompt running on the target
+
+   
+   ::
+   
+      root@analog:/# cd /sys/bus/iio/devices/iio:device1
+      root@analog:/sys/bus/iio/devices/iio:device1# cat out_voltage0_port_select_available
+      tx_a tx_b
+      root@analog:/sys/bus/iio/devices/iio:device1# echo tx_b > out_voltage0_port_select
+   
+
+Video Configuration
+-------------------
+
+The default configuration for most of the projects is to use the HDMI output, but for this project the DisplayPort is used. In order for it to work, you should follow the steps described here: `DisplayPort No Picture <https://wiki.analog.com/resources/eval/user-guides/ad-fmcomms2-ebz/software/linux/zynqmp>`_ After following the steps, the board should be rebooted.
+
+Setup Networking
+----------------
+
+Follow `this article for further network config. <https://wiki.analog.com/resources/tools-software/linux-software/network-config>`_

--- a/docs/solutions/reference-designs/jupiter_sdr/resources/02-048139-01-c.pdf
+++ b/docs/solutions/reference-designs/jupiter_sdr/resources/02-048139-01-c.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8e03de1d42d087c08c6bd8ce75ebd43a5278230e99faabae23bf1f5d463cf6b1
+size 4346233

--- a/docs/solutions/reference-designs/jupiter_sdr/resources/02-071103-01-b.pdf
+++ b/docs/solutions/reference-designs/jupiter_sdr/resources/02-071103-01-b.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f2cc525a119ec68fb94633e6197e28a18c90c1be07a1269d97393f75d3ec3cad
+size 302507

--- a/docs/solutions/reference-designs/jupiter_sdr/resources/05-048139-01-c.zip
+++ b/docs/solutions/reference-designs/jupiter_sdr/resources/05-048139-01-c.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9be29ff6b8ba5d3ad639cacb5b4a539f465199a4eef353049c2be42c10114aac
+size 15841

--- a/docs/solutions/reference-designs/jupiter_sdr/resources/05-071103-01-b.zip
+++ b/docs/solutions/reference-designs/jupiter_sdr/resources/05-071103-01-b.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6b7bb95db1ae16b822dc9ad768cc019bab3b2249b724b96cb4e09d748f8914cf
+size 2913

--- a/docs/solutions/reference-designs/jupiter_sdr/resources/jupiter-dma-coeherent.tar.gz
+++ b/docs/solutions/reference-designs/jupiter_sdr/resources/jupiter-dma-coeherent.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3e21cb2cf31ebff1801ea9c43c9ebf220b2d5d748897ba5f2f5123a95270a6d5
+size 13782752


### PR DESCRIPTION
## Summary
- Move Jupiter SDR landing page from `wiki-migration/resources/eval/user-guides/jupiter-sdr` to `solutions/reference-designs/jupiter_sdr/`
- 5 RST files (1 landing + 4 subpages)
- 14 images localized, 5 binary artifacts localized
- Updated `:doc:` cross-references and includes

Source: [wiki.analog.com/resources/eval/user-guides/jupiter-sdr](https://wiki.analog.com/resources/eval/user-guides/jupiter-sdr)

## Test plan
- [ ] Sphinx build passes without new warnings
- [ ] Landing page renders correctly
- [ ] Internal links resolve
- [ ] Images display properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)