### PR TITLE
reference-designs/active-bias-controllers: Add active-bias-controllers documentation

### DIFF
--- a/docs/solutions/reference-designs/active-bias-controllers/hmc920.rst
+++ b/docs/solutions/reference-designs/active-bias-controllers/hmc920.rst
@@ -1,0 +1,11 @@
+HMC920 Configuration Calculator
+===============================
+
+This calculator can be used to calculate all of the external component values
+that are required to configure current settings, voltage ranges and alarm levels
+for HMC920
+
+`hmc920.zip <resources/hmc920.zip>`_
+
+.. image:: images/hmc920_configuration_calculator.png
+   :width: 600

--- a/docs/solutions/reference-designs/active-bias-controllers/hmc980.rst
+++ b/docs/solutions/reference-designs/active-bias-controllers/hmc980.rst
@@ -1,0 +1,143 @@
+HMC980 Configuration Calculator
+===============================
+
+This calculator can be used to calculate all of the external component values
+that are required to configure current settings, voltage ranges and alarm levels
+for HMC980
+
+`HMC980 Configuration Calculator <resources/hmc980.zip>`_
+
+|image1|}
+
+--------------
+
+Verified Amplifier Designs using the HMC980
+===========================================
+
+.. important::
+
+   Please note that while these tables are extensive, they are not exhaustive. If a given RF amplifier is not included in this list, that does not mean that it cannot be actively biased using the :adi:`HMC980 <hmc980lp4e>`. Follow the :adi:`HMC980 Datasheet <media/en/technical-documentation/data-sheets/hmc980.pdf>` for design guidelines.
+
+|hmc980_schematic_for_calculator.png| **
+
+.. container:: centeralign
+
+   Figure 1: HMC980 Typical Circuit
+
+Gain Blocks & Drivers
+---------------------
+
+=========== ==== ====== ==== ====== === === ==== ==== === ==== ====
+Part Number VDD  VDRAIN R1   ISENSE S0  S1  R2   R3   VG2 R4   R5
+=========== ==== ====== ==== ====== === === ==== ==== === ==== ====
+            (V)  (V)    (kΩ) (mA)       ::: (kΩ) (kΩ) (V) (kΩ) (kΩ)
+HMC-AUH256  5.83 5      511  295    GND GND --   --   --  --   --
+=========== ==== ====== ==== ====== === === ==== ==== === ==== ====
+
+--------------
+
+LNAs
+----
+
+=========== ==== ====== ===== ====== === === ==== ==== === ==== ====
+Part Number VDD  VDRAIN R1    ISENSE S0  S1  R2   R3   VG2 R4   R5
+=========== ==== ====== ===== ====== === === ==== ==== === ==== ====
+            (V)  (V)    (kΩ)  (mA)       ::: (kΩ) (kΩ) (V) (kΩ) (kΩ)
+HMC-ALH465  5.08 5      4.99  30     GND GND 4.99 6.19 1.5 --   --
+HMC-ALH444  5.15 5      2.74  55     GND GND 4.99 5.9  1.5 --   --
+HMC490      5.56 5      0.75  200    GND GND ---  ---  --- --   --
+HMC594      6.28 6      1.5   100    GND GND ---  ---  --- --   --
+HMC609      6.48 6      0.887 170    GND GND ---  ---  --- --   --
+HMC753      5.15 5      2.74  55     GND GND 4.99 5.9  1.5 --   --
+=========== ==== ====== ===== ====== === === ==== ==== === ==== ====
+
+--------------
+
+Linear & Power
+--------------
+
+=========== ==== ====== ===== ====== ==== ==== ==== ==== === ==== ====
+Part Number VDD  VDRAIN R1    ISENSE S0   S1   R2   R3   VG2 R4   R5
+=========== ==== ====== ===== ====== ==== ==== ==== ==== === ==== ====
+            (V)  (V)    (kΩ)  (mA)        :::  (kΩ) (kΩ) (V) (kΩ) (kΩ)
+HMC-ABH209  5.22 5      1.87  80     GND  GND  ---  ---  --- --   --
+HMC-ABH264  5.34 5      1.24  120    GND  GND  ---  ---  --- --   --
+HMC442      5.24 5      1.78  85     GND  GND  ---  ---  --- --   --
+HMC499      5.56 5      0.75  200    GND  GND  ---  ---  --- --   --
+HMC-ABH241  5.62 5      6.81  220    GND  GND  ---  ---  --- --   --
+HMC-APH403  5.74 5      0.316 475    VDIG GND  ---  ---  --- --   --
+HMC-APH460  5.77 5      0.165 900    GND  VDIG ---  ---  --- --   --
+HMC-APH462  6.22 5      0.105 1440   VDIG VDIG ---  ---  --- --   --
+HMC-APH473  5.92 5      0.137 1080   GND  VDIG ---  ---  --- --   --
+HMC-APH478  5.77 5      0.165 900    GND  VDIG ---  ---  --- --   --
+HMC-APH510  5.99 5      0.232 640    GND  VDIG ---  ---  --- --   --
+HMC-APH518  5.81 5      0.158 950    GND  VDIG ---  ---  --- --   --
+HMC-APH596  5.62 5      0.374 400    VDIG GND  ---  ---  --- --   --
+HMC-APH608  5.81 5      0.158 950    GND  VDIG ---  ---  --- --   --
+HMC486      7.91 7      0.115 1300   VDIG VDIG ---  ---  --- --   --
+HMC487      7.91 7      0.115 1300   VDIG VDIG ---  ---  --- --   --
+HMC489      7.91 7      0.115 1300   VDIG VDIG ---  ---  --- --   --
+HMC498      5.70 5      0.604 250    GND  GND  ---  ---  --- --   --
+HMC590      7.70 7      0.182 820    GND  VDIG ---  ---  --- --   --
+HMC591      7.94 7      0.113 1340   VDIG VDIG ---  ---  --- --   --
+HMC592      7.64 7      0.200 750    GND  VDIG ---  ---  --- --   --
+HMC608      5.48 5      0.487 310    VDIG GND  ---  ---  --- --   --
+HMC693      5.68 5      0.187 800    GND  VDIG ---  ---  --- --   --
+HMC756      7.67 7      0.191 790    GND  VDIG ---  ---  --- --   --
+HMC757      7.61 7      0.383 395    VDIG GND  ---  ---  --- --   --
+HMC863      6.58 6      0.402 375    VDIG GND  ---  ---  --- --   --
+HMC864      6.64 6      0.200 750    GND  VDIG ---  ---  --- --   --
+HMC906      6.84 6      0.124 1200   VDIG VDIG ---  ---  --- --   --
+HMC943      6.34 5.5    0.124 1200   VDIG VDIG ---  ---  --- --   --
+HMC949      7.84 7      0.124 1200   VDIG VDIG ---  ---  --- --   --
+HMC965      6.84 6      0.124 1200   VDIG VDIG ---  ---  --- --   --
+HMC968      6.77 6      0.165 900    GND  VDIG ---  ---  --- --   --
+HMC969      6.77 6      0.165 900    GND  VDIG ---  ---  --- --   --
+=========== ==== ====== ===== ====== ==== ==== ==== ==== === ==== ====
+
+--------------
+
+Wideband (Distributed)
+----------------------
+
+=========== ===== ====== ===== ====== ==== === ==== ==== === ==== ====
+Part Number VDD   VDRAIN R1    ISENSE S0   S1  R2   R3   VG2 R4   R5
+=========== ===== ====== ===== ====== ==== === ==== ==== === ==== ====
+            (V)   (V)    (kΩ)  (mA)        ::: (kΩ) (kΩ) (V) (kΩ) (kΩ)
+HMC-AUH232  5.5   5      0.825 180    GND  GND 4.99 5.23 1.5 --   --
+HMC-AUH249  5.56  5      0.750 200    GND  GND 4.99 5.11 1.5 --   --
+HMC-AUH312  8.17  8      2.49  60     GND  GND 4.99 2.61 1.5 --   --
+HMC460      8.17  8      2.49  60     GND  GND ---  ---  --- --   --
+HMC460LC5   8.21  8      2.00  75     GND  GND ---  ---  --- --   --
+HMC463      5.17  5      2.49  60     GND  GND ---  ---  --- --   --
+HMC465      8.45  8      0.931 160    GND  GND 4.99 2.49 1.5 --   --
+HMC562      8.22  8      1.87  80     GND  GND ---  ---  --- --   --
+HMC633      5.5   5      0.825 180    GND  GND ---  ---  --- --   --
+HMC634      5.5   5      0.825 180    GND  GND ---  ---  --- --   --
+HMC930      10.49 10     0.866 175    GND  GND 4.99 4.22 3.5 --   --
+HMC459      8.81  8      0.523 290    GND  GND 4.99 4.75 3   --   --
+HMC464      8.81  8      0.523 290    GND  GND 4.99 4.75 3   --   --
+HMC559      10.62 10     0.374 400    VDIG GND 4.99 4.99 4   --   --
+HMC619      12.47 12     0.499 300    VDIG GND 4.99 5.11 5   --   --
+HMC635      5.78  5      0.536 280    GND  GND ---  ---  --- --   --
+HMC637      12.62 12     0.374 400    VDIG GND 4.99 6.81 6   --   --
+HMC659      8.47  8      0.499 300    VDIG GND 4.99 5.23 3   --   --
+HMC797      10.62 10     0.374 400    VDIG GND 4.99 4.12 3.5 --   --
+=========== ===== ====== ===== ====== ==== === ==== ==== === ==== ====
+
+--------------
+
+Microwave & Optical Drivers
+---------------------------
+
+=========== ==== ====== ===== ====== === === ==== ==== === ==== ====
+Part Number VDD  VDRAIN R1    ISENSE S0  S1  R2   R3   VG2 R4   R5
+=========== ==== ====== ===== ====== === === ==== ==== === ==== ====
+            (V)  (V)    (kΩ)  (mA)       ::: (kΩ) (kΩ) (V) (kΩ) (kΩ)
+HMC870      7.46 7      0.909 165    GND GND ---  ---  --- --   --
+HMC871      8.21 8      2.00  75     GND GND ---  ---  --- --   --
+=========== ==== ====== ===== ====== === === ==== ==== === ==== ====
+
+.. |image1| image:: https://wiki.analog.com/_media/{/resources/eval/user-guides/active-bias-controllers/hmc980_configuration_calculator.png
+   :width: 400
+.. |hmc980_schematic_for_calculator.png| image:: images/hmc980_schematic_for_calculator.png

--- a/docs/solutions/reference-designs/active-bias-controllers/hmc981.rst
+++ b/docs/solutions/reference-designs/active-bias-controllers/hmc981.rst
@@ -1,0 +1,11 @@
+HMC981 Configuration Calculator
+===============================
+
+This calculator can be used to calculate all of the external component values
+that are required to configure current settings, voltage ranges and alarm levels
+for HMC981
+
+`HMC981 Configuration Calculator <resources/hmc981.zip>`_
+
+.. image:: images/hmc981_configuration_calculator.png
+   :width: 600

--- a/docs/solutions/reference-designs/active-bias-controllers/images/hmc920_configuration_calculator.png
+++ b/docs/solutions/reference-designs/active-bias-controllers/images/hmc920_configuration_calculator.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:59af86544ec66f4fb91ce39f32793d6b71c6d8644ca12e86510ab97b6c5cd457
+size 116364

--- a/docs/solutions/reference-designs/active-bias-controllers/images/hmc980_schematic_for_calculator.png
+++ b/docs/solutions/reference-designs/active-bias-controllers/images/hmc980_schematic_for_calculator.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fb037b497d725a4428a258b4cbb013df0916df43a2c3b2b6ddf7c23aca122b17
+size 37260

--- a/docs/solutions/reference-designs/active-bias-controllers/images/hmc981_configuration_calculator.png
+++ b/docs/solutions/reference-designs/active-bias-controllers/images/hmc981_configuration_calculator.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0d0dae82c46fddef6e544aeed165a4e108ab76f62d5e439bd49cf8359cc69a84
+size 66683

--- a/docs/solutions/reference-designs/active-bias-controllers/index.rst
+++ b/docs/solutions/reference-designs/active-bias-controllers/index.rst
@@ -1,10 +1,48 @@
-ACTIVE-BIAS-CONTROLLERS
-=======================
+.. _active_bias_controllers eval:
+
+ACTIVE BIAS CONTROLLERS
+===========================================================================================================================================
+
+.. TODO: Add a picture of the chip/board
+
+Overview
+-------------------------------------------------------------------------------
+
+.. TODO: Describe in max 10 rows the main features and applications.
+
+Features:
+
+- feature 1
+- feature 2
+
+Applications:
+
+- application 1
+- application 2
 
 .. toctree::
-   :titlesonly:
+   :hidden:
 
    hmc920
    hmc980
    hmc981
    start
+
+Recommendations
+-------------------------------------------------------------------------------
+
+People who follow the flow that is outlined, have a much better experience with
+things. However, like many things, documentation is never as complete as it
+should be. If you have any questions, feel free to ask on our
+:ref:`EngineerZone forums <help-and-support>`, but before that, please make
+sure you read our documentation thoroughly.
+
+Warning
+-------------------------------------------------------------------------------
+
+.. esd-warning::
+
+Help and support
+-------------------------------------------------------------------------------
+
+Please go to :ref:`Help and Support <help-and-support>` page.

--- a/docs/solutions/reference-designs/active-bias-controllers/index.rst
+++ b/docs/solutions/reference-designs/active-bias-controllers/index.rst
@@ -1,0 +1,10 @@
+ACTIVE-BIAS-CONTROLLERS
+=======================
+
+.. toctree::
+   :titlesonly:
+
+   hmc920
+   hmc980
+   hmc981
+   start

--- a/docs/solutions/reference-designs/active-bias-controllers/resources/hmc920.zip
+++ b/docs/solutions/reference-designs/active-bias-controllers/resources/hmc920.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:19a76e4d0244e4fc1ce351a7693fd17d5ea19cabc05a7a4080e199f5d9fb2934
+size 204824

--- a/docs/solutions/reference-designs/active-bias-controllers/resources/hmc980.zip
+++ b/docs/solutions/reference-designs/active-bias-controllers/resources/hmc980.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d73de2b3d32d0dc77beb4296145a631293cc7576c74c02e072fc3a4a61407921
+size 168261

--- a/docs/solutions/reference-designs/active-bias-controllers/resources/hmc981.zip
+++ b/docs/solutions/reference-designs/active-bias-controllers/resources/hmc981.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bd95b6f1184a3b59057633b41ab5bfd413606bc48b3e8f91b56ad9aa73089b71
+size 77549

--- a/docs/solutions/reference-designs/active-bias-controllers/start.rst
+++ b/docs/solutions/reference-designs/active-bias-controllers/start.rst
@@ -1,0 +1,4 @@
+Active Bias Controller Recommended Circuits
+===========================================
+
+:doc:`HMC980 Recommended Circuits </solutions/reference-designs/active-bias-controllers/hmc980>`


### PR DESCRIPTION
## Summary
- Move active-bias-controllers wiki documentation to `solutions/reference-designs/active-bias-controllers/`
- 5 RST files with 3 localized images
- Generated stub `index.rst` with toctree

## Test plan
- [ ] Sphinx build passes without errors
- [ ] All toctree entries resolve correctly
- [ ] Images render properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)