### PR TITLE
reference-designs/ad7194: Add ad7194 documentation

### DIFF
--- a/docs/solutions/reference-designs/ad7194/ad7194.rst
+++ b/docs/solutions/reference-designs/ad7194/ad7194.rst
@@ -1,0 +1,126 @@
+AD7194 Evaluation Board User Guide
+==================================
+
+The EVAL-AD7194ASDZ evaluation kit features the AD7194 which is 4.8 kHz ultralow
+noise 24-bit sigma-delta (Σ-Δ) ADCs.The on-chip low noise gain stage means that
+signals of small amplitude can interface directly to the ADC.The internal clock
+option provides a compact solution for low BW requirements.
+
+The AD7194 ACE Plugin fully configures the AD7194 device register functionality
+and provides dc time domain analysis in the form of waveform graphs, histograms,
+and associated noise analysis for ADC performance evaluation.
+
+Full specifications on the AD7194 are available in the product data sheet, which
+should be consulted in conjunction with this user guide when working with the
+evaluation board.
+
+.. image:: images/ad7194_blockdiag.png
+   :align: center
+   :width: 600
+
+Features
+--------
+
+-  Full featured evaluation board for the AD7194
+-  PC control in conjunction with the system demonstration platform (EVAL-SDP-CB1Z/EVAL-SDP-CK1Z)
+-  PC software for control and data analysis (time and frequency domain)
+
+Related Documents
+-----------------
+
+-  :adi:`AD7194 Data Sheet <media/en/technical-documentation/data-sheets/ad7194.pdf>`
+
+Required Software
+-----------------
+
+-  :adi:`ACE Software <en/resources/evaluation-hardware-and-software/evaluation-boards-kits/eval-ad7194asdz.html#eb-documentation>`
+-  :adi:`AD7194 ACE Plugin <en/resources/evaluation-hardware-and-software/evaluation-boards-kits/eval-ad7194asdz.html#eb-documentation>`
+
+Quick Start Guide
+~~~~~~~~~~~~~~~~~
+
+The following steps highlight the process to begin using the evaluation board.
+
+Equipment Required
+------------------
+
+-  :adi:`EVAL-AD7194ASDZ evaluation board <en/design-center/evaluation-hardware-and-software/evaluation-boards-kits/EVAL-AD7194.html>`
+-  PC running Windows with a USB2.0 port and software installed.
+-  Controller Board
+
+   -  Option A: :adi:`EVAL-SDP-CK1Z <en/design-center/evaluation-hardware-and-software/evaluation-boards-kits/sdp-k1.html>` and a USB-C cable
+
+      -  Option B: :adi:`EVAL-SDP-CB1Z <en/design-center/evaluation-hardware-and-software/evaluation-boards-kits/sdp-b.html>` and a Micro-USB cable
+
+Getting started
+---------------
+
+.. warning::
+
+   Ensure the SDP board is not connected to the USB port of the PC
+
+-  Install the :adi:`ACE Software <en/design-center/evaluation-hardware-and-software/evaluation-development-platforms/ace-software.html?doc=EVAL-AD7383FMCZ-ug-1770.pdf>`
+-  `Ace Plugin Install guide available here <https://wiki.analog.com/resources/eval/user-guides/ad7190/softwareguide>`_
+-  If :adi:`ACE Software <en/design-center/evaluation-hardware-and-software/evaluation-development-platforms/ace-software.html?doc=EVAL-AD7383FMCZ-ug-1770.pdf>` is already installed, update the Plugins to download AD719x Plugin.
+
+-  Connect the EVAL-AD7194ASDZ to the controller board
+
+   -  **Option A:** Connect the EVAL-AD7194ASDZ to the EVAL-SDP-CK1Z
+
+      -  Using the 120 pin connector
+
+         -   Screw the two boards together using the plastic screw-washer set included in the evaluation board kit to ensure that the boards are connected firmly together.
+         -  Using the Arduino Connectors
+
+.. image:: images/sdp_connect.png
+   :align: center
+   :width: 400
+
+::
+
+     Option B: Connect the EVAL-AD7194ASDZ to the EVAL-SDP-CB1Z
+       * Using the 120 pin connector
+         *  Screw the two boards together using the plastic screw-washer set included in the evaluation board kit to ensure that the boards are connected firmly together.
+   * If using Windows® XP, it may be needed to search for the controller board drivers. Choose to automatically search for the drivers for the controller board if prompted by the operating system.
+   * Launch the ACE plugin from the Analog Devices subfolder in the Programs Menu.
+
+.. image:: images/ace_plugin_open.png
+   :align: center
+   :width: 300
+
+-  The :doc:`Low Noise Test Demo </solutions/reference-designs/ad7194/softwareguide>` is a useful demo mode of the Ace Plugin software to ensure that the Evaluation board is communicating correctly with the Ace Plugin software.
+
+Hardware Guide
+~~~~~~~~~~~~~~
+
+:doc:`Visit the hardware guide chapter here </solutions/reference-designs/ad7194/hardwareguide>` **Contents of the Hardware guide:**
+
+-  :doc:`Set-up Procedures </solutions/reference-designs/ad7194/hardwareguide>`
+-  :doc:`Block Diagram </solutions/reference-designs/ad7194/hardwareguide>`
+-   :doc:`Hardware Link Options </solutions/reference-designs/ad7194/hardwareguide>`
+-  :doc:`On Board Connections </solutions/reference-designs/ad7194/hardwareguide>`
+-  :doc:`Power Supplies </solutions/reference-designs/ad7194/hardwareguide>`
+-  :doc:`Serial Interface </solutions/reference-designs/ad7194/hardwareguide>`
+-  :doc:`Reference Options </solutions/reference-designs/ad7194/hardwareguide>`
+-  :doc:`GPIOs </solutions/reference-designs/ad7194/hardwareguide>`
+-  :doc:`Schematics </solutions/reference-designs/ad7194/hardwareguide>`
+-  :doc:`Bill of Materials </solutions/reference-designs/ad7194/hardwareguide>`
+
+Software Guide
+~~~~~~~~~~~~~~
+
+:doc:`Visit the software guide chapter here </solutions/reference-designs/ad7194/softwareguide>` **Contents of the Hardware guide:**
+
+-  :doc:`Ace Plugin </solutions/reference-designs/ad7194/softwareguide>`
+
+   -  :doc:`Ace Plugin Install </solutions/reference-designs/ad7194/softwareguide>`
+
+      -  :doc:`Ace Plugin Operation </solutions/reference-designs/ad7194/softwareguide>`
+      -  :doc:`Ace Plugin Demo Modes </solutions/reference-designs/ad7194/softwareguide>`
+
+         -  `Low Noise Test Demo <https://wiki.analog.com/resources/eval/user-guides/ad7194/softwareguide/demo_modes>`_
+
+            -  Weigh Scale Demo
+
+-  :doc:`Virtual Eval Guide </solutions/reference-designs/ad7194/softwareguide>`
+-  `AD7194 Firmware <https://wiki.analog.com/resources/tools-software/product-support-software/ad719x_mbed_iio_application>`_

--- a/docs/solutions/reference-designs/ad7194/hardwareguide.rst
+++ b/docs/solutions/reference-designs/ad7194/hardwareguide.rst
@@ -1,0 +1,336 @@
+EVAL-AD7194ASDZ Hardware Guide
+==============================
+
+Set-up Procedures
+=================
+
+After following the instructions in the :doc:`Software Procedures </solutions/reference-designs/ad7194/softwareguide>` section, set up the evaluation and SDP boards as detailed in this section.
+
+-  **Warning:** The evaluation software and drivers must be installed before connecting the EVAL-AD7194ASDZ evaluation board and EVAL-SDP-CB1Z board to the USB port of the PC to ensure the PC correctly recognizes the evaluation system.
+-  Connect the EVAL-AD7194ASDZ to the controller board
+
+   -  **Option A:** Connect the EVAL-AD7194ASDZ to the EVAL-SDP-CK1Z
+
+      -  Using the 120 pin connector
+
+         -   Screw the two boards together using the plastic screw-washer set included in the evaluation board kit to ensure that the boards are connected firmly together.
+         -  Using the Arduino Connectors
+
+.. image:: images/sdp_connect.png
+   :align: center
+   :width: 400
+
+-  **Option B:** Connect the EVAL-AD7194ASDZ to the EVAL-SDP-CB1Z
+
+   -  Using the 120 pin connector
+
+      -   Screw the two boards together using the plastic screw-washer set
+          included in the evaluation board kit to ensure that the boards are
+          connected firmly together.
+
+Block Diagram
+=============
+
+.. image:: images/ad7194_block_diag.png
+   :align: center
+   :width: 600
+
+Hardware Link Options
+=====================
+
++--------------+--------+------------------+------------------------------------------------------------------------------------+
+| Link Numbers | Colour | Default Position | Descirption                                                                        |
++==============+========+==================+====================================================================================+
+| LK1          | Black  | Uninserted       | REFIN+ to AVDD/EXC                                                                 |
++--------------+--------+------------------+------------------------------------------------------------------------------------+
+| LK2          | Black  | Inserted         | AVDD to AVDD/EXC For Brdige Connection                                             |
++--------------+--------+------------------+------------------------------------------------------------------------------------+
+| LK7          | Black  | A                | DVDD voltage select:                                                               |
+|              |        |                  | Pos A: DVDD is connected to 3.3V                                                   |
+|              |        |                  | Pos B: DVDD is connected to AVDD                                                   |
++--------------+--------+------------------+------------------------------------------------------------------------------------+
+| LK8          | Black  | A                | IOVDD voltage select:                                                              |
+|              |        |                  | Pos A: sets IOVDD to 3.3v LDO supply                                               |
+|              |        |                  | Pos B: sets IOVDD to external source                                               |
++--------------+--------+------------------+------------------------------------------------------------------------------------+
+| LK9          | Black  | C                | AVDD voltage select:                                                               |
+|              |        |                  | Pos A: sets AVDD to 3.3v LDO supply                                                |
+|              |        |                  | Pos B: sets AVDD to external source                                                |
+|              |        |                  | Pos C: sets AVDD to 5V LDO Supply                                                  |
++--------------+--------+------------------+------------------------------------------------------------------------------------+
+| LK10         | Black  | Uninserted       | Used as external AVDD voltage connector for scp boards                             |
++--------------+--------+------------------+------------------------------------------------------------------------------------+
+| LK11         | Black  | Uninserted       | Used as external IOVDD voltage connector for scp boards                            |
++--------------+--------+------------------+------------------------------------------------------------------------------------+
+| LK12         | Black  | A                | Used for stacking of Eval boards. To select Eval board(CS_N):                      |
+|              |        |                  | Pos A(1-2): selects eval board 1 (CS_ARD_1)                                        |
+|              |        |                  | Pos B(2-3): selects eval board 2 (CS_ARD_2)                                        |
++--------------+--------+------------------+------------------------------------------------------------------------------------+
+| LK13         | Black  | Uninserted       | This link shorts AIN1 to AIN2. This is useful to perform noise tests on the AD7194 |
++--------------+--------+------------------+------------------------------------------------------------------------------------+
+
+On Board Connections
+====================
+
+Bridge Connections
+------------------
+
+Connector P2: DC (Analog Input)
+-------------------------------
+
+**Functionality:**
+
+-  **Bridge Connection**
+
+========== ===========================
+Connection Function
+========== ===========================
+1          AIN 13 without DC filtering
+2          AIN 14 without DC filtering
+3          External Reference +
+4          External Reference -
+5          AIN 15 with DC filtering
+6          AIN 16 with DC filtering
+7          Excitation+
+8          Ground/Sheild
+========== ===========================
+
+Link Lk13: Low Noise Test Circuitry
+-----------------------------------
+
+**Functionality:**
+
+-  **Low Noise Test**
+
+-ALL INSERTED
+
+========== ========
+Connection Function
+========== ========
+1-2        AVDD
+3-4        AIN1
+5-6        AIN2
+========== ========
+
+External Powers
+---------------
+
+========== ========================================
+Connector  Function
+========== ========================================
+P4 Pin 1-2 External IOVDD connection
+P4 Pin 3-4 External AVDD connection
+LK10       External AVDD connection for SCP Boards
+LK11       External IOVDD connection for SCP Boards
+========== ========================================
+
+Digital Connectors
+------------------
+
+========================= ========= ==============================
+SDP 120 Pin Connector P5  Function  Arduino connector P6,P7,P9,P10
+========================= ========= ==============================
+3,4                       GND       P7-6,P7-7
+5                         V_USB     P7-5
+6,11,17,23,28,36,40,46,52 GND       P9-7
+56                        EEPROM_A0 -
+58,63,69,75               GND       -
+78                        SYNC_IN   P10-5
+79                        SCL       P10-10
+80                        SDA       P10-9
+81                        GND       -
+82                        SCLK      P10-6
+83                        SDO/MSIO  P10-5
+84                        SDI/MOSI  P10-4
+85                        CS_N      P9-3,P9-2
+86,93,98,109,115          GND       -
+116                       VIO       P7-2
+117,118                   GND       -
+========================= ========= ==============================
+
+.. image:: images/ad7193_arduinoheader.png
+   :align: center
+   :width: 400
+
+PMOD Connector P11
+~~~~~~~~~~~~~~~~~~
+
+========== ======== ========== ========
+Connection Function Connection Function
+========== ======== ========== ========
+1          CS_N     7          -
+2          DIN      8          -
+3          DOUT     9          -
+4          SCLK     10         -
+5          GND      11         GND
+6          IOVDD    12         IOVDD
+========== ======== ========== ========
+
+.. image:: images/ad7193_pmodheader.png
+   :align: center
+   :width: 200
+
+SMB Connections
+---------------
+
+There are 3 SMB connections on the board. To allow clock signals and reference
+into the board.
+
+-  J1 Provides option for External Reference+
+-  J2 Provides option for External Reference-
+-  J3 Brings external MCLK to the AD7193
+
+Power Supplies
+==============
+
+The evaluation board receives power through the controller board when connected
+to the PC via USB. Linear regulators generate the required power supply levels
+from the applied USB voltage.
+
+AVDD (LK9) selection
+--------------------
+
+-  **5V supply (DEFAULT)**
+
+   -  5V regulator supplies AVDD :adi:`ADP7142 <en/products/adp7142.html>`
+
+-  **3.3V supply**
+
+   -  3.3V regulator supplies AVDD :adi:`ADP150 <en/products/adp150.html>`
+
+-  **External AVDD**
+
+   -  Connections on Connector P4
+
+DVDD (LK7) selection
+--------------------
+
+-  **3.3V supply (DEFAULT)**
+
+   -  3.3V supplies DVDD
+
+-  **AVDD**
+
+   -  AVDD connected to DVDD
+
+IOVDD (LK8) selection
+---------------------
+
+-  **3.3V supply (DEFAULT)**
+
+   -  3.3V regulator supplies IOVDD :adi:`ADP150 <en/products/adp150.html>`
+
+-  **External IOVDD**
+
+   -  Connections on Connector P4
+
+-  **V_IO from SDP**
+
+   -  R38 to be mounted
+
+Serial Interface
+================
+
+There are four primary signals: CS, SCLK, SDI, and SDO/RDY (all are inputs,
+except for SDO/RDY, which is an output).
+
+Serial communication options
+----------------------------
+
+-  SDP-B board and the respective 120 pin SDP connector.
+
+- When using the SDP-B connection (120 pin) The evaluation board connects via the serial peripheral interface (SPI) to the Blackfin® :adi:`ADSP-BF527 <en/products/adsp-bf527.html>` on the SDP-B board.
+   * Arduino connection SDP-K1
+   * PMOD connector
+   * Standalone mode
+
+For an introduction to the Serial Peripheral Interface (SPI), click :adi:`here <en/analog-dialogue/articles/introduction-to-spi-interface.html>`
+
+.. image:: images/spi_pic.png
+   :align: center
+   :width: 400
+
+Reference Options
+=================
+
+-  **DEFAULT** :adi:`ADR4525 <en/products/adr4525.html>` On Board external reference on REFIN1+
+-   :adi:`LTC6655LN-2.5/LTC6655LN-4.096 <en/products/ltc6655.html>` On Board external reference on REFIN+
+
+   -  Option to use ultra low noise reference
+
+-  External Reference on REFIN1+ Connector J1
+-  AVDD as Reference via R25
+-  External reference can be supplied on P3-4 and P3-5 for REFIN2+ and REFIN2-
+
+Selecting the reference source:
+-------------------------------
+
+Software
+~~~~~~~~
+
+Board should be correctly connected to ACE
+
+-  **Option A:** Open AD7193 memory map
+
+::
+
+       Search for the Configuration register
+   * Set the REFSEL[] to the desired reference source by using these bits
+     REFSEL[0]: External reference applied between REFIN1(+) and REFIN1(−).
+       REFSEL[1]:External reference applied between P1/REFIN2(+) and P0/REFIN2(-) pins.
+   Option B: Open AD7194 Chip View
+     * Right click on ADC block
+     * Select Reference Source from the Reference Select option given as highlighted(1) below in the picture.
+     * Click on Apply Changes as highlighted(2) below.
+
+.. image:: images/refsel.png
+   :align: center
+   :width: 400
+
+GPIOs
+=====
+
+The General purpose inout pins are powered by AVDD/AVSS. They can be used to
+provide AC-Excitation signals for AC-Excited sensors, using 2 or 4 outputs. Can
+be used to automatically control an external multiplexer. Other optional
+functions include Current Source outputs , 2nd Reference input.
+
+====== ======== =========================
+GPIO   Bit Name Functionality
+====== ======== =========================
+**P3** P3DAT    Digital Output P3
+**P2** P2DAT    Digital Output P2
+**P1** P1DAT    Digital Output P1/REFIN2+
+**P0** P0DAT    Digital Output P0/REFIN2-
+====== ======== =========================
+
+Evaluation board Connections and Functionality
+----------------------------------------------
+
+The evaluation board highlights the functionality of the GPIOs
+
+P0/REFIN2-
+~~~~~~~~~~
+
+-  Available on the P3 connector.
+-  Also used as secondary reference option.
+
+P1/REFIN2+
+~~~~~~~~~~
+
+-  Available on the P3 connector.
+-  Also used as secondary reference option.
+
+Schematics
+==========
+
+`AD7194 Schematic pdf <resources/02-072728-01-a.pdf>`_
+
+Bill of Materials
+=================
+
+`AD7194 Evaluation board Bill of materials <resources/ad7194_bom.pdf>`_
+
+:doc:`Next Page: Software Procedures </solutions/reference-designs/ad7194/softwareguide>`
+
+:doc:`Return to Homepage </solutions/reference-designs/ad7194/ad7194>`

--- a/docs/solutions/reference-designs/ad7194/images/4170_ace_plugin_install_page_1.png
+++ b/docs/solutions/reference-designs/ad7194/images/4170_ace_plugin_install_page_1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e6b5e495a740f1d44237bc0ef1cb064e526607715c462551914acf21e9706571
+size 42579

--- a/docs/solutions/reference-designs/ad7194/images/4170_ace_plugin_page_1.png
+++ b/docs/solutions/reference-designs/ad7194/images/4170_ace_plugin_page_1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3702b0aa8a13262ff36736d4deeb53666414f1dc4d3988134a1415aa7a2a693c
+size 29177

--- a/docs/solutions/reference-designs/ad7194/images/4170_ace_plugin_page_2.png
+++ b/docs/solutions/reference-designs/ad7194/images/4170_ace_plugin_page_2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4da95c4b2e9e2b8597cc72c4ef2fdcfae43e63a3b9dfd325a0fb3d5bd93423c6
+size 32149

--- a/docs/solutions/reference-designs/ad7194/images/4170_ace_plugin_page_3.png
+++ b/docs/solutions/reference-designs/ad7194/images/4170_ace_plugin_page_3.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e38cc93654bc94b24de2e91382e0c4eaed9bd6e96c54a28770abecf4a295ddf9
+size 21864

--- a/docs/solutions/reference-designs/ad7194/images/4170_ace_plugin_page_4.png
+++ b/docs/solutions/reference-designs/ad7194/images/4170_ace_plugin_page_4.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:66fd37ba064255dd602bec7dced3e83ae08ddb07a246ecc55cb7ee5a4c8ac344
+size 22670

--- a/docs/solutions/reference-designs/ad7194/images/4170_ace_plugin_page_5.png
+++ b/docs/solutions/reference-designs/ad7194/images/4170_ace_plugin_page_5.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:64bac2b3c59f9b2074f8b2b13a6e678e1a6032ffbaed93efeab9650f53891557
+size 21346

--- a/docs/solutions/reference-designs/ad7194/images/4170_ace_plugin_page_6.png
+++ b/docs/solutions/reference-designs/ad7194/images/4170_ace_plugin_page_6.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:73d0182040c3cf4dd6935376d6105ff8914b77d256c9b7fe6b5374277c66e6d5
+size 25498

--- a/docs/solutions/reference-designs/ad7194/images/4170_ace_plugin_page_7.png
+++ b/docs/solutions/reference-designs/ad7194/images/4170_ace_plugin_page_7.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a6aa742abd9607ac916c416d282dc55c6589afe5ddc13d2182390967bf975935
+size 25185

--- a/docs/solutions/reference-designs/ad7194/images/ace_plugin_open.png
+++ b/docs/solutions/reference-designs/ad7194/images/ace_plugin_open.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:71fdecfb3a254fe252670ddd04b5c3c7ec062714d0434de1024c2c1408e57040
+size 67827

--- a/docs/solutions/reference-designs/ad7194/images/ad7192_memory_page.png
+++ b/docs/solutions/reference-designs/ad7194/images/ad7192_memory_page.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9318c6c44f78bbb44600edfa72b59d3a4a65d3387c702cd18ae24f2cb1f94b80
+size 410942

--- a/docs/solutions/reference-designs/ad7194/images/ad7193_arduinoheader.png
+++ b/docs/solutions/reference-designs/ad7194/images/ad7193_arduinoheader.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b0917d6b9d5a895100a3f762afdebf3f4183fda2e2d3e86a0bdfd3b9ac14d7df
+size 65255

--- a/docs/solutions/reference-designs/ad7194/images/ad7193_pmodheader.png
+++ b/docs/solutions/reference-designs/ad7194/images/ad7193_pmodheader.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6542bed78b650e0b9c865357568709b3ad7347893d16585d52a0665a2018f0d2
+size 14114

--- a/docs/solutions/reference-designs/ad7194/images/ad7194_ace.png
+++ b/docs/solutions/reference-designs/ad7194/images/ad7194_ace.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:14f5dece5eabf917d20e8a20273d61487c5808cf8226f50bc362df448ca50145
+size 162238

--- a/docs/solutions/reference-designs/ad7194/images/ad7194_attach_hardware.png
+++ b/docs/solutions/reference-designs/ad7194/images/ad7194_attach_hardware.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b07adb07a3a1d30461bc41d0c91fc5d48105a18db0db14c39230a7d4afc0a762
+size 439187

--- a/docs/solutions/reference-designs/ad7194/images/ad7194_block_diag.png
+++ b/docs/solutions/reference-designs/ad7194/images/ad7194_block_diag.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8897bcab28c5dc10704785ad1cb76a80d15f4a76a61e095acda1e15e89ed91e2
+size 91133

--- a/docs/solutions/reference-designs/ad7194/images/ad7194_blockdiag.png
+++ b/docs/solutions/reference-designs/ad7194/images/ad7194_blockdiag.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e3db80c464baf1ec62e07eaeff62d764a9ae963bbbcdb03650d6447bfc76f55b
+size 115153

--- a/docs/solutions/reference-designs/ad7194/images/ad7194_board_view.png
+++ b/docs/solutions/reference-designs/ad7194/images/ad7194_board_view.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7de7a80c6a1515bdb0e19c6768ccf6678f5f0dc8fe6fc30044df975b7d53d26e
+size 484634

--- a/docs/solutions/reference-designs/ad7194/images/ad7194_chip_view.png
+++ b/docs/solutions/reference-designs/ad7194/images/ad7194_chip_view.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:54a1c70a5537b07690dfef1eca635c833ffd1aad23c9249d51bf41bbb123d0c3
+size 453118

--- a/docs/solutions/reference-designs/ad7194/images/ad7194_waveform.png
+++ b/docs/solutions/reference-designs/ad7194/images/ad7194_waveform.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d33bd69a3b5d7bc7faf41db33f5709c5a4de536210381d886b85c8e0cbf7a72b
+size 514697

--- a/docs/solutions/reference-designs/ad7194/images/ad719x_virtual_eval.png
+++ b/docs/solutions/reference-designs/ad7194/images/ad719x_virtual_eval.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d91ab14a330488a15eb323f29b70ffb337792a25e5cde5254d275a24adf13130
+size 768859

--- a/docs/solutions/reference-designs/ad7194/images/refsel.png
+++ b/docs/solutions/reference-designs/ad7194/images/refsel.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:83babff425222b437d5b7ffeaadf27f0be4d2bbec135e5c13bf28929a35f3f1b
+size 562703

--- a/docs/solutions/reference-designs/ad7194/images/sdp_connect.png
+++ b/docs/solutions/reference-designs/ad7194/images/sdp_connect.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:49faba2c95649d2168e152457c5558ae7929dd80f568aa28a92f8006e4fd6930
+size 6341754

--- a/docs/solutions/reference-designs/ad7194/images/spi_pic.png
+++ b/docs/solutions/reference-designs/ad7194/images/spi_pic.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ddd6b31f63adb3a94fa0eb99d8ed854951bab2881577dc40d15be4bdab1dd497
+size 27967

--- a/docs/solutions/reference-designs/ad7194/index.rst
+++ b/docs/solutions/reference-designs/ad7194/index.rst
@@ -1,0 +1,9 @@
+AD7194 Evaluation Board User Guide
+==================================
+
+.. toctree::
+   :titlesonly:
+
+   ad7194
+   hardwareguide
+   softwareguide

--- a/docs/solutions/reference-designs/ad7194/index.rst
+++ b/docs/solutions/reference-designs/ad7194/index.rst
@@ -1,9 +1,47 @@
-AD7194 Evaluation Board User Guide
-==================================
+.. _ad7194 eval:
+
+AD7194
+=====================================
+
+.. TODO: Add a picture of the chip/board
+
+Overview
+-------------------------------------------------------------------------------
+
+.. TODO: Describe in max 10 rows the main features and applications.
+
+Features:
+
+- feature 1
+- feature 2
+
+Applications:
+
+- application 1
+- application 2
 
 .. toctree::
-   :titlesonly:
+   :hidden:
 
    ad7194
    hardwareguide
    softwareguide
+
+Recommendations
+-------------------------------------------------------------------------------
+
+People who follow the flow that is outlined, have a much better experience with
+things. However, like many things, documentation is never as complete as it
+should be. If you have any questions, feel free to ask on our
+:ref:`EngineerZone forums <help-and-support>`, but before that, please make
+sure you read our documentation thoroughly.
+
+Warning
+-------------------------------------------------------------------------------
+
+.. esd-warning::
+
+Help and support
+-------------------------------------------------------------------------------
+
+Please go to :ref:`Help and Support <help-and-support>` page.

--- a/docs/solutions/reference-designs/ad7194/resources/02-072728-01-a.pdf
+++ b/docs/solutions/reference-designs/ad7194/resources/02-072728-01-a.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2a81441cd662d691261a0e763c739343235e14e74e91e3efb0af39179a1e1a78
+size 657098

--- a/docs/solutions/reference-designs/ad7194/resources/ad7194_bom.pdf
+++ b/docs/solutions/reference-designs/ad7194/resources/ad7194_bom.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:80af75bbb6b5b9e8994f910f982228d2a1937d799d3fd0ce93b6508d60bcc56c
+size 180385

--- a/docs/solutions/reference-designs/ad7194/softwareguide.rst
+++ b/docs/solutions/reference-designs/ad7194/softwareguide.rst
@@ -1,0 +1,271 @@
+Software Guide
+==============
+
+Ace Plugin
+==========
+
+Ace Plugin Install guide
+------------------------
+
+-  **Warning**: The evaluation software and drivers must be installed before connecting both the evaluation board and the Controller (SDP) board to the PC. This ensures that the evaluations system is correctly recognized when it is connected to the PC.
+
+The software and drivers required for the installation walked through in this
+section can be found below:
+
+-  :adi:`Ace Software <en/design-center/evaluation-hardware-and-software/evaluation-development-platforms/ace-software.html?doc=EVAL-AD7383FMCZ-ug-1770.pdf>`
+-  :adi:`AD4130-8 Ace Plugin <media/en/evaluation-boards-kits/evaluation-software/AD4130-8>`
+-  `SDP controller system demonstration platform drivers <http://swdownloads.analog.com/ACE/SDP/SDPDrivers.exe>`_
+
+Installing the ACE Plugin software
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Download the ACE software from the ACE software page or the AD7194 product page. Install ACE on a PC **before using** the EVAL-AD7194ASDZ.
+
+Installing ACE
+~~~~~~~~~~~~~~
+
+-  Download the ACE software to a Windows®-based PC.
+-  Double click the ACEInstall.exe file to begin the installation. By default, the software is saved to the following location: C:\\Program Files (x86)\\Analog Devices\\ACE.
+-  A dialog box opens asking for permission to allow the program to make changes to the PC. Click Yes to begin the installation process.
+-  In the ACE Setup window, click Next > to continue the installation.
+
+.. image:: images/4170_ace_plugin_page_1.png
+   :align: center
+   :width: 400
+
+-  Read the software license agreement and click I Agree
+
+.. image:: images/4170_ace_plugin_page_2.png
+   :align: center
+   :width: 400
+
+-  Click Browse … to choose the installation location and then click Next >
+
+.. image:: images/4170_ace_plugin_page_3.png
+   :align: center
+   :width: 400
+
+-  The ACE software components to install are preselected. Click Install.
+
+.. image:: images/4170_ace_plugin_page_4.png
+   :align: center
+   :width: 400
+
+-  The Windows Security window opens . Click Install
+
+.. image:: images/4170_ace_plugin_page_5.png
+   :align: center
+   :width: 400
+
+-  The installation in progress in the window below. No action is required.
+
+.. image:: images/4170_ace_plugin_page_6.png
+   :align: center
+   :width: 400
+
+-   When the installation is complete, click Next >, and then click Finish to
+    complete the installation process
+
+.. image:: images/4170_ace_plugin_page_7.png
+   :align: center
+   :width: 400
+
+AD7194 Plugin Install
+~~~~~~~~~~~~~~~~~~~~~
+
+After the AD7194 Plugin is downloaded follow the steps to install the file: -
+Double click on the AD7194 Plugin. - Connect up your EVAL-AD7194ASDZ to your pc
+through a controller board. Alternatively, the AD7194 Plugin can be installed
+through the steps bellow:
+
+-  From the Start menu of the PC, select All Programs > Analog Devices > ACE> ACE.exe to open the ACE software main window shown below.
+-  Click on the Plug-in Manager Tab in the top left panel in Ace.
+-  Click on the Settings… button.
+
+.. image:: images/4170_ace_plugin_install_page_1.png
+   :align: center
+   :width: 400
+
+-  Hit the + button next to the Zipped Plug-in Sources.
+
+.. image:: images/ad7194_ace.png
+   :align: center
+   :width: 400
+
+-  Under the Name write “AD7194”
+-  Under Source hit the … button and set the path to where you have stored the AD7194 Plugin.
+-  Press “Ok”.
+-  Press “Close”.
+
+ACE software Operation
+----------------------
+
+Launching the software
+~~~~~~~~~~~~~~~~~~~~~~
+
+After the EVAL-AD7194ASDZ and controller board are properly connected to the PC,
+launch the ACE software by taking the following steps:
+
+-  From the Start menu of the PC, select All Programs > Analog Devices > ACE> ACE.exe to open the ACE software main window shown below
+-  If the EVAL-AD7194ASDZ is not connected to the USB port via the controller
+   board when the software launches, the AD7194 Eval Board icon does not appear
+   in the Attached Hardware section in ACE (see Figure below).To make the
+   AD7194Eval Board icon appear, connect the EVAL-AD7190ASDZ and the controller
+   board to the USB port of the PC, wait a few seconds, and then follow the
+   instructions in the dialog box that opens.
+
+.. image:: images/ad7194_attach_hardware.png
+   :align: center
+   :width: 600
+
+-  Double click the AD7194 Eval Board icon to open the AD7194 Eval Board view
+   window shown below:
+
+.. image:: images/ad7194_board_view.png
+   :align: center
+   :width: 600
+
+-  Double click the AD7194 chip icon in the AD7194 Eval Board view window to open the AD7194 chip view window shown below:
+-  Click Software Defaults and then click Apply Changes to apply the default
+   settings to the AD7194
+
+.. image:: images/ad7194_chip_view.png
+   :align: center
+   :width: 600
+
+Chip view window
+~~~~~~~~~~~~~~~~
+
+After completing the steps in the :doc:`Software Installation Procedures </solutions/reference-designs/ad7194/softwareguide>` section and the :doc:`Evaluation Board Set-up Procedures </solutions/reference-designs/ad7194/hardwareguide>` section, set up the system for data capture by taking the following steps:
+
+-  Block icons that are dark blue are programmable blocks. Click a dark blue block icon to open a configurable pop-up window to customize the data capture.
+-  The “Proceed to Memory Map” button brings the user to the memory map of the AD7194. This allows the user to configure the AD7194.
+-  The “Proceed to Analysis” button brings the user to the Analysis tab. This
+   allows the user to see the performance results of the AD7194 and displays the
+   data.
+
+Waveform Window
+~~~~~~~~~~~~~~~
+
+The Waveform tab graphs the conversions gathered and processes the data,
+calculating the peak-to-peak noise, rms noise, and resolution.
+
+1) Waveform graph and controls
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The data waveform graph shows each successive sample of the ADC output. Zoom in
+on the data in the graph using the scroll wheel on your mouse or by selecting
+the magnifying glass.
+
+2) Analysis Channel
+~~~~~~~~~~~~~~~~~~~
+
+The Result section shows the analysis of the channel selected
+
+|image1|
+
+3) Samples
+~~~~~~~~~~
+
+The Samples numeric control set the number of samples gathered per batch. This
+control is unrelated to the ADC mode. You can capture a defined sample set or
+continuously gather batches of samples. In both cases, the number of samples set
+in the Samples numeric input dictates the number of samples. The Noise Analysis
+section displays the results of the noise analysis for the selected analysis
+channel, including both noise and resolution measurements.
+
+4) Capture
+~~~~~~~~~~
+
+Click the Run Once button to start gathering ADC results. Click the Run
+Continuously button to start gathering ADC results continuously. Results appear
+in the waveform graph (Label 1).
+
+5) Display Units and Axis Controls
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Click the Codes drop-down menu to select whether the data graph displays in
+units of voltages or codes. This control affects both the waveform graph and the
+histogram graph. The axis controls is fixed. When selecting Fixed, the axis
+ranges can be programmed; however, these ranges do not automatically adjust
+after each batch of samples.
+
+Memory map Window
+^^^^^^^^^^^^^^^^^
+
+Use the Memory Map tab to access the registers of the AD7194, shown in the
+figure below. This tab changes register settings and shows additional
+information about each bit in each individual register.
+
+1) Export Buttons
+~~~~~~~~~~~~~~~~~
+
+The Export buttons on the Register Map tab allow the user to save and load
+register settings. Click Save to save all the current register settings to a
+file for later use. Click Load to load a previously saved register map.
+
+2) Register
+~~~~~~~~~~~
+
+The Register section shows the value that is set in the selected register. Check
+the value of the register in this window by clicking on the bits. Clicking any
+individual bit changes the bit from 1 to 0 or 0 to 1, depending on the initial
+state of the bit. The register value can also be changed by writing the
+hexadecimal value in the input field to the right of the individual bits.
+
+3) Bitfields
+~~~~~~~~~~~~
+
+The Bitfields section shows the individual bitfield of the selected register.
+The register is broken by name into its bitfields, name of the bitfields, a
+description of each bitfield, and access information. Show each individual
+bitfield by pressing the show bitfield button (label 3). Apply these changes
+using label 4. Search for specific registers using label 5.
+
+4) Register and Bitfield Description and dropdowns
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+For more information of the register and the bitfields in the register, double
+click on the register shown by label 2. This will show up the register
+description shown by label 6.\
+
+|image2|
+
+AD7194 Demo Modes
+-----------------
+
+AD7194 Demo Modes
+=================
+
+`Visit the demo mode section here <https://wiki.analog.com/resources/eval/user-guides/ad7194/softwareguide/demo_modes>`_ **Contents of the demo modes section:**
+
+-  `Low Noise Test Demo <https://wiki.analog.com/resources/eval/user-guides/ad7194/softwareguide/demo_modes>`_
+-  `Weigh scale Demo <https://wiki.analog.com/resources/eval/user-guides/ad7194/softwareguide/demo_modes>`_
+
+Virtual Eval Guide
+------------------
+
+This page provides a step by step guide to launching and using ADI's new Virtual
+Evaluation Tool.
+
+-  Navigate to the Virtual Eval tool by clicking this link: `Virtual Eval <http://beta-tools.analog.com/virtualeval/>`_ or alternatively, by going to the AD7190 homepage on analog.com and finding the link there.
+-  Select the AD7194 by going to 'Precision ADC < 10MSPS' and finding the part
+   there.
+
+.. image:: images/ad719x_virtual_eval.png
+   :align: center
+   :width: 600
+
+-  Now you are ready to start using the tool.
+
+Firmware Install Guide
+----------------------
+
+:doc:`Previous Page: Hardware Guide </solutions/reference-designs/ad7194/hardwareguide>`
+
+:doc:`Return to Homepage </solutions/reference-designs/ad7194/ad7194>`
+
+.. |image1| image:: images/ad7194_waveform.png
+   :width: 400
+.. |image2| image:: images/ad7192_memory_page.png
+   :width: 600


### PR DESCRIPTION
## Summary
- Move ad7194 wiki documentation to `solutions/reference-designs/ad7194/`
- 4 RST files with 23 localized images
- Generated stub `index.rst` with toctree

## Test plan
- [ ] Sphinx build passes without errors
- [ ] All toctree entries resolve correctly
- [ ] Images render properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)