### PR TITLE
reference-designs/ad-fmcmotcon1-ebz: Add ad-fmcmotcon1-ebz documentation

### DIFF
--- a/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/ad-fmcmotcon1-ebz.rst
+++ b/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/ad-fmcmotcon1-ebz.rst
@@ -72,11 +72,8 @@ Videos
 
 ADI/Avnet/MathWorks/Xilinx design seminar
 
-.. image:: https://wiki.analog.com/_media/resources/eval/user-guides/analogtv>3540825244001
-   :alt: analogTV>3540825244001
+`Watch on AnalogTV <https://www.analog.com/en/education/education-library/videos/3540825244001.html>`_
 
 From ADI's 2013 Design Conference
 
-|youtube>-7CscB5sUIw|
-
-.. |youtube>-7CscB5sUIw| image:: https://wiki.analog.com/_media/resources/eval/user-guides/youtube>-7cscb5suiw
+`YouTube: -7CscB5sUIw <https://www.youtube.com/watch?v=-7CscB5sUIw>`_

--- a/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/ad-fmcmotcon1-ebz.rst
+++ b/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/ad-fmcmotcon1-ebz.rst
@@ -1,0 +1,82 @@
+AD-FMCMOTCON1-EBZ User Guide
+============================
+
+.. warning::
+
+   Analog Devices uses six designations to inform our customers where a
+   semiconductor product is in its
+   :adi:`life cycle <en/support/customer-service-resources/sales/product-life-cycle-information.html>`.
+   From emerging innovations to products which have been in production for
+   twenty years, we understand that insight into life cycle status is important.
+   Device life cycles are tracked on their individual product pages on
+   `analog.com <https://www.analog.com/>`_, and should always be consulted
+   before making any design decisions.
+
+   This particular article/document/design has been retired or deprecated,
+   which means it is no longer maintained or actively updated, even though the
+   devices themselves may be Recommended for New Designs or in
+   Production. This page is here for historical/reference purposes only.
+
+The :adi:`AD-FMCMOTCON1-EBZ` is a complete motor drive system on an FMC board. Information on the card, and how to use it, the design package that surrounds it, and the software which can make it work, can be found here.
+
+The purpose of the **AD-FMCMOTCON1-EBZ** is to provide a complete motor drive system demonstrating efficient control of Brushed DC, BLDC, PMSM and Stepper motors. It consists of 2 boards: a controller board and a drive board. The system incorporates high quality power sources; reliable power, control, and feedback signals isolation; accurate measurement of motor current & voltage signals; high speed interfaces for control signals to allow fast controller response; industrial Ethernet high speed interfaces; flexible control with FPGA/SoC interface.
+
+The **AD-DYNO1-EBZ** dynamometer is provided as an extension of the drive system. This is a dynamically adjustable load that can be used to test real-time motor control performance. It consists of two BLDC motors directly coupled through a rigid connection. One of the BLDC motors acts as a load and is controlled by the DYNO’s embedded control system while then second motor is driven by the **AD-FMCMOTCON1-EBZ**.
+
+This platform is intended to be used as a prototyping system to verify the
+hardware and the control algorithms before moving to the production stage. It
+helps reduce the time needed to move a motor control system from concept to
+production. Example reference designs showing how to use the control solution
+with Xilinx FPGAs or SoCs and Simulink from Mathworks are provided together with
+the hardware.
+
+.. image:: images/mc_system.jpg
+   :align: right
+   :width: 600
+
+-  :doc:`Introduction </solutions/reference-designs/ad-fmcmotcon1-ebz/introduction>`
+
+   -  :doc:`Electric Motor Drives </solutions/reference-designs/ad-fmcmotcon1-ebz/introduction/drives>`
+   -  :doc:`Brushed DC Motor Control </solutions/reference-designs/ad-fmcmotcon1-ebz/introduction/dc_control>`
+   -  :doc:`Brusless DC Motor Control </solutions/reference-designs/ad-fmcmotcon1-ebz/introduction/bldc_control>`
+
+-  :doc:`Quick Start Guides </solutions/reference-designs/ad-fmcmotcon1-ebz/quickstart>`
+
+   -  :doc:`Hardware Setup Guide </solutions/reference-designs/ad-fmcmotcon1-ebz/quickstart/lv_setup_guide>`
+   -  :doc:`Linux on Zynq </solutions/reference-designs/ad-fmcmotcon1-ebz/quickstart/zynq>`
+   -  :doc:`ISE Project with Chipscope </solutions/reference-designs/ad-fmcmotcon1-ebz/quickstart/chipscope>`
+
+-  :doc:`Hardware </solutions/reference-designs/ad-fmcmotcon1-ebz/hardware>`
+
+   -  :doc:`Controller Board </solutions/reference-designs/ad-fmcmotcon1-ebz/hardware/controller_board>`
+   -  :doc:`Low Voltage Drive Board </solutions/reference-designs/ad-fmcmotcon1-ebz/hardware/lv_board>`
+   -  :doc:`Signal Measurement Chain </solutions/reference-designs/ad-fmcmotcon1-ebz/hardware/signal_chain>`
+   -  :doc:`Dynamometer Drive System </solutions/reference-designs/ad-fmcmotcon1-ebz/hardware/dyno>`
+
+-  :doc:`HDL </solutions/reference-designs/ad-fmcmotcon1-ebz/reference_hdl>`
+
+   -  :doc:`HDL Design for Linux </solutions/reference-designs/ad-fmcmotcon1-ebz/reference_hdl/linux>`
+   -  :doc:`ISE HDL Design </solutions/reference-designs/ad-fmcmotcon1-ebz/reference_hdl/ise>`
+
+-  :doc:`Software </solutions/reference-designs/ad-fmcmotcon1-ebz/software>`
+
+   -  :doc:`Linux Drivers </solutions/reference-designs/ad-fmcmotcon1-ebz/software/linux_drivers>`
+   -  :doc:`IIO Scope </solutions/reference-designs/ad-fmcmotcon1-ebz/software/iio_scope>`
+
+-  :doc:`Simulink Models </solutions/reference-designs/ad-fmcmotcon1-ebz/matlab_models>`
+-  :doc:`QDESYS Motor Control IP </solutions/reference-designs/ad-fmcmotcon1-ebz/qdesys_ip>`
+-  :doc:`Help and Support </solutions/reference-designs/ad-fmcmotcon1-ebz/help_and_support>`
+
+Videos
+======
+
+ADI/Avnet/MathWorks/Xilinx design seminar
+
+.. image:: https://wiki.analog.com/_media/resources/eval/user-guides/analogtv>3540825244001
+   :alt: analogTV>3540825244001
+
+From ADI's 2013 Design Conference
+
+|youtube>-7CscB5sUIw|
+
+.. |youtube>-7CscB5sUIw| image:: https://wiki.analog.com/_media/resources/eval/user-guides/youtube>-7cscb5suiw

--- a/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/hardware.rst
+++ b/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/hardware.rst
@@ -1,0 +1,91 @@
+Motor Control Hardware
+======================
+
+.. warning::
+
+   Analog Devices uses six designations to inform our customers where a
+   semiconductor product is in its
+   :adi:`life cycle <en/support/customer-service-resources/sales/product-life-cycle-information.html>`.
+   From emerging innovations to products which have been in production for
+   twenty years, we understand that insight into life cycle status is important.
+   Device life cycles are tracked on their individual product pages on
+   `analog.com <https://www.analog.com/>`_, and should always be consulted
+   before making any design decisions.
+
+   This particular article/document/design has been retired or deprecated,
+   which means it is no longer maintained or actively updated, even though the
+   devices themselves may be Recommended for New Designs or in
+   Production. This page is here for historical/reference purposes only.
+
+Hardware solutions
+------------------
+
+.. image:: images/ad-fmcmotcon1-ebz_top.jpg
+   :alt: AD-FMCMOTCON1-EBZ
+   :align: right
+   :width: 300
+
+-  :doc:`AD-FMCMOTCON1-EBZ </solutions/reference-designs/ad-fmcmotcon1-ebz/hardware/controller_board>` - Controller board.
+
+   -  Compatible with all Xilinx FPGA platforms with FMC LPC or HPC connectors
+
+      -  2 x Gbit Ethernet PHYs for high speed industrial communication
+      -  Hall + Differential Hall + Encoder + Resolver interfaces
+      -  Current and voltage measurement using isolated ADCs
+      -  Xilinx XADC interface
+      -  Fully isolated control and feedback signals
+
+.. image:: images/ad-drvlv1-ebz_top.jpg
+   :alt: AD-DRVLV1-EBZ
+   :align: right
+   :width: 300
+
+-  :doc:`AD-DRVLV1-EBZ </solutions/reference-designs/ad-fmcmotcon1-ebz/hardware/lv_board>` - Low voltage drive board.
+
+   -  Connects to the Controller board and has a power stage that can drive drive Brushed DC / BLDC / PMSM / Stepper motors up to 48V and 18A.
+   -  Integrated over current protection
+   -  Current measurement using isolated ADCs
+   -  Bus voltage, phase currents and total current analog feedback signals
+   -  PGAs to maximize the current measurement input range
+   -  BEMF zero cross detection for sensorless control of PMSM or BLDC motors
+
+.. image:: images/ad-dyno1-ebz.png
+   :alt: AD-DYNO1-EBZ
+   :align: right
+   :width: 300
+
+-  :doc:`AD-DYNO1-EBZ </solutions/reference-designs/ad-fmcmotcon1-ebz/hardware/dyno>` - Dynamometer Drive System.
+
+   -  Two BLDC motors connected in a dyno setup
+   -  Electronically adjustable load – the load value is set using the onboard buttons + LCD
+   -  Programmable step and ramp load changes
+   -  Measurement and display of load motor phase currents
+   -  Measurement and display of load motor speed
+   -  External control using Analog Discovery
+
+Where to Buy
+------------
+
+.. container:: round box
+
+   `ZYNQ Intelligent Drives Kit <http://www.em.avnet.com/en-us/design/drc/Pages/Zynq-Intelligent-Drives-Kit.aspx>`_
+
+Downloads
+---------
+
+.. admonition:: Download
+   :class: download
+
+   **AD-FMCMOTCON1-EBZ**
+
+   
+   -  `Schematics <resources/ad-fmcmotcon1-ebz_schematics.pdf>`_
+   -  `Bill of Materials <resources/ad-fmcmotcon1-ebz_bom.pdf>`_
+   -  `Allegro Board File <resources/ad-fmcmotcon1-ebz_layout.zip>`_ (This file is `compressed <http://www.7-zip.org/7z.html>`_). Get the `Allegro FREE Physical Viewer <https://www.cadence.com/en_US/home/tools/pcb-design-and-analysis/allegro-downloads-start.html>`_ (You need 16.5 or higher).
+   
+   **AD-DRVLV1-EBZ**
+   
+   -  `Schematics <resources/ad-drvlv1-ebz_schematics.pdf>`_
+   -  `Bill of Materials <resources/ad-drvlv1-ebz_bom.pdf>`_
+   -  `Allegro Board File <resources/ad-drvlv1-ebz_layout.zip>`_ (This file is `compressed <http://www.7-zip.org/7z.html>`_). Get the `Allegro FREE Physical Viewer <https://www.cadence.com/en_US/home/tools/pcb-design-and-analysis/allegro-downloads-start.html>`_ (You need 16.5 or higher).
+   

--- a/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/hardware.rst
+++ b/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/hardware.rst
@@ -78,14 +78,14 @@ Downloads
 
    **AD-FMCMOTCON1-EBZ**
 
-   
+
    -  `Schematics <resources/ad-fmcmotcon1-ebz_schematics.pdf>`_
    -  `Bill of Materials <resources/ad-fmcmotcon1-ebz_bom.pdf>`_
    -  `Allegro Board File <resources/ad-fmcmotcon1-ebz_layout.zip>`_ (This file is `compressed <http://www.7-zip.org/7z.html>`_). Get the `Allegro FREE Physical Viewer <https://www.cadence.com/en_US/home/tools/pcb-design-and-analysis/allegro-downloads-start.html>`_ (You need 16.5 or higher).
-   
+
    **AD-DRVLV1-EBZ**
-   
+
    -  `Schematics <resources/ad-drvlv1-ebz_schematics.pdf>`_
    -  `Bill of Materials <resources/ad-drvlv1-ebz_bom.pdf>`_
    -  `Allegro Board File <resources/ad-drvlv1-ebz_layout.zip>`_ (This file is `compressed <http://www.7-zip.org/7z.html>`_). Get the `Allegro FREE Physical Viewer <https://www.cadence.com/en_US/home/tools/pcb-design-and-analysis/allegro-downloads-start.html>`_ (You need 16.5 or higher).
-   
+

--- a/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/hardware/controller_board.rst
+++ b/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/hardware/controller_board.rst
@@ -1,0 +1,229 @@
+AD-FMCMOTCON1-EBZ Controller Board
+==================================
+
+.. warning::
+
+   Analog Devices uses six designations to inform our customers where a
+   semiconductor product is in its
+   :adi:`life cycle <en/support/customer-service-resources/sales/product-life-cycle-information.html>`.
+   From emerging innovations to products which have been in production for
+   twenty years, we understand that insight into life cycle status is important.
+   Device life cycles are tracked on their individual product pages on
+   `analog.com <https://www.analog.com/>`_, and should always be consulted
+   before making any design decisions.
+
+   This particular article/document/design has been retired or deprecated,
+   which means it is no longer maintained or actively updated, even though the
+   devices themselves may be Recommended for New Designs or in
+   Production. This page is here for historical/reference purposes only.
+
+Features and Block Diagram
+--------------------------
+
+-  Compatible with all Xilinx FPGA platforms with FMC LPC or HPC connectors
+-  2 x Gbit Ethernet PHYs for high speed industrial communication
+-  Hall + Differential Hall + Encoder + Resolver interfaces
+-  Current and voltage measurement using isolated ADCs
+-  Xilinx XADC interface
+-  Fully isolated control and feedback signals
+
+============================ ==========================
+**Simplified Block Diagram** **Detailed Block Diagram**
+============================ ==========================
+============================ ==========================
+
+|Simplified Block Diagram| |Detailed Block Diagram|
+
++---+
++---+
+
+Picture and Main Components
+---------------------------
+
+|AD-FMC-MOTCON1-EBZ Top| |AD-FMC-MOTCON1-EBZ Bottom|
+
++---+
++---+
+
+Key Parts
+---------
+
++--------------------------------------------------+-------------------------------------------------------------------------------+
+| Measurement                                      |                                                                               |
++==================================================+===============================================================================+
+| :adi:`AD7401A`                                   | 5 kV rms, isolated 2nd order Sigma-Delta modulator                            |
++--------------------------------------------------+-------------------------------------------------------------------------------+
+| :adi:`ADA4084-2`                                 | 30 V, Low noise, rail-to-rail I/O, low power operational amplifier            |
++--------------------------------------------------+-------------------------------------------------------------------------------+
+| :adi:`AD8646`                                    | 24 MHz rail-to-rail dual op amp                                               |
++--------------------------------------------------+-------------------------------------------------------------------------------+
+| :adi:`AD2S1210`                                  | Variable resolution, 10-bit to 16-bit R/D converter with reference oscillator |
++--------------------------------------------------+-------------------------------------------------------------------------------+
+| Power                                            |                                                                               |
++--------------------------------------------------+-------------------------------------------------------------------------------+
+| :adi:`ADuM5000`                                  | isoPower® integrated isolated dc-to-dc converter                              |
++--------------------------------------------------+-------------------------------------------------------------------------------+
+| :adi:`ADP1614`                                   | 1000 mA, 2.5 MHz buck-boost dc-to-dc converter                                |
++--------------------------------------------------+-------------------------------------------------------------------------------+
+| :adi:`ADM660`                                    | CMOS switched-capacitor voltage converter                                     |
++--------------------------------------------------+-------------------------------------------------------------------------------+
+| Isolation                                        |                                                                               |
++--------------------------------------------------+-------------------------------------------------------------------------------+
+| :adi:`ADuM7640`                                  | Triple channel digital isolator                                               |
++--------------------------------------------------+-------------------------------------------------------------------------------+
+| Voltage Translation                              |                                                                               |
++--------------------------------------------------+-------------------------------------------------------------------------------+
+| :adi:`ADG3308`                                   | 8-channel bidirectional level translator                                      |
++--------------------------------------------------+-------------------------------------------------------------------------------+
+| Multiplexers                                     |                                                                               |
++--------------------------------------------------+-------------------------------------------------------------------------------+
+| :adi:`ADG704`                                    | CMOS, low voltage 2.5 Ω 4-channel multiplexer                                 |
++--------------------------------------------------+-------------------------------------------------------------------------------+
+| :adi:`ADG759`                                    | CMOS low voltage, 3 ohms 4-channel multiplexer                                |
++--------------------------------------------------+-------------------------------------------------------------------------------+
+| High Speed Communication                         |                                                                               |
++--------------------------------------------------+-------------------------------------------------------------------------------+
+| **88E1512**                                      | Marvell Integrated 10/100/1000 Mbps Energy Efficient Ethernet Transceiver     |
++--------------------------------------------------+-------------------------------------------------------------------------------+
+
++---+
++---+
+
+Jumper settings
+---------------
+
+.. image:: ../images/controller_jumpers.jpg
+   :alt: AD-FMC-MOTCON1-EBZ Jumpers
+   :width: 600
+
++----------------------------------------+------------------------+-------------------+
+| Sensor Selection                       |                        |                   |
++========================================+========================+===================+
+| **Back EMF**                           | P9 - position 0        | P20 - position 0  |
++----------------------------------------+------------------------+-------------------+
+| **Single ended Hall**                  | P9 - position 1        | P20 - position 0  |
++----------------------------------------+------------------------+-------------------+
+| **Differential Hall**                  | P9 - position 0        | P20 - position 1  |
++----------------------------------------+------------------------+-------------------+
+| **Reserved**                           | P9 - position 1        | P20 - position 1  |
++----------------------------------------+------------------------+-------------------+
+| Resolver Configuration Mode            |                        |                   |
++----------------------------------------+------------------------+-------------------+
+| **Normal Mode - Position input**       | P3 - Not inserted      | P5 - Not inserted |
++----------------------------------------+------------------------+-------------------+
+| **Normal Mode - Velocity input**       | P3 - Not inserted      | P5 - Inserted     |
++----------------------------------------+------------------------+-------------------+
+| **Reserved**                           | P3 - Inserted          | P5 - Not inserted |
++----------------------------------------+------------------------+-------------------+
+| **Configuration Mode**                 | P3 - Inserted          | P5 - Inserted     |
++----------------------------------------+------------------------+-------------------+
+| Resolver Resolution Settings           |                        |                   |
++----------------------------------------+------------------------+-------------------+
+| **10 Bits**                            | P4 - Not inserted      | P6 - Not inserted |
++----------------------------------------+------------------------+-------------------+
+| **12 Bits**                            | P4 - Not inserted      | P6 - Inserted     |
++----------------------------------------+------------------------+-------------------+
+| **14 Bits**                            | P4 - Inserted          | P6 - Not inserted |
++----------------------------------------+------------------------+-------------------+
+| **16 Bits**                            | P4 - Inserted          | P6 - Inserted     |
++----------------------------------------+------------------------+-------------------+
+| PHYs Configuration                     |                        |                   |
++----------------------------------------+------------------------+-------------------+
+| **2.5V VDDO, different PHY addresses** | P11 & P12 - Position 0 | P9 - Inserted     |
++----------------------------------------+------------------------+-------------------+
+
++---+
++---+
+
+LEDs
+----
+
+=== ===================
+LED Description
+=== ===================
+DS1 FMC 3.3V Power Good
+DS2 Vadj Power Good
+DS3 5V Power Good
+DS7 12V Power Good
+=== ===================
+
++---+
++---+
+
+Power Map
+---------
+
+.. image:: ../images/controller_power_map.png
+   :width: 400
+
++---+
++---+
+
+ADC FPGA Interface
+------------------
+
+|image1| The AD7401 Isolated Sigma-Delta Modulators present on the controller board have a 2 wires signal interface with the FPGA:
+
+-  10 / 20 MHz clock input
+-  1 bit digital data stream output
+
+The reconstruction of the data provided by the AD7401 modulator can be done
+using a SINC3 filter. A filter model and HDL implementation are provided in the
+AD7401 datasheet. Typical filter output characteristics:
+
+-  Output code: 16 bit
+-  Sampling rate: 78kHz
+
+The output code resolution and sampling rate can be controlled by changing the
+filter’s model and decimation. Polyphase interpolation filters are utilized to
+increase the sampling rate of the system.
+
++---+
++---+
+
+Position & Speed Sensors FPGA Interface
+---------------------------------------
+
+**Single digital interface for multiple position sensors**
+
+-  Single Ended HALL
+-  Differential HALL
+-  BEMF
+-  Encoder
+
+**3 digital signals between HW and the FPGA**
+
+-  HALL A / BEMF A / Encoder Channel A
+-  HALL B / BEMF B / Encoder Channel B
+-  HALL C / BEMF C / Encoder Index
+
+Sensor selection is done with jumpers on the controller board. The hardware
+conditions the analog signals and sends clean digital signals to the FPGA.
+
++---+
++---+
+
+Downloads
+---------
+
+.. admonition:: Download
+   :class: download
+
+   **AD-FMCMOTCON1-EBZ**
+
+   
+   -  `Schematics <../resources/ad-fmcmotcon1-ebz_schematics.pdf>`_
+   -  `Bill of Materials <../resources/ad-fmcmotcon1-ebz_bom.pdf>`_
+   -  `Allegro Board File <../resources/ad-fmcmotcon1-ebz_layout.zip>`_ (This file is `compressed <http://www.7-zip.org/7z.html>`_). Get the `Allegro FREE Physical Viewer <https://www.cadence.com/en_US/home/tools/pcb-design-and-analysis/allegro-downloads-start.html>`_ (You need 16.5 or higher).
+   
+
+.. |Simplified Block Diagram| image:: ../images/controller_block_diagram_simplified.png
+   :width: 350
+.. |Detailed Block Diagram| image:: ../images/controller_block_diagram.png
+   :width: 500
+.. |AD-FMC-MOTCON1-EBZ Top| image:: ../images/ad-fmcmotcon1-ebz_top_parts.jpg
+   :width: 600
+.. |AD-FMC-MOTCON1-EBZ Bottom| image:: ../images/ad-fmcmotcon1-ebz_bottom_parts.jpg
+   :width: 600
+.. |image1| image:: ../images/ad7401_logo.png
+   :width: 100

--- a/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/hardware/controller_board.rst
+++ b/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/hardware/controller_board.rst
@@ -211,11 +211,11 @@ Downloads
 
    **AD-FMCMOTCON1-EBZ**
 
-   
+
    -  `Schematics <../resources/ad-fmcmotcon1-ebz_schematics.pdf>`_
    -  `Bill of Materials <../resources/ad-fmcmotcon1-ebz_bom.pdf>`_
    -  `Allegro Board File <../resources/ad-fmcmotcon1-ebz_layout.zip>`_ (This file is `compressed <http://www.7-zip.org/7z.html>`_). Get the `Allegro FREE Physical Viewer <https://www.cadence.com/en_US/home/tools/pcb-design-and-analysis/allegro-downloads-start.html>`_ (You need 16.5 or higher).
-   
+
 
 .. |Simplified Block Diagram| image:: ../images/controller_block_diagram_simplified.png
    :width: 350

--- a/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/hardware/dyno.rst
+++ b/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/hardware/dyno.rst
@@ -144,11 +144,11 @@ Downloads
 
    **AD-DYNO1-EBZ**
 
-   
+
    -  `Schematics <../resources/ad-dyno1-ebz_schematics.pdf>`_
    -  `Bill of Materials <../resources/ad-dyno1-ebz_bom.pdf>`_
    -  `Allegro Board File <../resources/ad-dyno1-ebz_layout.zip>`_ (This file is `compressed <http://www.7-zip.org/7z.html>`_). Get the `Allegro FREE Physical Viewer <https://www.cadence.com/en_US/home/tools/pcb-design-and-analysis/allegro-downloads-start.html>`_ (You need 16.5 or higher).
-   
+
 
 .. |Dyno menu| image:: ../images/dyno_menu.png
    :width: 500

--- a/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/hardware/dyno.rst
+++ b/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/hardware/dyno.rst
@@ -1,0 +1,154 @@
+Dynamometer Drive System
+========================
+
+.. warning::
+
+   Analog Devices uses six designations to inform our customers where a
+   semiconductor product is in its
+   :adi:`life cycle <en/support/customer-service-resources/sales/product-life-cycle-information.html>`.
+   From emerging innovations to products which have been in production for
+   twenty years, we understand that insight into life cycle status is important.
+   Device life cycles are tracked on their individual product pages on
+   `analog.com <https://www.analog.com/>`_, and should always be consulted
+   before making any design decisions.
+
+   This particular article/document/design has been retired or deprecated,
+   which means it is no longer maintained or actively updated, even though the
+   devices themselves may be Recommended for New Designs or in
+   Production. This page is here for historical/reference purposes only.
+
+.. image:: ../images/ad-dyno1-ebz.png
+   :alt: Dynamometer Drive System
+   :width: 400
+
+Features
+--------
+
+-  `Two BLDC motors connected in a dyno setup (BLY171S-24V-4000 and BLY171D-24V-4000) <http://www.anaheimautomation.com/products/brushless/brushless-motor-item.php?sID=143&pt=i&tID=96&cID=22>`_
+-  Electronically adjustable load – the load value is set using the onboard buttons + LCD
+-  Programmable step and ramp load changes
+-  Measurement and display of load motor phase currents
+-  Measurement and display of load motor speed
+-  External control using Analog Discovery
+
+Block Diagram
+-------------
+
+.. image:: ../images/dyno_diagram.png
+   :width: 800
+
++---+
++---+
+
+Key Parts
+---------
+
++------------------------------------------------+-----------------------------------------------------------------------+
+| Power                                          |                                                                       |
++================================================+=======================================================================+
+| :adi:`ADuM5000`                                | isoPower® integrated isolated dc-to-dc converter                      |
++------------------------------------------------+-----------------------------------------------------------------------+
+| :adi:`ADP3335`                                 | HIGH ACCURACY ULTRALOW QUIESCENT CURRENT, 500 mA, ANYCAP® LOW DROPOUT |
++------------------------------------------------+-----------------------------------------------------------------------+
+| Isolation                                      |                                                                       |
++------------------------------------------------+-----------------------------------------------------------------------+
+| :adi:`ADUM3223`                                | 3 KV RMS ISOLATED PRECISION HALF-BRIDGE DRIVER, 4 A OUTPUT            |
++------------------------------------------------+-----------------------------------------------------------------------+
+
++---+
++---+
+
+User Guide
+----------
+
+The system is equipped with an LCD which displays information about the state of the load such and together with the 3 push buttons placed below it can be used to display and configure different system parameters. The **+/-** buttons are used to navigate through the system's menu and to change different system parameters, while the **Enter** button is used to confirm parameter changes or to enter / exit the menu screens.
+
++--------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| Menu diagram | Menu description                                                                                                                                                                   |
++==============+====================================================================================================================================================================================+
+| |Dyno menu|  | Main menu is displayed at power up.                                                                                                                                                |
++--------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+|              | The measurement menu displays RMS phase currents and motor speed. The load can be adjusted by pressing the "+" or "-" buttons. In order to go back to the main menu press "Enter". |
++--------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+|              | Waveforms menu. Select ramp or step load.                                                                                                                                          |
+|              | In order to go back select "..." and press "Enter"                                                                                                                                 |
++--------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+|              | Step load menu. Select "Step" to start toggling the load.                                                                                                                          |
++--------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+|              | Press "+" or "-" to toggle between the preset step values.                                                                                                                         |
+|              | In order to go back press "Enter"                                                                                                                                                  |
++--------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+|              | Set maximum duty cycle.                                                                                                                                                            |
+|              | In order to go back press "Enter"                                                                                                                                                  |
++--------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+|              | Set minimum duty cycle.                                                                                                                                                            |
+|              | In order to go back press "Enter"                                                                                                                                                  |
++--------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+|              | Ramp load menu. Press "+" or "-" to change ramp period.                                                                                                                            |
+|              | In order to go back press "Enter"                                                                                                                                                  |
++--------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+|              | Settings menu.                                                                                                                                                                     |
+|              | In order to go back select "..." and press "Enter"                                                                                                                                 |
++--------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+|              | Change duty cycle step.                                                                                                                                                            |
++--------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+|              | About.                                                                                                                                                                             |
++--------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+
++---+
++---+
+
+Analog Discovery™
+-----------------
+
+In order interface the Dyno with the Analog Discovery™ USB Oscilloscope:
+
+-  Slide switch S2 to EXT_CTRL position
+-  Insert the Analog Discovery™ in P1 the connector(with the Analog Devices logo
+   facing the user)
+
+.. image:: ../images/dyno_discovery_control.jpg
+   :alt: Dynamometer Drive System
+   :width: 400
+
+Two software packages are available for interfacing with Analog Discovery™:
+
+-  `Digilent® WaveForms™ <http://www.digilentinc.com/Products/Detail.cfm?NavPath=2,66,849&Prod=WAVEFORMS>`_
+-  `MathWorks Analog Discovery toolbox <http://www.mathworks.co.uk/help/daq/examples/getting-started-acquiring-data-with-digilent-analog-discovery.html>`_
+
+The signals available to the Analog Discovery™ are:
+
+=========== ======================== ===============================
+Dyno Signal Analog Discovery channel Description
+=========== ======================== ===============================
+I_A         Scope Channel 1 Positive Phase A motor current (185mv/A)
+I_B         Scope Channel 2 Positive Phase B motor current (185mv/A)
+PWM1        Digital Channel 0        Phase A PWM (3.3V levels)
+PWM2        Digital Channel 2        Phase B PWM (3.3V levels)
+PWM3        Digital Channel 2        Phase C PWM (3.3V levels)
+=========== ======================== ===============================
+
++---+
++---+
+
+.. warning::
+
+   The system needs a 5V 500mA power supply. The power connector is a 2.1 X
+   5.5MM jack with the center pin positive(+)
+
+Downloads
+---------
+
+.. admonition:: Download
+   :class: download
+
+   **AD-DYNO1-EBZ**
+
+   
+   -  `Schematics <../resources/ad-dyno1-ebz_schematics.pdf>`_
+   -  `Bill of Materials <../resources/ad-dyno1-ebz_bom.pdf>`_
+   -  `Allegro Board File <../resources/ad-dyno1-ebz_layout.zip>`_ (This file is `compressed <http://www.7-zip.org/7z.html>`_). Get the `Allegro FREE Physical Viewer <https://www.cadence.com/en_US/home/tools/pcb-design-and-analysis/allegro-downloads-start.html>`_ (You need 16.5 or higher).
+   
+
+.. |Dyno menu| image:: ../images/dyno_menu.png
+   :width: 500

--- a/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/hardware/dyno_test.rst
+++ b/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/hardware/dyno_test.rst
@@ -1,0 +1,47 @@
+DYNO test procedure
+===================
+
+Required hardware
+-----------------
+
+-  ZedBoard with mouse and keyboard
+-  SD card with ADI Linux image
+-  HDMI monitor
+-  AD-FMCMOTCON1-EBZ
+-  AD-DYNO1-EBZ
+
+Test Procedure
+--------------
+
+-  Connect the hardware as shown in this video: `Hardware Connection <https://www.youtube.com/watch?v=eGYjnbYDiWg>`_
+
+-  In the Linux IIO scope go to the// Motor Control// tab and select the
+   following configuration:
+
+   -  **Delta**: ON
+   -  **Direction**: Clockwise
+   -  **Sensors**: hall
+   -  **Controller type**: Manual PWM
+   -  **PWM**: 90.96%
+
+-  Set **Run** to ON
+
+.. image:: ../images/s1.png
+   :alt: Motor Control Tab
+   :width: 400
+
+-  Make sure that there are no vibrations in the DYNO system.
+
+-  On the DYNO board open the *Measurements* menu
+-  Check the speed & current displayed under *Measurements* on the DYNO LCD to see if it reads 5300rpm +/- 250rpm for speed and 0.3A for current
+
+.. image:: ../images/s2.png
+   :alt: Motor Control Tab
+   :width: 200
+
+-  Set the load to 100%
+-  Check the speed & current displayed under *Measurements* on the DYNO LCD to see if it reads 3900rpm +/- 250rpm for speed and 1.5A +/- 0.1A for current
+
+.. image:: ../images/s3.png
+   :alt: Motor Control Tab
+   :width: 200

--- a/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/hardware/lv_board.rst
+++ b/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/hardware/lv_board.rst
@@ -174,11 +174,11 @@ Downloads
 
    **AD-DRVLV1-EBZ**
 
-   
+
    -  `Schematics <../resources/ad-drvlv1-ebz_schematics.pdf>`_
    -  `Bill of Materials <../resources/ad-drvlv1-ebz_bom.pdf>`_
    -  `Allegro Board File <../resources/ad-drvlv1-ebz_layout.zip>`_ (This file is `compressed <http://www.7-zip.org/7z.html>`_). Get the `Allegro FREE Physical Viewer <https://www.cadence.com/en_US/home/tools/pcb-design-and-analysis/allegro-downloads-start.html>`_ (You need 16.5 or higher).
-   
+
 
 .. |image1| image:: ../images/lv_block_diagram_simplified.png
    :width: 350

--- a/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/hardware/lv_board.rst
+++ b/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/hardware/lv_board.rst
@@ -1,0 +1,190 @@
+Low Voltage Drive Board
+=======================
+
+.. warning::
+
+   Analog Devices uses six designations to inform our customers where a
+   semiconductor product is in its
+   :adi:`life cycle <en/support/customer-service-resources/sales/product-life-cycle-information.html>`.
+   From emerging innovations to products which have been in production for
+   twenty years, we understand that insight into life cycle status is important.
+   Device life cycles are tracked on their individual product pages on
+   `analog.com <https://www.analog.com/>`_, and should always be consulted
+   before making any design decisions.
+
+   This particular article/document/design has been retired or deprecated,
+   which means it is no longer maintained or actively updated, even though the
+   devices themselves may be Recommended for New Designs or in
+   Production. This page is here for historical/reference purposes only.
+
+Features and Block Diagram
+--------------------------
+
+-  Drives BLDC / PMSM / Brushed DC / Stepper motors
+-  Drives motors up to 48V at 18A
+-  Integrated over current protection
+-  Current measurement using isolated ADCs
+-  Bus voltage, phase currents and total current analog feedback signals
+-  PGAs to maximize the current measurement input range
+-  BEMF zero cross detection for sensorless control of PMSM or BLDC motors
+
+============================ ==========================
+**Simplified Block Diagram** **Detailed Block Diagram**
+============================ ==========================
+============================ ==========================
+
+|image1| |image2|
+
++---+
++---+
+
+Picture and Main Components
+---------------------------
+
+|AD-DRVLV1-EBZ Top| |AD-DRVLV1-EBZ Bottom|
+
++---+
++---+
+
+Key Parts
+---------
+
++------------------------------------------------+--------------------------------------------------------------------+
+| Measurement                                    |                                                                    |
++================================================+====================================================================+
+| :adi:`AD7401A`                                 | 5 kV rms, isolated 2nd order Sigma-Delta modulator                 |
++------------------------------------------------+--------------------------------------------------------------------+
+| :adi:`AD8207`                                  | Zero drift, high voltage, bidirectional difference amplifier       |
++------------------------------------------------+--------------------------------------------------------------------+
+| :adi:`AD8251`                                  | 24 MHz rail-to-rail dual op amp                                    |
++------------------------------------------------+--------------------------------------------------------------------+
+| :adi:`AD8630`                                  | Zero drift, single-supply, rail-to-rail quad op amp                |
++------------------------------------------------+--------------------------------------------------------------------+
+| Power                                          |                                                                    |
++------------------------------------------------+--------------------------------------------------------------------+
+| :adi:`ADuM5000`                                | isoPower® integrated isolated dc-to-dc converter                   |
++------------------------------------------------+--------------------------------------------------------------------+
+| :adi:`ADP1621`                                 | Constant-frequency, current-mode step-up dc/dc controller          |
++------------------------------------------------+--------------------------------------------------------------------+
+| :adi:`ADP2301`                                 | 1.2 A, 20 V, 1.4 MHz non-synchronous step-down switching regulator |
++------------------------------------------------+--------------------------------------------------------------------+
+| :adi:`ADP7102`                                 | 20 V, 300 mA, low noise, CMOS LDO                                  |
++------------------------------------------------+--------------------------------------------------------------------+
+| MOSFET Drivers                                 |                                                                    |
++------------------------------------------------+--------------------------------------------------------------------+
+| :adi:`ADuM5230`                                | Isolated half-bridge driver with integrated high-side supply       |
++------------------------------------------------+--------------------------------------------------------------------+
+| **IRS2336DSTRPBF**                             | High voltage 3 phase gate driver IC                                |
++------------------------------------------------+--------------------------------------------------------------------+
+
++---+
++---+
+
+Connectors
+----------
+
+.. image:: ../images/lv_connectors.jpg
+   :alt: AD-FMC-MOTCON1-EBZ Connectors
+   :width: 400
+
+Power connector
+~~~~~~~~~~~~~~~
+
+-  The connector P4 is used to supply 12...48 VDC to the drive board
+-  The polarity is indicated in the picture above
+
+BLDC / Stepper motor connector
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+-  For BLDC motors use connector P1 (Phase 1, 2 and 3)
+-  For Stepper motors use connector P1 and pin 3 of P5 (Phase 1, 2, 3 and 4)
+
++---+
++---+
+
+Switches
+--------
+
+.. image:: ../images/lv_buttons.jpg
+   :alt: AD-FMC-MOTCON1-EBZ Buttons
+   :width: 600
+
+Emergency Stop Switch
+~~~~~~~~~~~~~~~~~~~~~
+
+-  S2 is a latching emergency stop switch.
+-  If triggered the supply for the power stage is turned off.
+-  Led DS3 indicates the state of the power stage.
+
+Reset switch
+~~~~~~~~~~~~
+
+-  S1 is a reset switch for the emergency stop latch.
+-  By pressing S1 when S2 is off the power stage is turned on.
+
++---+
++---+
+
+LEDs
+----
+
+=== ================
+LED Description
+=== ================
+DS1 Vadj Power Good
+DS2 12V Power Good
+DS3 Over Current
+DS4 Motor Fault
+DS5 PWM Enable
+DS6 Motor Power Good
+=== ================
+
++---+
++---+
+
+Power Map
+---------
+
+.. image:: ../images/lv_power_map.png
+   :width: 400
+
++---+
++---+
+
+Motor Driver Interface
+----------------------
+
+The IRS2336D Three Phase Gate Driver IC has the following interface signals
+features:
+
+-  3 pairs of complementary PWM signals with inverted logic
+-  PWM frequency up to 150 kHz
+-  Hardware integrated dead-time protection
+-  Enable signal to start / stop the driver
+-  Fault signal from the driver
+
++---+
++---+
+
+Downloads
+---------
+
+.. admonition:: Download
+   :class: download
+
+   **AD-DRVLV1-EBZ**
+
+   
+   -  `Schematics <../resources/ad-drvlv1-ebz_schematics.pdf>`_
+   -  `Bill of Materials <../resources/ad-drvlv1-ebz_bom.pdf>`_
+   -  `Allegro Board File <../resources/ad-drvlv1-ebz_layout.zip>`_ (This file is `compressed <http://www.7-zip.org/7z.html>`_). Get the `Allegro FREE Physical Viewer <https://www.cadence.com/en_US/home/tools/pcb-design-and-analysis/allegro-downloads-start.html>`_ (You need 16.5 or higher).
+   
+
+.. |image1| image:: ../images/lv_block_diagram_simplified.png
+   :width: 350
+.. |image2| image:: ../images/lv_block_diagram.png
+   :width: 500
+.. |AD-DRVLV1-EBZ Top| image:: ../images/ad-drvlv1-ebz_top_parts.jpg
+   :width: 600
+.. |AD-DRVLV1-EBZ Bottom| image:: ../images/ad-drvlv1-ebz_bottom_parts.jpg
+   :width: 600

--- a/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/hardware/signal_chain.rst
+++ b/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/hardware/signal_chain.rst
@@ -1,0 +1,145 @@
+AD-FMCMOTCON1-EBZ Signal Measurement Chain
+==========================================
+
+.. warning::
+
+   Analog Devices uses six designations to inform our customers where a
+   semiconductor product is in its
+   :adi:`life cycle <en/support/customer-service-resources/sales/product-life-cycle-information.html>`.
+   From emerging innovations to products which have been in production for
+   twenty years, we understand that insight into life cycle status is important.
+   Device life cycles are tracked on their individual product pages on
+   `analog.com <https://www.analog.com/>`_, and should always be consulted
+   before making any design decisions.
+
+   This particular article/document/design has been retired or deprecated,
+   which means it is no longer maintained or actively updated, even though the
+   devices themselves may be Recommended for New Designs or in
+   Production. This page is here for historical/reference purposes only.
+
+The motor control system allows the measurement of the Ia(phase A current),
+Ib(phase B current) and It(total current) as well as the measurement of Vbus
+using signal chains which involve components from both the controller and low
+voltage driver boards.
+
+Ia, Ib Measurement Signal Chain
+-------------------------------
+
+The Ia and Ib currents are sensed using 6mΩ shunt resistors. There are two
+possible measurement paths showing measurement techniques for the case where the
+ADC can be placed close to the shunt resistor and for the case where the ADC
+cannot be placed in the proximity of the shunt resistor. Both techniques aim to
+get the best measurement accuracy.
+
+**Case 1: The ADC is placed in the proximity of the shunt resistor**
+
+-  The signal path between the shunt resistor and the ADC is very short and less prone to noise coupling.
+-  The small differential voltage on the shunt resistor is measured directly with the :adi:`AD7401` isolated ΣΔ modulator without the need of extra interfacing and signal conditioning circuitry
+-  The digital data and clock signals of the ADC travel the entire length of the drive and controller boards all the way to the FPGA. Since the analog signals were digitized close to the source and sent in a digital format to the FPGA there are no concerns related to the quality of the measurements.
+-  The formula for calculating Ia or Ib is:
+
+:math:`I = (counts - 32768) \times ADCrange / 2^{ADCbits-1} \times RS` where $delimlbracematrix{4}{1}\ |counts = ADC value } {RS = 6e-3} {ADCrange = 320e-3 } {ADCbits = 16| $
+
+**Case 2: The ADC is not placed in the proximity of the shunt resistor**
+
+-  The signal path between the shunt resistor and the ADC is long and very prone to noise coupling, especially due to the switching noise of the power stage that's driving the motor and to the motor itself. Special care must be taken in properly designing the signal conditioning circuitry that sits between the ADC and the shunt resistor and in properly shielding the analog signals on the way to the ADC.
+-  The small differential voltage on the shunt resistor is amplified on the drive board with the :adi:`AD8207` difference amplifier placed close to the shunt resistor in order to avoid noise coupling. The signal is amplified from the 0..250mV input range to 0..5V to minimize the effect of the coupled noise.
+-  The amplified signal goes on the drive board through another programmable amplification stage realized using the :adi:`AD8251` PGA. This ensures that the ADC will always receive at input signals properly scaled to fit its input range.
+-  The amplified analog signals go through the connector to the controller board. The connector has proper shielding for each analog signal to mitigate noise coupling.
+-  On the controller board the analog signals coming from the drive board are transferred from the +/-2.5V input range to a +/-250mV range suited for the :adi:`AD7401` ΣΔ modulator. The attenuation is done using the :adi:`ADA4084-2` amplifier.
+-  The formula for calculating Ia or Ib is:
+
+:math:`I = (counts-32768) \times ADCrange/2^{ADCbits-1} \times CTRLgain / (RS \times DRVgain \times PGAgain)` where $\\displaystyle delimlbracematrix{7}{1}\ |counts = ADC value } {RS = 6e-3} {ADCrange = 320e-3} {ADCbits = 16} \\frac{CTRLgain = 1}{10}{DRVgain = 20}{PGAgain = 1, 2, 4 or 8| $
+
+.. image:: ../images/current_chain.png
+   :width: 800
+
++---+
++---+
+
+Ia, Ib XADC Measurement Signal Chain
+------------------------------------
+
+The Ia and Ib XADC measurement chain utilizes the entire path of the regular measurement chain and adds on the controller board after the :adi:`AD7401` isolated ΣΔ modulator a Sallen Key analog reconstruction filter implemented using :adi:`AD8646` operational amplifiers. The combination between the isolated ΣΔ modulator and the analog reconstruction filter provides a convenient and cheap way to achieve analog isolation of the XADC input signals. This analog isolation technique is described in this `paper <http://www.analog.com/static/imported-files/newsletters/digital_isolation/Using_the_AD7400A_as_an_Isolated_Amplifier.pdf>`_.
+
+.. image:: ../images/current_chain_xadc.png
+   :width: 800
+
++---+
++---+
+
+It Measurement Signal Chain
+---------------------------
+
+The It current is sensed using a 5mΩ shunt resistor. There are two possible
+measurement paths showing measurement techniques for the case where the ADC can
+be placed close to the shunt resistor and for the case where the ADC cannot be
+placed in the proximity of the shunt resistor. Both techniques aim to get the
+best measurement accuracy.
+
+**Case 1: The ADC is placed in the proximity of the shunt resistor**
+
+-  The signal path between the shunt resistor and the ADC is very short and less prone to noise coupling.
+-  The small differential voltage on the shunt resistor is measured directly with the :adi:`AD7401` isolated ΣΔ modulator without the need of extra interfacing and signal conditioning circuitry
+-  The formula for calculating It is:
+
+:math:`I = (32768-counts) \times ADCrange / 2^{ADCbits-1} \times RS` where $delimlbracematrix{4}{1}\ |counts = ADC value } {RS = 5e-3} {ADCrange = 320e-3 } {ADCbits = 16| $
+
+**Case 2: The ADC is not placed in the proximity of the shunt resistor**
+
+-  The small differential voltage on the shunt resistor is amplified on the drive board with the :adi:`AD8630` difference amplifier placed close to the shunt resistor in order to avoid noise coupling. The signal is amplified to 0..5V to minimize the effect of the coupled noise.
+-  The amplified signal goes on the drive board through another programmable amplification stage realized using the :adi:`AD8251` PGA. This ensures that the ADC will always receive at input signals properly scaled to fit its input range.
+-  The amplified analog signals go through the connector to the controller board. The connector has proper shielding for each analog signal to mitigate noise coupling.
+-  On the controller board the analog signals coming from the drive board are transferred from the 0..5V input range to a 0..250mV range suited for the :adi:`AD7401` ΣΔ modulator. The attenuation is done using the :adi:`ADA4084-2` amplifier.
+-  The formula for calculating It is:
+
+:math:`I = (32768-counts) \times ADCrange/2^{ADCbits-1} \times CTRLgain / (RS \times DRVgain \times PGAgain)` where $\\displaystyle delimlbracematrix{7}{1}\ |counts = ADC value } {RS = 5e-3} {ADCrange = 320e-3} {ADCbits = 16} \\frac{CTRLgain = 1}{10}{DRVgain = 20}{PGAgain = 1, 2, 4 or 8| $
+
+.. image:: ../images/current_chain_it.png
+   :width: 800
+
++---+
++---+
+
+It XADC Measurement Signal Chain
+--------------------------------
+
+The It XADC measurement chain utilizes the entire path of the regular measurement chain and adds on the controller board after the :adi:`AD7401` isolated ΣΔ modulator a Sallen Key analog reconstruction filter implemented using :adi:`AD8646` operational amplifiers. The combination between the isolated ΣΔ modulator and the analog reconstruction filter provides a convenient and cheap way to achieve analog isolation of the XADC input signals. This analog isolation technique is described in this `paper <http://www.analog.com/static/imported-files/newsletters/digital_isolation/Using_the_AD7400A_as_an_Isolated_Amplifier.pdf>`_.
+
+.. image:: ../images/current_chain_it_xadc.png
+   :width: 800
+
++---+
++---+
+
+Vbus Measurement Signal Chain
+-----------------------------
+
+Vbus sensing is done on the drive board using a resistive divider and an attenuation circuit implemented with the :adi:`AD8207` operational amplifier. The total gain of this stage is 0.83 giving an output range of 0..5V. The analog signals go through the connector to the controller board. On the controller board the analog signals coming from the drive board are transferred from the 0..5V input range to a 0..250mV range suited for the :adi:`AD7401` ΣΔ modulator. The attenuation is done using the :adi:`ADA4084-2` amplifier.
+
+-  The formula for calculating Vbus is:
+
+:math:`V = (32768-counts) \times ADCrange / 2^{ADCbits-1} \times DRVgain \times CTRLgain` where :math:`\displaystyle delimlbracematrix{5}{1}{{counts = ADC value } {ADCrange = 320e-3 } {ADCbits = 16 } \frac{DRVgain=5}{60} \frac{CTRLgain=1}{10 }}{ }`
+
+|image1|
+
++---+
++---+
+
+Vbus XADC Measurement Signal Chain
+----------------------------------
+
+The Vbus XADC measurement chain utilizes the entire path of the regular measurement chain and adds on the controller board after the :adi:`AD7401` isolated ΣΔ modulator a Sallen Key analog reconstruction filter implemented using :adi:`AD8646` operational amplifiers. The combination between the isolated ΣΔ modulator and the analog reconstruction filter provides a convenient and cheap way to achieve analog isolation of the XADC input signals. This analog isolation technique is described in this `paper <http://www.analog.com/static/imported-files/newsletters/digital_isolation/Using_the_AD7400A_as_an_Isolated_Amplifier.pdf>`_.
+
+.. image:: ../images/vbus_chain_xadc.png
+   :width: 800
+
++---+
++---+
+
+.. |counts = ADC value } {RS = 6e-3} {ADCrange = 320e-3 } {ADCbits = 16| image:: https://wiki.analog.com/_media/resources/eval/user-guides/ad-fmcmotcon1-ebz/hardware/counts_=_adc_value_}_{rs_=_6e-3}_{adcrange_=_320e-3_}_{adcbits_=_16
+.. |counts = ADC value } {RS = 6e-3} {ADCrange = 320e-3} {ADCbits = 16} \\frac{CTRLgain = 1}{10}{DRVgain = 20}{PGAgain = 1, 2, 4 or 8| image:: https://wiki.analog.com/_media/resources/eval/user-guides/ad-fmcmotcon1-ebz/hardware/counts_=_adc_value_}_{rs_=_6e-3}_{adcrange_=_320e-3}_{adcbits_=_16}_\frac{ctrlgain_=_1}{10}{drvgain_=_20}{pgagain_=_1,_2,_4_or_8
+.. |counts = ADC value } {RS = 5e-3} {ADCrange = 320e-3 } {ADCbits = 16| image:: https://wiki.analog.com/_media/resources/eval/user-guides/ad-fmcmotcon1-ebz/hardware/counts_=_adc_value_}_{rs_=_5e-3}_{adcrange_=_320e-3_}_{adcbits_=_16
+.. |counts = ADC value } {RS = 5e-3} {ADCrange = 320e-3} {ADCbits = 16} \\frac{CTRLgain = 1}{10}{DRVgain = 20}{PGAgain = 1, 2, 4 or 8| image:: https://wiki.analog.com/_media/resources/eval/user-guides/ad-fmcmotcon1-ebz/hardware/counts_=_adc_value_}_{rs_=_5e-3}_{adcrange_=_320e-3}_{adcbits_=_16}_\frac{ctrlgain_=_1}{10}{drvgain_=_20}{pgagain_=_1,_2,_4_or_8
+.. |image1| image:: ../images/vbus_chain.png
+   :width: 800

--- a/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/hardware/signal_chain.rst
+++ b/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/hardware/signal_chain.rst
@@ -38,7 +38,7 @@ get the best measurement accuracy.
 -  The digital data and clock signals of the ADC travel the entire length of the drive and controller boards all the way to the FPGA. Since the analog signals were digitized close to the source and sent in a digital format to the FPGA there are no concerns related to the quality of the measurements.
 -  The formula for calculating Ia or Ib is:
 
-:math:`I = (counts - 32768) \times ADCrange / 2^{ADCbits-1} \times RS` where $delimlbracematrix{4}{1}\ |counts = ADC value } {RS = 6e-3} {ADCrange = 320e-3 } {ADCbits = 16| $
+:math:`I = (counts - 32768) \times ADCrange / 2^{ADCbits-1} \times RS` where $delimlbracematrix{4}{1}\  $
 
 **Case 2: The ADC is not placed in the proximity of the shunt resistor**
 
@@ -49,7 +49,7 @@ get the best measurement accuracy.
 -  On the controller board the analog signals coming from the drive board are transferred from the +/-2.5V input range to a +/-250mV range suited for the :adi:`AD7401` ΣΔ modulator. The attenuation is done using the :adi:`ADA4084-2` amplifier.
 -  The formula for calculating Ia or Ib is:
 
-:math:`I = (counts-32768) \times ADCrange/2^{ADCbits-1} \times CTRLgain / (RS \times DRVgain \times PGAgain)` where $\\displaystyle delimlbracematrix{7}{1}\ |counts = ADC value } {RS = 6e-3} {ADCrange = 320e-3} {ADCbits = 16} \\frac{CTRLgain = 1}{10}{DRVgain = 20}{PGAgain = 1, 2, 4 or 8| $
+:math:`I = (counts-32768) \times ADCrange/2^{ADCbits-1} \times CTRLgain / (RS \times DRVgain \times PGAgain)` where $\\displaystyle delimlbracematrix{7}{1}\  $
 
 .. image:: ../images/current_chain.png
    :width: 800
@@ -83,7 +83,7 @@ best measurement accuracy.
 -  The small differential voltage on the shunt resistor is measured directly with the :adi:`AD7401` isolated ΣΔ modulator without the need of extra interfacing and signal conditioning circuitry
 -  The formula for calculating It is:
 
-:math:`I = (32768-counts) \times ADCrange / 2^{ADCbits-1} \times RS` where $delimlbracematrix{4}{1}\ |counts = ADC value } {RS = 5e-3} {ADCrange = 320e-3 } {ADCbits = 16| $
+:math:`I = (32768-counts) \times ADCrange / 2^{ADCbits-1} \times RS` where $delimlbracematrix{4}{1}\  $
 
 **Case 2: The ADC is not placed in the proximity of the shunt resistor**
 
@@ -93,7 +93,7 @@ best measurement accuracy.
 -  On the controller board the analog signals coming from the drive board are transferred from the 0..5V input range to a 0..250mV range suited for the :adi:`AD7401` ΣΔ modulator. The attenuation is done using the :adi:`ADA4084-2` amplifier.
 -  The formula for calculating It is:
 
-:math:`I = (32768-counts) \times ADCrange/2^{ADCbits-1} \times CTRLgain / (RS \times DRVgain \times PGAgain)` where $\\displaystyle delimlbracematrix{7}{1}\ |counts = ADC value } {RS = 5e-3} {ADCrange = 320e-3} {ADCbits = 16} \\frac{CTRLgain = 1}{10}{DRVgain = 20}{PGAgain = 1, 2, 4 or 8| $
+:math:`I = (32768-counts) \times ADCrange/2^{ADCbits-1} \times CTRLgain / (RS \times DRVgain \times PGAgain)` where $\\displaystyle delimlbracematrix{7}{1}\  $
 
 .. image:: ../images/current_chain_it.png
    :width: 800
@@ -137,9 +137,9 @@ The Vbus XADC measurement chain utilizes the entire path of the regular measurem
 +---+
 +---+
 
-.. |counts = ADC value } {RS = 6e-3} {ADCrange = 320e-3 } {ADCbits = 16| image:: https://wiki.analog.com/_media/resources/eval/user-guides/ad-fmcmotcon1-ebz/hardware/counts_=_adc_value_}_{rs_=_6e-3}_{adcrange_=_320e-3_}_{adcbits_=_16
-.. |counts = ADC value } {RS = 6e-3} {ADCrange = 320e-3} {ADCbits = 16} \\frac{CTRLgain = 1}{10}{DRVgain = 20}{PGAgain = 1, 2, 4 or 8| image:: https://wiki.analog.com/_media/resources/eval/user-guides/ad-fmcmotcon1-ebz/hardware/counts_=_adc_value_}_{rs_=_6e-3}_{adcrange_=_320e-3}_{adcbits_=_16}_\frac{ctrlgain_=_1}{10}{drvgain_=_20}{pgagain_=_1,_2,_4_or_8
-.. |counts = ADC value } {RS = 5e-3} {ADCrange = 320e-3 } {ADCbits = 16| image:: https://wiki.analog.com/_media/resources/eval/user-guides/ad-fmcmotcon1-ebz/hardware/counts_=_adc_value_}_{rs_=_5e-3}_{adcrange_=_320e-3_}_{adcbits_=_16
-.. |counts = ADC value } {RS = 5e-3} {ADCrange = 320e-3} {ADCbits = 16} \\frac{CTRLgain = 1}{10}{DRVgain = 20}{PGAgain = 1, 2, 4 or 8| image:: https://wiki.analog.com/_media/resources/eval/user-guides/ad-fmcmotcon1-ebz/hardware/counts_=_adc_value_}_{rs_=_5e-3}_{adcrange_=_320e-3}_{adcbits_=_16}_\frac{ctrlgain_=_1}{10}{drvgain_=_20}{pgagain_=_1,_2,_4_or_8
+..  image:: https://wiki.analog.com/_media/resources/eval/user-guides/ad-fmcmotcon1-ebz/hardware/counts_=_adc_value_}_{rs_=_6e-3}_{adcrange_=_320e-3_}_{adcbits_=_16
+..  image:: https://wiki.analog.com/_media/resources/eval/user-guides/ad-fmcmotcon1-ebz/hardware/counts_=_adc_value_}_{rs_=_6e-3}_{adcrange_=_320e-3}_{adcbits_=_16}_\frac{ctrlgain_=_1}{10}{drvgain_=_20}{pgagain_=_1,_2,_4_or_8
+..  image:: https://wiki.analog.com/_media/resources/eval/user-guides/ad-fmcmotcon1-ebz/hardware/counts_=_adc_value_}_{rs_=_5e-3}_{adcrange_=_320e-3_}_{adcbits_=_16
+..  image:: https://wiki.analog.com/_media/resources/eval/user-guides/ad-fmcmotcon1-ebz/hardware/counts_=_adc_value_}_{rs_=_5e-3}_{adcrange_=_320e-3}_{adcbits_=_16}_\frac{ctrlgain_=_1}{10}{drvgain_=_20}{pgagain_=_1,_2,_4_or_8
 .. |image1| image:: ../images/vbus_chain.png
    :width: 800

--- a/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/hardware/signal_chain.rst
+++ b/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/hardware/signal_chain.rst
@@ -38,7 +38,7 @@ get the best measurement accuracy.
 -  The digital data and clock signals of the ADC travel the entire length of the drive and controller boards all the way to the FPGA. Since the analog signals were digitized close to the source and sent in a digital format to the FPGA there are no concerns related to the quality of the measurements.
 -  The formula for calculating Ia or Ib is:
 
-:math:`I = (counts - 32768) \times ADCrange / 2^{ADCbits-1} \times RS` where $delimlbracematrix{4}{1}\  $
+:math:`I = (counts - 32768) \times ADCrange / 2^{ADCbits-1} \times RS` where :math:`counts = ADC\,value,\; RS = 6e{-3},\; ADCrange = 320e{-3},\; ADCbits = 16`
 
 **Case 2: The ADC is not placed in the proximity of the shunt resistor**
 
@@ -83,7 +83,7 @@ best measurement accuracy.
 -  The small differential voltage on the shunt resistor is measured directly with the :adi:`AD7401` isolated ΣΔ modulator without the need of extra interfacing and signal conditioning circuitry
 -  The formula for calculating It is:
 
-:math:`I = (32768-counts) \times ADCrange / 2^{ADCbits-1} \times RS` where $delimlbracematrix{4}{1}\  $
+:math:`I = (32768-counts) \times ADCrange / 2^{ADCbits-1} \times RS` where :math:`counts = ADC\,value,\; RS = 6e{-3},\; ADCrange = 320e{-3},\; ADCbits = 16`
 
 **Case 2: The ADC is not placed in the proximity of the shunt resistor**
 
@@ -93,7 +93,7 @@ best measurement accuracy.
 -  On the controller board the analog signals coming from the drive board are transferred from the 0..5V input range to a 0..250mV range suited for the :adi:`AD7401` ΣΔ modulator. The attenuation is done using the :adi:`ADA4084-2` amplifier.
 -  The formula for calculating It is:
 
-:math:`I = (32768-counts) \times ADCrange/2^{ADCbits-1} \times CTRLgain / (RS \times DRVgain \times PGAgain)` where $\\displaystyle delimlbracematrix{7}{1}\  $
+:math:`I = (32768-counts) \times ADCrange/2^{ADCbits-1} \times CTRLgain / (RS \times DRVgain \times PGAgain)` where :math:`counts = ADC\,value,\; RS = 6e{-3},\; ADCrange = 320e{-3},\; ADCbits = 16,\; CTRLgain = \frac{1}{10},\; DRVgain = 20,\; PGAgain = 1{,}2{,}4\,or\,8`
 
 .. image:: ../images/current_chain_it.png
    :width: 800
@@ -137,9 +137,12 @@ The Vbus XADC measurement chain utilizes the entire path of the regular measurem
 +---+
 +---+
 
-..  image:: https://wiki.analog.com/_media/resources/eval/user-guides/ad-fmcmotcon1-ebz/hardware/counts_=_adc_value_}_{rs_=_6e-3}_{adcrange_=_320e-3_}_{adcbits_=_16
-..  image:: https://wiki.analog.com/_media/resources/eval/user-guides/ad-fmcmotcon1-ebz/hardware/counts_=_adc_value_}_{rs_=_6e-3}_{adcrange_=_320e-3}_{adcbits_=_16}_\frac{ctrlgain_=_1}{10}{drvgain_=_20}{pgagain_=_1,_2,_4_or_8
-..  image:: https://wiki.analog.com/_media/resources/eval/user-guides/ad-fmcmotcon1-ebz/hardware/counts_=_adc_value_}_{rs_=_5e-3}_{adcrange_=_320e-3_}_{adcbits_=_16
-..  image:: https://wiki.analog.com/_media/resources/eval/user-guides/ad-fmcmotcon1-ebz/hardware/counts_=_adc_value_}_{rs_=_5e-3}_{adcrange_=_320e-3}_{adcbits_=_16}_\frac{ctrlgain_=_1}{10}{drvgain_=_20}{pgagain_=_1,_2,_4_or_8
+**For RS = 6mΩ:**
+
+:math:`counts = ADC\,value,\; RS = 6e{-3},\; ADCrange = 320e{-3},\; ADCbits = 16,\; CTRLgain = \frac{1}{10},\; DRVgain = 20,\; PGAgain = 1{,}2{,}4\,or\,8`
+
+**For RS = 5mΩ:**
+
+:math:`counts = ADC\,value,\; RS = 5e{-3},\; ADCrange = 320e{-3},\; ADCbits = 16,\; CTRLgain = \frac{1}{10},\; DRVgain = 20,\; PGAgain = 1{,}2{,}4\,or\,8`
 .. |image1| image:: ../images/vbus_chain.png
    :width: 800

--- a/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/hardware/signal_chain.rst
+++ b/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/hardware/signal_chain.rst
@@ -144,5 +144,6 @@ The Vbus XADC measurement chain utilizes the entire path of the regular measurem
 **For RS = 5mΩ:**
 
 :math:`counts = ADC\,value,\; RS = 5e{-3},\; ADCrange = 320e{-3},\; ADCbits = 16,\; CTRLgain = \frac{1}{10},\; DRVgain = 20,\; PGAgain = 1{,}2{,}4\,or\,8`
+
 .. |image1| image:: ../images/vbus_chain.png
    :width: 800

--- a/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/help_and_support.rst
+++ b/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/help_and_support.rst
@@ -1,0 +1,43 @@
+Help and Support
+================
+
+.. warning::
+
+   Analog Devices uses six designations to inform our customers where a
+   semiconductor product is in its
+   :adi:`life cycle <en/support/customer-service-resources/sales/product-life-cycle-information.html>`.
+   From emerging innovations to products which have been in production for
+   twenty years, we understand that insight into life cycle status is important.
+   Device life cycles are tracked on their individual product pages on
+   `analog.com <https://www.analog.com/>`_, and should always be consulted
+   before making any design decisions.
+
+   This particular article/document/design has been retired or deprecated,
+   which means it is no longer maintained or actively updated, even though the
+   devices themselves may be Recommended for New Designs or in
+   Production. This page is here for historical/reference purposes only.
+
+If you have any questions regarding the ADI motor drive solutions or are experiencing any problems while using the boards or while following any of the user guides feel free to ask us a question. Questions can be asked on our `EngineerZone support community <https://ez.analog.com/>`_.
+
+For questions regarding the hardware or the HDL reference design please state them in the :ez:`FPGA Reference Designs <community/fpga>` sub-community. For questions regarding the Linux drivers for any of the components on the motor control boards please use the :ez:`Linux Software Drivers <community/linux-device-drivers/linux-software-drivers>` sub-community.
+
+When asking a question please take the time to give a detailed description of
+your problem. Always include on which platform you are currently using the
+AD-FMCMOTCON1-EBZ. If you are experiencing a problem please state the steps you
+have executed, the result you expected you would get and the result you actually
+got. By doing so you enable us to provide you precise and detailed answers in a
+timely manner.
+
+Before asking questions please also take the time to check if somebody else
+already asked the same question and already got an answer.
+
+For more information also check:
+
+-  `VITA's FMC info <http://www.vita.com/fmc>`_
+
+Where to Buy
+------------
+
+.. container:: round box
+
+   `ZYNQ Intelligent Drives Kit <http://www.em.avnet.com/en-us/design/drc/Pages/Zynq-Intelligent-Drives-Kit.aspx>`_

--- a/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/ad-drvlv1-ebz_bottom_parts.jpg
+++ b/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/ad-drvlv1-ebz_bottom_parts.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0924bf66c00c23876c708ba038a38cb9381b42cb42a732e1707939c3801348f3
+size 1555862

--- a/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/ad-drvlv1-ebz_top.jpg
+++ b/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/ad-drvlv1-ebz_top.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d79100d76fdafd79bde6df930a3f5416e68dc1da122898595b9e56859913d2f1
+size 1110821

--- a/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/ad-drvlv1-ebz_top_parts.jpg
+++ b/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/ad-drvlv1-ebz_top_parts.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:afebdbce2a1bda806366ac62d32d00866604d36501ffa638211cafa0dbc85d81
+size 1526224

--- a/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/ad-dyno1-ebz.png
+++ b/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/ad-dyno1-ebz.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:672d1dfa8cb827ed746587cc704a02c99694b1f670b80fbe7f28f05b3dd47074
+size 620903

--- a/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/ad-fmcmotcon1-ebz_bottom_parts.jpg
+++ b/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/ad-fmcmotcon1-ebz_bottom_parts.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:43a2a0d1d920fbb87c41a5273435f910b184dba89ac2ebaa9e412fc7b484b0cd
+size 1742403

--- a/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/ad-fmcmotcon1-ebz_top.jpg
+++ b/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/ad-fmcmotcon1-ebz_top.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a6a041dcbc6b9dc64305268d33071cb35457cf188fc03dd055193b65373693f7
+size 1461484

--- a/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/ad-fmcmotcon1-ebz_top_parts.jpg
+++ b/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/ad-fmcmotcon1-ebz_top_parts.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f6201592a66797d93597e8ea8d840ffd89dc06ce2f7b332624b5551cb650332b
+size 1859052

--- a/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/ad7401_logo.png
+++ b/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/ad7401_logo.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:78e1149eb9366ce501573829ee1f6bb2d57b8ca2c65f6583e31bc33017ca21c6
+size 92528

--- a/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/bldc_delta.png
+++ b/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/bldc_delta.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:811e1e830527d79696a92aea30970d7963b533714d1bd2382d2eac4365611215
+size 26625

--- a/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/bldc_delta_switching.png
+++ b/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/bldc_delta_switching.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b0d5c4e94446d355a937af2cc1ca03d7d34d8cb69c1fa731c17c314b01b988eb
+size 44080

--- a/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/bldc_star.png
+++ b/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/bldc_star.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e4dce191e6aafe0e9fe97828d561c0e60b7304b161e5fdc57f07fc5f318b6759
+size 26440

--- a/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/bldc_star_switching.png
+++ b/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/bldc_star_switching.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5957ae12447e9fc1b95c613ccfcb7d944a120d5ec09a2bbcd92243a33dd6e454
+size 44919

--- a/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/chipscope.png
+++ b/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/chipscope.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f079bc62f846067969e016bae694f6350a882fc09d1a82ac9670ae3599c36398
+size 189109

--- a/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/controller_block_diagram.png
+++ b/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/controller_block_diagram.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:39fe0e447dac1266ed548df59f3e8358012c7bcceae266f56b2b86cbca9e0488
+size 281637

--- a/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/controller_block_diagram_simplified.png
+++ b/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/controller_block_diagram_simplified.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bd7a21b515fedde3a23a6f805d16056ff69b0f9cf5fb49d036461653eda54a5d
+size 165100

--- a/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/controller_jumpers.jpg
+++ b/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/controller_jumpers.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:596e696a0194e868302e759809f01f1738b292935a40a765a0a7ae4ab5cf0814
+size 982112

--- a/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/controller_power_map.png
+++ b/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/controller_power_map.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1a9616e8579b0217e4d376b1bd8bab680e3b5499650f57aa7a65212359c47d6e
+size 228660

--- a/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/current_chain.png
+++ b/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/current_chain.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:93d99df0ef73dcdc406df7f24445e55699df372789ed66143f002565e704000b
+size 58159

--- a/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/current_chain_it.png
+++ b/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/current_chain_it.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ae1b1be69c03949e82c5a8f72df2f77952e07fcefee99968c1108f874cd8aae9
+size 56457

--- a/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/current_chain_it_xadc.png
+++ b/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/current_chain_it_xadc.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cce367bb5bbcb3ffe2bd33a89b0281c52c8a4d3e606d29421536aae55a41fa0b
+size 64690

--- a/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/current_chain_xadc.png
+++ b/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/current_chain_xadc.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7700b08a508aec4dd5fa38103b9b232b15cad398a78f7918475066f765f1d98d
+size 65807

--- a/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/dc_control.png
+++ b/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/dc_control.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4529beade24ceacd7246d65dcfc9860e60fddcc91b3a9626c12e0f8d53dda083
+size 46676

--- a/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/drive_segments.png
+++ b/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/drive_segments.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:32e41c262a800da3dc41ceae2f8cb6eb024599948842bc1df16cfb778ca2867d
+size 218814

--- a/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/dyno_diagram.png
+++ b/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/dyno_diagram.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:012e69bdd1e68ae0fa87a1a7a41b00cae1f2dd8f04cfc4c4195ef156d527cd7c
+size 205621

--- a/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/dyno_discovery_control.jpg
+++ b/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/dyno_discovery_control.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:02a3401fbd68ce0bccc2aa7391e0e984d06781df87b662ddbaf8751d52073e10
+size 217675

--- a/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/dyno_menu.png
+++ b/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/dyno_menu.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a7b1502f548113c46d287f95aa7f689ff84c064714697f0d342043cb43a43a33
+size 90602

--- a/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/dyno_supply.png
+++ b/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/dyno_supply.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fbc643b785265140eebaf04253fb491e1b5c4cbab4b9b2c2ce4cc825c0c099ed
+size 617589

--- a/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/emergency_stop.jpg
+++ b/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/emergency_stop.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e8c131c84d0c3a5efbe8b7e16f777cbe6519194f7b9babec95bc59ac0f7cf63d
+size 201989

--- a/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/firefox.png
+++ b/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/firefox.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:996cfed50a497b707ce641aa0f1342c275a6373242b833999a738818bfda38e1
+size 222607

--- a/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/foc_simulink.png
+++ b/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/foc_simulink.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a67dad87e50724fed0f0c1a74aa52997a2c9e5fc129337c80721ca1c3cfeb526
+size 93000

--- a/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/hall_connector.jpg
+++ b/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/hall_connector.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5e53f3ac1bb9909db8b79c2f05328f90af48ae6ca68b075514a09f454b4177c8
+size 344347

--- a/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/iio_logo.png
+++ b/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/iio_logo.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1be41ded025b5c7d39da1dde91db1e079e5d029a8a536c004f50736a40c43f4d
+size 29126

--- a/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/iio_scope.png
+++ b/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/iio_scope.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6419c51811b34d36a27d46fc3ea0051523496234392b0df47dbde2372368c3cc
+size 91082

--- a/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/lv_block_diagram.png
+++ b/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/lv_block_diagram.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f43273e544940db9a67a502e72cd41871950482a720aff15f976956fe6f1835c
+size 200741

--- a/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/lv_block_diagram_simplified.png
+++ b/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/lv_block_diagram_simplified.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3cdac46f56ab7f89f43a512d8f0fbfe08abfc351db38644dec37dc60dd05e5e2
+size 281812

--- a/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/lv_buttons.jpg
+++ b/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/lv_buttons.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bd96d5299c5d7a845e9682efe457995f9be84731449820a6b0de8551bbc103a4
+size 146792

--- a/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/lv_connectors.jpg
+++ b/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/lv_connectors.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:988a4e59fdd20c61fbfe543a9a53cc456f25aa93376b3303dee482978eb92351
+size 492262

--- a/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/lv_power_map.png
+++ b/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/lv_power_map.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a5f61960e1244836e88bcbe5edb620f903ad6bc8a4b261e29a0a2f303ed69914
+size 111097

--- a/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/mc_adc1_sc.png
+++ b/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/mc_adc1_sc.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:01b35e9b74b8f15eb432c2f5a82ea5eab4cb5605c94a25f03e8cd787bc40a2e3
+size 580393

--- a/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/mc_adc2_sc.png
+++ b/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/mc_adc2_sc.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a74a4feb2812c89b39ceffb527d8ccea9afc813c167c60a3f88ddbd77891cc71
+size 580608

--- a/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/mc_design.png
+++ b/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/mc_design.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e0ec7257e43c563b2b2100553f3da3ec4d46524f8360307176cdc5d1fe843f58
+size 181196

--- a/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/mc_foc_ctrl.png
+++ b/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/mc_foc_ctrl.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a5efbbf06aef241ba64159492a0a7ee7c3414f3849b9bdaf656b998ad58ff19e
+size 98444

--- a/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/mc_full_sc.png
+++ b/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/mc_full_sc.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bebcdbb32e52b6b9fa93eabe90198f49a8247ad13a67e54a2323ec84566c4967
+size 388734

--- a/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/mc_manual_ctrl.png
+++ b/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/mc_manual_ctrl.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bdcbd214df31a6b6e58f9659c6cff9a97a982d6ac386bba5cac35950852c38c8
+size 46086

--- a/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/mc_speed_sc.png
+++ b/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/mc_speed_sc.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d152b5ab287622700ba2d475dfd57bb9499cd9dbaa24b384ec21acb07c9b7208
+size 739187

--- a/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/mc_system.jpg
+++ b/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/mc_system.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:00940429bdd4e6326477f4c34e6e42fd7ebea880f4c993a49457911920ad3abe
+size 787120

--- a/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/mc_system_iio_scope.jpg
+++ b/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/mc_system_iio_scope.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d08797950dc1e43caf3110d778b50e0bf302ae3e6108bc2d37e47dc7aa66f7e5
+size 1212258

--- a/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/motor_power_connections.jpg
+++ b/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/motor_power_connections.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:99dafc07c950c840ac4b4cf33e9b41097c2e54177bba220c07e8cb9d3d5de8d0
+size 131804

--- a/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/qdesys_current_settings.png
+++ b/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/qdesys_current_settings.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:731350bf9f27be956fafb0ccf5a19a031c4c750512f1b89429eeed6c43577007
+size 61345

--- a/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/qdesys_currents.png
+++ b/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/qdesys_currents.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a4f1ab3fc65d4c0c58d6d703293e8dd1211392d18af8e2d88e1748041aa7957b
+size 53364

--- a/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/qdesys_currents_xy.png
+++ b/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/qdesys_currents_xy.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e02168773807b4f78bb24035597b476ae71663bd98478f88a525e66a9c72ef50
+size 52533

--- a/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/qdesys_main_panel.png
+++ b/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/qdesys_main_panel.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:28edd0d24e78b52e3d6cc86220317f256f2cd0e630efd924c173dca0e231f7c2
+size 79969

--- a/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/qdesys_pwm_panel.png
+++ b/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/qdesys_pwm_panel.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bbd3f09af2b74effd6c56ebd406cecf97820a88946218da27043d620bc9794d1
+size 60590

--- a/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/qdesys_rpfm_panel.png
+++ b/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/qdesys_rpfm_panel.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:57bc505b3f90483693c15d558f9ac002a59deb1e11f0df088407fe0a100184b3
+size 31744

--- a/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/s1.png
+++ b/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/s1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c0fdf023311cb72fa24d055395a7442289af21945da4966324c52749b37fa387
+size 486859

--- a/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/s2.png
+++ b/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/s2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2256a0ab42cd371b6baef1dff322acbf6065af6cd9769004cf81accae57410e8
+size 99251

--- a/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/s3.png
+++ b/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/s3.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9de7ce3b71a0cf01fc35159c1ecd6daa28b4d95466031d4c36f504b1713920b8
+size 148965

--- a/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/shutdown.png
+++ b/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/shutdown.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:239c1de88af1c7fd88912b7fb9428345dc12c0a2434048d37a5ba9b066e01868
+size 18524

--- a/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/vbus_chain.png
+++ b/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/vbus_chain.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eb00fbabd70365556d4b1047f93cac1a743a9616b84097b462941321b366b42e
+size 35750

--- a/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/vbus_chain_xadc.png
+++ b/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/images/vbus_chain_xadc.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:671d693fa8289ece5d0941e42d8ab3a36a10ddb2971bd3ac9607db67e4038e50
+size 58309

--- a/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/index.rst
+++ b/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/index.rst
@@ -1,8 +1,27 @@
-AD-FMCMOTCON1-EBZ User Guide
-============================
+.. _ad_fmcmotcon1_ebz eval:
+
+AD FMCMOTCON1 EBZ
+=======================================================================================================
+
+.. TODO: Add a picture of the chip/board
+
+Overview
+-------------------------------------------------------------------------------
+
+.. TODO: Describe in max 10 rows the main features and applications.
+
+Features:
+
+- feature 1
+- feature 2
+
+Applications:
+
+- application 1
+- application 2
 
 .. toctree::
-   :titlesonly:
+   :hidden:
 
    ad-fmcmotcon1-ebz
    hardware
@@ -28,3 +47,22 @@ AD-FMCMOTCON1-EBZ User Guide
    software
    software/iio_scope
    software/linux_drivers
+
+Recommendations
+-------------------------------------------------------------------------------
+
+People who follow the flow that is outlined, have a much better experience with
+things. However, like many things, documentation is never as complete as it
+should be. If you have any questions, feel free to ask on our
+:ref:`EngineerZone forums <help-and-support>`, but before that, please make
+sure you read our documentation thoroughly.
+
+Warning
+-------------------------------------------------------------------------------
+
+.. esd-warning::
+
+Help and support
+-------------------------------------------------------------------------------
+
+Please go to :ref:`Help and Support <help-and-support>` page.

--- a/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/index.rst
+++ b/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/index.rst
@@ -1,0 +1,30 @@
+AD-FMCMOTCON1-EBZ User Guide
+============================
+
+.. toctree::
+   :titlesonly:
+
+   ad-fmcmotcon1-ebz
+   hardware
+   hardware/controller_board
+   hardware/dyno
+   hardware/dyno_test
+   hardware/lv_board
+   hardware/signal_chain
+   help_and_support
+   introduction
+   introduction/bldc_control
+   introduction/dc_control
+   introduction/drives
+   matlab_models
+   qdesys_ip
+   quickstart
+   quickstart/chipscope
+   quickstart/lv_setup_guide
+   quickstart/zynq
+   reference_hdl
+   reference_hdl/ise
+   reference_hdl/linux
+   software
+   software/iio_scope
+   software/linux_drivers

--- a/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/introduction.rst
+++ b/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/introduction.rst
@@ -1,0 +1,67 @@
+ADI FMC Motor Drive System Introduction
+=======================================
+
+.. warning::
+
+   Analog Devices uses six designations to inform our customers where a
+   semiconductor product is in its
+   :adi:`life cycle <en/support/customer-service-resources/sales/product-life-cycle-information.html>`.
+   From emerging innovations to products which have been in production for
+   twenty years, we understand that insight into life cycle status is important.
+   Device life cycles are tracked on their individual product pages on
+   `analog.com <https://www.analog.com/>`_, and should always be consulted
+   before making any design decisions.
+
+   This particular article/document/design has been retired or deprecated,
+   which means it is no longer maintained or actively updated, even though the
+   devices themselves may be Recommended for New Designs or in
+   Production. This page is here for historical/reference purposes only.
+
+**The ADI FMC motor drive solution solution consist of the following products**
+
+-  :doc:`AD-FMCMOTCON1-EBZ </solutions/reference-designs/ad-fmcmotcon1-ebz/hardware/controller_board>` - Controller board. Compatible with all Xilinx FPGA platforms with FMC LPC or HPC connectors.
+-  :doc:`AD-DRVLV1-EBZ </solutions/reference-designs/ad-fmcmotcon1-ebz/hardware/lv_board>` - Low voltage drive board. Connects to the Controller board and has a power stage that can drive drive Brushed DC / BLDC / PMSM / Stepper motors up to 48V and 18A.
+-  :doc:`AD-DYNO1-EBZ </solutions/reference-designs/ad-fmcmotcon1-ebz/hardware/dyno>` - Dynamometer drive system. Acts as an electronically adjustable load with two BLDC motors connected in a dyno setup.
+
+=================== =============== ==============
+AD-FMCMOTCON1-EBZ   AD-DRVLV1-EBZ   AD-DYNO1-EBZ
+=================== =============== ==============
+|AD-FMCMOTCON1-EBZ| |AD-DRVLV1-EBZ| |AD-DYNO1-EBZ|
+=================== =============== ==============
+
+**Purpose**
+
+-  Provide an efficient drive system for different types of electric motors
+-  Address power and isolation challenges encountered in motor control applications
+-  Provide accurate measurement of motor feedback signals
+-  Achieve flexible control with FPGA/SoC interface
+-  High speed industrial Ethernet interface
+
+**Added Value**
+
+-  Complete control solution showing how to integrate hardware for
+
+   -  Power
+
+      -  Isolation
+      -  Measurement
+      -  Control
+
+-  Increased control flexibility due to FPGA interfacing capabilities
+-  Increased versatility to be able to control different types of motors
+-  Example reference designs showing how to use the control solution with Xilinx
+   FPGAs and Simulink from Mathworks
+
+Where to Buy
+------------
+
+.. container:: round box
+
+   `ZYNQ Intelligent Drives Kit <http://www.em.avnet.com/en-us/design/drc/Pages/Zynq-Intelligent-Drives-Kit.aspx>`_
+
+.. |AD-FMCMOTCON1-EBZ| image:: images/ad-fmcmotcon1-ebz_top.jpg
+   :width: 200
+.. |AD-DRVLV1-EBZ| image:: images/ad-drvlv1-ebz_top.jpg
+   :width: 200
+.. |AD-DYNO1-EBZ| image:: images/ad-dyno1-ebz.png
+   :width: 200

--- a/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/introduction/bldc_control.rst
+++ b/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/introduction/bldc_control.rst
@@ -1,0 +1,33 @@
+Brushless DC Motor Control
+==========================
+
+Brushless DC motors windings generate a trapezoidal back EMF synchronized to the
+position of the rotor magnet. Hall effect sensors are used to detect the rotor
+magnet position and provide signals indicating the “flat top” portion for each
+winding’s back EMF.
+
+**Star Connection Control**
+
+-  For any one segment, two windings will be in the “flat top” portion of the back EMF and a third winding will be switching between a positive and negative output.
+-  Electronic control leaves one winding open circuit, connects one winding to the lower dc rail, and controls the voltage applied to the third winding using PWM.
+-  The fill factor of the applied PWM controls the speed of the motor.
+
+|image1| |image2|
+
+**Delta Connection Control**
+
+-  For any one segment, two windings are connected to the positive voltage supply and a third winding is connected to the negative voltage supply.
+-  The fill factor of the applied PWM controls the speed of the motor.
+
+|image3| |image4|
+
+**Sensorless control** can be achieved by detecting the zero crossings of the BEMF for each phase. *Benefits*: lower system cost, increased reliability. *Drawbacks*: BEMF zero crossings can’t be reliably detected at low motor speeds
+
+.. |image1| image:: ../images/bldc_star.png
+   :width: 400
+.. |image2| image:: ../images/bldc_star_switching.png
+   :width: 300
+.. |image3| image:: ../images/bldc_delta.png
+   :width: 400
+.. |image4| image:: ../images/bldc_delta_switching.png
+   :width: 300

--- a/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/introduction/dc_control.rst
+++ b/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/introduction/dc_control.rst
@@ -1,0 +1,18 @@
+Brushed DC Motor Control
+========================
+
+The Brushed DC motor is the simplest type of motor to control, all that needs to be done is to vary the supply voltage and the motor's speed will vary proportional to the voltage. The most common technique used to vary the applied voltage is called **Pulse Width Modulation (PWM)**, where constant amplitude voltage pulses of varying widths are provided to the motor - the wider the pulse, the more energy transferred to the motor. The frequency of the pulses is high enough that the motor’s inductance averages them, and it runs smooth.
+
+A single transistor and diode can control the speed of a dc motor.
+
+-  The motor speed (voltage) is proportional to the transistor ON duty cycle.
+-  Positive torque only—passive braking.
+
+An H-bridge power circuit enables four quadrant control
+
+-  Forward and reverse motion and braking
+-  Complementary PWM signals applied to the high and low side switches in the
+   bridge
+
+.. image:: ../images/dc_control.png
+   :width: 400

--- a/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/introduction/drives.rst
+++ b/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/introduction/drives.rst
@@ -1,0 +1,14 @@
+Electric Motor Drives
+=====================
+
+A **Motor Drive** is a system that varies the motor electrical input power to control the shaft torque, speed, or position. The motor drives can be classified into the following categories:
+
+-  *Application specific drive* — designed to run a specific motor in a specific application (e.g., variable speed pump drive).
+-  *Standard drive* — designed as a general-purpose motor speed controller capable of running a variety of motors within a given power range.
+-  *Servo drive* — designed to deliver accurate and high dynamic control of position, speed, or torque down to zero speed. Typically used in automation applications.
+-  *High performance servos* — designed to deliver best in class accuracy and connectivity. Typically used in CNC and pick and place machines.
+
+**Market sub-segments in motor control - partners and system value from ADI**
+
+.. image:: ../images/drive_segments.png
+   :width: 400

--- a/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/matlab_models.rst
+++ b/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/matlab_models.rst
@@ -1,0 +1,132 @@
+Simulink Controller Models
+==========================
+
+.. warning::
+
+   Analog Devices uses six designations to inform our customers where a
+   semiconductor product is in its
+   :adi:`life cycle <en/support/customer-service-resources/sales/product-life-cycle-information.html>`.
+   From emerging innovations to products which have been in production for
+   twenty years, we understand that insight into life cycle status is important.
+   Device life cycles are tracked on their individual product pages on
+   `analog.com <https://www.analog.com/>`_, and should always be consulted
+   before making any design decisions.
+
+   This particular article/document/design has been retired or deprecated,
+   which means it is no longer maintained or actively updated, even though the
+   devices themselves may be Recommended for New Designs or in
+   Production. This page is here for historical/reference purposes only.
+
+The Vivado HDL design is provided with an integrated FOC and speed & torque
+controller generated from a Simulink model provided by MathWorks. The controller
+is designed in Simulink and the corresponding HDL code is generated using the
+Mathworks HDL Coder.
+
+Field Oriented Controller (FOC)
+-------------------------------
+
+The FOC controller model is provided by MathWorks and it is integrated in the
+HDL design as a standalone IP core. Below is presented a top level diagram of
+the controller's Simulink model. For more information about the model check out
+the MathWorks website.
+
+.. image:: images/foc_simulink.png
+   :width: 700
+
+The controller model is packaged into an IP core using the Simulink Workflow
+Advisor. It exposes a set of AXI-Lite registers that can be used to control the
+IP's operation as well as a set of interface signals for encoder input, current
+measurement data, inverter control and internal operations monitoring. All the
+monitoring signals connect to an ADI IP which allows these signals to be
+monitored from the Linux IIO Scope application. The AXI-Lite registers exposed
+by the controller IP core can be directly accessed through an uio driver present
+in the ADI Linux distribution for Zynq. The table below lists the exposed
+AXI-Lite registers.
+
++-------------------------+---------+--------------------------+------+------------------------------------------------------------------------------------+
+| Register name           | Address | Data format              | Type | Description                                                                        |
++=========================+=========+==========================+======+====================================================================================+
+| axi_controller_mode     | 0x100   | 2 bit word               | W    | Sets the controller's operation modes: 3 = open loop, 2 = closed loop, 1 = standby |
++-------------------------+---------+--------------------------+------+------------------------------------------------------------------------------------+
+| axi_command             | 0x104   | Sigend fixed point 18.8  | W    | Motor reference speed in rad/s                                                     |
++-------------------------+---------+--------------------------+------+------------------------------------------------------------------------------------+
+| axi_velocity_p_gain     | 0x108   | Sigend fixed point 18.16 | W    | Proportional gain of the velocity PI controller                                    |
++-------------------------+---------+--------------------------+------+------------------------------------------------------------------------------------+
+| axi_velocity_i_gain     | 0x10C   | Sigend fixed point 18.15 | W    | Integral gain of the velocity PI controller                                        |
++-------------------------+---------+--------------------------+------+------------------------------------------------------------------------------------+
+| axi_current_p_gain      | 0x110   | Sigend fixed point 18.10 | W    | Proportional gain of the current PI controller                                     |
++-------------------------+---------+--------------------------+------+------------------------------------------------------------------------------------+
+| axi_current_i_gain      | 0x114   | Sigend fixed point 18.12 | W    | Integral gain of the current PI controller                                         |
++-------------------------+---------+--------------------------+------+------------------------------------------------------------------------------------+
+| axi_open_loop_bias      | 0x118   | Sigend fixed point 18.14 | W    | Open loop control command bias                                                     |
++-------------------------+---------+--------------------------+------+------------------------------------------------------------------------------------+
+| axi_open_loop_scalar    | 0x11C   | Sigend fixed point 18.16 | W    | Open loop control command gain                                                     |
++-------------------------+---------+--------------------------+------+------------------------------------------------------------------------------------+
+| axi_encoder_zero_offset | 0x120   | Sigend fixed point 18.14 | W    | Encoder offset                                                                     |
++-------------------------+---------+--------------------------+------+------------------------------------------------------------------------------------+
+| axi_electrical_pos_err  | 0x124   | Sigend fixed point 19.14 | R    | Error between actual electrical position and encoder position                      |
++-------------------------+---------+--------------------------+------+------------------------------------------------------------------------------------+
+
+The operation of the IP core is controlled through the :git-mathworks_tools:`motor_control/linux_utils/foc_script.sh` script located under */usr/local/bin*. The script executes the following steps:
+
+-  Set the FOC controller in open loop mode and wait for the user to start the motor by clicking the Run checkbox in IIO scope
+-  Calibrate the encoder readings to remove the offset between the motor's actual electrical position and the position read from the encoder
+-  Set the motor's reference speed
+-  Start the FOC controller in closed loop mode
+
+The IP core exposes a set of signals for interfacing with the rest of the
+system. The table below lists the exposed interface signals.
+
++-------------------------+-----------+-------+--------------------------+--------------------------------------+
+| Signal name             | Direction | Width | Data format              | Description                          |
++=========================+===========+=======+==========================+======================================+
+| adc_current1            | I         | 18    | Signed fixed point 18.17 | Phase A current measurement          |
++-------------------------+-----------+-------+--------------------------+--------------------------------------+
+| adc_current2            | I         | 18    | Signed fixed point 18.17 | Phase B current measurement          |
++-------------------------+-----------+-------+--------------------------+--------------------------------------+
+| encoder_a               | I         | 1     | Boolean                  | Encoder channel A                    |
++-------------------------+-----------+-------+--------------------------+--------------------------------------+
+| encoder_b               | I         | 1     | Boolean                  | Encoder channel B                    |
++-------------------------+-----------+-------+--------------------------+--------------------------------------+
+| encoder_index           | I         | 1     | Boolean                  | Encoder index                        |
++-------------------------+-----------+-------+--------------------------+--------------------------------------+
+| pwm_a                   | O         | 1     | Boolean                  | Phase A PWM control signal           |
++-------------------------+-----------+-------+--------------------------+--------------------------------------+
+| pwm_b                   | O         | 1     | Boolean                  | Phase B PWM control signal           |
++-------------------------+-----------+-------+--------------------------+--------------------------------------+
+| pwm_c                   | O         | 1     | Boolean                  | Phase C PWM control signal           |
++-------------------------+-----------+-------+--------------------------+--------------------------------------+
+| mon_phase_voltage_a     | O         | 32    | Signed fixed point 32.12 | Phase A voltage in Volts             |
++-------------------------+-----------+-------+--------------------------+--------------------------------------+
+| mon_phase_voltage_b     | O         | 32    | Signed fixed point 32.12 | Phase B voltage in Volts             |
++-------------------------+-----------+-------+--------------------------+--------------------------------------+
+| mon_phase_current_a     | O         | 32    | Signed fixed point 32.15 | Phase A current in Amps              |
++-------------------------+-----------+-------+--------------------------+--------------------------------------+
+| mon_phase_current_b     | O         | 32    | Signed fixed point 32.15 | Phase B current in Amps              |
++-------------------------+-----------+-------+--------------------------+--------------------------------------+
+| mon_rotor position      | O         | 32    | Signed fixed point 32.14 | Rotor mecahnical position in radians |
++-------------------------+-----------+-------+--------------------------+--------------------------------------+
+| mon_electrical position | O         | 32    | Signed fixed point 32.14 | Rotor electrical position in radians |
++-------------------------+-----------+-------+--------------------------+--------------------------------------+
+| mon_rotor_velocity      | O         | 32    | Signed fixed point 32.8  | Rotor velocity in rad/s              |
++-------------------------+-----------+-------+--------------------------+--------------------------------------+
+| mon_d_current           | O         | 32    | Signed fixed point 32.15 | d current in Amps                    |
++-------------------------+-----------+-------+--------------------------+--------------------------------------+
+| mon_q_current           | O         | 32    | Signed fixed point 32.15 | q current in Amps                    |
++-------------------------+-----------+-------+--------------------------+--------------------------------------+
+
+Below is presented a picture containing the output of the script, the IIO Scope
+settings and a controller monitored signals plot.
+
+.. image:: images/mc_full_sc.png
+   :alt: Motor Control IIO Scope
+   :width: 700
+
+Support
+-------
+
+.. hint::
+
+   
+   -  Questions? :ez:`Ask Help & Support <sw-interface-tools>`.
+   

--- a/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/matlab_models.rst
+++ b/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/matlab_models.rst
@@ -127,6 +127,6 @@ Support
 
 .. hint::
 
-   
+
    -  Questions? :ez:`Ask Help & Support <sw-interface-tools>`.
-   
+

--- a/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/qdesys_ip.rst
+++ b/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/qdesys_ip.rst
@@ -1,0 +1,37 @@
+QDESYS Motor Control IP
+=======================
+
+.. warning::
+
+   Analog Devices uses six designations to inform our customers where a
+   semiconductor product is in its
+   :adi:`life cycle <en/support/customer-service-resources/sales/product-life-cycle-information.html>`.
+   From emerging innovations to products which have been in production for
+   twenty years, we understand that insight into life cycle status is important.
+   Device life cycles are tracked on their individual product pages on
+   `analog.com <https://www.analog.com/>`_, and should always be consulted
+   before making any design decisions.
+
+   This particular article/document/design has been retired or deprecated,
+   which means it is no longer maintained or actively updated, even though the
+   devices themselves may be Recommended for New Designs or in
+   Production. This page is here for historical/reference purposes only.
+
+A FOC implementation targeted for the **AD-FMCMOTCON1-EBZ** is available from `QDESYS <http://www.qdesys.com/>`_. The control algorithm is provided as a highly optimized IP that can be integrated in the FPGA project. Below you can find a few screenshots from the user application provided with the IP taken while running with the **AD-FMCMOTCON1-EBZ**.
+
+|Main panel| |PWM control panel| |Current settings panel| |RPFM control panel|
+
+|Phase currents| |Stator Currents vs Space|
+
+.. |Main panel| image:: images/qdesys_main_panel.png
+   :width: 400
+.. |PWM control panel| image:: images/qdesys_pwm_panel.png
+   :width: 400
+.. |Current settings panel| image:: images/qdesys_current_settings.png
+   :width: 400
+.. |RPFM control panel| image:: images/qdesys_rpfm_panel.png
+   :width: 400
+.. |Phase currents| image:: images/qdesys_currents.png
+   :width: 400
+.. |Stator Currents vs Space| image:: images/qdesys_currents_xy.png
+   :width: 400

--- a/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/quickstart.rst
+++ b/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/quickstart.rst
@@ -1,0 +1,29 @@
+AD-FMCMOTCON1-EBZ Quick Start Guides
+====================================
+
+.. warning::
+
+   Analog Devices uses six designations to inform our customers where a
+   semiconductor product is in its
+   :adi:`life cycle <en/support/customer-service-resources/sales/product-life-cycle-information.html>`.
+   From emerging innovations to products which have been in production for
+   twenty years, we understand that insight into life cycle status is important.
+   Device life cycles are tracked on their individual product pages on
+   `analog.com <https://www.analog.com/>`_, and should always be consulted
+   before making any design decisions.
+
+   This particular article/document/design has been retired or deprecated,
+   which means it is no longer maintained or actively updated, even though the
+   devices themselves may be Recommended for New Designs or in
+   Production. This page is here for historical/reference purposes only.
+
+The Quick Start Guides provide a simple step by step instruction on how to do an initial system setup for the `AD-FMCMOTCON1-EBZ </>`_ on various FPGA development boards.
+
+Quick Start Guides are available for
+
+-  :doc:`Linux on ZED </solutions/reference-designs/ad-fmcmotcon1-ebz/quickstart/zynq>`
+-  :doc:`ISE Project with Chipscope on ZED </solutions/reference-designs/ad-fmcmotcon1-ebz/quickstart/chipscope>`
+
+.. image:: images/mc_system_iio_scope.jpg
+   :alt: FMCMOTCON1 on Zed board running linux
+   :width: 500

--- a/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/quickstart/chipscope.rst
+++ b/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/quickstart/chipscope.rst
@@ -1,0 +1,114 @@
+AD-FMCMOTCON1-EBZ ISE Project with Chipscope
+============================================
+
+.. warning::
+
+   Analog Devices uses six designations to inform our customers where a
+   semiconductor product is in its
+   :adi:`life cycle <en/support/customer-service-resources/sales/product-life-cycle-information.html>`.
+   From emerging innovations to products which have been in production for
+   twenty years, we understand that insight into life cycle status is important.
+   Device life cycles are tracked on their individual product pages on
+   `analog.com <https://www.analog.com/>`_, and should always be consulted
+   before making any design decisions.
+
+   This particular article/document/design has been retired or deprecated,
+   which means it is no longer maintained or actively updated, even though the
+   devices themselves may be Recommended for New Designs or in
+   Production. This page is here for historical/reference purposes only.
+
+This guide provides some quick instructions on how to setup the
+AD-FMCMOTCON1-EBZ on either:
+
+-  `ZED Board <http://www.zedboard.org/>`_, Rev C or later
+
+Software Tools
+--------------
+
+-  Xilinx ISE 14.6
+-  Xilinx Chipscope Pro 14.6
+
+Downloads
+---------
+
+.. admonition:: Download
+   :class: download
+
+   
+   :git-fpgahdl_xilinx:`ISE Project <motor_control/adi_zed_ise_rev2>` :git-fpgahdl_xilinx:`Chipscope Project <motor_control/adi_zed_ise_rev2/Chipscope>`
+   
+
+System Setup
+------------
+
+To setup the hardware follow the steps described in the :doc:`Hardware Setup Guide </solutions/reference-designs/ad-fmcmotcon1-ebz/quickstart/lv_setup_guide>` section.
+
+The FPGA must be programmed with the **top.bit** bitstream that results after compiling the ISE project. This has already been done, the bitstream was generated and it can be found in the ISE project's folder. To program the FPGA use the **iMPACT** tool from Xilinx.
+
+The operation of the system can be controlled and monitored using the Chipscope project from the **Downloads** section.
+
+Chipscope Interface
+-------------------
+
+The user interface uses Xilinx Chipscope 14.6. The project is available in the **Downloads** section. In order to be able to see the plots from section C and D, the triggers from UNIT:1 and UNIT:2 must be enabled.
+
+| |chipscope.png|
+
+| The A section is used for control.
+
++---------------------------------------------+-------+----------------------------------------------------------------------------------------+
+| Name                                        | Width | Description                                                                            |
++=============================================+=======+========================================================================================+
+| PWM                                         | 32    | PWM value for controlling the motor. It must be larger than 0x480 and less than 0x800  |
++---------------------------------------------+-------+----------------------------------------------------------------------------------------+
+| GAIN                                        | 2     | Amplification on the ADC signal chain. 0 - Gain 1, 1 - Gain 4, 2 - Gain 2, 3 - Gain 8  |
++---------------------------------------------+-------+----------------------------------------------------------------------------------------+
+| RUN_MOTOR                                   | 1     | Start / Stop the motor                                                                 |
++---------------------------------------------+-------+----------------------------------------------------------------------------------------+
+| STAR_MOTOR                                  | 1     | Set to 1 for star wired motors, set to 0 for delta wired motors                        |
++---------------------------------------------+-------+----------------------------------------------------------------------------------------+
+| CW_DIR                                      | 1     | Set to 1 for clockwise direction of rotation, set to 0 for counter-clockwise direction |
++---------------------------------------------+-------+----------------------------------------------------------------------------------------+
+| **Table 1 Section A parameter description** |       |                                                                                        |
++---------------------------------------------+-------+----------------------------------------------------------------------------------------+
+
+The B section is used for checking the waveform for the currents in the design.
+
++---------------------------------------------+-------------------------------------------------------------------------+
+| Name                                        | Description                                                             |
++=============================================+=========================================================================+
+| IA_DRV                                      | IA current as read on the low voltage motor driver board                |
++---------------------------------------------+-------------------------------------------------------------------------+
+| IB_DRV                                      | IB current as read on the low voltage motor driver board                |
++---------------------------------------------+-------------------------------------------------------------------------+
+| IT_DRV                                      | IT current as read on the low voltage motor driver board                |
++---------------------------------------------+-------------------------------------------------------------------------+
+| IA                                          | IA current as read on the controller board                              |
++---------------------------------------------+-------------------------------------------------------------------------+
+| IB                                          | IB current as read on the controller board                              |
++---------------------------------------------+-------------------------------------------------------------------------+
+| IT                                          | IT current as read on the controller board                              |
++---------------------------------------------+-------------------------------------------------------------------------+
+| VBUS                                        | VBUS voltage as seen on the controller board                            |
++---------------------------------------------+-------------------------------------------------------------------------+
+| SPEED                                       | Time between a change of the HALL sensors state measured in 100ns units |
++---------------------------------------------+-------------------------------------------------------------------------+
+| POSITION                                    | HALL sensors reading                                                    |
++---------------------------------------------+-------------------------------------------------------------------------+
+| **Table 2 Section B parameter description** |                                                                         |
++---------------------------------------------+-------------------------------------------------------------------------+
+
+Section C is used to represent graphically the speed of the motor.
+
++---------------------------------------------+-------------------------------------------------------------------------+
+| Name                                        | Description                                                             |
++=============================================+=========================================================================+
+| SPEED                                       | Time between a change of the HALL sensors state measured in 100ns units |
++---------------------------------------------+-------------------------------------------------------------------------+
+| **Table 3 Section C parameter description** |                                                                         |
++---------------------------------------------+-------------------------------------------------------------------------+
+
+Section D is used to plot the currents and voltages described in section B.
+
+.. |chipscope.png| image:: ../images/chipscope.png
+   :width: 800

--- a/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/quickstart/chipscope.rst
+++ b/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/quickstart/chipscope.rst
@@ -34,9 +34,9 @@ Downloads
 .. admonition:: Download
    :class: download
 
-   
+
    :git-fpgahdl_xilinx:`ISE Project <motor_control/adi_zed_ise_rev2>` :git-fpgahdl_xilinx:`Chipscope Project <motor_control/adi_zed_ise_rev2/Chipscope>`
-   
+
 
 System Setup
 ------------

--- a/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/quickstart/lv_setup_guide.rst
+++ b/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/quickstart/lv_setup_guide.rst
@@ -1,0 +1,84 @@
+Hardware Setup Guide
+====================
+
+.. warning::
+
+   Analog Devices uses six designations to inform our customers where a
+   semiconductor product is in its
+   :adi:`life cycle <en/support/customer-service-resources/sales/product-life-cycle-information.html>`.
+   From emerging innovations to products which have been in production for
+   twenty years, we understand that insight into life cycle status is important.
+   Device life cycles are tracked on their individual product pages on
+   `analog.com <https://www.analog.com/>`_, and should always be consulted
+   before making any design decisions.
+
+   This particular article/document/design has been retired or deprecated,
+   which means it is no longer maintained or actively updated, even though the
+   devices themselves may be Recommended for New Designs or in
+   Production. This page is here for historical/reference purposes only.
+
+.. image:: ../images/mc_system.jpg
+   :width: 600
+
+Supported Carriers
+------------------
+
+-  `ZedBoard <http://www.zedboard.org>`_
+
++---+
++---+
+
+Required Hardware
+-----------------
+
+-  AD-FMCMOTCON1-EBZ - Controller board.
+-  AD-DRVLV1-EBZ - Low voltage drive board.
+-  AD-DYNO1-EBZ - Dynamo-meter Drive System (Optional).
+-  `ZedBoard <http://www.zedboard.org>`_
+-  24V 3A capable lab power supply.
+
++---+
++---+
+
+Getting Started
+---------------
+
+-  Connect the Low voltage drive board to the Controller board.
+-  Connect the Controller + Drive boards assembly to FMC connector of the ZedBoard
+-  Insert the 6 pin Hall connector into P7 - pin 1 is the empty slot of the Hall
+   connector. In case an encoder is used there is a one to one corespondence of
+   the encoder's pins to the pins of the P7 connector.
+
+.. image:: ../images/hall_connector.jpg
+   :alt: Hall connector
+   :align: center
+   :width: 300
+
+-  Insert the 5V supply in the left side of the DYNAMO-METER DRIVE SYSTEM
+
+.. image:: ../images/dyno_supply.png
+   :alt: Dynamo-meter Drive System
+   :align: center
+   :width: 300
+
+-  Ensure that the Emergency Stop button P2 is pressed (more information about drive board buttons :doc:`here </solutions/reference-designs/ad-fmcmotcon1-ebz/hardware/lv_board>`)
+
+.. image:: ../images/emergency_stop.jpg
+   :alt: Motor and Power connections
+   :align: center
+   :width: 300
+
+-  Insert the 3 pin motor connector into P1 and connect the lab power supply to P4 (more information about drive board connectors :doc:`here </solutions/reference-designs/ad-fmcmotcon1-ebz/hardware/lv_board>`)
+
+.. image:: ../images/motor_power_connections.jpg
+   :alt: Motor and Power connections
+   :align: center
+   :width: 300
+
+-  Power on the ZedBoard
+-  After the board is programmed, in order to start the motor, the Emergency
+   Stop button P2 must be released and then the Reset switch S1 must be pressed
+   for a few seconds.
+
++---+
++---+

--- a/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/quickstart/zynq.rst
+++ b/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/quickstart/zynq.rst
@@ -1,0 +1,78 @@
+AD-FMCMOTCON1-EBZ Linux on Zynq Quick Start Guide
+=================================================
+
+.. warning::
+
+   Analog Devices uses six designations to inform our customers where a
+   semiconductor product is in its
+   :adi:`life cycle <en/support/customer-service-resources/sales/product-life-cycle-information.html>`.
+   From emerging innovations to products which have been in production for
+   twenty years, we understand that insight into life cycle status is important.
+   Device life cycles are tracked on their individual product pages on
+   `analog.com <https://www.analog.com/>`_, and should always be consulted
+   before making any design decisions.
+
+   This particular article/document/design has been retired or deprecated,
+   which means it is no longer maintained or actively updated, even though the
+   devices themselves may be Recommended for New Designs or in
+   Production. This page is here for historical/reference purposes only.
+
+This guide provides some quick instructions (still takes awhile to download, and
+set things up) on how to setup the AD-FMCMOTCON1-EBZ on either:
+
+-  `ZED Board <http://www.zedboard.org/>`_, Rev C or later
+
+Requirements
+------------
+
+-  You need a Host PC (Windows or Linux).
+-  You need a SD card writer connected to above PC (Supported USB SD readers/writers are OK).
+-  USB keyboard/mouse for the Zynq Device
+-  HDMI Display (monitor or TV)
+
+Creating the SD Card
+--------------------
+
+`Create SD Image for Zynq Boards <https://wiki.analog.com/resources/tools-software/linux-software/kuiper-linux>`_
+
+Connecting the hardware together
+--------------------------------
+
+Instruction regarding the hardware connection can be found at: :doc:`Hardware connection user guide ZED board </solutions/reference-designs/ad-fmcmotcon1-ebz/quickstart/lv_setup_guide>`
+
+Booting the SD Card
+-------------------
+
+-  ignore your PC, and now interact on the USB mouse/keyboard on the Zynq device
+-  You should see two screens:
+
+   -  firefox:
+
+   |image1|
+
+-  IIO Scope tool:
+
+|image2|
+
+   -  Learn more about the `IIO Scope <https://wiki.analog.com/resources/tools-software/linux-software/iio_oscilloscope>`_.
+
+-  You are now done with booting from the SD card. You can interact with the GUI
+   either over the network, or with the HDMI monitor/USB keyboard mouse.
+
+Using IIO SCOPE for AD-FMCMOTCON1-EBZ
+-------------------------------------
+
+:doc:`Software user guide </solutions/reference-designs/ad-fmcmotcon1-ebz/software/iio_scope>`
+
+.. important::
+
+   Even thought this is Linux, this is a persistent file system. Care should be taken not to corrupt the file system -- please shut down things, don't just turn off the power switch. Depending on your monitor, the standard power off could be hiding. You can do this from the terminal as well with: ``sudo shutdown -h now``
+
+   |image3|
+
+.. |image1| image:: ../images/firefox.png
+   :width: 200
+.. |image2| image:: ../images/iio_scope.png
+   :width: 200
+.. |image3| image:: ../images/shutdown.png
+   :width: 300

--- a/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/quickstart/zynq.rst
+++ b/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/quickstart/zynq.rst
@@ -33,7 +33,7 @@ Requirements
 Creating the SD Card
 --------------------
 
-`Create SD Image for Zynq Boards <https://wiki.analog.com/resources/tools-software/linux-software/kuiper-linux>`_
+:external+kuiper:doc:`Create SD Image for Zynq Boards <index>`
 
 Connecting the hardware together
 --------------------------------

--- a/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/reference_hdl.rst
+++ b/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/reference_hdl.rst
@@ -1,0 +1,37 @@
+HDL Reference Designs
+=====================
+
+.. warning::
+
+   Analog Devices uses six designations to inform our customers where a
+   semiconductor product is in its
+   :adi:`life cycle <en/support/customer-service-resources/sales/product-life-cycle-information.html>`.
+   From emerging innovations to products which have been in production for
+   twenty years, we understand that insight into life cycle status is important.
+   Device life cycles are tracked on their individual product pages on
+   `analog.com <https://www.analog.com/>`_, and should always be consulted
+   before making any design decisions.
+
+   This particular article/document/design has been retired or deprecated,
+   which means it is no longer maintained or actively updated, even though the
+   devices themselves may be Recommended for New Designs or in
+   Production. This page is here for historical/reference purposes only.
+
+Two HDL reference designs are provided targeting different use cases and system
+complexity levels:
+
+-  :doc:`Xilinx ISE HDL Project + Chipscope Interface </solutions/reference-designs/ad-fmcmotcon1-ebz/reference_hdl/ise>`
+
+   -  Control and monitoring through Chipscope
+
+      -  Only manual control
+      -  Monitoring of system important parameters
+      -  Simple to synthetize / understand / utilize
+
+-  :doc:`HDL Project for Linux </solutions/reference-designs/ad-fmcmotcon1-ebz/reference_hdl/linux>`
+
+   -  Complex HDL blocks with AXI Lite and AXI streaming interfaces
+
+      -  Infrastructure for Linux support
+      -  Integration of automatically generated HDL code for Simulink designed motor controller
+      -  EDK and Vivado projects

--- a/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/reference_hdl/ise.rst
+++ b/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/reference_hdl/ise.rst
@@ -47,6 +47,6 @@ Support
 
 .. hint::
 
-   
+
    -  Questions? :ez:`Ask Help & Support <fpga>`.
-   
+

--- a/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/reference_hdl/ise.rst
+++ b/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/reference_hdl/ise.rst
@@ -1,0 +1,52 @@
+Xilinx ISE HDL Reference Design
+===============================
+
+.. warning::
+
+   Analog Devices uses six designations to inform our customers where a
+   semiconductor product is in its
+   :adi:`life cycle <en/support/customer-service-resources/sales/product-life-cycle-information.html>`.
+   From emerging innovations to products which have been in production for
+   twenty years, we understand that insight into life cycle status is important.
+   Device life cycles are tracked on their individual product pages on
+   `analog.com <https://www.analog.com/>`_, and should always be consulted
+   before making any design decisions.
+
+   This particular article/document/design has been retired or deprecated,
+   which means it is no longer maintained or actively updated, even though the
+   devices themselves may be Recommended for New Designs or in
+   Production. This page is here for historical/reference purposes only.
+
+This design is targeted for Zynq based FPGA systems.
+
+Reference Design
+----------------
+
+The reference design contains HDL blocks for interfacing with the various
+components of the motor control hardware:
+
+-  **ADC Interface** - Implements the communication with the AD7401 sigma delta modulators present on the AD-FMCMOTCON1-EBZ and also the SINC3 filters for demodulating the 1-bit digital stream provided by these parts.
+-  **Controller** - Implements the motor control algorithm. The algorithm is designed and simulated in Simulink from Matworks and afterwards translated to HDL using the Mathworks HDL Coder.
+-  **Speed Sensor Interface** - Implements the algorithm for converting Hall, BEMF and Encoder signals into speed and position data.
+
+All the HDL blocks connect to Chipscope ILA and VIO modules which provide the
+means to monitor and control their operation.
+
+Details about the Chipscope interface and how to run the ISE project can be found in the :doc:`ISE Project with Chipscope Quick Start Guide </solutions/reference-designs/ad-fmcmotcon1-ebz/quickstart/chipscope>`.
+
+Downloads
+---------
+
+.. admonition:: Download
+   :class: download
+
+   :git-fpgahdl_xilinx:`ISE HDL Reference Design <motor_control/adi_zed_ise_rev2>` :git-fpgahdl_xilinx:`Chipscope Project <motor_control/adi_zed_ise_rev2/Chipscope>`
+
+Support
+-------
+
+.. hint::
+
+   
+   -  Questions? :ez:`Ask Help & Support <fpga>`.
+   

--- a/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/reference_hdl/linux.rst
+++ b/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/reference_hdl/linux.rst
@@ -52,12 +52,12 @@ Downloads
 .. admonition:: Download
    :class: download
 
-   
+
    -  `Vivado ADI Libraries <https://github.com/analogdevicesinc/hdl/tree/hdl_2014_r1/library>`_
    -  `Vivado Motor Control Reference Design <https://github.com/analogdevicesinc/hdl/tree/hdl_2014_r1/projects/motor_control>`_
-   
+
    :
-   
+
 
 Setting up Linux
 ----------------
@@ -71,6 +71,6 @@ Support
 
 .. hint::
 
-   
+
    -  Questions? :ez:`Ask Help & Support <fpga>`.
-   
+

--- a/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/reference_hdl/linux.rst
+++ b/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/reference_hdl/linux.rst
@@ -1,0 +1,76 @@
+Xilinx HDL Reference Design
+===========================
+
+.. warning::
+
+   Analog Devices uses six designations to inform our customers where a
+   semiconductor product is in its
+   :adi:`life cycle <en/support/customer-service-resources/sales/product-life-cycle-information.html>`.
+   From emerging innovations to products which have been in production for
+   twenty years, we understand that insight into life cycle status is important.
+   Device life cycles are tracked on their individual product pages on
+   `analog.com <https://www.analog.com/>`_, and should always be consulted
+   before making any design decisions.
+
+   This particular article/document/design has been retired or deprecated,
+   which means it is no longer maintained or actively updated, even though the
+   devices themselves may be Recommended for New Designs or in
+   Production. This page is here for historical/reference purposes only.
+
+This design is targeted for Zynq based FPGA systems. It has the complete
+infrastructure for Linux support.
+
+Reference Design
+----------------
+
+The reference design contains HDL blocks for interfacing with the various
+components of the motor control hardware:
+
+-  **ADC Interface** - Implements the communication with the AD7401 sigma delta modulators present on the AD-FMCMOTCON1-EBZ and also the SINC3 filters for demodulating the 1-bit digital stream provided by these parts. This HDL block exposes a set of registers that can be accessed through the AXI Lite interface. An AXI Streaming interface connected to a DMA controller allows the block to stream real time data to the application layer.
+-  **Controller Interface** - Implements the interface to the IP control blocks in the system. An AXI Streaming interface connected to a DMA controller allows the block to stream real time data to the application layer.
+-  **MathWorks FOC IP** - The FOC controller model is provided by MathWorks and it is integrated in the HDL design as a standalone IP core. The controller model is packaged into an IP core using the Simulink Workflow Advisor. It exposes a set of AXI-Lite registers that can be used to control the IP's operation as well as a set of interface signals for encoder input, current measurement data, inverter control and internal operations monitoring. All the monitoring signals connect to the Controller Interface IP which allows these signals to be monitored from the Linux IIO Scope application. The AXI-Lite registers exposed by the controller IP core can be directly accessed through an uio driver present in the ADI Linux distribution for Zynq.
+-  **Position & Speed Processing** - Implements the algorithm for converting Hall, BEMF and Encoder signals into speed and position data. This HDL block exposes a set of registers that can be accessed through the AXI Lite interface. An AXI Streaming interface connected to a DMA controller allows the block to stream real time data to the application layer.
+
+.. image:: ../images/mc_design.png
+   :alt: Reference Design
+   :width: 600
+
+Vivado Design Generation
+------------------------
+
+Start Vivado in GUI mode, in a Windows environment. The project is generateed
+using the Vivado TCL console by issuing the following commands:
+
+-  *cd [project_path]/projects/motor_control/zed*
+-  *source ./system_project.tcl*
+
+This will generate the entire system and create the bit file.
+
+Downloads
+---------
+
+.. admonition:: Download
+   :class: download
+
+   
+   -  `Vivado ADI Libraries <https://github.com/analogdevicesinc/hdl/tree/hdl_2014_r1/library>`_
+   -  `Vivado Motor Control Reference Design <https://github.com/analogdevicesinc/hdl/tree/hdl_2014_r1/projects/motor_control>`_
+   
+   :
+   
+
+Setting up Linux
+----------------
+
+.. note::
+
+   For instructions on how to setup linux on the ZED board, please follow instructions at: :doc:`Linux on Zynq Quick Start Guide </solutions/reference-designs/ad-fmcmotcon1-ebz/quickstart/zynq>`
+
+Support
+-------
+
+.. hint::
+
+   
+   -  Questions? :ez:`Ask Help & Support <fpga>`.
+   

--- a/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/resources/ad-drvlv1-ebz_bom.pdf
+++ b/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/resources/ad-drvlv1-ebz_bom.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1a4ce50208160258d8ca648d6dc74eb42edb11be15b3bb4ed9a72b1cf1805a25
+size 85810

--- a/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/resources/ad-drvlv1-ebz_layout.zip
+++ b/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/resources/ad-drvlv1-ebz_layout.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e7758bb790dfb2e3b0cc1dd820a9e9cf095ee0304fb2c47677ff675226993e35
+size 894152

--- a/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/resources/ad-drvlv1-ebz_schematics.pdf
+++ b/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/resources/ad-drvlv1-ebz_schematics.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d56c27d2d74d41aec55d299b0595f3523eab8b38354600cd96f25ea71fbf0434
+size 879436

--- a/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/resources/ad-dyno1-ebz_bom.pdf
+++ b/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/resources/ad-dyno1-ebz_bom.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0e7085caa79f5829146f022a687a2733890219e4c4203ba1f0ab45cdeb5cb5a0
+size 60378

--- a/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/resources/ad-dyno1-ebz_layout.zip
+++ b/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/resources/ad-dyno1-ebz_layout.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7c5026b3af4c8419e6f5ab27215c1f2c45e0a35128cbc25394dcafcd6951c1ee
+size 421384

--- a/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/resources/ad-dyno1-ebz_schematics.pdf
+++ b/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/resources/ad-dyno1-ebz_schematics.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:68be0698d0489d02ae2d8022e1cfac7e41303b29b99c5796d450ba254377b01f
+size 183218

--- a/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/resources/ad-fmcmotcon1-ebz_bom.pdf
+++ b/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/resources/ad-fmcmotcon1-ebz_bom.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:346d5743e8c97d095b97a59c5ee771db8a3b9cb8c44d58c990a3c1723908f789
+size 89663

--- a/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/resources/ad-fmcmotcon1-ebz_layout.zip
+++ b/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/resources/ad-fmcmotcon1-ebz_layout.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5982560838678733a0ac7f945d30f426820d4ccb990644ce9fd932aad3016f45
+size 1388674

--- a/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/resources/ad-fmcmotcon1-ebz_schematics.pdf
+++ b/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/resources/ad-fmcmotcon1-ebz_schematics.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0efa29639af316702e1ca60ad9e02ba5456ed7f53b74f0908267a67f1c02eb52
+size 1396664

--- a/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/software.rst
+++ b/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/software.rst
@@ -1,0 +1,24 @@
+Software
+========
+
+.. warning::
+
+   Analog Devices uses six designations to inform our customers where a
+   semiconductor product is in its
+   :adi:`life cycle <en/support/customer-service-resources/sales/product-life-cycle-information.html>`.
+   From emerging innovations to products which have been in production for
+   twenty years, we understand that insight into life cycle status is important.
+   Device life cycles are tracked on their individual product pages on
+   `analog.com <https://www.analog.com/>`_, and should always be consulted
+   before making any design decisions.
+
+   This particular article/document/design has been retired or deprecated,
+   which means it is no longer maintained or actively updated, even though the
+   devices themselves may be Recommended for New Designs or in
+   Production. This page is here for historical/reference purposes only.
+
+The software suite for the motor control system consists of the following
+elements:
+
+-  :doc:`Linux IIO Drivers </solutions/reference-designs/ad-fmcmotcon1-ebz/software/linux_drivers>`
+-  :doc:`Linux IIO Scope user-space application for monitoring and control </solutions/reference-designs/ad-fmcmotcon1-ebz/software/iio_scope>`

--- a/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/software/iio_scope.rst
+++ b/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/software/iio_scope.rst
@@ -1,0 +1,134 @@
+AD-FMCMOTCON1-EBZ IIO User Guide
+================================
+
+.. warning::
+
+   Analog Devices uses six designations to inform our customers where a
+   semiconductor product is in its
+   :adi:`life cycle <en/support/customer-service-resources/sales/product-life-cycle-information.html>`.
+   From emerging innovations to products which have been in production for
+   twenty years, we understand that insight into life cycle status is important.
+   Device life cycles are tracked on their individual product pages on
+   `analog.com <https://www.analog.com/>`_, and should always be consulted
+   before making any design decisions.
+
+   This particular article/document/design has been retired or deprecated,
+   which means it is no longer maintained or actively updated, even though the
+   devices themselves may be Recommended for New Designs or in
+   Production. This page is here for historical/reference purposes only.
+
+IIO OSC
+-------
+
+ADI IIO oscilloscope is used for monitoring and controlling the
+AD-FMCMOTCON1-EBZ board, when using Linux operating system.
+
+There are two main tabs that are to be used: **Capture** and **Motor Control**.
+
+Capture
+~~~~~~~
+
+The Capture tab is used for monitoring the system.
+
+Current monitoring
+^^^^^^^^^^^^^^^^^^
+
+On the AD-FMCMOTCON1-EBZ system, there are two sets of ADCs for monitoring the
+current to the motor:
+
+The first AD7401A based measuring system is part of the controller board. The
+signal is pre amplified on the Low Voltage Drive board. The amplification factor
+is controlled by the GPO0 and GPO1 pins
+
+-  in_voltage0 corresponds to IA
+-  in_voltage1 corresponds to IB
+-  in_voltage2 corresponds to IT
+-  in_voltage3 corresponds to VBUS
+
+.. image:: ../images/mc_adc1_sc.png
+   :alt: Current measurement using the control board ADCs
+   :width: 600
+
+The second AD7401A measuring system is part of the Low Voltage Drive board. The
+signal is not preamplified in this case
+
+-  in_voltage0 corresponds to IA
+-  in_voltage1 corresponds to IB
+-  in_voltage2 corresponds to IT
+-  in_voltage3 is always 0
+
+.. image:: ../images/mc_adc2_sc.png
+   :alt: Current measurement using the drivel board ADCs
+   :width: 600
+
+Speed monitoring
+^^^^^^^^^^^^^^^^
+
+This IP monitors the speed, and display the number of counts ( in 10ns units)
+between two motor commutations. In order to display the speed in RPM, the data
+should be processed by checking the 1/x option and multiply by 25.000.000
+
+.. image:: ../images/mc_speed_sc.png
+   :alt: Speed measurement
+   :width: 600
+
+FOC Controller monitoring
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This IP allows monitoring of the following signals from the :doc:`MathWorks FOC IP </solutions/reference-designs/ad-fmcmotcon1-ebz/matlab_models>`:
+
+-  voltage_0 - Phase A voltage
+-  voltage_1 - Phase B voltage
+-  voltage_2 - Phase A current
+-  voltage_3 - Phase B current
+-  voltage_4 - Rotor mechanical position
+-  voltage_5 - Rotor velocity
+-  voltage_6 - d current
+-  voltage_7 - q current
+
+.. image:: ../images/mc_full_sc.png
+   :alt: FOC monitoring
+   :width: 600
+
+Control
+~~~~~~~
+
+Manual Control
+^^^^^^^^^^^^^^
+
+This controller allows the control of the motor in manual mode by directly
+specifying the fill factor of the PWM signal applied used to control the 3 phase
+inverter. The motor is driven using a 6 step comutation algorithm.
+
+.. image:: ../images/mc_manual_ctrl.png
+   :alt: Manual Control
+   :align: left
+   :width: 400
+
++-----------------+--------------------------------------------------------------------------------+
+| Control         | Description                                                                    |
++=================+================================================================================+
+| Run             | Starts the motor                                                               |
++-----------------+--------------------------------------------------------------------------------+
+| Delta           | Selects between driving the motor using a Star-like sequence or Delta sequence |
++-----------------+--------------------------------------------------------------------------------+
+| Direction       | Selects between clockwise and counterclockwise rotation directions             |
++-----------------+--------------------------------------------------------------------------------+
+| Controller Type | Selects between the Manual PWM drive or the MathWorks FOC Controller           |
++-----------------+--------------------------------------------------------------------------------+
+| PWM             | In Manual mode, the PWM can be set between 50% - 100%                          |
++-----------------+--------------------------------------------------------------------------------+
+
+Matlab Controller
+^^^^^^^^^^^^^^^^^
+
+This selects the :doc:`MathWorks FOC IP </solutions/reference-designs/ad-fmcmotcon1-ebz/matlab_models>`. From the IIO Scope the only available is to Start/Stop the motor, while the operation of the IP core is controlled through the :git-mathworks_tools:`motor_control/linux_utils/foc_script.sh` script located under */usr/local/bin*. The script executes the following steps:
+
+-  Set the FOC controller in open loop mode and wait for the user to start the motor by clicking the Run checkbox in IIO scope
+-  Calibrate the encoder readings to remove the offset between the motor's actual electrical position and the position read from the encoder
+-  Set the motor's reference speed
+-  Start the FOC controller in closed loop mode
+
+.. image:: ../images/mc_foc_ctrl.png
+   :alt: Matlab Controller
+   :width: 500

--- a/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/software/linux_drivers.rst
+++ b/docs/solutions/reference-designs/ad-fmcmotcon1-ebz/software/linux_drivers.rst
@@ -1,0 +1,125 @@
+Linux Drivers
+=============
+
+.. warning::
+
+   Analog Devices uses six designations to inform our customers where a
+   semiconductor product is in its
+   :adi:`life cycle <en/support/customer-service-resources/sales/product-life-cycle-information.html>`.
+   From emerging innovations to products which have been in production for
+   twenty years, we understand that insight into life cycle status is important.
+   Device life cycles are tracked on their individual product pages on
+   `analog.com <https://www.analog.com/>`_, and should always be consulted
+   before making any design decisions.
+
+   This particular article/document/design has been retired or deprecated,
+   which means it is no longer maintained or actively updated, even though the
+   devices themselves may be Recommended for New Designs or in
+   Production. This page is here for historical/reference purposes only.
+
+|IIO| The Linux Industrial I/O (IIO) subsystem is intended to provide support for devices that, in some sense, are analog-to-digital or digital-to-analog converters. Devices that fall into this category are:
+
+-  ADCs - can be used on ADCs ranging from a 1MSPS SoC ADC to >250 MSPS industrial ADCs
+-  DACs
+-  Accelerometers, gyros, IMUs
+-  Capacitance-to-Digital converters (CDCs)
+-  Pressure, temperature, and light sensors, etc.
+-  RF Transceivers (like the AD9361)
+
+The IIO Divers for the motor control solution require the HDL cores to have a
+specified register map. A DMA interface is set up for high speed data transfer
+using multiple multiplexed data channels. Below is the list of IIO drivers for
+the motor control solution.
+
++-----------------+----------------------------------------------------+-------------------------------------------+
+| IIO DriverName  | Description                                        | Channels                                  |
++=================+====================================================+===========================================+
+| **ad-mc-adc**   | Driver for the controller board ADCs               | CH1 - Ia measurement                      |
+|                 |                                                    | CH2 - Ib measurement                      |
+|                 |                                                    | CH3 - It measurement                      |
+|                 |                                                    | CH4 - Vbus measurement                    |
++-----------------+----------------------------------------------------+-------------------------------------------+
+| **ad-mc-adc2**  | Driver for the low voltage drive board ADCs        | CH1 - Ia measurement                      |
+|                 |                                                    | CH2 - Ib measurement                      |
+|                 |                                                    | CH3 - It measurement                      |
++-----------------+----------------------------------------------------+-------------------------------------------+
+| **ad-mc-speed** | Driver for the speed and position processing block | CH1 - Speed measurement                   |
++-----------------+----------------------------------------------------+-------------------------------------------+
+| **ad-mc-ctrl**  | Driver for the motor controller block              | CH1 : CH8 - Controller monitoring signals |
++-----------------+----------------------------------------------------+-------------------------------------------+
+
+Each IIO driver has in the device tree and entry related to the actual driver
+and an entry corresponding to the allocated DMA. Below is an example of how the
+device tree looks for the motor control IIO drivers.
+
+::
+
+   ad-mc-adc@40500000 {
+       compatible = "xlnx,axi-ad-mc-adc-1.00.a";
+       reg = <0x40500000 0x10000>;
+       dmas = <&axi_dma_0 0>;
+       dma-names = "ad-mc-adc-dma";
+   };
+
+   axi_dma_1: axidma1@40420000 {
+       compatible = "adi,axi-dmac-1.00.a";
+       reg = <0x40420000 0x10000>;
+       #dma-cells = <1>;
+       interrupts = <0 54 0>;
+       clocks = <&clkc 16>;
+
+       dma-channel {
+           adi,buswidth = <32>;
+           adi,type = <0>;
+       };
+   };
+
+   ad-mc-ctrl@40520000 {
+       compatible = "xlnx,axi-ad-mc-ctrl-1.00.a";
+       reg = <0x40520000 0x10000>;
+       dmas = <&axi_dma_1 0>;
+       dma-names = "ad-mc-ctrl-dma";
+   };
+
+   axi_dma_2: axidma2@40410000 {
+       compatible = "adi,axi-dmac-1.00.a";
+       reg = <0x40410000 0x10000>;
+       #dma-cells = <1>;
+       interrupts = <0 56 0>;
+       clocks = <&clkc 16>;
+
+       dma-channel {
+           adi,buswidth = <32>;
+           adi,type = <0>;
+       };
+   };
+
+   ad-mc-speed@40510000 {
+       compatible = "xlnx,axi-ad-mc-speed-1.00.a";
+       reg = <0x40510000 0x10000>;
+       dmas = <&axi_dma_2 0>;
+       dma-names = "ad-mc-speed-dma";
+   };
+
+   axi_dma_3: axidma3@40430000 {
+       compatible = "adi,axi-dmac-1.00.a";
+       reg = <0x40430000 0x10000>;
+       #dma-cells = <1>;
+       interrupts = <0 53 0>;
+       clocks = <&clkc 16>;
+
+       dma-channel {
+           adi,buswidth = <64>;
+           adi,type = <0>;
+       };
+   };
+
+   ad-mc-adc2@40530000 {
+       compatible = "xlnx,axi-ad-mc-adc-1.00.a";
+       reg = <0x40530000 0x10000>;
+       dmas = <&axi_dma_3 0>;
+       dma-names = "ad-mc-adc-dma";
+   };
+
+.. |IIO| image:: ../images/iio_logo.png
+   :width: 200


### PR DESCRIPTION
## Summary
- Move ad-fmcmotcon1-ebz wiki documentation to `solutions/reference-designs/ad-fmcmotcon1-ebz/`
- 25 RST files with 60 localized images
- Generated stub `index.rst` with toctree

## Test plan
- [ ] Sphinx build passes without errors
- [ ] All toctree entries resolve correctly
- [ ] Images render properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)