### PR TITLE
reference-designs/adin1300-and-adin1200: Add adin1300-and-adin1200 documentation

### DIFF
--- a/docs/solutions/reference-designs/adin1300-and-adin1200/adin1200-ieee-compliance-test-mode-access.rst
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/adin1200-ieee-compliance-test-mode-access.rst
@@ -1,0 +1,168 @@
+Configuring the ADIN1200 for Ethernet PHY Compliance Test Modes
+===============================================================
+
+Overview
+--------
+
+The purpose of this application note is to describe the configuration of the
+ADIN1200 for the various Ethernet PHY compliance test modes as set out by
+IEEE802.3.
+
+The ADIN1200 supports test modes for 100BASE-TX and 10BASE-T that are useful for
+compliance testing. Details of the registers, sequences of writes are captured
+in this document. Use this application note in conjunction with the product
+datasheet.
+
+Testing Equipment and Setup
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When performing this testing, user will need Ethernet compliance test fixture
+and associated Ethernet physical layer compliance software. There are a number
+of vendors provide Ethernet Compliance test equipment. For ADI in-house
+validation, we used Tektronix TDSET3 compliance software in addition to having
+UNH (University of New Hampshire perform compliance testing).
+
+Once equipment is in place and hardware powered and connected to the test
+fixture, configure the PHY through the MDIO interface to set the required test
+mode and use the compliance software to record and report the results.
+
+Reset Between Tests
+~~~~~~~~~~~~~~~~~~~
+
+To ensure the device is in a known state, either start from a power cycle or
+alternatively, issue the following writes to reset the device with fresh read of
+the hardware configuration.
+
+-  GE_SFT_RST_CFG_EN.Write(0b1) - Register 0xFF0D to ensure the hardware configuration is refreshed.
+-  GE_SFT_RST. Write(0b1) - Register 0xFF0C subsystem reset
+
+Extended Register Addressing
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ADIN1200 supports a range of extended management interface registers which
+can be accessed using Clause 45 access or alternatively using Clause 22 access
+through the EXT_REG_PTR (address 0x0010) and EXT_REG_DATA (address 0x0011),
+these registers provide user ability to read/write to the extended register
+space (any register greater than 0x001F) indirectly.
+
+If using Clause 22 access, write the 16-bit register address into the
+EXT_REG_PTR register and then read or write the EXT_REG_DATA register.
+
+--------------
+
+100BASE-TX
+----------
+
+For 100BASE-TX operation there are a variety of tests. There are two main test
+modes main register involved here is the B_100_TX_TST_MODE register at address
+0xB413 (available via Clause 45 access)
+
+100BASE-TX Transmit Test Mode Register
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Address: 0xB413, Reset: 0x0000, Name: B_100_TX_TST_MODE This register provides
+the ability to transmit a 100BASE-TX test signal.
+
+.. image:: images/2_-_b100tx_tst_mode_register.png
+   :align: center
+
+To configure the device for 100BASE-TX VOD measurements, issue the following
+writes over MDIO
+
+-  MII_CONTROL.Write(0x2900) - Register 0x0000 to place the device into Software PD, configure 100BASE-TX full duplex, autoneg disabled
+-  PHY_CTRL_1.AUTO_MDI_EN.Write(0b) - Register 0x0012, bit 10: Disable Auto MDI/MDIX
+-  PHY_CTRL_1.MAN_MDIX.Write(0b0) - Register 0x0012, bit 9: Operate in MDI configuration
+-  B_100_TX_TST_MODE.Write(1/2/3/4) - Register 0xB413 bits 2:0: Configure required test mode on Dim 0 or 1
+-  PHY_CTRL_3. LINK_EN.Write(0b1) - Register 0x0017, bit 13: Enable linking
+-  MII_CONTROL.SFT_PD.Write(0b0) - Register 0x0000 bit 11: Bring PHY out of
+   Software Power Down
+
+--------------
+
+10BASE-TE/10BASE-T TRANSMIT TEST SIGNAL
+---------------------------------------
+
+When operating in 10 Mbps speeds, the PHY is configured for 10BASE-Te transmit
+levels by default. 10BASE-T provides larger transmit levels and can be
+configured by clearing the B_10_E_EN register. The 10BASE-Te/T compliance tests
+are:
+
+-  Link Pulse Testing
+-  Medium Attachment Unit (MAU)
+-  TP_IDL
+-  Jitter
+-  Differential Voltage
+-  Harmonics
+-  Transmitter Return Loss
+-  Receiver Return Loss
+-  Common-Mode Voltage
+
+The B_10_TX_TST_MODE register is used to select transmit test signals useful for
+10BASE-T compliance testing.
+
+10BASE-T Transmit Test Mode Register
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Address: 0xB412, Reset: 0x0000, Name: B_10_TX_TST_MODE This register provides
+the ability to transmit a 10BASE-T test signal.
+
+.. image:: images/3_-_b10tx_tst_mode_register.png
+   :align: center
+
+To configure the device for 10BASE-T transmit test mode, consisting of 5MHz
+square wave on desired dimension, issue the following writes over MDIO
+
+-  GE_SFT_RST_CFG_EN.Write(0b1) - Register 0xFF0D to ensure the hardware configuration is refreshed.
+-  GE_SFT_RST. Write(0b1) - Register 0xFF0C subsystem reset
+-  MII_CONTROL.SFT_RST. Write(0b1) - Register 0x0000 Issue a software reset, this bit is self clearing
+-  MII_CONTROL.Write(0x0900) - Register 0x0000 Enter Software Power Down and configure 10M FD, disable AutoNegotiation
+-  B_10_TX_TST_MODE.Write(0b100) - Register 0xB412 Choice of 100: Enable Transmit 5MHz square wave on Dim 1; 011: 5MHz on Dim0; 010 10MHz on Dim1; 001: 10MHz on Dim0.
+-  MII_CONTROL.SFT_PD.Write(0b0) - Register 0x0000 Bring PHY out of Software PD
+
+An alternative configuration, where the device is configured in 10BASE-T forced
+mode in loopback with Tx suppression disabled, with transmission of frames with
+random payloads using the frame generator as follows:
+
+-  GE_SFT_RST_CFG_EN.Write(0b1) - Register 0xFF0D to ensure the hardware configuration is refreshed.
+-  GE_SFT_RST. Write(0b1) - Register 0xFF0C subsystem reset
+-  MII_CONTROL.SFT_RST. Write(0b1) - Register 0x0000 bit 15, Issue a software reset, this bit is self clearing
+-  MII_CONTROL.SFT_PD.Write(0b0) - Register 0x0000 bit 11, Bring PHY out of Software PD
+-  PHY_CTRL_1.DIAG_CLK_EN.Write(0b1) - Register 0x0012 bit 2, Enable the Diagnostic Clock
+-  MII_CONTROL.LOOPBACK.Write(0b1) - Register 0x0000 bit 14, Enable Loopback
+-  PHY_CTRL_1.MAN_MDIX.Write(0b0) - Register 0x0012 bit 9, Operate in MDI configuration
+-  PHY_CTRL_STATUS_1.LB_TX_SUP.Write(0b0) - Register 0x0013 bit 6, Stop suppressing the transmit signal at the MDI pins in all digital loopback
+-  PHY_CTRL_STATUS_1.LB_ALL_DIG_SEL.Write(0b1) - Register 0x0013 bit12 Enable all digital loopback
+-  PHY_CTRL_3. LINK_EN.Write(0b1) - Register 0x0017 bit 13, Enable linking
+-  MII_CONTROL.SFT_PD.Write(0b0) - Register 0x0000 bit 11, Bring PHY out of Software PD
+-  Wait for Link up
+-  FG_CONT_MODE_EN.Write(0b1) - Register 0x9417 Enable the frame generator into continuous mode
+-  FG_CNTRL_RSTRT.FG_CNTRL.Write(1) - Register 0x9416, bits 2:0: Enable random number in the MAC client data frame field, options of decrementing, alternative 0x55, all ones, all zeroes, random number
+-  FG_EN.FG_EN.Write(1) - Enable Frame Generator
+
+Setup for 10BASE-T forced mode in loopback with Tx suppression disabled, with
+transmission of frames with random payloads using the frame generator, configure
+as follows in sequence above
+
+-  FG_CNTRL_RSTRT.FG_CNTRL.Write(0b011) - 0xFF repeating payloads
+-  FG_CNTRL_RSTRT.FG_CNTRL.Write(0b010) - 0x00 repeating payloads
+-  FG_CNTRL_RSTRT.FG_CNTRL.Write(0b100) - alternative 0x55 payloads
+-  FG_CNTRL_RSTRT.FG_CNTRL.Write(0b101) - data field decrementing from 255 to
+   0(decimal)
+
+10BASE-T is configured by writing the following register – include it in the sequence above if 10BASE-T operation is required.
+
+-  B_10_E_EN.Write(0x0) - 10BASE-Te is enabled by default, write 0 to configure
+   10BASE-T.
+
+--------------
+
+Testing Using ADI Evaluation GUI
+--------------------------------
+
+The ADI evaluation board uses small MDIO dongle board for USB to MDIO
+communications and the accompanying GUI provides access to the various Test
+modes from the “Test Mode” tab. Select the relevant test mode to configure and
+“Execute Test”. In the “Activity log” the register writes can be observed.
+
+.. image:: images/4_-_adin1200_gui_screenshot.png
+   :align: center

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/adin1300-and-adin1200.rst
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/adin1300-and-adin1200.rst
@@ -1,0 +1,42 @@
+ADIN1300 and ADIN1200 Product Wiki Page and Evaluation Documentation
+====================================================================
+
+The product pages for the ADIN1300 and ADIN1200 Ethernet PHYs can be found on the link below: :adi:`en/products/adin1300.html` :adi:`en/products/adin1200.html`
+
+**Content**
+
+1. :doc:`ADIN1300 and ADIN1200 Layout Considerations </solutions/reference-designs/adin1300-and-adin1200/layout-considerations>` - This user guide contains recommended PCB layout considerations when designing a physical layer circuit using the ADIN1300 and ADIN1200.
+
+2. :doc:`ADIN1300 and ADIN1200 with Capacitive Coupling </solutions/reference-designs/adin1300-and-adin1200/cap-coupling>` - This wiki page contains recommended circuit, and application for a transformerless ADIN1300 and ADIN1200 Physical Layer Circuit.
+
+3. :doc:`PHY FAQ </solutions/reference-designs/adin1300-and-adin1200/phy_faq>` -A quick overview of frequently asked questions.
+
+4. **PHY Exchange Guides**
+
+10/100Mbit PHYs
+
+-  :doc:`DP83822 to ADIN1200 </solutions/reference-designs/adin1300-and-adin1200/dp83822_to_adin1200_phy_exchange_guide>`
+
+-  :doc:`KSZ8081 to ADIN1200 </solutions/reference-designs/adin1300-and-adin1200/ksz8081_to_adin1200_phy_exchange_guide>`
+
+-  :doc:`DP83825 to ADIN1200 </solutions/reference-designs/adin1300-and-adin1200/dp83825_to_adin1200_phy_exchange_guide>`
+
+10/100/1000Mbit PHYs
+
+-  :doc:`DP83867 to ADIN1300 </solutions/reference-designs/adin1300-and-adin1200/dp83867_to_adin1300_phy_exchange_guide>`
+
+-   :doc:`DP83869 to ADIN1300 </solutions/reference-designs/adin1300-and-adin1200/dp83869_to_adin1300_phy_exchange_guide>`
+
+-  :doc:`AR8035 to ADIN1300 </solutions/reference-designs/adin1300-and-adin1200/ar8035_to_adin1300_phy_exchange_guide>`
+
+-  :doc:`AR8031/8033 to ADIN1300 </solutions/reference-designs/adin1300-and-adin1200/ar8031_to_adin1300_phy_exchange_guide>`
+
+-  :doc:`Marvell 88E1510_to_ADIN1300 </solutions/reference-designs/adin1300-and-adin1200/marvell88e1510_to_adin1300_phy_exchange_guide>`
+
+-  :doc:`Marvell 88E1512_to_ADIN1300 </solutions/reference-designs/adin1300-and-adin1200/marvell88e1512_to_adin1300_phy_exchange_guide>`
+
+5. **IEEE Compliance Test Mode Access**
+
+-  :doc:`ADIN1300 IEEE Compliance Test Mode Access </solutions/reference-designs/adin1300-and-adin1200/adin1300-ieee-compliance-test-mode-access>`
+
+-  :doc:`ADIN1200 IEEE Compliance Test Mode Access </solutions/reference-designs/adin1300-and-adin1200/adin1200-ieee-compliance-test-mode-access>`

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/adin1300-ieee-compliance-test-mode-access.rst
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/adin1300-ieee-compliance-test-mode-access.rst
@@ -1,0 +1,250 @@
+Configuring the ADIN1300 for Ethernet PHY Compliance Test Modes
+===============================================================
+
+Overview
+--------
+
+The purpose of this application note is to describe the configuration of the
+ADIN1300 for the various Ethernet PHY compliance test modes as set out by
+IEEE802.3.
+
+The ADIN1300 supports the IEEE test modes, Test Mode 1, Test Mode 2, Test Mode 3
+and Test Mode 4 used for 1000BASE-T IEEE compliance testing. The ADIN1300 has
+some additional test modes that are useful for 10BASE-T and 100BASE-TX
+compliance testing. Details of the registers, sequences of writes are captured
+in this document. Use this application note in conjunction with the product
+datasheet.
+
+Testing Equipment and Setup
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When performing this testing, user will need Ethernet compliance test fixture
+and associated Ethernet physical layer compliance software. There are a number
+of vendors provide Ethernet Compliance test equipment. For ADI in-house
+validation, we used Tektronix TDSET3 compliance software in addition to having
+UNH (University of New Hampshire perform compliance testing).
+
+Once equipment is in place and hardware powered and connected to the test
+fixture, configure the PHY through the MDIO interface to set the required test
+mode and use the compliance software to record and report the results.
+
+Reset Between Tests
+~~~~~~~~~~~~~~~~~~~
+
+To ensure the device is in a known state, either start from a power cycle or
+alternatively, issue the following writes to reset the device with fresh read of
+the hardware configuration.
+
+-  GE_SFT_RST_CFG_EN.Write(0b1) - Register 0xFF0D to ensure the hardware configuration is refreshed.
+-  GE_SFT_RST. Write(0b1) - Register 0xFF0C subsystem reset
+
+Extended Register Addressing
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ADIN1300 supports a range of extended management interface registers which
+can be accessed using Clause 45 access or alternatively using Clause 22 access
+through the EXT_REG_PTR (address 0x0010) and EXT_REG_DATA (address 0x0011),
+these registers provide user ability to read/write to the extended register
+space (any register greater than 0x001F) indirectly. If using Clause 22 access,
+write the 16-bit register address into the EXT_REG_PTR register and then read or
+write the EXT_REG_DATA register.
+
+--------------
+
+1000BASE-T Testing
+------------------
+
+IEEE Test Modes
+~~~~~~~~~~~~~~~
+
+The ADIN1300 supports the IEEE test modes, Test Mode 1, Test Mode 2, Test Mode 3
+and Test Mode 4 used for 1000BASE-T IEEE compliance testing. An IEEE test mode
+can be selected by writing to register address 9, bits 15:13. The TST_MODE bit
+field can be used to select the transmit test waveforms required for Gigabit
+IEEE compliance testing.
+
+-  Test Mode 1 is used for testing of the 1000BASE-T transmitter waveform.
+-  Test Mode 2 and 3 are used for testing of the 1000BASE-T transmitter jitter.
+-  Test Mode 4 is used testing of the 1000BASE-T transmitter distortion.
+
+1000BASE-T Test Modes (Master Slave Control Register)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Address: 0x09: Reset, 0x0200, Name: MSTR_SLV_CONTROL This address corresponds to
+the MASTER-SLAVE Control register specified in clause 40.5.1.1 of IEEE Std
+802.3. Only Test mode bits are show in table below, refer to datasheet register
+map for further detail.
+
+.. image:: images/1_-1000baset_master_slave_register.png
+   :align: center
+
+TEST MODE 1: TRANSMIT WAVEFORM TEST
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This test mode is used for a number of tests as follows:
+
+-  To verify the PHY transmit waveforms fit the IEEE defined templates.
+-  To verify the PHY transmitter output voltage levels are in range
+-  To verify the PHY transmitter output voltage droop is in range
+
+To configure the device in Test Mode 1, issue the following writes over MDIO
+
+-  MII_CONTROL.SFT_PD. Write(0b1) - Register 0x0000, bit 11: Place the device into Software Power Down
+-  MSTR_SLV_CONTROL.TST_MODE.Write(1) - Register 0x0009, bit 15:13: Enable Test Mode 1
+-  MII_CONTROL.SFT_PD.Write(0b0) - Register 0x0000, bit 11: Bring PHY out of
+   Software Power Down
+
+TEST MODE 2 & 3
+~~~~~~~~~~~~~~~
+
+This test mode is used to ensure the TX_TCLK jitter with respect to an
+un-jittered reference is within range. Note the ADIN1300 does not expose TX_TCLK
+directly. To configure the device in Test Mode 2, issue the following writes
+over MDIO
+
+-  MII_CONTROL.SFT_PD. Write(0b1) - Register 0x0000, bit 11: Place the device into Software Power Down
+-  MSTR_SLV_CONTROL.TST_MODE.Write(2) - Register 0x0009, bits 15:13: Enable Test Mode 2
+-  MII_CONTROL.SFT_PD.Write(0b0) - Register 0x0000, bit 11: Bring PHY out of
+   Software Power Down
+
+To configure the device in Test Mode 3, issue the following writes over MDIO
+
+-  MII_CONTROL.SFT_PD. Write(0b1) - Register 0x0000, bit 11: Place the device into Software Power Down
+-  MSTR_SLV_CONTROL.TST_MODE.Write(3) - Register 0x0009, bits 15:13: Enable Test Mode 3
+-  MII_CONTROL.SFT_PD.Write(0b0) - Register 0x0000, bit 11: Bring PHY out of
+   Software Power Down
+
+TEST MODE 4
+~~~~~~~~~~~
+
+This test mode is used
+
+-  To ensure the peak distortion is within the specified range.
+-  To verify the return loss is above the specified attenuation.
+-  To verify the PHYs common-mode rejection ratio is in range
+
+To configure the device in Test Mode 4, issue the following writes over MDIO
+
+-  MII_CONTROL.SFT_PD. Write(0b1) - Register 0x0000, bit 11: Place the device into Software Power Down
+-  MSTR_SLV_CONTROL.TST_MODE.Write(4) - Register 0x0009, bits 15:13. Enable Test Mode 4
+-  MII_CONTROL.SFT_PD.Write(0b0) - Register 0x0000 bit 11: Bring PHY out of
+   Software Power Down
+
+--------------
+
+100BASE-TX
+----------
+
+For 100BASE-TX operation there are a variety of tests. There are two main test
+modes main register involved here is the B_100_TX_TST_MODE register at address
+0xB413 (available via Clause 45 access)
+
+100BASE-TX Transmit Test Mode Register
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Address: 0xB413, Reset: 0x0000, Name: B_100_TX_TST_MODE This register provides
+the ability to transmit a 100BASE-TX test signal.
+
+.. image:: images/2_-_b100tx_tst_mode_register.png
+   :align: center
+
+To configure the device for 100BASE-TX VOD measurements, issue the following
+writes over MDIO
+
+-  MII_CONTROL.Write(0x2900) - Register 0x0000 to place the device into Software PD, configure 100BASE-TX full duplex, autoneg disabled
+-  PHY_CTRL_1.AUTO_MDI_EN.Write(0b) - Register 0x0012, bit 10: Disable Auto MDI/MDIX
+-  PHY_CTRL_1.MAN_MDIX.Write(0b0) - Register 0x0012, bit 9: Operate in MDI configuration
+-  B_100_TX_TST_MODE.Write(1/2/3/4) - Register 0xB413 bits 2:0: Configure required test mode on Dim 0 or 1
+-  PHY_CTRL_3. LINK_EN.Write(0b1) - Register 0x0017, bit 13: Enable linking
+-  MII_CONTROL.SFT_PD.Write(0b0) - Register 0x0000 bit 11: Bring PHY out of
+   Software Power Down
+
+--------------
+
+10BASE-TE/10BASE-T TRANSMIT TEST SIGNAL
+---------------------------------------
+
+When operating in 10 Mbps speeds, the PHY is configured for 10BASE-Te transmit
+levels by default. 10BASE-T provides larger transmit levels and can be
+configured by clearing the B_10_E_EN register. The 10BASE-Te/T compliance tests
+are:
+
+-  Link Pulse Testing
+-  Medium Attachment Unit (MAU)
+-  TP_IDL
+-  Jitter
+-  Differential Voltage
+-  Harmonics
+-  Transmitter Return Loss
+-  Receiver Return Loss
+-  Common-Mode Voltage
+
+The B_10_TX_TST_MODE register is used to select transmit test signals useful for
+10BASE-T compliance testing.
+
+10BASE-T Transmit Test Mode Register
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Address: 0xB412, Reset: 0x0000, Name: B_10_TX_TST_MODE This register provides
+the ability to transmit a 10BASE-T test signal.
+
+.. image:: images/3_-_b10tx_tst_mode_register.png
+   :align: center
+
+To configure the device for 10BASE-T transmit test mode, consisting of 5MHz
+square wave on desired dimension, issue the following writes over MDIO
+
+-  GE_SFT_RST_CFG_EN.Write(0b1) - Register 0xFF0D to ensure the hardware configuration is refreshed.
+-  GE_SFT_RST. Write(0b1) - Register 0xFF0C subsystem reset
+-  MII_CONTROL.SFT_RST. Write(0b1) - Register 0x0000 Issue a software reset, this bit is self clearing
+-  MII_CONTROL.Write(0x0900) - Register 0x0000 Enter Software Power Down and configure 10M FD, disable AutoNegotiation
+-  B_10_TX_TST_MODE.Write(0b100) - Register 0xB412 Choice of 100: Enable Transmit 5MHz square wave on Dim 1; 011: 5MHz on Dim0; 010 10MHz on Dim1; 001: 10MHz on Dim0.
+-  MII_CONTROL.SFT_PD.Write(0b0) - Register 0x0000 Bring PHY out of Software PD
+
+An alternative configuration, where the device is configured in 10BASE-T forced
+mode in loopback with Tx suppression disabled, with transmission of frames with
+random payloads using the frame generator as follows:
+
+-  GE_SFT_RST_CFG_EN.Write(0b1) - Register 0xFF0D to ensure the hardware configuration is refreshed.
+-  GE_SFT_RST. Write(0b1) - Register 0xFF0C subsystem reset
+-  MII_CONTROL.SFT_RST. Write(0b1) - Register 0x0000 bit 15, Issue a software reset, this bit is self clearing
+-  MII_CONTROL.SFT_PD.Write(0b0) - Register 0x0000 bit 11, Bring PHY out of Software PD
+-  PHY_CTRL_1.DIAG_CLK_EN.Write(0b1) - Register 0x0012 bit 2, Enable the Diagnostic Clock
+-  MII_CONTROL.LOOPBACK.Write(0b1) - Register 0x0000 bit 14, Enable Loopback
+-  PHY_CTRL_1.MAN_MDIX.Write(0b0) - Register 0x0012 bit 9, Operate in MDI configuration
+-  PHY_CTRL_STATUS_1.LB_TX_SUP.Write(0b0) - Register 0x0013 bit 6, Stop suppressing the transmit signal at the MDI pins in all digital loopback
+-  PHY_CTRL_STATUS_1.LB_ALL_DIG_SEL.Write(0b1) - Register 0x0013 bit12 Enable all digital loopback
+-  PHY_CTRL_3. LINK_EN.Write(0b1) - Register 0x0017 bit 13, Enable linking
+-  MII_CONTROL.SFT_PD.Write(0b0) - Register 0x0000 bit 11, Bring PHY out of Software PD
+-  Wait for Link up
+-  FG_CONT_MODE_EN.Write(0b1) - Register 0x9417 Enable the frame generator into continuous mode
+-  FG_CNTRL_RSTRT.FG_CNTRL.Write(1) - Register 0x9416, bits 2:0: Enable random number in the MAC client data frame field, options of decrementing, alternative 0x55, all ones, all zeroes, random number
+-  FG_EN.FG_EN.Write(1) - Enable Frame Generator
+
+Setup for 10BASE-T forced mode in loopback with Tx suppression disabled, with
+transmission of frames with random payloads using the frame generator, configure
+as follows in sequence above
+
+-  FG_CNTRL_RSTRT.FG_CNTRL.Write(0b011) - 0xFF repeating payloads
+-  FG_CNTRL_RSTRT.FG_CNTRL.Write(0b010) - 0x00 repeating payloads
+-  FG_CNTRL_RSTRT.FG_CNTRL.Write(0b100) - alternative 0x55 payloads
+-  FG_CNTRL_RSTRT.FG_CNTRL.Write(0b101) - data field decrementing from 255 to
+   0(decimal)
+
+10BASE-T is configured by writing the following register – include it in the sequence above if 10BASE-T operation is required.
+
+-  B_10_E_EN.Write(0x0) - 10BASE-Te is enabled by default, write 0 to configure
+   10BASE-T.
+
+--------------
+
+Testing Using ADI Evaluation GUI
+--------------------------------
+
+The ADI evaluation board uses small MDIO dongle board for USB to MDIO
+communications and the accompanying GUI provides access to the various Test
+modes from the “Test Mode” tab. Select the relevant test mode to configure and
+“Execute Test”. In the “Activity log” the register writes can be observed.
+
+.. image:: images/4_-_gui_screenshot.png
+   :align: center

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/ar8031_to_adin1300_phy_exchange_guide.rst
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/ar8031_to_adin1300_phy_exchange_guide.rst
@@ -1,0 +1,502 @@
+PHY Exchange Guide, AR8031/8033 to ADIN1300 Gb
+==============================================
+
+.. container:: group
+
+   
+   .. container:: half column
+
+         
+         **Overview**
+
+         
+         This PHY exchange guide captures pertinent information to support
+         migration from the Qualcomm AR8031/8033 to the Analog Devices ADIN1300
+         Ethernet PHY. The ADIN1300 has compelling reasons for adoption versus
+         this competitor PHY, such as reduced power consumption, lower latency
+         and supports MII/RMII and RGMII MAC interface modes. The ADIN1300
+         Ethernet PHY supports all the standard functions and pins of an
+         Ethernet PHY and it is very straight forward to migrate an existing
+         design to the ADIN1300. The following sections detail the modifications
+         at the schematic level required to migrate from a AR8031/8033 device to
+         the ADIN1300 device. Including a description of differences
+         corresponding to each functional group of pins and differences in the
+         hardware pin configuration of the device. A side-by-side pinout and
+         package comparison and a feature comparison table are included for easy
+         reference. The ADIN1300 datasheet provides a detailed description of
+         all functions of the device and should also be consulted for reference.
+         
+         Hardware Changes By Function
+         
+         **Power Supplies Overview**
+
+         
+         The ADIN1300 requires a minimum of 2 power supply rails, where the
+         VDDIO is connected to the same power supply voltage as the MAC or as
+         the PHY analog supply AVDD_3P3 (AVDD33). The VDDIO supply rail powers
+         the MAC interface and MDIO blocks, this can operate from 1.8V, 2.5V or
+         3.3V. The AR8031/8033 can operate off a single 3.3V supply with an
+         internal switching regulator used to generate the 1.1V supply with an
+         external inductor. The supply requirements are listed in Table 1.
+         
+         .. image:: images/1_ar8031_overview_of_power_supply_rails_table1.png
+         
+         The ADIN1300 is robust to power supply sequencing and the power can be
+         applied in any order. Decoupling requirements for each device differ as
+         described in Table 2.
+         
+         .. image:: images/2_ar8031_decoupling_requirements_for_each_phy_table2.png
+         
+         **RESET Operation**
+
+         
+         Both devices have a RESET_N (RSTn) pin which initializes the device and
+         latches the hardware pin configuration. To reset the ADIN1300 the
+         RESET_N pin should be held low for >10 μs. Deglitch circuitry is
+         included on this pin to reject pulses shorter than ~1 μs. This pin
+         requires a 1 kΩ pull-up resistor to AVDD_3P3. The ADIN1300 includes
+         power monitoring circuitry to monitor all of the supplies. At power-up,
+         the ADIN1300 is held in hardware reset until each of the supplies has
+         crossed its minimum rising threshold value. The hardware strapping pins
+         are read and updated at the de-assertion of reset for both devices. For
+         the ADIN1300, the RESET_N pin resides in the AVDD_3P3 voltage domain.
+         After 5 ms from the deassertion of RESET_N, the management interface
+         registers are accessible and the device can be programmed. In
+         applications where the MAC interface is powered from VDDIO of 1.8V,
+         level shifting of the RESET_N signal applied to the ADIN1300 may be
+         required to ensure the voltage level on the RESET_N pin is in excess of
+         the minimum input high threshold level. The AR8031/8033 requires an
+         external pull-up resistor on RSTn. The AR8031/8033 requires external
+         input clock that should be stable for at least 1ms before RESET can be
+         deasserted and for chip reliability the external clock must be input
+         after the power-on sequence. When using crystal with the AR8031/8033,
+         the clock is generated internally after power is stable and for a
+         reliable power on reset, reset low long enough (10ms) to ensure the
+         clock is stable and clock-to-reset 1ms requirement is satisfied.
+         
+         **Clocking**
+
+         
+         A 25 MHz crystal or external clock source is used to provide the
+         reference clock for both devices. A crystal can be connected to pins
+         XTAL_I/XTAL_O (XTLI/XTLO), with both devices using the same external
+         circuit. Or a 25 MHz refence clock can be provided on the input clock
+         pin CLK_IN (XI). The AR8031/8033 does not support the RMII MAC
+         interface. The ADIN1300 does support RMII and requires an external 50
+         MHz REF_CLK on the XTAL_I/REF_CLK pin in RMII mode.
+         
+         **Bias Resistor**
+
+         
+         An external resistor is required to bias internal reference circuitry
+         for both AR8031/8033 and ADIN1300. The ADIN1300 requires a 3.01 kΩ
+         resistor (1% tolerance, 100 ppm/°C temperature coefficient) connected
+         to pin 10. The AR8031/8033 uses a 2.37 kΩ (1%) on pin 9.
+         
+         .. image:: images/3_ar8031_bias_resistor_values_table3.png
+         
+         **Media Dependent Interface (MDI)**
+
+         
+         The ADIN1300 has voltage mode line drivers with on-chip terminations so
+         no external termination resistors are required. Both devices use
+         voltage mode line drive for connection from the MDI_0:3_P/N (TRXP/N0:3)
+         pins to the magnetics and RJ-45 line using the same external circuit.
+         The recommended external circuit for the interface to the magnetics and
+         RJ-45 is shown in Figure 1.
+
+         
+         |image1|
+
+   .. container:: half column
+
+         
+         **MDIO/Management Interface**
+
+         
+         Both devices support the IEEE management interface using the MDIO/MDC
+         pins and require a pullup resistor on the MDIO pin (Management Data
+         Open Drain Input/Output). The recommended value for ADIN1300 is a 1.5kΩ
+         resistor connected to pin 24. The AR8031/8033 also recommends a 1.5kΩ
+         resistor connected to pin 48. Both devices provide an interrupt pin,
+         INT_N (¯INT). This pin requires a 1.5 kΩ pull-up resistor to VDDIO. The
+         AR8031/8033 recommends 10kΩ pull-up resistors for their interrupt pin.
+         
+         **LED Function**
+
+         
+         The ADIN1300 support two LED pins on LED_0 and LINK_ST. The LED_0 has
+         programmability of LED functions, with different blinking operation
+         possible through MDIO configuration, the default mode is ON when Link
+         is Up, blink if activity. The LINK_ST provides static information about
+         Link up or down status. The AR8031/8033 supports 3 LEDs pins 23, 24,
+         26. Both devices use these pins for strapping purposes.
+         
+         **LED Circuit**
+
+         
+         The ADIN1300 LED_0 operates from the AVDD_3P3 voltage domain, therefore
+         can support driving LEDs even when the MAC interface is running at the
+         lower voltage of 1.8V. The default LED operation is on if the Link is
+         up and blinks when there is activity, this operation can be
+         reprogrammed through MDIO write. For the LED_0 of the ADIN1300, it can
+         be configured with 4-level strapping. The strapping configuration will
+         have an impact on how the LED function operates and needs to be
+         considered if the LED pins are used to directly drive an LED. If the
+         strap pin is pulled high by the strapping resistors, (MODE_3/MODE_4)
+         the output will be configured as an active low driver and conversely if
+         the strapping input is pulled low (MODE_0/MODE_1), the output will be
+         configured as active high. This LED circuit should be configured
+         accordingly.
+         
+         .. image:: images/5_ar8031_led_0_hw_config_pin_interaction_figure2.png
+         
+         **Link Status, LINK_ST**
+
+         
+         The ADIN1300 has a dedicated LINK_ST pin to provide information to the
+         MAC on the status of the Link. By default, the LINK_ST pin goes high
+         indicating the link is up and low to indicate the link is down. The
+         LINK_ST polarity is programmable by setting the bit high
+         GE_LNK_STAT_INV_EN. The LINK_ST could be used to drive an LED, however
+         it resides in the VDDIO voltage domain, therefore, when driving an LED
+         in an integrated RJ45 jack where the PHY VDDIO is 1.8V, level shifting
+         will be required. This can be done using a FET.
+         
+
+   
+
+--------------
+
+.. container:: group
+
+   
+   .. container:: half column
+
+         
+         **MAC Interface**
+
+         
+         The ADIN1300 supports RGMII, MII and RMII MAC interface modes. The
+         following sections describe the RGMII, MII and RMII interfaces for both
+         devices. The AR8031/8033 only supports RGMII and does not support the
+         MII or RMII interface.
+         
+         **RGMII Interface**
+
+         
+         The RGMII interface is the communication path between the PHY and MAC
+         devices. The RGMII interface has a low pin count interface supports
+         10M, 100M and Gigabit operation, with a total of 12 pins for data
+         transmission, reception and to signal errors or collision. It is the
+         most common interface for Gigabit applications and has the lowest
+         latency. Table 5 shows a pin overview of both devices for the RGMII MAC
+         interface mode. Both devices support the internal delay on the clocks.
+         By default, the ADIN1300 is configured in RGMII mode with a 2 ns delay
+         on RXC and TXC.
+         
+         .. image:: images/6_rgmii_mac_interface_mode_pin_comparison_table4.png
+         
+         **MII Interface**
+
+         
+         The AR8031/8033 does not support the MII interface. The MII interface
+         is the communication path between the PHY and MAC devices. The MII
+         interface has a high pin count, with a total of 15 pins for data
+         transmission, reception and to signal errors or collision. It is
+         sometimes used in 100M applications as it has a lower latency than
+         RGMII and is much lower than RMII. Table 5 shows a pin overview of both
+         devices for the MII MAC interface mode. When using the ADIN1300 in MII
+         mode, the multifunction pin “LED_0/COL/TX_ER” automatically becomes
+         either COL or TX_ER. If EEE advertisement is disabled, the pin function
+         is COL as full and half-duplex operation is supported and TX_ER is not
+         required as an input. If EEE advertisement is enabled the pin function
+         is TX_ER as only full duplex operation is supported with EEE and the
+         COL pin is not required. Similarly, the “INT_N/CRS” becomes CRS. The
+         ADIN1300 sub-system registers provide user with ability to reconfigure
+         which pin the COL and CRS functions are provided on (option of
+         redirecting to GP_CLK, LINK_ST or INT_N). This requires a register
+         write over MDIO interface to reconfigure.
+         
+
+   
+   .. container:: half column
+
+         
+
+   
+      ..
+
+   |image2|
+
+         **RMII Interface**
+
+         
+         The AR8031/8033 does not support the RMII interface. RMII is a reduced
+         MII interface using fewer pins as shown in Table 6. The pin count for
+         this interface is 8 pins.
+         
+         .. image:: images/8_rmii_mac_interface_mode_pin_comparison_table6.png
+         
+         In RMII mode, the ADIN1300 requires an external 50MHz clock applied to
+         XTAL_I. This clock could come from the MAC.
+         
+         **Output Clocks**
+
+         
+         The ADIN1300 provides a 25 MHz output reference clock on the REF_CLK
+         pin. This can be used a 25 MHz input reference clock for another PHY
+         device. The ADIN1300 can optionally provide a number of clock signals
+         on the GP_CLK pin. This is configured via MDIO writes and the clocks
+         available are a 125 MHz free running clock, 25 MHz clock and 25 MHz/125
+         MHz recovered clock.
+         
+
+   
+
+--------------
+
+.. container:: group
+
+   
+   .. container:: half column
+
+         
+         Hardware Configuration
+         
+         Both devices have a number of strapping options to enable managed or
+         unmanaged configurations of the PHY function such as PHY address, mode
+         of operation, Auto-Negotiation and MAC Interface. After power on, the
+         strapping pin voltages get sensed and latched upon existing from a
+         reset and the sensed voltages are used to set the personality of the
+         PHY. When configuring any strapping configurations, ensure to review
+         the default state of the MAC side, whether the pins are being driven
+         when coming out of reset or if there are internal pulls. Understanding
+         the behavior on the MAC side is key to ensuring there are no conflicts
+         with the hardware strapping implemented, or to adjust the strapping
+         resistor values if required. The ADIN1300 uses a mix of 2-level and
+         4-level strapping options. The AR8031/8033 just uses 2-level strapping.
+         In general, strapping pins are multi-functional and have different
+         operation after the device is brought out of reset. The ADIN1300 has
+         internal pull downs on many of its strapping pins (not all), therefore
+         it would be possible to minimize external strapping resistors.
+         
+         |image3| |image4|
+         
+         Strapping configurations are very specific to the device, consult the
+         respective datasheets to determine the exact configuration for required
+         use case.
+         
+         **Hardware Configuration of Speed**
+
+         
+         For the ADIN1300, speed configuration is done using two pins, PHY_CFG0
+         and PHY_CFG1. These pins do not have any internal pull resistors,
+         therefore external strapping is required. Both pins support 4-level
+         strapping, providing much flexibility in terms of the possible
+         combinations, such as Auto-neg speeds shown in Table 8 or Forced modes
+         shown in Table 9. Review the datasheet hardware configuration pin
+         section for full detail on the possible settings using these pins.
+         
+         .. image:: images/11_auto_neg_speeds_adin1300_table8.png
+         
+
+   
+   .. container:: half column
+
+         
+
+   
+      ..
+
+   |image5|
+
+         **Hardware Configuration of Auto-MDIX**
+
+         
+         Selection of Auto-MDIX for the ADIN1300 is done using one pin,
+         (MDIX_MODE) with 4-level strapping.
+         
+         .. image:: images/13_auto_mdix_mode_table10.png
+         
+         **MAC Interface Selection**
+
+         
+         The ADIN1300 uses two hardware pins, MACIF_SEL0 and MACIF_SEL1 to
+         provide user ability to select different MAC interfaces. These two pins
+         have internal weak pull downs, therefore the default operation would be
+         RGMII with delays as shown in Table 11. To configure any other MAC
+         interface mode, use 10kΩ pull up or pull down resistors to select
+         accordingly.
+         
+         .. image:: images/14_mac_interface_selection_adin1300_table11.png
+         
+         **Hardware Configuration of PHY Address**
+
+         
+         The ADIN1300 has a default strapping providing a PHY address of 0x0000.
+         The AR8031/8033 has a default strapping providing a PHY address of
+         0x0004. The ADIN1300 uses two-level strapping for the four PHY address
+         pins, either pull high or low to configure the PHY address, with an
+         option of 16 unique addresses possible. Two level strapping provides a
+         very robust PHY addressing scheme. The AR8031/8033 provides two- level
+         strapping for the PHY address pins, capable of 8 unique address. When
+         configuring any strapping configurations, assess the default state of
+         the MAC side, in case it conflicts with the hardware strapping
+         implemented.
+         
+
+   
+
+--------------
+
+.. container:: group
+
+   
+   .. container:: half column
+
+         
+         Package
+         
+         The ADIN1300 is available in a 40 lead LFCSP (6 mm x 6 mm footprint).
+         The AR8031/8033 is available in a 48 lead QFN (6 mm x 6 mm). Note the
+         AR8031/8033 package has a 0.4 mm pin pitch, where the ADIN1300 uses a
+         standard 0.5 mm pin pitch. Due to the different package footprint and
+         differing pinout, the ADIN1300 is not a drop-in replacement for the
+         AR8031/8033 product. It will require a re-spin of schematic and board
+         layout to achieve this exchange.
+         
+         .. image:: images/15_ar8031_package_comparison_table12.png
+         
+         The underside of the LFCSP package for the ADIN1300 includes an exposed
+         paddle which should be soldered directly to the board with an array of
+         vias for thermal purposes. There are also two exposed stripes adjacent
+         to the exposed paddle. These do not need to be soldered to the board,
+         they should be treated as a keep out area as they are connected to
+         supply rails in the device, therefore should not be tied to ground and
+         there should be no routing or traces on the PCB layer directly
+         underneath them.
+         
+         Other Pinout Considerations
+         
+         **Integrated MDI Termination**
+
+         
+         Both devices include integrated termination resistors on the MDI paths.
+         These are voltage mode PHYs, no external resistors are required for
+         biasing and no supply voltage is required at the center tap of the
+         transformer.
+         
+
+   
+   .. container:: half column
+
+         
+         **RGMII Drive/Termination resistors**
+
+         
+         The ADIN1300 provides user with ability to adjust the RGMII drive
+         current through the GE_RGMII_IO_CNTRL register.
+         
+         **MII**
+
+         
+         The ADIN1300 supports MII MAC interface mode for 10/100M operation. The
+         AR8031/8033 does not support the MII interface.
+         
+         **RMII**
+
+         
+         The ADIN1300 supports RMII MAC interface mode for 10/100M operation.
+         The AR8031/8033 does not support the RMII interface.
+         
+         **GMII**
+
+         
+         The ADIN1300 and AR8031/8033 do not support the GMII interface.
+         
+         **SGMII**
+
+         
+         The ADIN1300 and AR8031/8033 do not support the SGMII interface.
+         
+         **FIBER**
+
+         
+         The ADIN1300 and AR8031/8033 do not support fiber protocols.
+         
+         Software Considerations
+         
+         Both devices can be hardware strapped to be used in an unmanaged
+         configuration. Alternatively, they can provide SMI/MII access over the
+         MDIO interface. The AR8031/8033 supports Clause 22 register access,
+         while the ADIN1300 supports both Clause 22 and Clause 45 register
+         access using both the 802.3 Clause 22 and Clause 45 management frame
+         structures. Registers 0x0 to 0xF are common across all PHYs.
+         
+         **Linux Driver**
+
+         
+         The ADIN1300 has a Linux Driver available in the Linux mainline kernel. The ADIN1300 linux driver detail is captured here: `adin <https://wiki.analog.com/resources/tools-software/linux-drivers/net-phy/adin>`_
+         
+         **Non Operating System Driver**
+
+         
+         The ADIN1300 has a Non Operating System Driver available from the devices product page here: :adi:`en/products/adin1300.html#product-requirement`
+         
+
+   
+
+.. tip::
+
+   The ADIN1300 has a Linux Driver available in the Linux mainline kernel.
+
+Side by Side Package/Pinout Comparison
+--------------------------------------
+
+The following is a side-by-side comparison of the package and pinouts, showing
+the position of the corresponding functional pins on each device.
+
+.. image:: images/16_adin1300_pinout_comparison_vs_ar8031_figure4.png
+
+--------------
+
+Feature Comparison Table
+------------------------
+
+.. image:: images/17_ar8031_feature_comparison_table_table13.png
+
+Example Configuration for RGMII
+-------------------------------
+
+The following example captures how to configure the ADIN1300 for an unmanaged
+configuration with RGMII Interface, operating in Auto Negotiation mode
+advertising all speeds. The PHY will power up in this state, ready to establish
+a link with a link partner. The MAC interface configuration pins (MACIF_SEL0/1)
+are pulled to ground, setting the PHY to RGMII mode with 2ns Delay on RXC & TXC.
+GP_CLK is pulled to VDDIO to configure an automatic MDIX operation. In addition,
+the PHY_CFG0 and PHY_CFG1 pins are configured for MODE_4 and MODE_1
+respectively. The PHY_CFG0 pin is also shared with the LED_0 pin, it’s
+configuration with MODE_4 means an active low LED can be used on LED_0.
+
+The following list summarizes an RGMII auto negotiate, 10 Mbps, 100 Mbps, or
+1000 Mbps with full duplex or half duplex, with the software power-down enabled
+after reset:
+
+-  MAC Interface = RGMII with 2ns delay on RXC/TXC
+-  MACIF_SEL0 = MODE_1 = 10 kΩ pull-down resistor
+-  MACIF_SEL1 = MODE_1 = 10 kΩ pull-down resistor
+-  MDIX_MODE = automatic MDIX, preferred MDI
+-  MDIX_MODE = MODE_4
+-  PHY address = 0b0001
+-  Speed selection = 10 Mbps, 100 Mbps, or 1000 Mbps with full duplex or half duplex, automatic negotiate enabled
+-  PHY_CFG0 = MODE_4 = 10 kΩ pull-up resistor
+-  PHY_CFG1 = MODE_1 = 10 kΩ pull-down resistor
+
+.. image:: images/18_ar8031_rgmii_auto_neg_10_100_and_1000_mbps_with_full_and_half_duplex_figure5.png
+
+.. |image1| image:: images/4_ar8031_iso_using_magnetics_figure1.png
+.. |image2| image:: images/7_mii_mac_interface_mode_pin_comparison_table5.png
+.. |image3| image:: images/9_adin1300_hw_strapping_2_and_4_level_figure3.png
+.. |image4| image:: images/10_4_level_resistor_strapping_rations_table7.png
+.. |image5| image:: images/12_forced_speeds_adin1300_table9.png

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/ar8031_to_adin1300_phy_exchange_guide.rst
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/ar8031_to_adin1300_phy_exchange_guide.rst
@@ -3,13 +3,13 @@ PHY Exchange Guide, AR8031/8033 to ADIN1300 Gb
 
 .. container:: group
 
-   
+
    .. container:: half column
 
-         
+
          **Overview**
 
-         
+
          This PHY exchange guide captures pertinent information to support
          migration from the Qualcomm AR8031/8033 to the Analog Devices ADIN1300
          Ethernet PHY. The ADIN1300 has compelling reasons for adoption versus
@@ -25,12 +25,12 @@ PHY Exchange Guide, AR8031/8033 to ADIN1300 Gb
          package comparison and a feature comparison table are included for easy
          reference. The ADIN1300 datasheet provides a detailed description of
          all functions of the device and should also be consulted for reference.
-         
+
          Hardware Changes By Function
-         
+
          **Power Supplies Overview**
 
-         
+
          The ADIN1300 requires a minimum of 2 power supply rails, where the
          VDDIO is connected to the same power supply voltage as the MAC or as
          the PHY analog supply AVDD_3P3 (AVDD33). The VDDIO supply rail powers
@@ -38,18 +38,18 @@ PHY Exchange Guide, AR8031/8033 to ADIN1300 Gb
          3.3V. The AR8031/8033 can operate off a single 3.3V supply with an
          internal switching regulator used to generate the 1.1V supply with an
          external inductor. The supply requirements are listed in Table 1.
-         
+
          .. image:: images/1_ar8031_overview_of_power_supply_rails_table1.png
-         
+
          The ADIN1300 is robust to power supply sequencing and the power can be
          applied in any order. Decoupling requirements for each device differ as
          described in Table 2.
-         
+
          .. image:: images/2_ar8031_decoupling_requirements_for_each_phy_table2.png
-         
+
          **RESET Operation**
 
-         
+
          Both devices have a RESET_N (RSTn) pin which initializes the device and
          latches the hardware pin configuration. To reset the ADIN1300 the
          RESET_N pin should be held low for >10 μs. Deglitch circuitry is
@@ -73,10 +73,10 @@ PHY Exchange Guide, AR8031/8033 to ADIN1300 Gb
          the clock is generated internally after power is stable and for a
          reliable power on reset, reset low long enough (10ms) to ensure the
          clock is stable and clock-to-reset 1ms requirement is satisfied.
-         
+
          **Clocking**
 
-         
+
          A 25 MHz crystal or external clock source is used to provide the
          reference clock for both devices. A crystal can be connected to pins
          XTAL_I/XTAL_O (XTLI/XTLO), with both devices using the same external
@@ -84,20 +84,20 @@ PHY Exchange Guide, AR8031/8033 to ADIN1300 Gb
          pin CLK_IN (XI). The AR8031/8033 does not support the RMII MAC
          interface. The ADIN1300 does support RMII and requires an external 50
          MHz REF_CLK on the XTAL_I/REF_CLK pin in RMII mode.
-         
+
          **Bias Resistor**
 
-         
+
          An external resistor is required to bias internal reference circuitry
          for both AR8031/8033 and ADIN1300. The ADIN1300 requires a 3.01 kΩ
          resistor (1% tolerance, 100 ppm/°C temperature coefficient) connected
          to pin 10. The AR8031/8033 uses a 2.37 kΩ (1%) on pin 9.
-         
+
          .. image:: images/3_ar8031_bias_resistor_values_table3.png
-         
+
          **Media Dependent Interface (MDI)**
 
-         
+
          The ADIN1300 has voltage mode line drivers with on-chip terminations so
          no external termination resistors are required. Both devices use
          voltage mode line drive for connection from the MDI_0:3_P/N (TRXP/N0:3)
@@ -105,15 +105,15 @@ PHY Exchange Guide, AR8031/8033 to ADIN1300 Gb
          The recommended external circuit for the interface to the magnetics and
          RJ-45 is shown in Figure 1.
 
-         
+
          |image1|
 
    .. container:: half column
 
-         
+
          **MDIO/Management Interface**
 
-         
+
          Both devices support the IEEE management interface using the MDIO/MDC
          pins and require a pullup resistor on the MDIO pin (Management Data
          Open Drain Input/Output). The recommended value for ADIN1300 is a 1.5kΩ
@@ -121,20 +121,20 @@ PHY Exchange Guide, AR8031/8033 to ADIN1300 Gb
          resistor connected to pin 48. Both devices provide an interrupt pin,
          INT_N (¯INT). This pin requires a 1.5 kΩ pull-up resistor to VDDIO. The
          AR8031/8033 recommends 10kΩ pull-up resistors for their interrupt pin.
-         
+
          **LED Function**
 
-         
+
          The ADIN1300 support two LED pins on LED_0 and LINK_ST. The LED_0 has
          programmability of LED functions, with different blinking operation
          possible through MDIO configuration, the default mode is ON when Link
          is Up, blink if activity. The LINK_ST provides static information about
          Link up or down status. The AR8031/8033 supports 3 LEDs pins 23, 24,
          26. Both devices use these pins for strapping purposes.
-         
+
          **LED Circuit**
 
-         
+
          The ADIN1300 LED_0 operates from the AVDD_3P3 voltage domain, therefore
          can support driving LEDs even when the MAC interface is running at the
          lower voltage of 1.8V. The default LED operation is on if the Link is
@@ -148,12 +148,12 @@ PHY Exchange Guide, AR8031/8033 to ADIN1300 Gb
          the strapping input is pulled low (MODE_0/MODE_1), the output will be
          configured as active high. This LED circuit should be configured
          accordingly.
-         
+
          .. image:: images/5_ar8031_led_0_hw_config_pin_interaction_figure2.png
-         
+
          **Link Status, LINK_ST**
 
-         
+
          The ADIN1300 has a dedicated LINK_ST pin to provide information to the
          MAC on the status of the Link. By default, the LINK_ST pin goes high
          indicating the link is up and low to indicate the link is down. The
@@ -162,29 +162,29 @@ PHY Exchange Guide, AR8031/8033 to ADIN1300 Gb
          it resides in the VDDIO voltage domain, therefore, when driving an LED
          in an integrated RJ45 jack where the PHY VDDIO is 1.8V, level shifting
          will be required. This can be done using a FET.
-         
 
-   
+
+
 
 --------------
 
 .. container:: group
 
-   
+
    .. container:: half column
 
-         
+
          **MAC Interface**
 
-         
+
          The ADIN1300 supports RGMII, MII and RMII MAC interface modes. The
          following sections describe the RGMII, MII and RMII interfaces for both
          devices. The AR8031/8033 only supports RGMII and does not support the
          MII or RMII interface.
-         
+
          **RGMII Interface**
 
-         
+
          The RGMII interface is the communication path between the PHY and MAC
          devices. The RGMII interface has a low pin count interface supports
          10M, 100M and Gigabit operation, with a total of 12 pins for data
@@ -194,12 +194,12 @@ PHY Exchange Guide, AR8031/8033 to ADIN1300 Gb
          interface mode. Both devices support the internal delay on the clocks.
          By default, the ADIN1300 is configured in RGMII mode with a 2 ns delay
          on RXC and TXC.
-         
+
          .. image:: images/6_rgmii_mac_interface_mode_pin_comparison_table4.png
-         
+
          **MII Interface**
 
-         
+
          The AR8031/8033 does not support the MII interface. The MII interface
          is the communication path between the PHY and MAC devices. The MII
          interface has a high pin count, with a total of 15 pins for data
@@ -217,53 +217,53 @@ PHY Exchange Guide, AR8031/8033 to ADIN1300 Gb
          which pin the COL and CRS functions are provided on (option of
          redirecting to GP_CLK, LINK_ST or INT_N). This requires a register
          write over MDIO interface to reconfigure.
-         
 
-   
+
+
    .. container:: half column
 
-         
 
-   
+
+
       ..
 
    |image2|
 
          **RMII Interface**
 
-         
+
          The AR8031/8033 does not support the RMII interface. RMII is a reduced
          MII interface using fewer pins as shown in Table 6. The pin count for
          this interface is 8 pins.
-         
+
          .. image:: images/8_rmii_mac_interface_mode_pin_comparison_table6.png
-         
+
          In RMII mode, the ADIN1300 requires an external 50MHz clock applied to
          XTAL_I. This clock could come from the MAC.
-         
+
          **Output Clocks**
 
-         
+
          The ADIN1300 provides a 25 MHz output reference clock on the REF_CLK
          pin. This can be used a 25 MHz input reference clock for another PHY
          device. The ADIN1300 can optionally provide a number of clock signals
          on the GP_CLK pin. This is configured via MDIO writes and the clocks
          available are a 125 MHz free running clock, 25 MHz clock and 25 MHz/125
          MHz recovered clock.
-         
 
-   
+
+
 
 --------------
 
 .. container:: group
 
-   
+
    .. container:: half column
 
-         
+
          Hardware Configuration
-         
+
          Both devices have a number of strapping options to enable managed or
          unmanaged configurations of the PHY function such as PHY address, mode
          of operation, Auto-Negotiation and MAC Interface. After power on, the
@@ -280,16 +280,16 @@ PHY Exchange Guide, AR8031/8033 to ADIN1300 Gb
          operation after the device is brought out of reset. The ADIN1300 has
          internal pull downs on many of its strapping pins (not all), therefore
          it would be possible to minimize external strapping resistors.
-         
+
          |image3| |image4|
-         
+
          Strapping configurations are very specific to the device, consult the
          respective datasheets to determine the exact configuration for required
          use case.
-         
+
          **Hardware Configuration of Speed**
 
-         
+
          For the ADIN1300, speed configuration is done using two pins, PHY_CFG0
          and PHY_CFG1. These pins do not have any internal pull resistors,
          therefore external strapping is required. Both pins support 4-level
@@ -297,43 +297,43 @@ PHY Exchange Guide, AR8031/8033 to ADIN1300 Gb
          combinations, such as Auto-neg speeds shown in Table 8 or Forced modes
          shown in Table 9. Review the datasheet hardware configuration pin
          section for full detail on the possible settings using these pins.
-         
-         .. image:: images/11_auto_neg_speeds_adin1300_table8.png
-         
 
-   
+         .. image:: images/11_auto_neg_speeds_adin1300_table8.png
+
+
+
    .. container:: half column
 
-         
 
-   
+
+
       ..
 
    |image5|
 
          **Hardware Configuration of Auto-MDIX**
 
-         
+
          Selection of Auto-MDIX for the ADIN1300 is done using one pin,
          (MDIX_MODE) with 4-level strapping.
-         
+
          .. image:: images/13_auto_mdix_mode_table10.png
-         
+
          **MAC Interface Selection**
 
-         
+
          The ADIN1300 uses two hardware pins, MACIF_SEL0 and MACIF_SEL1 to
          provide user ability to select different MAC interfaces. These two pins
          have internal weak pull downs, therefore the default operation would be
          RGMII with delays as shown in Table 11. To configure any other MAC
          interface mode, use 10kΩ pull up or pull down resistors to select
          accordingly.
-         
+
          .. image:: images/14_mac_interface_selection_adin1300_table11.png
-         
+
          **Hardware Configuration of PHY Address**
 
-         
+
          The ADIN1300 has a default strapping providing a PHY address of 0x0000.
          The AR8031/8033 has a default strapping providing a PHY address of
          0x0004. The ADIN1300 uses two-level strapping for the four PHY address
@@ -344,20 +344,20 @@ PHY Exchange Guide, AR8031/8033 to ADIN1300 Gb
          configuring any strapping configurations, assess the default state of
          the MAC side, in case it conflicts with the hardware strapping
          implemented.
-         
 
-   
+
+
 
 --------------
 
 .. container:: group
 
-   
+
    .. container:: half column
 
-         
+
          Package
-         
+
          The ADIN1300 is available in a 40 lead LFCSP (6 mm x 6 mm footprint).
          The AR8031/8033 is available in a 48 lead QFN (6 mm x 6 mm). Note the
          AR8031/8033 package has a 0.4 mm pin pitch, where the ADIN1300 uses a
@@ -365,9 +365,9 @@ PHY Exchange Guide, AR8031/8033 to ADIN1300 Gb
          differing pinout, the ADIN1300 is not a drop-in replacement for the
          AR8031/8033 product. It will require a re-spin of schematic and board
          layout to achieve this exchange.
-         
+
          .. image:: images/15_ar8031_package_comparison_table12.png
-         
+
          The underside of the LFCSP package for the ADIN1300 includes an exposed
          paddle which should be soldered directly to the board with an array of
          vias for thermal purposes. There are also two exposed stripes adjacent
@@ -376,76 +376,76 @@ PHY Exchange Guide, AR8031/8033 to ADIN1300 Gb
          supply rails in the device, therefore should not be tied to ground and
          there should be no routing or traces on the PCB layer directly
          underneath them.
-         
+
          Other Pinout Considerations
-         
+
          **Integrated MDI Termination**
 
-         
+
          Both devices include integrated termination resistors on the MDI paths.
          These are voltage mode PHYs, no external resistors are required for
          biasing and no supply voltage is required at the center tap of the
          transformer.
-         
 
-   
+
+
    .. container:: half column
 
-         
+
          **RGMII Drive/Termination resistors**
 
-         
+
          The ADIN1300 provides user with ability to adjust the RGMII drive
          current through the GE_RGMII_IO_CNTRL register.
-         
+
          **MII**
 
-         
+
          The ADIN1300 supports MII MAC interface mode for 10/100M operation. The
          AR8031/8033 does not support the MII interface.
-         
+
          **RMII**
 
-         
+
          The ADIN1300 supports RMII MAC interface mode for 10/100M operation.
          The AR8031/8033 does not support the RMII interface.
-         
+
          **GMII**
 
-         
+
          The ADIN1300 and AR8031/8033 do not support the GMII interface.
-         
+
          **SGMII**
 
-         
+
          The ADIN1300 and AR8031/8033 do not support the SGMII interface.
-         
+
          **FIBER**
 
-         
+
          The ADIN1300 and AR8031/8033 do not support fiber protocols.
-         
+
          Software Considerations
-         
+
          Both devices can be hardware strapped to be used in an unmanaged
          configuration. Alternatively, they can provide SMI/MII access over the
          MDIO interface. The AR8031/8033 supports Clause 22 register access,
          while the ADIN1300 supports both Clause 22 and Clause 45 register
          access using both the 802.3 Clause 22 and Clause 45 management frame
          structures. Registers 0x0 to 0xF are common across all PHYs.
-         
+
          **Linux Driver**
 
-         
+
          The ADIN1300 has a Linux Driver available in the Linux mainline kernel. The ADIN1300 linux driver detail is captured here: `adin <https://wiki.analog.com/resources/tools-software/linux-drivers/net-phy/adin>`_
-         
+
          **Non Operating System Driver**
 
-         
-         The ADIN1300 has a Non Operating System Driver available from the devices product page here: :adi:`en/products/adin1300.html#product-requirement`
-         
 
-   
+         The ADIN1300 has a Non Operating System Driver available from the devices product page here: :adi:`en/products/adin1300.html#product-requirement`
+
+
+
 
 .. tip::
 

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/ar8035_to_adin1300_phy_exchange_guide.rst
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/ar8035_to_adin1300_phy_exchange_guide.rst
@@ -3,13 +3,13 @@ PHY Exchange Guide, AR8035 to ADIN1300 Gb
 
 .. container:: group
 
-   
+
    .. container:: half column
 
-         
+
          **Overview**
 
-         
+
          This PHY exchange guide captures pertinent information to support
          migration from the Qualcomm AR8035 to the Analog Devices ADIN1300
          Ethernet PHY. The ADIN1300 has compelling reasons for adoption versus
@@ -25,12 +25,12 @@ PHY Exchange Guide, AR8035 to ADIN1300 Gb
          comparison and a feature comparison table are included for easy
          reference. The ADIN1300 datasheet provides a detailed description of
          all functions of the device and should also be consulted for reference.
-         
+
          Hardware Changes By Function
-         
+
          **Power Supplies Overview**
 
-         
+
          The ADIN1300 requires a minimum of 2 power supply rails, where the
          VDDIO is connected to the same power supply voltage as the MAC or as
          the PHY analog supply AVDD_3P3 (AVDD33). The VDDIO supply rail powers
@@ -38,18 +38,18 @@ PHY Exchange Guide, AR8035 to ADIN1300 Gb
          3.3V. The AR8035 can operate off a single 3.3V supply with an internal
          switching regulator used to generate the 1.1V supply with an external
          inductor. The supply requirements are listed in Table 1.
-         
+
          .. image:: images/1_ar8035_overview_of_power_supply_rails_table1.png
-         
+
          The ADIN1300 is robust to power supply sequencing and the power can be
          applied in any order. Decoupling requirements for each device differ as
          described in Table 2
-         
+
          .. image:: images/2_decoupling_requirements_for_each_phy_table2.png
-         
+
          **RESET Operation**
 
-         
+
          Both devices have a RESET_N (RSTn) pin which initializes the device and
          latches the hardware pin configuration. To reset the ADIN1300 the
          RESET_N pin should be held low for >10 μs. Deglitch circuitry is
@@ -73,10 +73,10 @@ PHY Exchange Guide, AR8035 to ADIN1300 Gb
          generated internally after power is stable and for a reliable power on
          reset, reset low long enough (10ms) to ensure the clock is stable and
          clock-to-reset 1ms requirement is satisfied.
-         
+
          **Clocking**
 
-         
+
          A 25 MHz crystal or external clock source is used to provide the
          reference clock for both devices. A crystal can be connected to pins
          XTAL_I/XTAL_O (XTLI/XTLO), with both devices using the same external
@@ -84,37 +84,37 @@ PHY Exchange Guide, AR8035 to ADIN1300 Gb
          pin CLK_IN (XI). The AR8035 does not support the RMII MAC interface.
          The ADIN1300 does support RMII and requires an external 50 MHz REF_CLK
          on the XTAL_I/REF_CLK pin in RMII mode.
-         
+
          **Bias Resistor**
 
-         
+
          An external resistor is required to bias internal reference circuitry
          for both AR8035 and ADIN1300. The ADIN1300 requires a 3.01 kΩ resistor
          (1% tolerance, 100 ppm/°C temperature coefficient) connected to pin 10.
          The AR8035 uses an 2.37 kΩ (1%) on pin 7.
-         
+
          .. image:: images/ar8035_table3_bias_resistor_values.png
-         
+
          **Media Dependent Interface (MDI)**
 
-         
+
          The ADIN1300 has voltage mode line drivers with on-chip terminations so
          no external termination resistors are required. Both devices use
          voltage mode line drive for connection from the MDI_0:3_P/N (TRXP/N0:3)
          pins to the magnetics and RJ-45 line using the same external circuit.
          The recommended external circuit for the interface to the magnetics and
          RJ-45 is shown in Figure 1.
-         
-         .. image:: images/4_isolation_using_discrete_magnetics_figure1.png
-         
 
-   
+         .. image:: images/4_isolation_using_discrete_magnetics_figure1.png
+
+
+
    .. container:: half column
 
-         
+
          **MDIO/Management Interface**
 
-         
+
          Both devices support the IEEE management interface using the MDIO/MDC
          pins and require a pullup resistor on the MDIO pin (Management Data
          Open Drain Input/Output). The recommended value for ADIN1300 is a 1.5kΩ
@@ -122,20 +122,20 @@ PHY Exchange Guide, AR8035 to ADIN1300 Gb
          resistor connected to pin 39. Both devices provide an interrupt pin,
          INT_N (¯INT). This pin requires a 1.5 kΩ pull-up resistor to VDDIO. The
          AR8035 recommends 10kΩ pull-up resistors for their interrupt pin.
-         
+
          **LED Function**
 
-         
+
          The ADIN1300 support two LED pins on LED_0 and LINK_ST. The LED_0 has
          programmability of LED functions, with different blinking operation
          possible through MDIO configuration, the default mode is ON when Link
          is Up, blink if activity. The LINK_ST provides static information about
          Link up or down status. The AR8035 supports 3 LEDs pins 21, 22, 24.
          Both devices use these pins for strapping purposes.
-         
+
          **LED Circuit**
 
-         
+
          The ADIN1300 LED_0 operates from the AVDD_3P3 voltage domain, therefore
          can support driving LEDs even when the MAC interface is running at the
          lower voltage of 1.8V. The default LED operation is on if the Link is
@@ -149,12 +149,12 @@ PHY Exchange Guide, AR8035 to ADIN1300 Gb
          the strapping input is pulled low (MODE_0/MODE_1), the output will be
          configured as active high. This LED circuit should be configured
          accordingly.
-         
+
          .. image:: images/5_ar8035_led_0_hw_config_pin_interaction_figure2.png
-         
+
          **Link Status, LINK_ST**
 
-         
+
          The ADIN1300 has a dedicated LINK_ST pin to provide information to the
          MAC on the status of the Link. By default, the LINK_ST pin goes high
          indicating the link is up and low to indicate the link is down. The
@@ -163,29 +163,29 @@ PHY Exchange Guide, AR8035 to ADIN1300 Gb
          it resides in the VDDIO voltage domain, therefore, when driving an LED
          in an integrated RJ45 jack where the PHY VDDIO is 1.8V, level shifting
          will be required. This can be done using a FET.
-         
 
-   
+
+
 
 --------------
 
 .. container:: group
 
-   
+
    .. container:: half column
 
-         
+
          **MAC Interface**
 
-         
+
          The ADIN1300 supports RGMII, MII and RMII MAC interface modes. The
          following sections describe the RGMII, MII and RMII interfaces for both
          devices. The AR8035 only supports RGMII and does not support the MII or
          RMII interface.
-         
+
          **RGMII Interface**
 
-         
+
          The RGMII interface is the communication path between the PHY and MAC
          devices. The RGMII interface has a low pin count interface supports
          10M, 100M and Gigabit operation, with a total of 12 pins for data
@@ -195,12 +195,12 @@ PHY Exchange Guide, AR8035 to ADIN1300 Gb
          interface mode. Both devices support the internal delay on the clocks.
          By default, the ADIN1300 is configured in RGMII mode with a 2 ns delay
          on RXC and TXC.
-         
+
          .. image:: images/6_ar8035_rgmii_mac_interface_mode_pin_comparison_table4.png
-         
+
          **MII Interface**
 
-         
+
          The AR8035 does not support the MII interface. The MII interface is the
          communication path between the PHY and MAC devices. The MII interface
          has a high pin count, with a total of 15 pins for data transmission,
@@ -218,53 +218,53 @@ PHY Exchange Guide, AR8035 to ADIN1300 Gb
          the COL and CRS functions are provided on (option of redirecting to
          GP_CLK, LINK_ST or INT_N). This requires a register write over MDIO
          interface to reconfigure.
-         
 
-   
+
+
    .. container:: half column
 
-         
 
-   
+
+
       ..
 
    |image1|
 
          **RMII Interface**
 
-         
+
          The AR8035 does not support the RMII interface. RMII is a reduced MII
          interface using fewer pins as shown in Table 6. The pin count for this
          interface is 8 pins.
-         
+
          .. image:: images/8_ar8035_rmii_mac_interface_mode_pin_comparison_table6.png
-         
+
          In RMII mode, the ADIN1300 requires an external 50MHz clock applied to
          XTAL_I. This clock could come from the MAC.
-         
+
          **Output Clocks**
 
-         
+
          The ADIN1300 provides a 25 MHz output reference clock on the REF_CLK
          pin. This can be used a 25 MHz input reference clock for another PHY
          device. The ADIN1300 can optionally provide a number of clock signals
          on the GP_CLK pin. This is configured via MDIO writes and the clocks
          available are a 125 MHz free running clock, 25 MHz clock and 25 MHz/125
          MHz recovered clock.
-         
 
-   
+
+
 
 --------------
 
 .. container:: group
 
-   
+
    .. container:: half column
 
-         
+
          Hardware Configuration
-         
+
          Both devices have a number of strapping options to enable managed or
          unmanaged configurations of the PHY function such as PHY address, mode
          of operation, Auto-Negotiation and MAC Interface. After power on, the
@@ -281,16 +281,16 @@ PHY Exchange Guide, AR8035 to ADIN1300 Gb
          operation after the device is brought out of reset. The ADIN1300 has
          internal pull downs on many of its strapping pins (not all), therefore
          it would be possible to minimize external strapping resistors.
-         
+
          |image2| |image3|
-         
+
          Strapping configurations are very specific to the device, consult the
          respective datasheets to determine the exact configuration for required
          use case.
-         
+
          **Hardware Configuration of Speed**
 
-         
+
          For the ADIN1300, speed configuration is done using two pins, PHY_CFG0
          and PHY_CFG1. These pins do not have any internal pull resistors,
          therefore external strapping is required. Both pins support 4-level
@@ -298,43 +298,43 @@ PHY Exchange Guide, AR8035 to ADIN1300 Gb
          combinations, such as Auto-neg speeds shown in Table 8 or Forced modes
          shown in Table 9. Review the datasheet hardware configuration pin
          section for full detail on the possible settings using these pins.
-         
-         .. image:: images/11_auto_negotiated_speeds_table8.png
-         
 
-   
+         .. image:: images/11_auto_negotiated_speeds_table8.png
+
+
+
    .. container:: half column
 
-         
 
-   
+
+
       ..
 
    |image4|
 
          **Hardware Configuration of Auto-MDIX**
 
-         
+
          Selection of Auto-MDIX for the ADIN1300 is done using one pin,
          (MDIX_MODE) with 4-level strapping.
-         
+
          .. image:: images/13_auto_mdix_more_adin_1300_table10.png
-         
+
          **MAC Interface Selection**
 
-         
+
          The ADIN1300 uses two hardware pins, MACIF_SEL0 and MACIF_SEL1 to
          provide user ability to select different MAC interfaces. These two pins
          have internal weak pull downs, therefore the default operation would be
          RGMII with delays as shown in Table 11. To configure any other MAC
          interface mode, use 10kΩ pull up or pull down resistors to select
          accordingly.
-         
+
          .. image:: images/14_mac_interface_selection_adin_1300_table11.png
-         
+
          **Hardware Configuration of PHY Address**
 
-         
+
          The ADIN1300 has a default strapping providing a PHY address of 0x0000.
          The AR8035 has a default strapping providing a PHY address of 0x0004.
          The ADIN1300 uses two-level strapping for the four PHY address pins,
@@ -344,20 +344,20 @@ PHY Exchange Guide, AR8035 to ADIN1300 Gb
          for the PHY address pins, capable of 8 unique address. When configuring
          any strapping configurations, assess the default state of the MAC side,
          in case it conflicts with the hardware strapping implemented.
-         
 
-   
+
+
 
 --------------
 
 .. container:: group
 
-   
+
    .. container:: half column
 
-         
+
          Package
-         
+
          The ADIN1300 is available in a 40 lead LFCSP (6 mm x 6 mm footprint).
          The AR8035 is available in a 40 lead QFN (5 mm x 5 mm). Note the AR8035
          package has a 0.4 mm pin pitch, where the ADIN1300 uses a standard 0.5
@@ -365,9 +365,9 @@ PHY Exchange Guide, AR8035 to ADIN1300 Gb
          pinout, the ADIN1300 is not a drop-in replacement for the AR8035
          product. It will require a re-spin of schematic and board layout to
          achieve this exchange.
-         
+
          .. image:: images/15_package_comparison_table12.png
-         
+
          The underside of the LFCSP package for the ADIN1300 includes an exposed
          paddle which should be soldered directly to the board with an array of
          vias for thermal purposes. There are also two exposed stripes adjacent
@@ -376,76 +376,76 @@ PHY Exchange Guide, AR8035 to ADIN1300 Gb
          supply rails in the device, therefore should not be tied to ground and
          there should be no routing or traces on the PCB layer directly
          underneath them.
-         
+
          Other Pinout Considerations
-         
+
          **Integrated MDI Termination**
 
-         
+
          Both devices include integrated termination resistors on the MDI paths.
          These are voltage mode PHYs, no external resistors are required for
          biasing and no supply voltage is required at the center tap of the
          transformer.
-         
+
          **RGMII Drive/Termination resistors**
 
-         
+
          The ADIN1300 provides user with ability to adjust the RGMII drive
          current through the GE_RGMII_IO_CNTRL register.
-         
 
-   
+
+
    .. container:: half column
 
-         
+
          **MII**
 
-         
+
          The ADIN1300 supports MII MAC interface mode for 10/100M operation. The
          AR8035 does not support the MII interface.
-         
+
          **RMII**
 
-         
+
          The ADIN1300 supports RMII MAC interface mode for 10/100M operation.
          The AR8035 does not support the RMII interface.
-         
+
          **GMII**
 
-         
+
          The ADIN1300 and AR8035 do not support the GMII interface.
-         
+
          **SGMII**
 
-         
+
          The ADIN1300 and AR8035 do not support the SGMII interface.
-         
+
          **FIBER**
 
-         
+
          The ADIN1300 and AR8035 do not support fiber protocols.
-         
+
          Software Considerations
-         
+
          Both devices can be hardware strapped to be used in an unmanaged
          configuration. Alternatively, they can provide SMI/MII access over the
          MDIO interface. The AR8035 supports Clause 22 register access, while
          the ADIN1300 supports both Clause 22 and Clause 45 register access
          using both the 802.3 Clause 22 and Clause 45 management frame
          structures. Registers 0x0 to 0xF are common across all PHYs.
-         
+
          **Linux Driver**
 
-         
+
          The ADIN1300 has a Linux Driver available in the Linux mainline kernel. The ADIN1300 linux driver detail is captured here: `adin <https://wiki.analog.com/resources/tools-software/linux-drivers/net-phy/adin>`_
-         
+
          **Non Operating System Driver**
 
-         
-         The ADIN1300 has a Non Operating System Driver available from the devices product page here: :adi:`en/products/adin1300.html#product-requirement`
-         
 
-   
+         The ADIN1300 has a Non Operating System Driver available from the devices product page here: :adi:`en/products/adin1300.html#product-requirement`
+
+
+
 
 .. tip::
 

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/ar8035_to_adin1300_phy_exchange_guide.rst
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/ar8035_to_adin1300_phy_exchange_guide.rst
@@ -1,0 +1,501 @@
+PHY Exchange Guide, AR8035 to ADIN1300 Gb
+=========================================
+
+.. container:: group
+
+   
+   .. container:: half column
+
+         
+         **Overview**
+
+         
+         This PHY exchange guide captures pertinent information to support
+         migration from the Qualcomm AR8035 to the Analog Devices ADIN1300
+         Ethernet PHY. The ADIN1300 has compelling reasons for adoption versus
+         this competitor PHY, such as reduced power consumption, lower latency
+         and supports MII/RMII and RGMII MAC interface modes. The ADIN1300
+         Ethernet PHY supports all the standard functions and pins of an
+         Ethernet PHY and it is very straight forward to migrate an existing
+         design to the ADIN1300. The following sections detail the modifications
+         at the schematic level required to migrate from a AR8035 device to the
+         ADIN1300 device. Including a description of differences corresponding
+         to each functional group of pins and differences in the hardware pin
+         configuration of the device. A side-by-side pinout and package
+         comparison and a feature comparison table are included for easy
+         reference. The ADIN1300 datasheet provides a detailed description of
+         all functions of the device and should also be consulted for reference.
+         
+         Hardware Changes By Function
+         
+         **Power Supplies Overview**
+
+         
+         The ADIN1300 requires a minimum of 2 power supply rails, where the
+         VDDIO is connected to the same power supply voltage as the MAC or as
+         the PHY analog supply AVDD_3P3 (AVDD33). The VDDIO supply rail powers
+         the MAC interface and MDIO blocks, this can operate from 1.8V, 2.5V or
+         3.3V. The AR8035 can operate off a single 3.3V supply with an internal
+         switching regulator used to generate the 1.1V supply with an external
+         inductor. The supply requirements are listed in Table 1.
+         
+         .. image:: images/1_ar8035_overview_of_power_supply_rails_table1.png
+         
+         The ADIN1300 is robust to power supply sequencing and the power can be
+         applied in any order. Decoupling requirements for each device differ as
+         described in Table 2
+         
+         .. image:: images/2_decoupling_requirements_for_each_phy_table2.png
+         
+         **RESET Operation**
+
+         
+         Both devices have a RESET_N (RSTn) pin which initializes the device and
+         latches the hardware pin configuration. To reset the ADIN1300 the
+         RESET_N pin should be held low for >10 μs. Deglitch circuitry is
+         included on this pin to reject pulses shorter than ~1 μs. This pin
+         requires a 1 kΩ pull-up resistor to AVDD_3P3. The ADIN1300 includes
+         power monitoring circuitry to monitor all of the supplies. At power-up,
+         the ADIN1300 is held in hardware reset until each of the supplies has
+         crossed its minimum rising threshold value. The hardware strapping pins
+         are read and updated at the de-assertion of reset for both devices. For
+         the ADIN1300, the RESET_N pin resides in the AVDD_3P3 voltage domain.
+         After 5 ms from the deassertion of RESET_N, the management interface
+         registers are accessible and the device can be programmed. In
+         applications where the MAC interface is powered from VDDIO of 1.8V,
+         level shifting of the RESET_N signal applied to the ADIN1300 may be
+         required to ensure the voltage level on the RESET_N pin is in excess of
+         the minimum input high threshold level. The AR8035 requires an external
+         pull-up resistor on RSTn. The AR8035 requires external input clock that
+         should be stable for at least 1ms before RESET can be deasserted and
+         for chip reliability the external clock must be input after the
+         power-on sequence. When using crystal with the AR8035, the clock is
+         generated internally after power is stable and for a reliable power on
+         reset, reset low long enough (10ms) to ensure the clock is stable and
+         clock-to-reset 1ms requirement is satisfied.
+         
+         **Clocking**
+
+         
+         A 25 MHz crystal or external clock source is used to provide the
+         reference clock for both devices. A crystal can be connected to pins
+         XTAL_I/XTAL_O (XTLI/XTLO), with both devices using the same external
+         circuit. Or a 25 MHz refence clock can be provided on the input clock
+         pin CLK_IN (XI). The AR8035 does not support the RMII MAC interface.
+         The ADIN1300 does support RMII and requires an external 50 MHz REF_CLK
+         on the XTAL_I/REF_CLK pin in RMII mode.
+         
+         **Bias Resistor**
+
+         
+         An external resistor is required to bias internal reference circuitry
+         for both AR8035 and ADIN1300. The ADIN1300 requires a 3.01 kΩ resistor
+         (1% tolerance, 100 ppm/°C temperature coefficient) connected to pin 10.
+         The AR8035 uses an 2.37 kΩ (1%) on pin 7.
+         
+         .. image:: images/ar8035_table3_bias_resistor_values.png
+         
+         **Media Dependent Interface (MDI)**
+
+         
+         The ADIN1300 has voltage mode line drivers with on-chip terminations so
+         no external termination resistors are required. Both devices use
+         voltage mode line drive for connection from the MDI_0:3_P/N (TRXP/N0:3)
+         pins to the magnetics and RJ-45 line using the same external circuit.
+         The recommended external circuit for the interface to the magnetics and
+         RJ-45 is shown in Figure 1.
+         
+         .. image:: images/4_isolation_using_discrete_magnetics_figure1.png
+         
+
+   
+   .. container:: half column
+
+         
+         **MDIO/Management Interface**
+
+         
+         Both devices support the IEEE management interface using the MDIO/MDC
+         pins and require a pullup resistor on the MDIO pin (Management Data
+         Open Drain Input/Output). The recommended value for ADIN1300 is a 1.5kΩ
+         resistor connected to pin 24. The AR8035 also recommends a 1.5kΩ
+         resistor connected to pin 39. Both devices provide an interrupt pin,
+         INT_N (¯INT). This pin requires a 1.5 kΩ pull-up resistor to VDDIO. The
+         AR8035 recommends 10kΩ pull-up resistors for their interrupt pin.
+         
+         **LED Function**
+
+         
+         The ADIN1300 support two LED pins on LED_0 and LINK_ST. The LED_0 has
+         programmability of LED functions, with different blinking operation
+         possible through MDIO configuration, the default mode is ON when Link
+         is Up, blink if activity. The LINK_ST provides static information about
+         Link up or down status. The AR8035 supports 3 LEDs pins 21, 22, 24.
+         Both devices use these pins for strapping purposes.
+         
+         **LED Circuit**
+
+         
+         The ADIN1300 LED_0 operates from the AVDD_3P3 voltage domain, therefore
+         can support driving LEDs even when the MAC interface is running at the
+         lower voltage of 1.8V. The default LED operation is on if the Link is
+         up and blinks when there is activity, this operation can be
+         reprogrammed through MDIO write. For the LED_0 of the ADIN1300, it can
+         be configured with 4-level strapping. The strapping configuration will
+         have an impact on how the LED function operates and needs to be
+         considered if the LED pins are used to directly drive an LED. If the
+         strap pin is pulled high by the strapping resistors, (MODE_3/MODE_4)
+         the output will be configured as an active low driver and conversely if
+         the strapping input is pulled low (MODE_0/MODE_1), the output will be
+         configured as active high. This LED circuit should be configured
+         accordingly.
+         
+         .. image:: images/5_ar8035_led_0_hw_config_pin_interaction_figure2.png
+         
+         **Link Status, LINK_ST**
+
+         
+         The ADIN1300 has a dedicated LINK_ST pin to provide information to the
+         MAC on the status of the Link. By default, the LINK_ST pin goes high
+         indicating the link is up and low to indicate the link is down. The
+         LINK_ST polarity is programmable by setting the bit high
+         GE_LNK_STAT_INV_EN. The LINK_ST could be used to drive an LED, however
+         it resides in the VDDIO voltage domain, therefore, when driving an LED
+         in an integrated RJ45 jack where the PHY VDDIO is 1.8V, level shifting
+         will be required. This can be done using a FET.
+         
+
+   
+
+--------------
+
+.. container:: group
+
+   
+   .. container:: half column
+
+         
+         **MAC Interface**
+
+         
+         The ADIN1300 supports RGMII, MII and RMII MAC interface modes. The
+         following sections describe the RGMII, MII and RMII interfaces for both
+         devices. The AR8035 only supports RGMII and does not support the MII or
+         RMII interface.
+         
+         **RGMII Interface**
+
+         
+         The RGMII interface is the communication path between the PHY and MAC
+         devices. The RGMII interface has a low pin count interface supports
+         10M, 100M and Gigabit operation, with a total of 12 pins for data
+         transmission, reception and to signal errors or collision. It is the
+         most common interface for Gigabit applications and has the lowest
+         latency. Table 5 shows a pin overview of both devices for the RGMII MAC
+         interface mode. Both devices support the internal delay on the clocks.
+         By default, the ADIN1300 is configured in RGMII mode with a 2 ns delay
+         on RXC and TXC.
+         
+         .. image:: images/6_ar8035_rgmii_mac_interface_mode_pin_comparison_table4.png
+         
+         **MII Interface**
+
+         
+         The AR8035 does not support the MII interface. The MII interface is the
+         communication path between the PHY and MAC devices. The MII interface
+         has a high pin count, with a total of 15 pins for data transmission,
+         reception and to signal errors or collision. It is sometimes used in
+         100M applications as it has a lower latency than RGMII and is much
+         lower than RMII. Table 5 shows a pin overview of both devices for the
+         MII MAC interface mode. When using the ADIN1300 in MII mode, the
+         multifunction pin “LED_0/COL/TX_ER” automatically becomes either COL or
+         TX_ER. If EEE advertisement is disabled, the pin function is COL as
+         full and half-duplex operation is supported and TX_ER is not required
+         as an input. If EEE advertisement is enabled the pin function is TX_ER
+         as only full duplex operation is supported with EEE and the COL pin is
+         not required. Similarly, the “INT_N/CRS” becomes CRS. The ADIN1300
+         sub-system registers provide user with ability to reconfigure which pin
+         the COL and CRS functions are provided on (option of redirecting to
+         GP_CLK, LINK_ST or INT_N). This requires a register write over MDIO
+         interface to reconfigure.
+         
+
+   
+   .. container:: half column
+
+         
+
+   
+      ..
+
+   |image1|
+
+         **RMII Interface**
+
+         
+         The AR8035 does not support the RMII interface. RMII is a reduced MII
+         interface using fewer pins as shown in Table 6. The pin count for this
+         interface is 8 pins.
+         
+         .. image:: images/8_ar8035_rmii_mac_interface_mode_pin_comparison_table6.png
+         
+         In RMII mode, the ADIN1300 requires an external 50MHz clock applied to
+         XTAL_I. This clock could come from the MAC.
+         
+         **Output Clocks**
+
+         
+         The ADIN1300 provides a 25 MHz output reference clock on the REF_CLK
+         pin. This can be used a 25 MHz input reference clock for another PHY
+         device. The ADIN1300 can optionally provide a number of clock signals
+         on the GP_CLK pin. This is configured via MDIO writes and the clocks
+         available are a 125 MHz free running clock, 25 MHz clock and 25 MHz/125
+         MHz recovered clock.
+         
+
+   
+
+--------------
+
+.. container:: group
+
+   
+   .. container:: half column
+
+         
+         Hardware Configuration
+         
+         Both devices have a number of strapping options to enable managed or
+         unmanaged configurations of the PHY function such as PHY address, mode
+         of operation, Auto-Negotiation and MAC Interface. After power on, the
+         strapping pin voltages get sensed and latched upon existing from a
+         reset and the sensed voltages are used to set the personality of the
+         PHY. When configuring any strapping configurations, ensure to review
+         the default state of the MAC side, whether the pins are being driven
+         when coming out of reset or if there are internal pulls. Understanding
+         the behavior on the MAC side is key to ensuring there are no conflicts
+         with the hardware strapping implemented, or to adjust the strapping
+         resistor values if required. The ADIN1300 uses a mix of 2-level and
+         4-level strapping options. The AR8035 just uses 2-level strapping. In
+         general, strapping pins are multi-functional and have different
+         operation after the device is brought out of reset. The ADIN1300 has
+         internal pull downs on many of its strapping pins (not all), therefore
+         it would be possible to minimize external strapping resistors.
+         
+         |image2| |image3|
+         
+         Strapping configurations are very specific to the device, consult the
+         respective datasheets to determine the exact configuration for required
+         use case.
+         
+         **Hardware Configuration of Speed**
+
+         
+         For the ADIN1300, speed configuration is done using two pins, PHY_CFG0
+         and PHY_CFG1. These pins do not have any internal pull resistors,
+         therefore external strapping is required. Both pins support 4-level
+         strapping, providing much flexibility in terms of the possible
+         combinations, such as Auto-neg speeds shown in Table 8 or Forced modes
+         shown in Table 9. Review the datasheet hardware configuration pin
+         section for full detail on the possible settings using these pins.
+         
+         .. image:: images/11_auto_negotiated_speeds_table8.png
+         
+
+   
+   .. container:: half column
+
+         
+
+   
+      ..
+
+   |image4|
+
+         **Hardware Configuration of Auto-MDIX**
+
+         
+         Selection of Auto-MDIX for the ADIN1300 is done using one pin,
+         (MDIX_MODE) with 4-level strapping.
+         
+         .. image:: images/13_auto_mdix_more_adin_1300_table10.png
+         
+         **MAC Interface Selection**
+
+         
+         The ADIN1300 uses two hardware pins, MACIF_SEL0 and MACIF_SEL1 to
+         provide user ability to select different MAC interfaces. These two pins
+         have internal weak pull downs, therefore the default operation would be
+         RGMII with delays as shown in Table 11. To configure any other MAC
+         interface mode, use 10kΩ pull up or pull down resistors to select
+         accordingly.
+         
+         .. image:: images/14_mac_interface_selection_adin_1300_table11.png
+         
+         **Hardware Configuration of PHY Address**
+
+         
+         The ADIN1300 has a default strapping providing a PHY address of 0x0000.
+         The AR8035 has a default strapping providing a PHY address of 0x0004.
+         The ADIN1300 uses two-level strapping for the four PHY address pins,
+         either pull high or low to configure the PHY address, with an option of
+         16 unique addresses possible. Two level strapping provides a very
+         robust PHY addressing scheme. The AR8035 provides two- level strapping
+         for the PHY address pins, capable of 8 unique address. When configuring
+         any strapping configurations, assess the default state of the MAC side,
+         in case it conflicts with the hardware strapping implemented.
+         
+
+   
+
+--------------
+
+.. container:: group
+
+   
+   .. container:: half column
+
+         
+         Package
+         
+         The ADIN1300 is available in a 40 lead LFCSP (6 mm x 6 mm footprint).
+         The AR8035 is available in a 40 lead QFN (5 mm x 5 mm). Note the AR8035
+         package has a 0.4 mm pin pitch, where the ADIN1300 uses a standard 0.5
+         mm pin pitch. Due to the different package footprint and differing
+         pinout, the ADIN1300 is not a drop-in replacement for the AR8035
+         product. It will require a re-spin of schematic and board layout to
+         achieve this exchange.
+         
+         .. image:: images/15_package_comparison_table12.png
+         
+         The underside of the LFCSP package for the ADIN1300 includes an exposed
+         paddle which should be soldered directly to the board with an array of
+         vias for thermal purposes. There are also two exposed stripes adjacent
+         to the exposed paddle. These do not need to be soldered to the board,
+         they should be treated as a keep out area as they are connected to
+         supply rails in the device, therefore should not be tied to ground and
+         there should be no routing or traces on the PCB layer directly
+         underneath them.
+         
+         Other Pinout Considerations
+         
+         **Integrated MDI Termination**
+
+         
+         Both devices include integrated termination resistors on the MDI paths.
+         These are voltage mode PHYs, no external resistors are required for
+         biasing and no supply voltage is required at the center tap of the
+         transformer.
+         
+         **RGMII Drive/Termination resistors**
+
+         
+         The ADIN1300 provides user with ability to adjust the RGMII drive
+         current through the GE_RGMII_IO_CNTRL register.
+         
+
+   
+   .. container:: half column
+
+         
+         **MII**
+
+         
+         The ADIN1300 supports MII MAC interface mode for 10/100M operation. The
+         AR8035 does not support the MII interface.
+         
+         **RMII**
+
+         
+         The ADIN1300 supports RMII MAC interface mode for 10/100M operation.
+         The AR8035 does not support the RMII interface.
+         
+         **GMII**
+
+         
+         The ADIN1300 and AR8035 do not support the GMII interface.
+         
+         **SGMII**
+
+         
+         The ADIN1300 and AR8035 do not support the SGMII interface.
+         
+         **FIBER**
+
+         
+         The ADIN1300 and AR8035 do not support fiber protocols.
+         
+         Software Considerations
+         
+         Both devices can be hardware strapped to be used in an unmanaged
+         configuration. Alternatively, they can provide SMI/MII access over the
+         MDIO interface. The AR8035 supports Clause 22 register access, while
+         the ADIN1300 supports both Clause 22 and Clause 45 register access
+         using both the 802.3 Clause 22 and Clause 45 management frame
+         structures. Registers 0x0 to 0xF are common across all PHYs.
+         
+         **Linux Driver**
+
+         
+         The ADIN1300 has a Linux Driver available in the Linux mainline kernel. The ADIN1300 linux driver detail is captured here: `adin <https://wiki.analog.com/resources/tools-software/linux-drivers/net-phy/adin>`_
+         
+         **Non Operating System Driver**
+
+         
+         The ADIN1300 has a Non Operating System Driver available from the devices product page here: :adi:`en/products/adin1300.html#product-requirement`
+         
+
+   
+
+.. tip::
+
+   The ADIN1300 has a Linux Driver available in the Linux mainline kernel.
+
+Side by Side Package/Pinout Comparison
+--------------------------------------
+
+The following is a side-by-side comparison of the package and pinouts, showing
+the position of the corresponding functional pins on each device.
+
+.. image:: images/16_adin1300_pinout_vs_ar8035_figure_4.png
+
+--------------
+
+Feature Comparison Table
+------------------------
+
+.. image:: images/17_feature_comparison_table_table13.png
+
+Example Configuration for RGMII
+-------------------------------
+
+The following example captures how to configure the ADIN1300 for an unmanaged
+configuration with RGMII Interface, operating in Auto Negotiation mode
+advertising all speeds. The PHY will power up in this state, ready to establish
+a link with a link partner. The MAC interface configuration pins (MACIF_SEL0/1)
+are pulled to ground, setting the PHY to RGMII mode with 2ns Delay on RXC & TXC.
+GP_CLK is pulled to VDDIO to configure an automatic MDIX operation. In addition,
+the PHY_CFG0 and PHY_CFG1 pins are configured for MODE_4 and MODE_1
+respectively. The PHY_CFG0 pin is also shared with the LED_0 pin, it’s
+configuration with MODE_4 means an active low LED can be used on LED_0.
+
+The following list summarizes an RGMII auto negotiate, 10 Mbps, 100 Mbps, or
+1000 Mbps with full duplex or half duplex, with the software power-down enabled
+after reset:
+
+-  MAC Interface = RGMII with 2ns delay on RXC/TXC
+-  MACIF_SEL0 = MODE_1 = 10 kΩ pull-down resistor
+-  MACIF_SEL1 = MODE_1 = 10 kΩ pull-down resistor
+-  MDIX_MODE = automatic MDIX, preferred MDI
+-  MDIX_MODE = MODE_4
+-  PHY address = 0b0001
+-  Speed selection = 10 Mbps, 100 Mbps, or 1000 Mbps with full duplex or half duplex, automatic negotiate enabled
+-  PHY_CFG0 = MODE_4 = 10 kΩ pull-up resistor
+-  PHY_CFG1 = MODE_1 = 10 kΩ pull-down resistor
+
+.. image:: images/18_rgmii_auto_neg_10_100_and_1000_mbps_with_full_and_half_duplex_figure5.png
+
+.. |image1| image:: images/7_ar8035_mii_mac_interface_mode_pin_comparison_table5.png
+.. |image2| image:: images/9_adin1300_hw_strapping_2_and_4_level_figure3.png
+.. |image3| image:: images/10_4level_strapping_resistor_ratios_table7.png
+.. |image4| image:: images/12_forced_speeds_table9.png

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/cap-coupling.rst
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/cap-coupling.rst
@@ -4,7 +4,7 @@ ADIN1300 and ADIN1200 with Capacitive Coupling
 **ARCHITECTING A TRANSFORMERLESS PHYSICAL LAYER DEVICE USING ADIN1300/ADIN1200**
 
 Introduction
-============
+------------
 
 Ethernet applications typically use galvanic isolation in the form of magnetics
 between link partners. The isolation helps to protect against faults and
@@ -19,7 +19,7 @@ ADIN1200 Ethernet PHY with capacitive coupling and covers discussion on the
 typical circuit, recommended capacitor.
 
 ADIN1300 and ADIN1200 Ethernet PHY
-==================================
+----------------------------------
 
 The ADIN1300 and ADIN1200 are low power, low latency single-port Ethernet
 transceivers designed for industrial Ethernet applications. Both are compliant
@@ -31,7 +31,7 @@ The ADIN1300 and ADIN1200 support MII, RMII, and RGMII MAC interfaces. More
 information about ADIN300 and ADIN1200 is found in the product datasheets.
 
 Application Circuits
-====================
+--------------------
 
 Figure 1(a) shows a typical ADIN1300 (or ADIN1200) Ethernet PHY Media Dependent
 Interface Connection with magnetics for galvanic isolation. Figure 1(b) shows
@@ -49,14 +49,12 @@ For ADIN1200, two pairs of the MDI must all contain a capacitor, the same as the
 ADIN1300. Figure 2 shows the recommended circuit for capacitively coupled
 ADIN1200 circuit.
 
-|image1| //**Figure 2. Typical Ethernet application configuration for ADIN1200 with Magnetics (a) or Capacitive Coupling (b)**
+|image1|
 
-::
-
-   //
+**Figure 2. Typical Ethernet application configuration for ADIN1200 with Magnetics (a) or Capacitive Coupling (b)**
 
 Capacitor Selection
-===================
+-------------------
 
 Select the capacitors based on the following guidelines.
 
@@ -85,7 +83,7 @@ signal and there could be a deviation in signal rise/fall time, propagation
 delay, magnitude deviation that results in common-mode noise.
 
 ADIN1300 & ADIN1200 MDI Properties
-==================================
+----------------------------------
 
 The ADIN1300 and ADIN1200 PHY are voltage-driven PHYs on the MDI with 50 ohms
 (each pin) serial resistors. The proper common mode is half the supply voltage
@@ -95,16 +93,18 @@ pull-up or pull-down resistors for proper biasing, either with or without a
 transformer.
 
 Protection
-==========
+----------
 
 Place a TVS on the MDI lines of the ADIN1300 and ADIN1200 for protection against
 ESD, fast transients, and surges. The TVS is placed in between the
 ADIN1300/ADIN1200 MDI pins and blocking capacitors.
 
-|image4| // **Figure 3. TVS and Common Mode Choke Applied to ADIN1300/ADIN1200** //
+|image4|
+
+**Figure 3. TVS and Common Mode Choke Applied to ADIN1300/ADIN1200**
 
 Common Mode Noise
-=================
+-----------------
 
 When the capacitive coupling is used for configurations with cabling,
 common-mode noise could be induced, thus a filter is necessary to remove those
@@ -113,7 +113,7 @@ short connections, such as backplane applications, there should be little
 common-mode noise induced, so a choke is likely not required.
 
 Configurations
-==============
+--------------
 
 The most common application where capacitively coupled Ethernet PHYs are used is
 in backplane applications where a single cap can be used to isolate the two
@@ -180,7 +180,7 @@ distances, using longer ethernet cables, then it is highly recommended to add a
 common mode choke.
 
 Evaluation
-==========
+----------
 
 The ADIN1200 and ADIN1300 are capable of operating at all speeds with the capacitively coupled configuration in both forced and auto-negotiation modes. The driver architecture supports symmetrical transmission in all modes. Figure 7 to Figure 10 show typical signaling for transformer and capacitively coupled configurations measured at the cable. Evaluation under nominal supply and temperature conditions using the ADIN1300 capacitively coupled (local and remote) showed no packet loss, no CRCs errors and signal quality (MSE – mean square error) remained comparable to transformer arrangement over a range of cable lengths (2 m to 100 m). In industrial applications, where common mode noise may be significant as already discussed, a common mode choke is recommended where there are long cable lengths.
 
@@ -197,7 +197,7 @@ The ADIN1200 and ADIN1300 are capable of operating at all speeds with the capaci
 +-------------------------------------------------+-------------------------------------------------+
 
 EMC Simulation
-==============
+--------------
 
 Computing power, SPICE, electromagnetic field simulators, and CAD software have
 converged and reached a maturity point where a virtual lab is feasible.
@@ -223,19 +223,31 @@ EMC - radiated emissions
 -  If using a longer cable (> 2m) it is recommended that the customer add a
    discrete CMC to the interface.
 
-Figure 11 shows a block diagram representation of an EMC simulation schematic. This simulation investigates the robustness of the Ethernet physical interface to IEC 61000-4-4 Electrical Fast Transients (EFT). The EFT source is injected at 1kV and at 4kV. The TVS used is the SP4065-08ATG, with 4.4pF typical capacitance, and a 1A clamp voltage of 5.5V. Two meters of standard Cat5e is used in the simulation model. The EFT source is injected through a 100 pF capacitor to the Cat5e cable shield, at 0.5 meters from the Ethernet interface. The interface includes 33nF series capacitive isolation. |image13| // Figure 11. EMC simulation block diagram //
+Figure 11 shows a block diagram representation of an EMC simulation schematic. This simulation investigates the robustness of the Ethernet physical interface to IEC 61000-4-4 Electrical Fast Transients (EFT). The EFT source is injected at 1kV and at 4kV. The TVS used is the SP4065-08ATG, with 4.4pF typical capacitance, and a 1A clamp voltage of 5.5V. Two meters of standard Cat5e is used in the simulation model. The EFT source is injected through a 100 pF capacitor to the Cat5e cable shield, at 0.5 meters from the Ethernet interface. The interface includes 33nF series capacitive isolation.
+
+|image13|
+
+**Figure 11. EMC simulation block diagram**
 
 **Running this simulation without TVS** results in overvoltage on the Ethernet MDI pins. Figures 12 (for 1 kV EFT) and 13 (for 4 kV EFT) show that 100 to 400V overvoltage will be present on the Ethernet MDI pins.
 
-|image14| // **Figure 12. Running simulation without TVS and 1 kV EFT** //
+|image14|
 
-|image15| // **Figure 13. Running simulation without TVS and 4 kV EFT** //
+**Figure 12. Running simulation without TVS and 1 kV EFT**
+
+|image15|
+
+**Figure 13. Running simulation without TVS and 4 kV EFT**
 
 **Running this simulation with TVS** results in much better performance. Most of the EFT noise is shunted to ground using the TVS, as shown in Figures 14 and 15. The pin voltage is < 10V for very short time periods, unlikely to cause ADIN1300 damage. The ringing in some of the waveform edges is very high frequency, & very unlikely to be present in the real system.
 
-|image16| // **Figure 14. Running simulation with TVS and 1 kV EFT** //
+|image16|
 
-|image17| // **Figure 15. Running simulation with TVS and 4 kV EFT** //
+**Figure 14. Running simulation with TVS and 1 kV EFT**
+
+|image17|
+
+**Figure 15. Running simulation with TVS and 4 kV EFT**
 
 When adding the TVS to the Ethernet capacitive isolation architecture there is
 one additional question - is there any degradation in signal integrity? This can
@@ -251,7 +263,7 @@ effected.
 --------------
 
 Conclusion
-==========
+----------
 
 When architecting a physical layer circuit using capacitively coupled ADIN1300
 and ADIN1200, consider the cable length to be used. Any cable more than 1 meter

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/cap-coupling.rst
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/cap-coupling.rst
@@ -1,0 +1,298 @@
+ADIN1300 and ADIN1200 with Capacitive Coupling
+==============================================
+
+**ARCHITECTING A TRANSFORMERLESS PHYSICAL LAYER DEVICE USING ADIN1300/ADIN1200**
+
+Introduction
+============
+
+Ethernet applications typically use galvanic isolation in the form of magnetics
+between link partners. The isolation helps to protect against faults and
+transients in addition to achieving the best electromagnetic compatibility
+performance. Magnetic coupling between the PHY and the RJ45 is the most common
+way of achieving this isolation as shown in Figure 1 (a). Some applications
+choose to forgo magnetics for various reasons, typically space or cost, or both.
+Moving into a transformer-less operation, isolation in accordance with the IEEE
+802.3 standard is obtained by choosing capacitive coupling instead of magnetic
+coupling. This application note captures detail around using the ADIN1300 and
+ADIN1200 Ethernet PHY with capacitive coupling and covers discussion on the
+typical circuit, recommended capacitor.
+
+ADIN1300 and ADIN1200 Ethernet PHY
+==================================
+
+The ADIN1300 and ADIN1200 are low power, low latency single-port Ethernet
+transceivers designed for industrial Ethernet applications. Both are compliant
+with the IEEE 802.3 Ethernet standard. The ADIN1300 supports 10/100/1000 Mbps
+and ADIN1200 supports 10/100 Mbps Ethernet speeds. These PHYs support unmanaged
+configuration using multi-level strapping, or managed configuration using MDIO
+access and operate over a wide industrial temperature range (−40°C to + 105°C).
+The ADIN1300 and ADIN1200 support MII, RMII, and RGMII MAC interfaces. More
+information about ADIN300 and ADIN1200 is found in the product datasheets.
+
+Application Circuits
+====================
+
+Figure 1(a) shows a typical ADIN1300 (or ADIN1200) Ethernet PHY Media Dependent
+Interface Connection with magnetics for galvanic isolation. Figure 1(b) shows
+the recommended circuit using capacitive coupling. In this case, the transformer
+is replaced with a capacitor in each path from MDI pins to the RJ-45 connector.
+Proper selection of capacitors, layout recommendations, and other guidelines are
+discussed in the succeeding sections.
+
+.. image:: images/adin1300_magnetics.jpg
+   :align: center
+
+**Figure 1. Typical Ethernet application configuration for ADIN1300 with Magnetics (a) or Capacitive Coupling (b)**
+
+For ADIN1200, two pairs of the MDI must all contain a capacitor, the same as the
+ADIN1300. Figure 2 shows the recommended circuit for capacitively coupled
+ADIN1200 circuit.
+
+|image1| //**Figure 2. Typical Ethernet application configuration for ADIN1200 with Magnetics (a) or Capacitive Coupling (b)**
+
+::
+
+   //
+
+Capacitor Selection
+===================
+
+Select the capacitors based on the following guidelines.
+
+-   Using non-polarized capacitors.
+-   The capacitors must meet the isolation requirements as specified in Clause 40.6.1.1(ac and dc isolation).
+-   Use 33 nF capacitor value as recommended.
+
+.. tip::
+
+   Choosing the Capacitor
+
+The capacitor value is calculated by following the required 3 radians phase angle over a frequency range of 2-80 MHz according to ANSI INCITS 263-1995 in order to meet the return loss requirement according to IEEE 802.3 33.4.7 subclause. |image2|
+
+|image3|
+
+The value of recommended capacitance would be **C = 30.369 nF ≈ 33 nF**
+
+Where:
+
+-  f = 2 MHz as the frequency of interest for worst-case condition
+-  Zo = 100 ohms
+
+Use an NPO capacitor as it exhibits tighter tolerance (0.1%) than any other cap
+type. Any difference from the capacitances might greatly affect the differential
+signal and there could be a deviation in signal rise/fall time, propagation
+delay, magnitude deviation that results in common-mode noise.
+
+ADIN1300 & ADIN1200 MDI Properties
+==================================
+
+The ADIN1300 and ADIN1200 PHY are voltage-driven PHYs on the MDI with 50 ohms
+(each pin) serial resistors. The proper common mode is half the supply voltage
+(3.3V/2) and the Tx drivers provide this DC voltage automatically. Since the
+common mode is controlled by the Line Driver, the MDI pins should not use any
+pull-up or pull-down resistors for proper biasing, either with or without a
+transformer.
+
+Protection
+==========
+
+Place a TVS on the MDI lines of the ADIN1300 and ADIN1200 for protection against
+ESD, fast transients, and surges. The TVS is placed in between the
+ADIN1300/ADIN1200 MDI pins and blocking capacitors.
+
+|image4| // **Figure 3. TVS and Common Mode Choke Applied to ADIN1300/ADIN1200** //
+
+Common Mode Noise
+=================
+
+When the capacitive coupling is used for configurations with cabling,
+common-mode noise could be induced, thus a filter is necessary to remove those
+CM noises. Using a common mode choke gives better common-mode rejection. For
+short connections, such as backplane applications, there should be little
+common-mode noise induced, so a choke is likely not required.
+
+Configurations
+==============
+
+The most common application where capacitively coupled Ethernet PHYs are used is
+in backplane applications where a single cap can be used to isolate the two
+nodes that are attached to the backplane using ethernet compliant connectors.
+Capacitive coupling may also be used in applications requiring a short cable
+less than 1 meter.
+
+Single Cap Configuration
+------------------------
+
+This configuration can be used for backplane applications where the two nodes
+are attached to the backplane. This configuration uses PCB traces as the
+connecting medium for the two nodes. The PCB traces must be 50 ohms. A single
+blocking capacitor separates the two nodes in the backplane. This configuration
+doesn’t necessarily include a common mode choke. The PCB traces must be of equal
+lengths to have a well-balanced impedance because any unbalanced path would
+introduce common-mode noise.
+
+A benefit of using capacitive coupling is a smaller footprint than magnetics,
+which is very useful in backplane applications. Figure 4 shows a single cap
+configuration using ADIN1300.
+
+Cap - Cable - Cap Configuration
+-------------------------------
+
+The cap-cable-cap approach is similar to the backplane application but the two
+nodes use short Ethernet compliant wires instead of copper PCB traces as
+connecting medium. Figure 5 shows a simple illustration of the cap-cable-cap
+using the ADIN1300/ ADIN1200. This configuration would work well when the cable
+is 1 meter or less. Anything more than 1 meter might introduce some common-mode
+noise. Commonly, these two boards belong to one shielded casing. A common mode
+choke might not be needed in this configuration as common mode noise induced is
+very low. There are situations (non-backplane), mostly in industrial
+applications, where the nodes are separated at longer distances, using a long
+cable (more than 1 meter), therefore, it is recommended to use a common mode
+choke to attenuate the noise. The cable can also be shielded as an additional
+immunity.
+
+.. image:: images/single_cap_backplane.jpg
+   :align: center
+
+**Figure 4. ADIN1300 Configuration for Backplane Applications (Single Capacitor)**
+
+.. image:: images/cap_with_cable.jpg
+   :align: center
+
+**Figure 5. Capacitive Coupling Configuration (with Cable)**
+
+.. image:: images/cap_and_magnetic.jpg
+   :align: center
+
+*\*\* Figure 6. Capacitive and Magnetic Coupling Configuration (with Cable)*\**
+
+Cap - Cable - Transformer Configuration
+---------------------------------------
+
+The Cap-Cable-Transformer approach is a non-typical ethernet connection, shown
+in Figure 6. It is important to note that Node 1 uses capacitive coupling and
+Node 2 uses Magnetic coupling and the two nodes are connected via ethernet
+cable. The Ethernet cable must not exceed one meter because one of the nodes
+uses capacitive coupling. It is best to use a shielded Ethernet cable when using
+this type of configuration. However, if the two nodes are separated at longer
+distances, using longer ethernet cables, then it is highly recommended to add a
+common mode choke.
+
+Evaluation
+==========
+
+The ADIN1200 and ADIN1300 are capable of operating at all speeds with the capacitively coupled configuration in both forced and auto-negotiation modes. The driver architecture supports symmetrical transmission in all modes. Figure 7 to Figure 10 show typical signaling for transformer and capacitively coupled configurations measured at the cable. Evaluation under nominal supply and temperature conditions using the ADIN1300 capacitively coupled (local and remote) showed no packet loss, no CRCs errors and signal quality (MSE – mean square error) remained comparable to transformer arrangement over a range of cable lengths (2 m to 100 m). In industrial applications, where common mode noise may be significant as already discussed, a common mode choke is recommended where there are long cable lengths.
+
++-------------------------------------------------+-------------------------------------------------+
+| Transformer                                     | Capacitive Coupling                             |
++=================================================+=================================================+
+| |image9|                                        | |image10|                                       |
++-------------------------------------------------+-------------------------------------------------+
+| **Figure 7. 100 Mbps with Transformer circuit** | **Figure 8. 100 Mbps with Capacitive Coupling** |
++-------------------------------------------------+-------------------------------------------------+
+| |image11|                                       | |image12|                                       |
++-------------------------------------------------+-------------------------------------------------+
+| **Figure 9. 10 Mbps with Transformer circuit**  | **Figure 10. 10 Mbps with Capacitive Coupling** |
++-------------------------------------------------+-------------------------------------------------+
+
+EMC Simulation
+==============
+
+Computing power, SPICE, electromagnetic field simulators, and CAD software have
+converged and reached a maturity point where a virtual lab is feasible.
+Simulating an Ethernet link with ADIN1300 PHY, PCB, cable models, EMC source
+(stimulus), and active/passive components is possible.
+
+When considering EMC performance for an Ethernet link both transient immunity
+and radiated emissions require careful consideration.
+
+EMC - transient immunity
+
+-  High voltage transients, such as IEC 61000-4-4 EFT to the Cat5e cable will result in overvoltage at the Ethernet ADIN1300 MDI pins.
+-  If using capacitive isolation, a TVS is recommended to clamp the overvoltage.
+-  Using a low capacitance TVS, such as the SP4065-08ATG will help to protect the ADIN1300 Ethernet PHY.
+-  There are many ‘high speed’ TVS options available, however the clamp voltage vs. current specification varies.
+-  The Littlefuse SP4065-08ATG has a lower clamp voltage at high current compared to other devices.
+-  Littlefuse provide SPICE parameters for the SP4065-08ATG .
+
+EMC - radiated emissions
+
+-  An ethernet transformer, with integrated common mode choke (CMC) provides very good common mode noise attenuation.
+-  Without a transformer and integrated CMC, any common mode noise from the Ethernet PHY driver will go straight to the cable and radiate very efficiently. More radiation will occur with a longer cable.
+-  If using a longer cable (> 2m) it is recommended that the customer add a
+   discrete CMC to the interface.
+
+Figure 11 shows a block diagram representation of an EMC simulation schematic. This simulation investigates the robustness of the Ethernet physical interface to IEC 61000-4-4 Electrical Fast Transients (EFT). The EFT source is injected at 1kV and at 4kV. The TVS used is the SP4065-08ATG, with 4.4pF typical capacitance, and a 1A clamp voltage of 5.5V. Two meters of standard Cat5e is used in the simulation model. The EFT source is injected through a 100 pF capacitor to the Cat5e cable shield, at 0.5 meters from the Ethernet interface. The interface includes 33nF series capacitive isolation. |image13| // Figure 11. EMC simulation block diagram //
+
+**Running this simulation without TVS** results in overvoltage on the Ethernet MDI pins. Figures 12 (for 1 kV EFT) and 13 (for 4 kV EFT) show that 100 to 400V overvoltage will be present on the Ethernet MDI pins.
+
+|image14| // **Figure 12. Running simulation without TVS and 1 kV EFT** //
+
+|image15| // **Figure 13. Running simulation without TVS and 4 kV EFT** //
+
+**Running this simulation with TVS** results in much better performance. Most of the EFT noise is shunted to ground using the TVS, as shown in Figures 14 and 15. The pin voltage is < 10V for very short time periods, unlikely to cause ADIN1300 damage. The ringing in some of the waveform edges is very high frequency, & very unlikely to be present in the real system.
+
+|image16| // **Figure 14. Running simulation with TVS and 1 kV EFT** //
+
+|image17| // **Figure 15. Running simulation with TVS and 4 kV EFT** //
+
+When adding the TVS to the Ethernet capacitive isolation architecture there is
+one additional question - is there any degradation in signal integrity? This can
+be simulated by injecting a MLT-3 31.25 MHz signal on each MDI pin
+(corresponding to 100 Mbps Ethernet MII). Simulation shows that adding 33nF
+series capacitors, with TVS and 2 meters of cabling does not attenuate
+signaling. Some minor signal reflections are likely to occur (due to cable
+effects) as shown in Figure 16, but differential signaling levels are not
+effected.
+
+|image18| **Figure 16. Signal integrity simulation - using Capacitive Isolation and TVS on the MDI Interface**
+
+--------------
+
+Conclusion
+==========
+
+When architecting a physical layer circuit using capacitively coupled ADIN1300
+and ADIN1200, consider the cable length to be used. Any cable more than 1 meter
+would introduce noise that can be eliminated by putting a common mode choke in
+the MDI signal path and shielding the ethernet cable. Use NPO 33 nF capacitors
+in designing the circuit. Include a TVS for immunity to ESD and fast transients.
+For backplane applications, the PCB traces must be of the same length with 50
+ohms impedance.
+
+.. |image1| image:: images/1200_capcouple_transformer.jpg
+.. |image2| image:: images/second_formula.jpg
+   :width: 300
+.. |image3| image:: images/first_formula.jpg
+   :width: 300
+.. |image4| image:: images/tvs_and_cmc.jpg
+   :width: 600
+.. |image5| image:: images/fig_7.jpg
+   :width: 400
+.. |image6| image:: images/fig_8.jpg
+   :width: 400
+.. |image7| image:: images/fig_9.jpg
+   :width: 400
+.. |image8| image:: images/fig_10.jpg
+   :width: 400
+.. |image9| image:: images/fig_7.jpg
+   :width: 400
+.. |image10| image:: images/fig_8.jpg
+   :width: 400
+.. |image11| image:: images/fig_9.jpg
+   :width: 400
+.. |image12| image:: images/fig_10.jpg
+   :width: 400
+.. |image13| image:: images/capiso_sch.png
+   :width: 400
+.. |image14| image:: images/12.png
+   :width: 400
+.. |image15| image:: images/13.png
+   :width: 400
+.. |image16| image:: images/14.png
+   :width: 400
+.. |image17| image:: images/15.png
+   :width: 400
+.. |image18| image:: images/16.png
+   :width: 400

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/dp83822_to_adin1200_phy_exchange_guide.rst
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/dp83822_to_adin1200_phy_exchange_guide.rst
@@ -1,0 +1,498 @@
+PHY Exchange Guide, DP83822 to ADIN1200 10/100Mb
+================================================
+
+.. container:: group
+
+   
+   .. container:: half column
+
+         
+         **Overview**
+
+         
+         This PHY exchange guide captures pertinent information to support
+         migration from the TI DP83822 to the Analog Devices ADIN1200 Ethernet
+         PHY. Both devices support MII, RMII and RGMII MAC interfaces from the
+         same package version. The PHYs have different pinouts, therefore the
+         ADIN1200 is not a drop-in replacement for the TI product. This requires
+         edits to the schematic and board layout to achieve this exchange. The
+         following sections detail the modifications at the schematic level
+         required to migrate from DP83822 to the ADIN1200 device.
+         
+         Hardware Changes By Function
+         
+         **Power Supplies Overview**
+
+         
+         The supply requirements are listed in Table 1. Both devices can operate
+         from a minimum of one 3.3V power supply rail AVDD_3P3 (AVD), where the
+         VDDIO rail is connected to 3.3V, alternatively the VDDIO rails can be
+         run with a different supply voltage. The ADIN1200 has an on chip
+         voltage regulator to generate the internal core supply rail and
+         provided to a pin for decoupling purposes.
+         
+         .. image:: images/dp83822_table1.png
+            :align: center
+            :width: 600
+         
+         The ADIN1200 is robust to power supply sequencing and the power can be
+         applied in any order. The ADIN1200 provides two pins for each supply
+         rail, whereas the TI device provides one power supply pin for each
+         rail. The VDDIO supply rail powers the MAC interface and MDIO blocks,
+         this can operate from 1.8V, 2.5V or 3.3V. Decoupling requirements for
+         each device differs as described in Table 2 {{
+         :resources:eval:user-guides:adin1300-and-adin1200:dp83822_table2.png?direct&600
+         \|
+         
+         **RESET Operation**
+
+         
+         An active low hardware reset pin, RESET_N is provided on Pin 6 of the
+         ADIN1200 and pin 18 of the DP83822. The hardware strapping pins are
+         read and updated at the de-assertion of reset for both devices. For the
+         ADIN1200, the RESET_N pin resides in the AVDD_3P3 voltage domain,
+         whereas for the TI device, the RESET_N pin is referenced to VDDIO. In
+         applications where the MAC interface is powered from VDDIO of 1.8V,
+         level shifting of the RESET_N signal applied to the ADIN1200 may be
+         required to ensure the voltage level on the RESET_N pin is in excess of
+         the minimum input high threshold level.
+         
+         **Clocking**
+
+         
+         A 25 MHz crystal or external clock source is used to provide the
+         reference clock for both devices. In RMII mode, the ADIN1200 expects an
+         external 50MHz REF_CLK provided to the XTAL_I/REF_CLK pin. In RMII
+         master mode, the DP83822 (RMII mode) can provide a 50 MHz REF_CLK to
+         the MAC device from the 25 MHz source. Alternatively, in RMII slave
+         mode, provide an external 50 MHz both the PHY and MAC.
+         
+         **Bias Resistor**
+
+         
+         An external resistor, REXT (RBIAS) is required to bias internal
+         reference circuitry for both DP83822 and ADIN1200. The ADIN1200
+         requires a 3.01 kΩ resistor (1% tolerance, 100 ppm/°C temperature
+         coefficient) connected to pin 10. The DP83822 uses a 4.87 kΩ on pin 16
+         (RBIAS).
+         
+         .. image:: images/dp83822_table3.png
+            :align: center
+            :width: 600
+         
+         **Media Dependent Interface (MDI)**
+
+         
+         The ADIN1200 has voltage mode line drivers with on-chip terminations so
+         no external termination resistors are required and the center tap of
+         the transformer does not require biasing to supply voltage. The
+         recommended external circuit for the interface to the magnetics and
+         RJ-45 is shown in Figure 1 for the voltage mode ADIN1200. The DP83822
+         uses current mode drivers requiring external termination resistors on
+         the differential pairs in addition to requiring the center tap pin on
+         the device side of the transformer be pulled to the analog supply rail
+         (AVD). The configuration shown in Figure 2 illustrates a simplified
+         diagram showing the additional termination resistors and the biasing of
+         the center tap required for current mode PHYs. Note there may be
+         additional decoupling and inductance used in practice.
+         
+         |image1| **Figure 1 Isolation using Discrete Magnetics (Voltage Mode Driver) ADIN1200** |image2| **Figure 2 Simplified circuit for Current Mode Driver (DP83822)**
+         
+         **MDIO/Management Interface**
+
+         
+      Both devices can be hardware strapped to be used in an unmanaged
+      configuration. Alternatively, they can provide SMI/MII access over the two
+      wire MDIO interface. The MDIO pin (Management Data Open Drain
+      Input/Output) for SMI/MII interface to MAC and requires an external pullup
+      resistor. The recommended value for ADIN1200 is a 1.5kΩ resistor connected
+      to pin 24. The DP83822 recommends 2.2kΩ connected to pin 19. The ADIN1200
+      supports an MDC clock up to 5.5MHz, while the DP83822 supports an MDC
+      clock as fast as 25MHz. A hardware interrupt output pin INT_N (INTb) is
+      provided in both devices and is open drain. The recommended value for
+      ADIN1200 is a 1.5kΩ resistor connected to INT_N pin 27. The DP83822 has a
+      weak internal pullup, and in application circuit shows a 2.2kΩ connected
+      to INTb, pin 8.
+
+   
+   .. container:: half column
+
+         
+         **LED Function**
+
+         
+         Both devices support two LED pins. The ADIN1200 pins are LED_0 and
+         LINK_ST. The LED_0 has programmability of LED functions, with different
+         blinking operation possible through MDIO configuration, the default
+         mode is ON when Link is Up, blink if activity. The LINK_ST provides
+         static information about Link up or down status. The DP83822 pins are
+         LED0, LED1, where LED0 can be configured for On/Off and Blink if
+         activity while LED1 can be configured to indicate 10 or 100M link
+         speed. Both devices use these pins for Speed and Auto-Neg strapping
+         purposes.
+         
+         **LED Circuit**
+
+         
+         The ADIN1200 LED_0 operates from the AVDD_3P3 voltage domain, therefore
+         can support driving LEDs even when the MAC interface is running at the
+         lower voltage of VDDIO= 1.8V. The default LED operation is on if the
+         Link is up and blinks when there is activity, this operation can be
+         reprogrammed through MDIO write. For the LED_0 of the ADIN1200, it can
+         be configured with 4-level strapping. The strapping configuration will
+         have an impact on how the LED function operates, and needs to be
+         considered if the LED pins are used to directly drive an LED. If the
+         strap pin is pulled high by the strapping resistors, (MODE_3/MODE_4)
+         the output will be configured as an active low driver and conversely if
+         the strapping input is pulled low (MODE_0/MODE_1), the output will be
+         configured as active high. This LED circuit should be configured
+         accordingly.
+         
+         |image3| Figure 2. LED_0 Hardware Configuration Pin Interaction
+         
+         **Link Status, LINK_ST**
+
+         
+         The ADIN1200 has a dedicated LINK_ST pin to provide information to the
+         MAC on the status of the Link. By default, the LINK_ST pin goes high
+         indicating the link is up and low to indicate the link is down. The
+         LINK_ST polarity is programmable by setting the bit high
+         GE_LNK_STAT_INV_EN. The LINK_ST could be used to drive an LED, however
+         it resides in the VDDIO voltage domain, therefore, when driving an LED
+         in an integrated RJ45 jack where the PHY VDDIO is 1.8V, level shifting
+         will be required.
+         
+
+   
+
+--------------
+
+.. container:: group
+
+   
+   .. container:: half column
+
+         
+         **MAC Interface**
+
+         
+         Both PHYs support MII, RMII and RGMII MAC interface modes. The
+         following sections describe specifically the interfaces for both
+         devices.
+         
+         **MII Interface**
+
+         
+         The MII interface is the communication path between the PHY and MAC
+         devices. The MII interface has a high pin count, with a total of 15
+         pins for data transmission, reception and to signal errors or
+         collision. It is sometimes used in 100M applications as it has a lower
+         latency than RGMII and is much lower than RMII. Table 4 shows a pin
+         overview of both devices for the MII MAC interface mode. When using the
+         ADIN1200 in MII mode, the multifunction pin “LED_0/COL/TX_ER”
+         automatically becomes COL. Similarly, the “INT_N/CRS” becomes CRS. The
+         ADIN1200 sub-system registers provide user with ability to reconfigure
+         which pin the COL and CRS functions are provided on (option of
+         redirecting to GP_CLK, LINK_ST or INT_N). This requires a register
+         write over MDIO interface to reconfigure.
+         
+         .. image:: images/dp38322_table_4_mii_mac_interface_mode_pin_comparison.png
+         
+         **RMII Interface**
+
+         
+         RMII is a reduced MII interface using fewer pins as shown in Table 5.
+         The pin count for this interface is 8 pins.
+
+         
+         |image4|
+
+      RMII mode requires a 50MHz clock, REF_CLK. In RMII mode, the ADIN1200
+      requires an external 50MHz clock applied to XTAL_I. The DP83822 can
+      generate a 50MHz clock internally and provide it to the MAC (master mode).
+      Alternatively in slave mode, it can accept an external 50MHz clock from
+      the MAC.
+
+   
+   .. container:: half column
+
+         
+         **RGMII Interface**
+
+         
+         Both support an RGMII interface mode. The RGMII interface has a low pin
+         count interface support for 10M, 100M and Gigabit operation with a
+         total of 12 pins for data transmission, reception and to signal errors
+         or collisions. It is the most common interface used for Gigabit
+         applications. These PHYs can support 10/100 M speeds over the RGMII
+         interface.
+
+         
+         |image5|
+
+         **100BASE-FX**
+
+         
+         The DP83822 “F” versions also support 100BASE-FX interface. The
+         ADIN1200 does not support 100BASE-FX.
+         
+         **Output Clocks**
+
+         
+         The ADIN1200 can optionally provide a number of clock signals on the
+         GP_CLK pin. This is configured via MDIO writes and the clocks available
+         are a 125 MHz free running clock, 25 MHz clock and 25MHz/125 MHz
+         recovered clock.
+         
+
+   
+
+--------------
+
+.. container:: group
+
+   
+   .. container:: half column
+
+         
+         Hardware Configuration
+         
+         Both devices have a number of strapping options to enable managed or
+         unmanaged configurations of the PHY function such as PHY address, mode
+         of operation, Auto-Negotiation and MAC Interface. After power on, the
+         strapping pin voltages get sensed and latched upon existing from a
+         reset and the sensed voltages are used to set the personality of the
+         PHY. When configuring any strapping configurations, ensure to review
+         the default state of the MAC side, whether the pins are being driven
+         when coming out of reset or if there are internal pulls. Understanding
+         the behavior on the MAC side is key to ensuring there are no conflicts
+         with the hardware strapping implemented, or to adjust the strapping
+         resistor values if required. The DP83822 uses 4-level strapping options
+         throughout, while the ADIN1200 uses a mix of 2-level and 4-level. In
+         general, strapping pins are multi-functional and have different
+         operation after the device is brought out of reset. The ADIN1200 has
+         internal pull downs on many of its strapping pins (not all), therefore
+         it would be possible to minimize external strapping resistors.
+         
+         |image6| Figure 4. ADIN1200 Hardware Strapping, 2 and 4 level strapping resistors |image7|
+         
+         Strapping configurations are very specific to the device, consult the
+         respective datasheets to determine the exact configuration for required
+         use case. The DP83822 has internal pullup resistors of 50kΩ on COL,
+         LED_0, CRS and RX_ER. All other pins used in strapping functios have
+         internal 9 kΩ pulldown resistors, therefore external strapping values
+         differ depending on pin as shown in Table 8 and Table 9.
+
+         
+         |image8|
+
+   .. container:: half column
+
+         
+         **Hardware Configuration of Speed**
+
+         
+         For the ADIN1200, speed configuration is done using two pins, PHY_CFG0
+         and PHY_CFG1. These pins do not have any internal pull resistors,
+         therefore external strapping is required. Both pins support 4-level
+         strapping, providing much flexibility in terms of the possible
+         combinations, such as Auto-neg speeds shown in Table 10 or Forced modes
+         shown in Table 11. Review the datasheet hardware configuration pin
+         section for full detail on the possible settings using these pins. The
+         DP83822 uses pins RX_D0, RX_D3 and LED_0 to select speeds 10 or 100 M
+         speeds, duplex and forced mode or auto-negotiation.
+
+         
+         |image9|
+
+         .. image:: images/ksz_table9.png
+            :width: 600
+         
+         **Hardware Configuration of Auto-MDIX**
+
+         
+         Selection of Auto-MDIX for the ADIN1200 is done using one pin,
+         (MDIX_MODE) with 4-level strapping. In the DP83822 Auto-MDI/MDI-X is
+         enabled by default and set by the RX_ER strapping pin.
+         
+         .. image:: images/ksz_table10.png
+            :width: 600
+         
+         **MAC Interface Selection**
+
+         
+         The ADIN1200 uses two hardware pins, MACIF_SEL0 and MACIF_SEL1 to
+         provide user ability to select different MAC interfaces. These two pins
+         have internal weak pull downs, therefore the default operation would be
+         RGMII with delays as shown in Table 13. To configure any other MAC
+         interface mode, use 10kΩ pull up or pull down resistors to select
+         accordingly. The DP83822 MAC interface selection is chosen by selecting
+         the appropriate configuration of RX_DV, RX_ER (for MII, RMII or RGMII
+         mode) with combination of RX_ER, LED_1 and COL for 100BASE-FX mode.
+         
+         **Hardware Configuration of PHY Address**
+
+         
+         Both devices use two-level strapping, either pull high or low to
+         configure the PHY address. The ADIN1200 provides four PHY address pins,
+         allowing up to 16 unique addresses possible. The PHY address pins are
+         shared with the RXD output pins. The default PHY address strapping for
+         ADIN1200 is 0x0000. The DP83822 provides five PHY address pins, capable
+         of 32 unique addresses. The PHY Address pins are also on RX_Dx pins and
+         COL. The default PHY address strapping for DP83822 is 0x0001.
+         
+
+   
+
+.. important::
+
+   Strapping configurations are very specific to the device, consult the
+   respective datasheets to determine the exact configuration for required use
+   case.
+
+--------------
+
+.. container:: group
+
+   
+   .. container:: half column
+
+         
+         Package
+         
+         Both the ADIN1200 and the DP83822 are available in a 32 lead QFN/LFCSP
+         package of 5 mm x 5mm body size. The devices have different pinouts,
+         therefore the ADIN1200 is not a drop-in replacement for the TI product.
+         This requires edits to the schematic and board layout to achieve this
+         exchange.
+         
+         .. image:: images/dp83822_table14.png
+            :align: center
+            :width: 600
+         
+         The underside of the LFCSP package for the ADIN1200 includes an exposed
+         paddle which should be soldered directly to the board with an array of
+         vias for thermal purposes. There are also two exposed stripes adjacent
+         to the exposed paddle. These do not need to be soldered to the board,
+         they should be treated as a keepout area as they are connected to
+         supply rails in the device, therefore should not be tied to ground and
+         there should be no routing or traces on the PCB layer directly
+         underneath them.
+         
+         Other Pinout Considerations
+         
+         **Integrated MDI Termination**
+
+         
+         The ADIN1200 is a voltage mode PHY, therefore includes integrated
+         termination resistors on the MDI paths. The DP83822 is a current mode
+         PHY, so requires external resistors for biasing and center tap of the
+         transformer must be pulled to supply.
+         
+
+   
+   .. container:: half column
+
+         
+         Software Considerations
+         
+         Both devices can be hardware strapped to be used in an unmanaged
+         configuration. Alternatively, they can provide SMI/MII access over the
+         MDIO interface. The KSZ8081 supports Clause 22 register access, while
+         the ADIN1200 supports both Clause 22 and Clause 45 access. Registers
+         0x0 to 0xF are common across all PHYs.
+         
+         **Linux Driver**
+
+         
+         The ADIN1200 has a Linux Driver available in the Linux mainline kernel. The ADIN1200 linux driver detail is captured here: `adin <https://wiki.analog.com/resources/tools-software/linux-drivers/net-phy/adin>`_
+         
+         **Non Operating System Driver**
+
+         
+         The ADIN1200 has a Non Operating System Driver available from the devices product page here: :adi:`en/products/adin1200.html#product-requirement`
+         
+
+   
+
+.. tip::
+
+   The ADIN1200 has a Linux Driver available in the Linux mainline kernel.
+
+--------------
+
+High Level Comparison
+---------------------
+
+.. image:: images/dp83822_table_comparison.png
+   :align: center
+
+--------------
+
+Side by Side Package/Pinout Comparison
+--------------------------------------
+
+The following is a side-by-side comparison of the package and pinouts, showing
+the position of the corresponding functional pins on each device.
+
+.. image:: images/dp83822_side_by_side.png
+   :align: center
+
+--------------
+
+Example Configurations for RMII
+-------------------------------
+
+The following example captures how to configure the ADIN1200 for an unmanaged
+configuration with RGMII Interface, operating in Auto-negotiation mode
+advertising all speeds. The PHY will power up in this state, ready to establish
+a link with a link partner. The MAC interface configuration pins (MACIF_SEL0/1)
+are pulled to ground, setting the PHY to RGMII mode. GP_CLK is set to MODE_3 to
+configure an automatic MDIX operation. In addition, the PHY_CFG0 and PHY_CFG1
+pins are configured for MODE_4 and MODE_1 respectively. The PHY_CFG0 pin is also
+shared with the LED_0 pin, it’s configuration with MODE_4 means an active low
+LED can be used on LED_0. The following list summarizes an RMII auto negotiate,
+10 Mbps or 100 Mbps full duplex or half duplex:
+
+-  MAC Interface = RMII
+
+::
+
+      *MACIF_SEL0 = MODE_1 = 10 kΩ pull-down resistor
+      *MACIF_SEL1 = MODE_1 = 10 kΩ pull-down resistor
+
+-  MDIX_MODE = automatic MDIX, preferred MDIX
+
+   -  MDIX_MODE = MODE_3
+
+-  PHY address = 0b0001
+-  Speed selection = 10 Mbps, 100 Mbps with full duplex or half duplex,
+   auto-negotiation enabled
+
+   -  PHY_CFG0 = MODE_4 = 10 kΩ pull-up resistor
+
+::
+
+     *PHY_CFG1 = MODE_1 = 10 kΩ pull-down resistor
+
+.. image:: images/rgmii_example.png
+   :align: center
+
+.. |image1| image:: images/adin1200_magnetics_cmchoke.png
+   :width: 600
+.. |image2| image:: images/dp83822_magnetics_cmchoke.png
+   :width: 600
+.. |image3| image:: images/led.png
+   :width: 600
+.. |image4| image:: images/dp83822_table5.png
+   :width: 600
+.. |image5| image:: images/dp83822_table6.png
+   :width: 600
+.. |image6| image:: images/strapping.png
+   :width: 600
+.. |image7| image:: images/ksz_table7.png
+   :width: 600
+.. |image8| image:: images/dp83822_table8_9.png
+   :width: 600
+.. |image9| image:: images/ksz_table8.png
+   :width: 600

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/dp83822_to_adin1200_phy_exchange_guide.rst
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/dp83822_to_adin1200_phy_exchange_guide.rst
@@ -3,13 +3,13 @@ PHY Exchange Guide, DP83822 to ADIN1200 10/100Mb
 
 .. container:: group
 
-   
+
    .. container:: half column
 
-         
+
          **Overview**
 
-         
+
          This PHY exchange guide captures pertinent information to support
          migration from the TI DP83822 to the Analog Devices ADIN1200 Ethernet
          PHY. Both devices support MII, RMII and RGMII MAC interfaces from the
@@ -18,23 +18,23 @@ PHY Exchange Guide, DP83822 to ADIN1200 10/100Mb
          edits to the schematic and board layout to achieve this exchange. The
          following sections detail the modifications at the schematic level
          required to migrate from DP83822 to the ADIN1200 device.
-         
+
          Hardware Changes By Function
-         
+
          **Power Supplies Overview**
 
-         
+
          The supply requirements are listed in Table 1. Both devices can operate
          from a minimum of one 3.3V power supply rail AVDD_3P3 (AVD), where the
          VDDIO rail is connected to 3.3V, alternatively the VDDIO rails can be
          run with a different supply voltage. The ADIN1200 has an on chip
          voltage regulator to generate the internal core supply rail and
          provided to a pin for decoupling purposes.
-         
+
          .. image:: images/dp83822_table1.png
             :align: center
             :width: 600
-         
+
          The ADIN1200 is robust to power supply sequencing and the power can be
          applied in any order. The ADIN1200 provides two pins for each supply
          rail, whereas the TI device provides one power supply pin for each
@@ -43,10 +43,10 @@ PHY Exchange Guide, DP83822 to ADIN1200 10/100Mb
          each device differs as described in Table 2 {{
          :resources:eval:user-guides:adin1300-and-adin1200:dp83822_table2.png?direct&600
          \|
-         
+
          **RESET Operation**
 
-         
+
          An active low hardware reset pin, RESET_N is provided on Pin 6 of the
          ADIN1200 and pin 18 of the DP83822. The hardware strapping pins are
          read and updated at the de-assertion of reset for both devices. For the
@@ -56,33 +56,33 @@ PHY Exchange Guide, DP83822 to ADIN1200 10/100Mb
          level shifting of the RESET_N signal applied to the ADIN1200 may be
          required to ensure the voltage level on the RESET_N pin is in excess of
          the minimum input high threshold level.
-         
+
          **Clocking**
 
-         
+
          A 25 MHz crystal or external clock source is used to provide the
          reference clock for both devices. In RMII mode, the ADIN1200 expects an
          external 50MHz REF_CLK provided to the XTAL_I/REF_CLK pin. In RMII
          master mode, the DP83822 (RMII mode) can provide a 50 MHz REF_CLK to
          the MAC device from the 25 MHz source. Alternatively, in RMII slave
          mode, provide an external 50 MHz both the PHY and MAC.
-         
+
          **Bias Resistor**
 
-         
+
          An external resistor, REXT (RBIAS) is required to bias internal
          reference circuitry for both DP83822 and ADIN1200. The ADIN1200
          requires a 3.01 kΩ resistor (1% tolerance, 100 ppm/°C temperature
          coefficient) connected to pin 10. The DP83822 uses a 4.87 kΩ on pin 16
          (RBIAS).
-         
+
          .. image:: images/dp83822_table3.png
             :align: center
             :width: 600
-         
+
          **Media Dependent Interface (MDI)**
 
-         
+
          The ADIN1200 has voltage mode line drivers with on-chip terminations so
          no external termination resistors are required and the center tap of
          the transformer does not require biasing to supply voltage. The
@@ -95,12 +95,12 @@ PHY Exchange Guide, DP83822 to ADIN1200 10/100Mb
          diagram showing the additional termination resistors and the biasing of
          the center tap required for current mode PHYs. Note there may be
          additional decoupling and inductance used in practice.
-         
+
          |image1| **Figure 1 Isolation using Discrete Magnetics (Voltage Mode Driver) ADIN1200** |image2| **Figure 2 Simplified circuit for Current Mode Driver (DP83822)**
-         
+
          **MDIO/Management Interface**
 
-         
+
       Both devices can be hardware strapped to be used in an unmanaged
       configuration. Alternatively, they can provide SMI/MII access over the two
       wire MDIO interface. The MDIO pin (Management Data Open Drain
@@ -114,13 +114,13 @@ PHY Exchange Guide, DP83822 to ADIN1200 10/100Mb
       weak internal pullup, and in application circuit shows a 2.2kΩ connected
       to INTb, pin 8.
 
-   
+
    .. container:: half column
 
-         
+
          **LED Function**
 
-         
+
          Both devices support two LED pins. The ADIN1200 pins are LED_0 and
          LINK_ST. The LED_0 has programmability of LED functions, with different
          blinking operation possible through MDIO configuration, the default
@@ -130,10 +130,10 @@ PHY Exchange Guide, DP83822 to ADIN1200 10/100Mb
          activity while LED1 can be configured to indicate 10 or 100M link
          speed. Both devices use these pins for Speed and Auto-Neg strapping
          purposes.
-         
+
          **LED Circuit**
 
-         
+
          The ADIN1200 LED_0 operates from the AVDD_3P3 voltage domain, therefore
          can support driving LEDs even when the MAC interface is running at the
          lower voltage of VDDIO= 1.8V. The default LED operation is on if the
@@ -147,12 +147,12 @@ PHY Exchange Guide, DP83822 to ADIN1200 10/100Mb
          the strapping input is pulled low (MODE_0/MODE_1), the output will be
          configured as active high. This LED circuit should be configured
          accordingly.
-         
+
          |image3| Figure 2. LED_0 Hardware Configuration Pin Interaction
-         
+
          **Link Status, LINK_ST**
 
-         
+
          The ADIN1200 has a dedicated LINK_ST pin to provide information to the
          MAC on the status of the Link. By default, the LINK_ST pin goes high
          indicating the link is up and low to indicate the link is down. The
@@ -161,28 +161,28 @@ PHY Exchange Guide, DP83822 to ADIN1200 10/100Mb
          it resides in the VDDIO voltage domain, therefore, when driving an LED
          in an integrated RJ45 jack where the PHY VDDIO is 1.8V, level shifting
          will be required.
-         
 
-   
+
+
 
 --------------
 
 .. container:: group
 
-   
+
    .. container:: half column
 
-         
+
          **MAC Interface**
 
-         
+
          Both PHYs support MII, RMII and RGMII MAC interface modes. The
          following sections describe specifically the interfaces for both
          devices.
-         
+
          **MII Interface**
 
-         
+
          The MII interface is the communication path between the PHY and MAC
          devices. The MII interface has a high pin count, with a total of 15
          pins for data transmission, reception and to signal errors or
@@ -195,16 +195,16 @@ PHY Exchange Guide, DP83822 to ADIN1200 10/100Mb
          which pin the COL and CRS functions are provided on (option of
          redirecting to GP_CLK, LINK_ST or INT_N). This requires a register
          write over MDIO interface to reconfigure.
-         
+
          .. image:: images/dp38322_table_4_mii_mac_interface_mode_pin_comparison.png
-         
+
          **RMII Interface**
 
-         
+
          RMII is a reduced MII interface using fewer pins as shown in Table 5.
          The pin count for this interface is 8 pins.
 
-         
+
          |image4|
 
       RMII mode requires a 50MHz clock, REF_CLK. In RMII mode, the ADIN1200
@@ -213,13 +213,13 @@ PHY Exchange Guide, DP83822 to ADIN1200 10/100Mb
       Alternatively in slave mode, it can accept an external 50MHz clock from
       the MAC.
 
-   
+
    .. container:: half column
 
-         
+
          **RGMII Interface**
 
-         
+
          Both support an RGMII interface mode. The RGMII interface has a low pin
          count interface support for 10M, 100M and Gigabit operation with a
          total of 12 pins for data transmission, reception and to signal errors
@@ -227,36 +227,36 @@ PHY Exchange Guide, DP83822 to ADIN1200 10/100Mb
          applications. These PHYs can support 10/100 M speeds over the RGMII
          interface.
 
-         
+
          |image5|
 
          **100BASE-FX**
 
-         
+
          The DP83822 “F” versions also support 100BASE-FX interface. The
          ADIN1200 does not support 100BASE-FX.
-         
+
          **Output Clocks**
 
-         
+
          The ADIN1200 can optionally provide a number of clock signals on the
          GP_CLK pin. This is configured via MDIO writes and the clocks available
          are a 125 MHz free running clock, 25 MHz clock and 25MHz/125 MHz
          recovered clock.
-         
 
-   
+
+
 
 --------------
 
 .. container:: group
 
-   
+
    .. container:: half column
 
-         
+
          Hardware Configuration
-         
+
          Both devices have a number of strapping options to enable managed or
          unmanaged configurations of the PHY function such as PHY address, mode
          of operation, Auto-Negotiation and MAC Interface. After power on, the
@@ -273,9 +273,9 @@ PHY Exchange Guide, DP83822 to ADIN1200 10/100Mb
          operation after the device is brought out of reset. The ADIN1200 has
          internal pull downs on many of its strapping pins (not all), therefore
          it would be possible to minimize external strapping resistors.
-         
+
          |image6| Figure 4. ADIN1200 Hardware Strapping, 2 and 4 level strapping resistors |image7|
-         
+
          Strapping configurations are very specific to the device, consult the
          respective datasheets to determine the exact configuration for required
          use case. The DP83822 has internal pullup resistors of 50kΩ on COL,
@@ -283,15 +283,15 @@ PHY Exchange Guide, DP83822 to ADIN1200 10/100Mb
          internal 9 kΩ pulldown resistors, therefore external strapping values
          differ depending on pin as shown in Table 8 and Table 9.
 
-         
+
          |image8|
 
    .. container:: half column
 
-         
+
          **Hardware Configuration of Speed**
 
-         
+
          For the ADIN1200, speed configuration is done using two pins, PHY_CFG0
          and PHY_CFG1. These pins do not have any internal pull resistors,
          therefore external strapping is required. Both pins support 4-level
@@ -302,25 +302,25 @@ PHY Exchange Guide, DP83822 to ADIN1200 10/100Mb
          DP83822 uses pins RX_D0, RX_D3 and LED_0 to select speeds 10 or 100 M
          speeds, duplex and forced mode or auto-negotiation.
 
-         
+
          |image9|
 
          .. image:: images/ksz_table9.png
             :width: 600
-         
+
          **Hardware Configuration of Auto-MDIX**
 
-         
+
          Selection of Auto-MDIX for the ADIN1200 is done using one pin,
          (MDIX_MODE) with 4-level strapping. In the DP83822 Auto-MDI/MDI-X is
          enabled by default and set by the RX_ER strapping pin.
-         
+
          .. image:: images/ksz_table10.png
             :width: 600
-         
+
          **MAC Interface Selection**
 
-         
+
          The ADIN1200 uses two hardware pins, MACIF_SEL0 and MACIF_SEL1 to
          provide user ability to select different MAC interfaces. These two pins
          have internal weak pull downs, therefore the default operation would be
@@ -329,10 +329,10 @@ PHY Exchange Guide, DP83822 to ADIN1200 10/100Mb
          accordingly. The DP83822 MAC interface selection is chosen by selecting
          the appropriate configuration of RX_DV, RX_ER (for MII, RMII or RGMII
          mode) with combination of RX_ER, LED_1 and COL for 100BASE-FX mode.
-         
+
          **Hardware Configuration of PHY Address**
 
-         
+
          Both devices use two-level strapping, either pull high or low to
          configure the PHY address. The ADIN1200 provides four PHY address pins,
          allowing up to 16 unique addresses possible. The PHY address pins are
@@ -340,9 +340,9 @@ PHY Exchange Guide, DP83822 to ADIN1200 10/100Mb
          ADIN1200 is 0x0000. The DP83822 provides five PHY address pins, capable
          of 32 unique addresses. The PHY Address pins are also on RX_Dx pins and
          COL. The default PHY address strapping for DP83822 is 0x0001.
-         
 
-   
+
+
 
 .. important::
 
@@ -354,22 +354,22 @@ PHY Exchange Guide, DP83822 to ADIN1200 10/100Mb
 
 .. container:: group
 
-   
+
    .. container:: half column
 
-         
+
          Package
-         
+
          Both the ADIN1200 and the DP83822 are available in a 32 lead QFN/LFCSP
          package of 5 mm x 5mm body size. The devices have different pinouts,
          therefore the ADIN1200 is not a drop-in replacement for the TI product.
          This requires edits to the schematic and board layout to achieve this
          exchange.
-         
+
          .. image:: images/dp83822_table14.png
             :align: center
             :width: 600
-         
+
          The underside of the LFCSP package for the ADIN1200 includes an exposed
          paddle which should be soldered directly to the board with an array of
          vias for thermal purposes. There are also two exposed stripes adjacent
@@ -378,42 +378,42 @@ PHY Exchange Guide, DP83822 to ADIN1200 10/100Mb
          supply rails in the device, therefore should not be tied to ground and
          there should be no routing or traces on the PCB layer directly
          underneath them.
-         
+
          Other Pinout Considerations
-         
+
          **Integrated MDI Termination**
 
-         
+
          The ADIN1200 is a voltage mode PHY, therefore includes integrated
          termination resistors on the MDI paths. The DP83822 is a current mode
          PHY, so requires external resistors for biasing and center tap of the
          transformer must be pulled to supply.
-         
 
-   
+
+
    .. container:: half column
 
-         
+
          Software Considerations
-         
+
          Both devices can be hardware strapped to be used in an unmanaged
          configuration. Alternatively, they can provide SMI/MII access over the
          MDIO interface. The KSZ8081 supports Clause 22 register access, while
          the ADIN1200 supports both Clause 22 and Clause 45 access. Registers
          0x0 to 0xF are common across all PHYs.
-         
+
          **Linux Driver**
 
-         
+
          The ADIN1200 has a Linux Driver available in the Linux mainline kernel. The ADIN1200 linux driver detail is captured here: `adin <https://wiki.analog.com/resources/tools-software/linux-drivers/net-phy/adin>`_
-         
+
          **Non Operating System Driver**
 
-         
-         The ADIN1200 has a Non Operating System Driver available from the devices product page here: :adi:`en/products/adin1200.html#product-requirement`
-         
 
-   
+         The ADIN1200 has a Non Operating System Driver available from the devices product page here: :adi:`en/products/adin1200.html#product-requirement`
+
+
+
 
 .. tip::
 

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/dp83825_to_adin1200_phy_exchange_guide.rst
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/dp83825_to_adin1200_phy_exchange_guide.rst
@@ -3,13 +3,13 @@ PHY Exchange Guide, DP83825 to ADIN1200 10/100Mb
 
 .. container:: group
 
-   
+
    .. container:: half column
 
-         
+
          **Overview**
 
-         
+
          This PHY exchange guide captures pertinent information to support
          migration from the TI DP83825 to the Analog Devices ADIN1200 Ethernet
          PHY. The ADIN1200 supports MII, RMII and RGMII MAC interfaces from the
@@ -19,12 +19,12 @@ PHY Exchange Guide, DP83825 to ADIN1200 10/100Mb
          and board layout to achieve this exchange. The following sections
          detail the modifications at the schematic level required to migrate
          from DP83825 to the ADIN1200 device.
-         
+
          Hardware Changes By Function
-         
+
          **Power Supplies Overview**
 
-         
+
          The supply requirements are listed in Table 1. Both devices can operate
          from a minimum of one 3.3V power supply rail AVDD_3P3 (VDDA3V3), where
          the VDDIO rail is connected to 3.3V, alternatively the VDDIO rails can
@@ -32,33 +32,33 @@ PHY Exchange Guide, DP83825 to ADIN1200 10/100Mb
          voltage regulator to generate the internal core supply rail and
          provided to a pin for decoupling purposes.
 
-         
+
          |image1|
 
          .. container:: centeralign
 
             \ *Table 1. Overview of Power Supply Rails*\
 
-         
+
          The ADIN1200 is robust to power supply sequencing and the power can be
          applied in any order. The ADIN1200 provides two pins for each supply
          rail, whereas the TI device provides one power supply pin for each
          rail. The VDDIO supply rail powers the MAC interface and MDIO blocks,
          this can operate from 1.8V, 2.5V or 3.3V.
-         
+
          Decoupling requirements for each device differs as described in Table 2
 
-         
+
          |image2|
 
          .. container:: centeralign
 
             \ *Table 2. Decoupling Requirements for each PHY*\
 
-         
+
          **RESET Operation**
 
-         
+
          An active low hardware reset pin, RESET_N is provided on Pin 6 of the
          ADIN1200 and pin 18 of the DP83825. The hardware strapping pins are
          read and updated at the de-assertion of reset for both devices. For the
@@ -68,37 +68,37 @@ PHY Exchange Guide, DP83825 to ADIN1200 10/100Mb
          level shifting of the RESET_N signal applied to the ADIN1200 may be
          required to ensure the voltage level on the RESET_N pin is in excess of
          the minimum input high threshold level.
-         
+
          **Clocking**
 
-         
+
          A 25 MHz crystal or external clock source is used to provide the
          reference clock for both devices. In RMII mode, the ADIN1200 expects an
          external 50MHz REF_CLK provided to the XTAL_I/REF_CLK pin. In RMII
          master mode, the DP83825 (RMII mode) can provide a 50 MHz REF_CLK to
          the MAC device from the 25 MHz source. Alternatively, in RMII slave
          mode, provide an external 50 MHz both the PHY and MAC.
-         
+
          **Bias Resistor**
 
-         
+
          An external resistor, REXT (RBIAS) is required to bias internal
          reference circuitry for both DP83825 and ADIN1200. The ADIN1200
          requires a 3.01 kΩ resistor (1% tolerance, 100 ppm/°C temperature
          coefficient) connected to pin 10. The DP83825 uses a 6.49 kΩ on pin 13
          (RBIAS).
 
-         
+
          |image3|
 
          .. container:: centeralign
 
             \ *Table 3. Bias Resistor Values*\
 
-         
+
          **Media Dependent Interface (MDI)**
 
-         
+
          The ADIN1200 has voltage mode line drivers with on-chip terminations so
          no external termination resistors are required and the center tap of
          the transformer does not require biasing to supply voltage. Both
@@ -107,22 +107,22 @@ PHY Exchange Guide, DP83825 to ADIN1200 10/100Mb
          external circuit. The recommended external circuit for the interface to
          the magnetics and RJ-45 is shown in Figure 1.
 
-         
+
          |image4|
 
          .. container:: centeralign
 
             *Figure 1 Isolation using Discrete Magnetics (Voltage Mode Driver)*
 
-         
 
-   
+
+
    .. container:: half column
 
-         
+
          **MDIO/Management Interface**
 
-         
+
          Both devices can be hardware strapped to be used in an unmanaged
          configuration. Alternatively, they can provide SMI/MII access over the
          two wire MDIO interface. The MDIO pin (Management Data Open Drain
@@ -135,10 +135,10 @@ PHY Exchange Guide, DP83825 to ADIN1200 10/100Mb
          recommended value for ADIN1200 is a 1.5kΩ resistor connected to INT_N
          pin 27. The DP83825 has a weak internal pullup, and in application
          circuit shows a 2.2kΩ connected to INTb, pin 8.
-         
+
          **LED Function**
 
-         
+
          Both devices support two LED pins. The ADIN1200 pins are LED_0 and
          LINK_ST. The LED_0 has programmability of LED functions, with different
          blinking operation possible through MDIO configuration, the default
@@ -147,10 +147,10 @@ PHY Exchange Guide, DP83825 to ADIN1200 10/100Mb
          LED0, LED1, where both can be configured for On/Off and Blink if
          activity or to indicate link speed. Both devices use these pins for
          Speed and Auto-Neg strapping purposes.
-         
+
          **LED Circuit**
 
-         
+
          The ADIN1200 LED_0 operates from the AVDD_3P3 voltage domain, therefore
          can support driving LEDs even when the MAC interface is running at the
          lower voltage of VDDIO= 1.8V. The default LED operation is on if the
@@ -164,12 +164,12 @@ PHY Exchange Guide, DP83825 to ADIN1200 10/100Mb
          the strapping input is pulled low (MODE_0/MODE_1), the output will be
          configured as active high. This LED circuit should be configured
          accordingly.
-         
+
          |image5| Figure 2. LED_0 Hardware Configuration Pin Interaction
-         
+
          **Link Status, LINK_ST**
 
-         
+
          The ADIN1200 has a dedicated LINK_ST pin to provide information to the
          MAC on the status of the Link. By default, the LINK_ST pin goes high
          indicating the link is up and low to indicate the link is down. The
@@ -178,52 +178,52 @@ PHY Exchange Guide, DP83825 to ADIN1200 10/100Mb
          it resides in the VDDIO voltage domain, therefore, when driving an LED
          in an integrated RJ45 jack where the PHY VDDIO is 1.8V, level shifting
          will be required.
-         
 
-   
+
+
 
 --------------
 
 .. container:: group
 
-   
+
    .. container:: half column
 
-         
+
          **MAC Interface**
 
-         
+
          The ADIN1200 PHY supports MII, RMII and RGMII MAC interface modes,
          whereas the DP83825 supports only RMII. The following sections describe
          specifically the interfaces.
-         
+
          **RMII Interface**
 
-         
+
          RMII is a reduced MII interface using fewer pins as shown in Table 4.
          The pin count for this interface is 8 pins.
 
-         
+
          |image6|
 
          .. container:: centeralign
 
             \ *Table 4. RMII MAC Interface Mode Pin Comparison*\
 
-         
+
       RMII mode requires a 50MHz clock, REF_CLK. In RMII mode, the ADIN1200
       requires an external 50MHz clock applied to XTAL_I. The DP83825 can
       generate a 50MHz clock internally and provide it to the MAC (master mode).
       Alternatively, in slave mode, it can accept an external 50MHz clock from
       the MAC.
 
-   
+
    .. container:: half column
 
-         
+
          **MII Interface**
 
-         
+
          The MII interface is the communication path between the PHY and MAC
          devices. The MII interface has a high pin count, with a total of 15
          pins for data transmission, reception and to signal errors or
@@ -238,17 +238,17 @@ PHY Exchange Guide, DP83825 to ADIN1200 10/100Mb
          write over MDIO interface to reconfigure. The DP83825 does not support
          MII interface.
 
-         
+
          |image7|
 
          .. container:: centeralign
 
             \ *Table 5. MII MAC Interface Mode Pin Comparison*\
 
-         
+
          **RGMII Interface**
 
-         
+
          The ADIN1200 supports an RGMII interface mode, while the DP82825 does
          not. The RGMII interface has a low pin count interface support for 10M,
          100M and Gigabit operation with a total of 12 pins for data
@@ -257,35 +257,35 @@ PHY Exchange Guide, DP83825 to ADIN1200 10/100Mb
          support 10/100 M speeds over the RGMII interface. Table 6 shows a pin
          overview of the ADIN1200 RGMII interface.
 
-         
+
          |image8|
 
          .. container:: centeralign
 
             *Table 6. RGMII MAC Interface Mode Pin*
 
-         
+
          **Output Clocks**
 
-         
+
          The ADIN1200 can optionally provide a number of clock signals on the
          GP_CLK pin. This is configured via MDIO writes and the clocks available
          are a 125 MHz free running clock, 25 MHz clock and 25MHz/125 MHz
          recovered clock.
-         
 
-   
+
+
 
 --------------
 
 .. container:: group
 
-   
+
    .. container:: half column
 
-         
+
          Hardware Configuration
-         
+
          Both devices have a number of strapping options to enable managed or
          unmanaged configurations of the PHY function such as PHY address, mode
          of operation, Auto-Negotiation and MAC Interface. After power on, the
@@ -302,22 +302,22 @@ PHY Exchange Guide, DP83825 to ADIN1200 10/100Mb
          operation after the device is brought out of reset. The ADIN1200 has
          internal pull downs on many of its strapping pins (not all), therefore
          it would be possible to minimize external strapping resistors.
-         
+
          |image9| Figure 3. ADIN1200 Hardware Strapping, 2 and 4 level strapping resistors |image10|
-         
+
          .. container:: centeralign
 
             \ *Table 7. 4-level Strapping Resistor Ratios (ADIN1200)*\
 
-         
+
          Strapping configurations are very specific to the device, consult the
          respective datasheets to determine the exact configuration for required
          use case. The DP83825 uses 2-level strapping, so either a pull up or
          pull down. The recommended strapping resistor value is 2.49k.
-         
+
          **Hardware Configuration of Speed**
 
-         
+
          For the ADIN1200, speed configuration is done using two pins, PHY_CFG0
          and PHY_CFG1. These pins do not have any internal pull resistors,
          therefore external strapping is required. Both pins support 4-level
@@ -326,14 +326,14 @@ PHY Exchange Guide, DP83825 to ADIN1200 10/100Mb
          shown in Table 9. Review the datasheet hardware configuration pin
          section for full detail on the possible settings using these pins. The
          DP83825 uses the LED0 pin for Auto-neg enable/disable.
-         
 
-   
+
+
    .. container:: half column
 
-         
 
-   
+
+
       ..
 
    |image11|
@@ -348,25 +348,25 @@ PHY Exchange Guide, DP83825 to ADIN1200 10/100Mb
 
             \ *Table 9. Forced Speeds, ADIN1200*\
 
-         
+
          **Hardware Configuration of Auto-MDIX**
 
-         
+
          Selection of Auto-MDIX for the ADIN1200 is done using one pin,
          (MDIX_MODE) with 4-level strapping. In the DP82833 Auto-MDI/MDI-X is
          set by the RX_ER strapping pin, with option of enabled or disabled.
 
-         
+
          |image13|
 
          .. container:: centeralign
 
             \ *Table 10. Auto MDIX Mode, ADIN1200*\
 
-         
+
          **MAC Interface Selection**
 
-         
+
          The ADIN1200 uses two hardware pins, MACIF_SEL0 and MACIF_SEL1 to
          provide user ability to select different MAC interfaces. These two pins
          have internal weak pull downs, therefore the default operation would be
@@ -376,17 +376,17 @@ PHY Exchange Guide, DP83825 to ADIN1200 10/100Mb
          configure the PHY for Master or Slave mode using the RX_D1 pin. The
          LED2 pin is used to choose between CRS_DV or RX_DV.
 
-         
+
          |image14|
 
          .. container:: centeralign
 
             \ *Table 11. MAC Interface Selection, ADIN1200*\
 
-         
+
          **Hardware Configuration of PHY Address**
 
-         
+
          Both devices use two-level strapping for PHY Address selection, either
          pull high or low to configure the PHY address. The ADIN1200 provides
          four PHY address pins, allowing up to 16 unique addresses possible. The
@@ -394,9 +394,9 @@ PHY Exchange Guide, DP83825 to ADIN1200 10/100Mb
          address strapping for ADIN1200 is 0x0000. The DP83825 provides two PHY
          address pins, capable of 4 unique addresses. The default PHY address
          strapping for DP83825 is 0x00.
-         
 
-   
+
+
 
 .. important::
 
@@ -408,26 +408,26 @@ PHY Exchange Guide, DP83825 to ADIN1200 10/100Mb
 
 .. container:: group
 
-   
+
    .. container:: half column
 
-         
+
          Package
-         
+
          The ADIN1200 is available in a 32 lead QFN/LFCSP package of 5 mm x 5mm
          body size, whereas the DP83825 is packaged in a 24 lead QFN with 3mm x
          3mm body size. Given the different package, the ADIN1200 is not a
          drop-in replacement for the TI product. This requires edits to the
          schematic and board layout to achieve this exchange.
 
-         
+
          |image15|
 
          .. container:: centeralign
 
             \ *Table 12. Package comparison*\
 
-         
+
          The underside of the LFCSP package for the ADIN1200 includes an exposed
          paddle which should be soldered directly to the board with an array of
          vias for thermal purposes. There are also two exposed stripes adjacent
@@ -435,41 +435,41 @@ PHY Exchange Guide, DP83825 to ADIN1200 10/100Mb
          they should be treated as a keepout area as they are connected to
          supply rails in the device, therefore should not be tied to ground and
          no routing or traces on the PCB layer directly underneath them.
-         
+
          Other Pinout Considerations
-         
+
          **Integrated MDI Termination**
 
-         
+
          The ADIN1200 is a voltage mode PHY, therefore includes integrated
          termination resistors on the MDI paths. The DP83825 is a current mode
          PHY, so requires external resistors for biasing and center tap of the
          transformer must be pulled to supply.
-         
 
-   
+
+
    .. container:: half column
 
-         
+
          Software Considerations
-         
+
          Both devices can be hardware strapped to be used in an unmanaged
          configuration. Alternatively, they can provide SMI/MII access over the
          MDIO interface. Both support Clause 22 and Clause 45 access. Registers
          0x0 to 0xF are common across all PHYs.
-         
+
          **Linux Driver**
 
-         
+
          The ADIN1200 has a Linux Driver available in the Linux mainline kernel. The ADIN1200 linux driver detail is captured here: `adin <https://wiki.analog.com/resources/tools-software/linux-drivers/net-phy/adin>`_
-         
+
          **Non Operating System Driver**
 
-         
-         The ADIN1200 has a Non Operating System Driver available from the devices product page here: :adi:`en/products/adin1200.html#product-requirement`
-         
 
-   
+         The ADIN1200 has a Non Operating System Driver available from the devices product page here: :adi:`en/products/adin1200.html#product-requirement`
+
+
+
 
 .. tip::
 

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/dp83825_to_adin1200_phy_exchange_guide.rst
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/dp83825_to_adin1200_phy_exchange_guide.rst
@@ -1,0 +1,573 @@
+PHY Exchange Guide, DP83825 to ADIN1200 10/100Mb
+================================================
+
+.. container:: group
+
+   
+   .. container:: half column
+
+         
+         **Overview**
+
+         
+         This PHY exchange guide captures pertinent information to support
+         migration from the TI DP83825 to the Analog Devices ADIN1200 Ethernet
+         PHY. The ADIN1200 supports MII, RMII and RGMII MAC interfaces from the
+         same package version, whereas the DP83825 supports RMII only. The PHYs
+         have different pinouts, therefore the ADIN1200 is not a drop-in
+         replacement for the TI product. This requires edits to the schematic
+         and board layout to achieve this exchange. The following sections
+         detail the modifications at the schematic level required to migrate
+         from DP83825 to the ADIN1200 device.
+         
+         Hardware Changes By Function
+         
+         **Power Supplies Overview**
+
+         
+         The supply requirements are listed in Table 1. Both devices can operate
+         from a minimum of one 3.3V power supply rail AVDD_3P3 (VDDA3V3), where
+         the VDDIO rail is connected to 3.3V, alternatively the VDDIO rails can
+         be run with a different supply voltage. The ADIN1200 has an on chip
+         voltage regulator to generate the internal core supply rail and
+         provided to a pin for decoupling purposes.
+
+         
+         |image1|
+
+         .. container:: centeralign
+
+            \ *Table 1. Overview of Power Supply Rails*\
+
+         
+         The ADIN1200 is robust to power supply sequencing and the power can be
+         applied in any order. The ADIN1200 provides two pins for each supply
+         rail, whereas the TI device provides one power supply pin for each
+         rail. The VDDIO supply rail powers the MAC interface and MDIO blocks,
+         this can operate from 1.8V, 2.5V or 3.3V.
+         
+         Decoupling requirements for each device differs as described in Table 2
+
+         
+         |image2|
+
+         .. container:: centeralign
+
+            \ *Table 2. Decoupling Requirements for each PHY*\
+
+         
+         **RESET Operation**
+
+         
+         An active low hardware reset pin, RESET_N is provided on Pin 6 of the
+         ADIN1200 and pin 18 of the DP83825. The hardware strapping pins are
+         read and updated at the de-assertion of reset for both devices. For the
+         ADIN1200, the RESET_N pin resides in the AVDD_3P3 voltage domain,
+         whereas for the TI device, the RESET_N pin is referenced to VDDIO. In
+         applications where the MAC interface is powered from VDDIO of 1.8V,
+         level shifting of the RESET_N signal applied to the ADIN1200 may be
+         required to ensure the voltage level on the RESET_N pin is in excess of
+         the minimum input high threshold level.
+         
+         **Clocking**
+
+         
+         A 25 MHz crystal or external clock source is used to provide the
+         reference clock for both devices. In RMII mode, the ADIN1200 expects an
+         external 50MHz REF_CLK provided to the XTAL_I/REF_CLK pin. In RMII
+         master mode, the DP83825 (RMII mode) can provide a 50 MHz REF_CLK to
+         the MAC device from the 25 MHz source. Alternatively, in RMII slave
+         mode, provide an external 50 MHz both the PHY and MAC.
+         
+         **Bias Resistor**
+
+         
+         An external resistor, REXT (RBIAS) is required to bias internal
+         reference circuitry for both DP83825 and ADIN1200. The ADIN1200
+         requires a 3.01 kΩ resistor (1% tolerance, 100 ppm/°C temperature
+         coefficient) connected to pin 10. The DP83825 uses a 6.49 kΩ on pin 13
+         (RBIAS).
+
+         
+         |image3|
+
+         .. container:: centeralign
+
+            \ *Table 3. Bias Resistor Values*\
+
+         
+         **Media Dependent Interface (MDI)**
+
+         
+         The ADIN1200 has voltage mode line drivers with on-chip terminations so
+         no external termination resistors are required and the center tap of
+         the transformer does not require biasing to supply voltage. Both
+         devices use voltage mode line drive for connection from the MDI_0:1_P/N
+         (TD_M/P, RDM/P) pins to the magnetics and RJ-45 line using the same
+         external circuit. The recommended external circuit for the interface to
+         the magnetics and RJ-45 is shown in Figure 1.
+
+         
+         |image4|
+
+         .. container:: centeralign
+
+            *Figure 1 Isolation using Discrete Magnetics (Voltage Mode Driver)*
+
+         
+
+   
+   .. container:: half column
+
+         
+         **MDIO/Management Interface**
+
+         
+         Both devices can be hardware strapped to be used in an unmanaged
+         configuration. Alternatively, they can provide SMI/MII access over the
+         two wire MDIO interface. The MDIO pin (Management Data Open Drain
+         Input/Output) for SMI/MII interface to MAC and requires an external
+         pullup resistor. The recommended value for ADIN1200 is a 1.5kΩ resistor
+         connected to pin 24. The DP83825 recommends 2.2kΩ connected to pin 15.
+         The ADIN1200 supports an MDC clock up to 5.5MHz, while the DP83825
+         supports an MDC clock as fast as 20MHz. A hardware interrupt output pin
+         INT_N (INTR) is provided in both devices and is open drain. The
+         recommended value for ADIN1200 is a 1.5kΩ resistor connected to INT_N
+         pin 27. The DP83825 has a weak internal pullup, and in application
+         circuit shows a 2.2kΩ connected to INTb, pin 8.
+         
+         **LED Function**
+
+         
+         Both devices support two LED pins. The ADIN1200 pins are LED_0 and
+         LINK_ST. The LED_0 has programmability of LED functions, with different
+         blinking operation possible through MDIO configuration, the default
+         mode is ON when Link is Up, blink if activity. The LINK_ST provides
+         static information about Link up or down status. The DP83825 pins are
+         LED0, LED1, where both can be configured for On/Off and Blink if
+         activity or to indicate link speed. Both devices use these pins for
+         Speed and Auto-Neg strapping purposes.
+         
+         **LED Circuit**
+
+         
+         The ADIN1200 LED_0 operates from the AVDD_3P3 voltage domain, therefore
+         can support driving LEDs even when the MAC interface is running at the
+         lower voltage of VDDIO= 1.8V. The default LED operation is on if the
+         Link is up and blinks when there is activity, this operation can be
+         reprogrammed through MDIO write. For the LED_0 of the ADIN1200, it can
+         be configured with 4-level strapping. The strapping configuration will
+         have an impact on how the LED function operates, and needs to be
+         considered if the LED pins are used to directly drive an LED. If the
+         strap pin is pulled high by the strapping resistors, (MODE_3/MODE_4)
+         the output will be configured as an active low driver and conversely if
+         the strapping input is pulled low (MODE_0/MODE_1), the output will be
+         configured as active high. This LED circuit should be configured
+         accordingly.
+         
+         |image5| Figure 2. LED_0 Hardware Configuration Pin Interaction
+         
+         **Link Status, LINK_ST**
+
+         
+         The ADIN1200 has a dedicated LINK_ST pin to provide information to the
+         MAC on the status of the Link. By default, the LINK_ST pin goes high
+         indicating the link is up and low to indicate the link is down. The
+         LINK_ST polarity is programmable by setting the bit high
+         GE_LNK_STAT_INV_EN. The LINK_ST could be used to drive an LED, however
+         it resides in the VDDIO voltage domain, therefore, when driving an LED
+         in an integrated RJ45 jack where the PHY VDDIO is 1.8V, level shifting
+         will be required.
+         
+
+   
+
+--------------
+
+.. container:: group
+
+   
+   .. container:: half column
+
+         
+         **MAC Interface**
+
+         
+         The ADIN1200 PHY supports MII, RMII and RGMII MAC interface modes,
+         whereas the DP83825 supports only RMII. The following sections describe
+         specifically the interfaces.
+         
+         **RMII Interface**
+
+         
+         RMII is a reduced MII interface using fewer pins as shown in Table 4.
+         The pin count for this interface is 8 pins.
+
+         
+         |image6|
+
+         .. container:: centeralign
+
+            \ *Table 4. RMII MAC Interface Mode Pin Comparison*\
+
+         
+      RMII mode requires a 50MHz clock, REF_CLK. In RMII mode, the ADIN1200
+      requires an external 50MHz clock applied to XTAL_I. The DP83825 can
+      generate a 50MHz clock internally and provide it to the MAC (master mode).
+      Alternatively, in slave mode, it can accept an external 50MHz clock from
+      the MAC.
+
+   
+   .. container:: half column
+
+         
+         **MII Interface**
+
+         
+         The MII interface is the communication path between the PHY and MAC
+         devices. The MII interface has a high pin count, with a total of 15
+         pins for data transmission, reception and to signal errors or
+         collision. It is sometimes used in 100M applications as it has a lower
+         latency than RGMII and is much lower than RMII. Table 5 shows a pin
+         overview of both devices for the MII MAC interface mode. When using the
+         ADIN1200 in MII mode, the multifunction pin “LED_0/COL/TX_ER”
+         automatically becomes COL. Similarly, the “INT_N/CRS” becomes CRS. The
+         ADIN1200 sub-system registers provide user with ability to reconfigure
+         which pin the COL and CRS functions are provided on (option of
+         redirecting to GP_CLK, LINK_ST or INT_N). This requires a register
+         write over MDIO interface to reconfigure. The DP83825 does not support
+         MII interface.
+
+         
+         |image7|
+
+         .. container:: centeralign
+
+            \ *Table 5. MII MAC Interface Mode Pin Comparison*\
+
+         
+         **RGMII Interface**
+
+         
+         The ADIN1200 supports an RGMII interface mode, while the DP82825 does
+         not. The RGMII interface has a low pin count interface support for 10M,
+         100M and Gigabit operation with a total of 12 pins for data
+         transmission, reception and to signal errors or collisions. It is the
+         most common interface used for Gigabit applications. The ADIN1200 can
+         support 10/100 M speeds over the RGMII interface. Table 6 shows a pin
+         overview of the ADIN1200 RGMII interface.
+
+         
+         |image8|
+
+         .. container:: centeralign
+
+            *Table 6. RGMII MAC Interface Mode Pin*
+
+         
+         **Output Clocks**
+
+         
+         The ADIN1200 can optionally provide a number of clock signals on the
+         GP_CLK pin. This is configured via MDIO writes and the clocks available
+         are a 125 MHz free running clock, 25 MHz clock and 25MHz/125 MHz
+         recovered clock.
+         
+
+   
+
+--------------
+
+.. container:: group
+
+   
+   .. container:: half column
+
+         
+         Hardware Configuration
+         
+         Both devices have a number of strapping options to enable managed or
+         unmanaged configurations of the PHY function such as PHY address, mode
+         of operation, Auto-Negotiation and MAC Interface. After power on, the
+         strapping pin voltages get sensed and latched upon existing from a
+         reset and the sensed voltages are used to set the personality of the
+         PHY. When configuring any strapping configurations, ensure to review
+         the default state of the MAC side, whether the pins are being driven
+         when coming out of reset or if there are internal pulls. Understanding
+         the behavior on the MAC side is key to ensuring there are no conflicts
+         with the hardware strapping implemented, or to adjust the strapping
+         resistor values if required. The DP83825 uses 2-level strapping options
+         throughout, while the ADIN1200 uses a mix of 2-level and 4-level. In
+         general, strapping pins are multi-functional and have different
+         operation after the device is brought out of reset. The ADIN1200 has
+         internal pull downs on many of its strapping pins (not all), therefore
+         it would be possible to minimize external strapping resistors.
+         
+         |image9| Figure 3. ADIN1200 Hardware Strapping, 2 and 4 level strapping resistors |image10|
+         
+         .. container:: centeralign
+
+            \ *Table 7. 4-level Strapping Resistor Ratios (ADIN1200)*\
+
+         
+         Strapping configurations are very specific to the device, consult the
+         respective datasheets to determine the exact configuration for required
+         use case. The DP83825 uses 2-level strapping, so either a pull up or
+         pull down. The recommended strapping resistor value is 2.49k.
+         
+         **Hardware Configuration of Speed**
+
+         
+         For the ADIN1200, speed configuration is done using two pins, PHY_CFG0
+         and PHY_CFG1. These pins do not have any internal pull resistors,
+         therefore external strapping is required. Both pins support 4-level
+         strapping, providing much flexibility in terms of the possible
+         combinations, such as Auto-neg speeds shown in Table 8 or Forced modes
+         shown in Table 9. Review the datasheet hardware configuration pin
+         section for full detail on the possible settings using these pins. The
+         DP83825 uses the LED0 pin for Auto-neg enable/disable.
+         
+
+   
+   .. container:: half column
+
+         
+
+   
+      ..
+
+   |image11|
+
+         .. container:: centeralign
+
+            \ *Table 8. Auto-Negotiated Speeds, ADIN1200*\
+
+            |image12|
+
+         .. container:: centeralign
+
+            \ *Table 9. Forced Speeds, ADIN1200*\
+
+         
+         **Hardware Configuration of Auto-MDIX**
+
+         
+         Selection of Auto-MDIX for the ADIN1200 is done using one pin,
+         (MDIX_MODE) with 4-level strapping. In the DP82833 Auto-MDI/MDI-X is
+         set by the RX_ER strapping pin, with option of enabled or disabled.
+
+         
+         |image13|
+
+         .. container:: centeralign
+
+            \ *Table 10. Auto MDIX Mode, ADIN1200*\
+
+         
+         **MAC Interface Selection**
+
+         
+         The ADIN1200 uses two hardware pins, MACIF_SEL0 and MACIF_SEL1 to
+         provide user ability to select different MAC interfaces. These two pins
+         have internal weak pull downs, therefore the default operation would be
+         RGMII with delays as shown in Table 11. To configure any other MAC
+         interface mode, use 10kΩ pull up or pull down resistors to select
+         accordingly. The DP83825 only supports RMII mode, but has strapping to
+         configure the PHY for Master or Slave mode using the RX_D1 pin. The
+         LED2 pin is used to choose between CRS_DV or RX_DV.
+
+         
+         |image14|
+
+         .. container:: centeralign
+
+            \ *Table 11. MAC Interface Selection, ADIN1200*\
+
+         
+         **Hardware Configuration of PHY Address**
+
+         
+         Both devices use two-level strapping for PHY Address selection, either
+         pull high or low to configure the PHY address. The ADIN1200 provides
+         four PHY address pins, allowing up to 16 unique addresses possible. The
+         PHY address pins are shared with the RXD output pins. The default PHY
+         address strapping for ADIN1200 is 0x0000. The DP83825 provides two PHY
+         address pins, capable of 4 unique addresses. The default PHY address
+         strapping for DP83825 is 0x00.
+         
+
+   
+
+.. important::
+
+   Strapping configurations are very specific to the device, consult the
+   respective datasheets to determine the exact configuration for required use
+   case.
+
+--------------
+
+.. container:: group
+
+   
+   .. container:: half column
+
+         
+         Package
+         
+         The ADIN1200 is available in a 32 lead QFN/LFCSP package of 5 mm x 5mm
+         body size, whereas the DP83825 is packaged in a 24 lead QFN with 3mm x
+         3mm body size. Given the different package, the ADIN1200 is not a
+         drop-in replacement for the TI product. This requires edits to the
+         schematic and board layout to achieve this exchange.
+
+         
+         |image15|
+
+         .. container:: centeralign
+
+            \ *Table 12. Package comparison*\
+
+         
+         The underside of the LFCSP package for the ADIN1200 includes an exposed
+         paddle which should be soldered directly to the board with an array of
+         vias for thermal purposes. There are also two exposed stripes adjacent
+         to the exposed paddle. These do not need to be soldered to the board,
+         they should be treated as a keepout area as they are connected to
+         supply rails in the device, therefore should not be tied to ground and
+         no routing or traces on the PCB layer directly underneath them.
+         
+         Other Pinout Considerations
+         
+         **Integrated MDI Termination**
+
+         
+         The ADIN1200 is a voltage mode PHY, therefore includes integrated
+         termination resistors on the MDI paths. The DP83825 is a current mode
+         PHY, so requires external resistors for biasing and center tap of the
+         transformer must be pulled to supply.
+         
+
+   
+   .. container:: half column
+
+         
+         Software Considerations
+         
+         Both devices can be hardware strapped to be used in an unmanaged
+         configuration. Alternatively, they can provide SMI/MII access over the
+         MDIO interface. Both support Clause 22 and Clause 45 access. Registers
+         0x0 to 0xF are common across all PHYs.
+         
+         **Linux Driver**
+
+         
+         The ADIN1200 has a Linux Driver available in the Linux mainline kernel. The ADIN1200 linux driver detail is captured here: `adin <https://wiki.analog.com/resources/tools-software/linux-drivers/net-phy/adin>`_
+         
+         **Non Operating System Driver**
+
+         
+         The ADIN1200 has a Non Operating System Driver available from the devices product page here: :adi:`en/products/adin1200.html#product-requirement`
+         
+
+   
+
+.. tip::
+
+   The ADIN1200 has a Linux Driver available in the Linux mainline kernel.
+
+--------------
+
+High Level Comparison
+---------------------
+
+.. image:: images/phy_exchange_dp83825_to_adin1200_tablehighlevelcomp.png
+
+.. container:: centeralign
+
+   \ *Table 13. High Level Comparison Table*\
+
+--------------
+
+Side by Side Package/Pinout Comparison
+--------------------------------------
+
+The following is a side-by-side comparison of the package and pinouts, showing
+the position of the corresponding functional pins on each device.
+
+|image16|
+
+.. container:: centeralign
+
+   \ *Figure 4 ADIN1200 pinout comparison versus DP83825*\
+
+--------------
+
+Example Configurations for RMII
+-------------------------------
+
+The following example captures how to configure the ADIN1200 for an unmanaged
+configuration with RMII Interface, operating in Auto-negotiation mode
+advertising all speeds. The PHY will power up in this state, ready to establish
+a link with a link partner. The MAC interface configuration pins (MACIF_SEL0/1)
+are pulled to VDDIO, setting the PHY to RMII mode. GP_CLK is set to MODE_3 to
+configure an automatic MDIX operation. In addition, the PHY_CFG0 and PHY_CFG1
+pins are configured for MODE_4 and MODE_1 respectively. The PHY_CFG0 pin is also
+shared with the LED_0 pin, it’s configuration with MODE_4 means an active low
+LED can be used on LED_0. The following list summarizes an RMII auto negotiate,
+10 Mbps or 100 Mbps full duplex or half duplex:
+
+-  MAC Interface = RMII
+
+   -  MACIF_SEL0 = MODE_1 = 10 kΩ pull-up resistor
+   -  MACIF_SEL1 = MODE_1 = 10 kΩ pull-up resistor
+
+-  MDIX_MODE = automatic MDIX, preferred MDIX
+
+   -  MDIX_MODE = MODE_3
+
+-  PHY address = 0b0001
+-  Speed selection = 10 Mbps, 100 Mbps with full duplex or half duplex,
+   auto-negotiation enabled
+
+   -  PHY_CFG0 = MODE_4 = 10 kΩ pull-up resistor
+
+::
+
+     *PHY_CFG1 = MODE_1 = 10 kΩ pull-down resistor
+
+.. image:: images/phy_exchange_dp83825_to_adin1200_figrmiiauto.png
+
+.. container:: centeralign
+
+   \ *Figure 5 RMII Auto Negotiate, 10Mbps and 100Mbps with Half Duplex or Full Duplex*\
+
+.. |image1| image:: images/phy_exchange_dp83825_to_adin1200_table1.png
+   :width: 400
+.. |image2| image:: images/phy_exchange_dp83825_to_adin1200_table2.png
+   :width: 400
+.. |image3| image:: images/phy_exchange_dp83825_to_adin1200_table3.png
+   :width: 400
+.. |image4| image:: images/phy_exchange_dp83825_to_adin1200_fig1.png
+   :width: 400
+.. |image5| image:: images/phy_exchange_dp83825_to_adin1200_fig2.png
+   :width: 600
+.. |image6| image:: images/phy_exchange_dp83825_to_adin1200_table5.png
+   :width: 400
+.. |image7| image:: images/dp38325_table_5_mii_mac_interface_mode_pin_comparison.png
+.. |image8| image:: images/phy_exchange_dp83825_to_adin1200_table6.png
+   :width: 400
+.. |image9| image:: images/strapping.png
+   :width: 600
+.. |image10| image:: images/phy_exchange_dp83825_to_adin1200_table7.png
+   :width: 400
+.. |image11| image:: images/phy_exchange_dp83825_to_adin1200_tableautonegspeed.png
+   :width: 400
+.. |image12| image:: images/phy_exchange_dp83825_to_adin1200_tableforcedspeed.png
+   :width: 400
+.. |image13| image:: images/phy_exchange_dp83825_to_adin1200_tablemdx.png
+   :width: 400
+.. |image14| image:: images/phy_exchange_dp83825_to_adin1200_tablemacsel.png
+   :width: 400
+.. |image15| image:: images/phy_exchange_dp83825_to_adin1200_tablepackagecomp.png
+   :width: 400
+.. |image16| image:: images/phy_exchange_dp83825_to_adin1200_figpinoutcomp.png

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/dp83867_to_adin1300_phy_exchange_guide.rst
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/dp83867_to_adin1300_phy_exchange_guide.rst
@@ -3,21 +3,21 @@ PHY Exchange Guide, DP83867 to ADIN1300 Gb
 
 .. container:: group
 
-   
+
    .. container:: half column
 
-         
+
          **Overview**
 
-         
+
          This PHY exchange guide captures pertinent information to support
          migration from the TI DP83867IR/CR/CS/E/IS to the Analog Devices
          ADIN1300 Ethernet PHY. The ADIN1300 has compelling reasons for adoption
          versus this competitor PHY, such as reduced power consumption, lower
          latency, and smaller footprint due to the small package size.
-         
+
          .. image:: images/figure1_motivators_to_migrate_dp83867.png
-         
+
          The ADIN1300 Ethernet PHY supports all the standard functions and pins
          of an Ethernet PHY and it is very straight forward to migrate an
          existing design to the ADIN1300. The following sections detail the
@@ -28,30 +28,30 @@ PHY Exchange Guide, DP83867 to ADIN1300 Gb
          package comparison and a feature comparison table are included for easy
          reference. The ADIN1300 datasheet provides a detailed description of
          all functions of the device and should also be consulted for reference.
-         
+
          Hardware Changes By Function
-         
+
          **Power Supplies Overview**
 
-         
+
          Both devices require a minimum of 2 power supply rails, where the VDDIO
          is connected to the same power supply voltage as the MAC or as the PHY
          analog supply AVDD_3P3 (VDDA2P5). The VDDIO supply rail powers the MAC
          interface and MDIO blocks, this can operate from 1.8V, 2.5V or 3.3V.
          Both devices have an on-chip voltage regulator to generate the internal
          core supply rail. The supply requirements are listed in Table 1.
-         
+
          .. image:: images/table1_overview_of_power_supply_rails_dp83867.png
-         
+
          The ADIN1300 is robust to power supply sequencing and the power can be
          applied in any order. Decoupling requirements for each device differ as
          described in Table 2
-         
+
          .. image:: images/table2_decoupling_requirements_for_each_phy_dp83867.png
-         
+
          **RESET Operation**
 
-         
+
          Both devices have a RESET_N pin which initializes the device and
          latches the hardware pin configuration. To reset the device the RESET_N
          pin should be held low for >10 μs. Deglitch circuitry is included on
@@ -60,7 +60,7 @@ PHY Exchange Guide, DP83867 to ADIN1300 Gb
          circuitry to monitor all of the supplies. At power-up, the ADIN1300 is
          held in hardware reset until each of the supplies has crossed its
          minimum rising threshold value.
-         
+
          The hardware strapping pins are read and updated at the de-assertion of
          reset for both devices. For the ADIN1300, the RESET_N pin resides in
          the AVDD_3P3 voltage domain. In applications where the MAC interface is
@@ -74,52 +74,52 @@ PHY Exchange Guide, DP83867 to ADIN1300 Gb
          supply powers up. If the host controller cannot be connected to
          RESET_N, then a 100-Ω resistor and 47-uF capacitor are required to be
          connected in series between the RESET_N pin and ground.
-         
+
          **Clocking**
 
-         
+
          A 25 MHz crystal or external clock source is used to provide the
          reference clock for both devices. A crystal can be connected to pins
          XTAL_I/XTAL_O (XI/XO), with both devices using the same external
          circuit. Or a 25 MHz refence clock can be provided on the input clock
          pin CLK_IN (XI). In RMII mode, the ADIN1300 expects an external 50 MHz
          REF_CLK provided to the XTAL_I/REF_CLK pin.
-         
+
          **Bias Resistor**
 
-         
+
          An external resistor is required to bias internal reference circuitry
          for both DP83867 and ADIN1300. The ADIN1300 requires a 3.01 kΩ resistor
          (1% tolerance, 100 ppm/°C temperature coefficient) connected to pin 10.
          The DP83687 uses an 11 kΩ (1%) on pin 12 in QFN package or pin 15 in
          QFP package.
-         
+
          .. image:: images/table3_bias_resistor_values_dp83867.png
-         
+
          **Media Dependent Interface (MDI)**
 
-         
+
          The ADIN1300 has voltage mode line drivers with on-chip terminations so
          no external termination resistors are required. Both devices use
          voltage mode line drive for connection from the MDI_0:3_P/N
          (TD_P/M_A:D) pins to the magnetics and RJ-45 line using the same
          external circuit. The recommended external circuit for the interface to
          the magnetics and RJ-45 is shown in Figure 2.
-         
 
-   
+
+
    .. container:: half column
 
-         
 
-   
+
+
       ..
 
    |image1|
 
          **MDIO/Management Interface**
 
-         
+
          Both devices support the IEEE management interface using the MDIO/MDC
          pins and require a pullup resistor on the MDIO pin (Management Data
          Open Drain Input/Output). The recommended value for ADIN1300 is a 1.5kΩ
@@ -127,10 +127,10 @@ PHY Exchange Guide, DP83867 to ADIN1300 Gb
          pin 17 (QFN) or pin 21 (QFP). Both devices provide an interrupt pin,
          INT_N (¯INT). This pin requires a 1.5 kΩ pull-up resistor to VDDIO. The
          DP83867 recommends 2.2kΩ pull-up resistors for their interrupt pin.
-         
+
          **LED Function**
 
-         
+
          The ADIN1300 support two LED pins on LED_0 and LINK_ST. The LED_0 has
          programmability of LED functions, with different blinking operation
          possible through MDIO configuration, the default mode is ON when Link
@@ -139,10 +139,10 @@ PHY Exchange Guide, DP83867 to ADIN1300 Gb
          (QFN) or pins 61, 62, 63 (QFP) in addition to one GPIO pin that can be
          configured to operate as LED_3. Both devices use these pins for
          strapping purposes.
-         
+
          **LED Circuit**
 
-         
+
          The ADIN1300 LED_0 operates from the AVDD_3P3 voltage domain, therefore
          can support driving LEDs even when the MAC interface is running at the
          lower voltage of 1.8V. The default LED operation is on if the Link is
@@ -156,12 +156,12 @@ PHY Exchange Guide, DP83867 to ADIN1300 Gb
          the strapping input is pulled low (MODE_0/MODE_1), the output will be
          configured as active high. This LED circuit should be configured
          accordingly.
-         
+
          .. image:: images/figure3_led0_hardware_config_dp83867.png
-         
+
          **Link Status, LINK_ST**
 
-         
+
          The ADIN1300 has a dedicated LINK_ST pin to provide information to the
          MAC on the status of the Link. By default, the LINK_ST pin goes high
          indicating the link is up and low to indicate the link is down. The
@@ -170,28 +170,28 @@ PHY Exchange Guide, DP83867 to ADIN1300 Gb
          it resides in the VDDIO voltage domain, therefore, when driving an LED
          in an integrated RJ45 jack where the PHY VDDIO is 1.8V, level shifting
          will be required. This can be done using a FET.
-         
 
-   
+
+
 
 --------------
 
 .. container:: group
 
-   
+
    .. container:: half column
 
-         
+
          **MAC Interface**
 
-         
+
          The ADIN1300 supports RGMII, MII and RMII MAC interface modes. The
          following sections describe the RGMII, MII and RMII interfaces for both
          devices.
-         
+
          **RGMII Interface**
 
-         
+
          The RGMII interface is the communication path between the PHY and MAC
          devices. The RGMII interface has a low pin count interface supports
          10M, 100M and Gigabit operation, with a total of 12 pins for data
@@ -201,12 +201,12 @@ PHY Exchange Guide, DP83867 to ADIN1300 Gb
          interface mode. Both devices support the internal delay on the clocks.
          By default, the ADIN1300 is configured in RGMII mode with a 2 ns delay
          on RXC and TXC.
-         
+
          .. image:: images/table4_rgmii_mac_interface_pin_mode_comparison_dp83867.png
-         
+
          **MII Interface**
 
-         
+
          The MII interface is the communication path between the PHY and MAC
          devices. The MII interface has a high pin count, with a total of 15
          pins for data transmission, reception and to signal errors or
@@ -220,9 +220,9 @@ PHY Exchange Guide, DP83867 to ADIN1300 Gb
          is enabled the pin function is TX_ER as only full duplex operation is
          supported with EEE and the COL pin is not required. Similarly, the
          “INT_N/CRS” becomes CRS.
-         
 
-   
+
+
    .. container:: half column
 
       The ADIN1300 sub-system registers provide user with ability to reconfigure
@@ -231,37 +231,37 @@ PHY Exchange Guide, DP83867 to ADIN1300 Gb
       interface to reconfigure. Note, the DP83867IR only support MII mode with
       the 64-QFP 12x12 mm package.
 
-         
+
          .. image:: images/table5_mii_mac_interface_pin_mode_comparison_dp83867.png
-         
+
          **RMII Interface**
 
-         
-         The DP83867 does not support the RMII interface. RMII is a reduced MII interface using fewer pins as shown in Table 6. The pin count for this interface is 8 pins. |image2| In RMII mode, the ADIN1300 requires an external 50MHz clock applied to XTAL_I. This clock could come from the MAC.
-         
 
-   
+         The DP83867 does not support the RMII interface. RMII is a reduced MII interface using fewer pins as shown in Table 6. The pin count for this interface is 8 pins. |image2| In RMII mode, the ADIN1300 requires an external 50MHz clock applied to XTAL_I. This clock could come from the MAC.
+
+
+
 
 --------------
 
 .. container:: group
 
-   
+
    .. container:: half column
 
-         
+
          **Output Clocks**
 
-         
+
          The ADIN1300 provides a 25 MHz output reference clock on the REF_CLK
          pin. This can be used a 25 MHz input reference clock for another PHY
          device. The ADIN1300 can optionally provide a number of clock signals
          on the GP_CLK pin. This is configured via MDIO writes and the clocks
          available are a 125 MHz free running clock, 25 MHz clock and 25 MHz/125
          MHz recovered clock.
-         
+
          Hardware Configuration
-         
+
          Both devices have a number of strapping options to enable managed or
          unmanaged configurations of the PHY function such as PHY address, mode
          of operation, Auto-Negotiation and MAC Interface. After power on, the
@@ -278,21 +278,21 @@ PHY Exchange Guide, DP83867 to ADIN1300 Gb
          operation after the device is brought out of reset. The ADIN1300 has
          internal pull downs on many of its strapping pins (not all), therefore
          it would be possible to minimize external strapping resistors.
-         
+
          .. image:: images/figure4_adin1300_hardware_strapping_2and4_level_dp83867.png
-         
+
          .. image:: images/table7_4level_strapping_resistor_ratios_adin_1300_dp83867.png
-         
+
          Strapping configurations are very specific to the device, consult the
          respective datasheets to determine the exact configuration for required
          use case. The DP83867 has internal 9 kΩ pulldown resistors on all pins
          used for strapping functions.
-         
+
          .. image:: images/table8_4level_strapping_resistor_ratios_dp83867.png
-         
+
          **Hardware Configuration of Speed**
 
-         
+
          For the ADIN1300, speed configuration is done using two pins, PHY_CFG0
          and PHY_CFG1. These pins do not have any internal pull resistors,
          therefore external strapping is required. Both pins support 4-level
@@ -300,25 +300,25 @@ PHY Exchange Guide, DP83867 to ADIN1300 Gb
          combinations, such as Auto-neg speeds shown in Table 9 or Forced modes
          shown in Table 10. Review the datasheet hardware configuration pin
          section for full detail on the possible settings using these pins.
-         
 
-   
+
+
    .. container:: half column
 
       |image3| |image4|
 
-         
+
          **Hardware Configuration of Auto-MDIX**
 
-         
+
          Selection of Auto-MDIX for the ADIN1300 is done using one pin,
          (MDIX_MODE) with 4-level strapping.
-         
+
          .. image:: images/table11_auto_mdix_modes_1300_dp83867.png
-         
+
          **MAC Interface Selection**
 
-         
+
          The ADIN1300 uses two hardware pins, MACIF_SEL0 and MACIF_SEL1 to
          provide user ability to select different MAC interfaces. These two pins
          have internal weak pull downs, therefore the default operation would be
@@ -326,12 +326,12 @@ PHY Exchange Guide, DP83867 to ADIN1300 Gb
          interface mode, use 10kΩ pull up or pull down resistors to select
          accordingly.
 
-         
+
          |image5|
 
          **Hardware Configuration of PHY Address**
 
-         
+
          Both devices have a default strapping providing a PHY address of
          0x0000. The ADIN1300 uses two-level strapping for the four PHY address
          pins, either pull high or low to configure the PHY address, with an
@@ -341,9 +341,9 @@ PHY Exchange Guide, DP83867 to ADIN1300 Gb
          using the QFN device or 32 when using the QFP. When configuring any
          strapping configurations, assess the default state of the MAC side, in
          case it conflicts with the hardware strapping implemented.
-         
 
-   
+
+
 
 .. important::
 
@@ -355,26 +355,26 @@ PHY Exchange Guide, DP83867 to ADIN1300 Gb
 
 .. container:: group
 
-   
+
    .. container:: half column
 
-         
+
          Package
-         
+
          The ADIN1300 is available in a 40 lead LFCSP (6 mm x 6 mm footprint).
          The DP83867 is available in two package options, 48 lead QFN (7 mm x 7
          mm) and 64 pin QFP (12 mm x 12 mm). Due to the smaller package
          footprint and differing pinout, the ADIN1300 is not a drop-in
          replacement for the DP83867 product. It will require a re-spin of
          schematic and board layout to achieve this exchange.
-         
+
          .. image:: images/table13_package_comparrison_dp83867.png
-         
+
          The DP83867 requires the 64-QFP (12 mm x 12 mm) option to support MII
          or RMII interface.
-         
+
          .. image:: images/table14_package_comparrison_dp83867.png
-         
+
          The underside of the LFCSP package for the ADIN1300 includes an exposed
          paddle which should be soldered directly to the board with an array of
          vias for thermal purposes. There are also two exposed stripes adjacent
@@ -383,74 +383,74 @@ PHY Exchange Guide, DP83867 to ADIN1300 Gb
          supply rails in the device, therefore should not be tied to ground and
          there should be no routing or traces on the PCB layer directly
          underneath them.
-         
+
          Other Pinout Considerations
-         
+
          **Integrated MDI Termination**
 
-         
+
          Both devices include integrated termination resistors on the MDI paths.
          These are voltage mode PHYs, no external resistors are required for
          biasing and no supply voltage is required at the center tap of the
          transformer.
-         
 
-   
+
+
    .. container:: half column
 
-         
+
          **RGMII Drive/Termination resistors**
 
-         
+
          The ADIN1300 provides user with ability to adjust the RGMII drive
          current through the GE_RGMII_IO_CNTRL register.
-         
+
          **MII**
 
-         
+
          The ADIN1300 also supports MII MAC interface mode in the standard
          40-QFN (6 mm x 6mm) package for 10/100M operation. The DP83867 must use
          the 64-QFP (12 mm x 12 mm) package.
-         
+
          **RMII**
 
-         
+
          The ADIN1300 also supports RMII MAC interface mode for 10/100M
          operation. The DP83867 does not support the RMII interface.
-         
+
          **SGMII**
 
-         
+
          The DP83867 supports SGMII interface in the CS/E/IS variants. The
          ADIN1300 does not support SGMII interface.
-         
+
          **GMII**
 
-         
+
          The DP83867 supports GMII interface in the 64-lead QFP (12 mm x 12 mm)
          package option. The ADIN1300 does not support GMII interface.
-         
+
          Software Considerations
-         
+
          Both devices can be hardware strapped to be used in an unmanaged
          configuration. Alternatively, they can provide SMI/MII access over the
          MDIO interface. - The DP83869 supports Clause 22 register access, while
          the ADIN1300 supports both Clause 22 and Clause 45 register access
          using both the 802.3 Clause 22 and Clause 45 management frame
          structures. Registers 0x0 to 0xF are common across all PHYs.
-         
+
          **Linux Driver**
 
-         
+
          The ADIN1300 has a Linux Driver available in the Linux mainline kernel. The ADIN1300 linux driver detail is captured here: `adin <https://wiki.analog.com/resources/tools-software/linux-drivers/net-phy/adin>`_
-         
+
          **Non Operating System Driver**
 
-         
-         The ADIN1300 has a Non Operating System Driver available from the devices product page here: :adi:`en/products/adin1300.html#product-requirement`
-         
 
-   
+         The ADIN1300 has a Non Operating System Driver available from the devices product page here: :adi:`en/products/adin1300.html#product-requirement`
+
+
+
 
 .. tip::
 

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/dp83867_to_adin1300_phy_exchange_guide.rst
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/dp83867_to_adin1300_phy_exchange_guide.rst
@@ -1,0 +1,517 @@
+PHY Exchange Guide, DP83867 to ADIN1300 Gb
+==========================================
+
+.. container:: group
+
+   
+   .. container:: half column
+
+         
+         **Overview**
+
+         
+         This PHY exchange guide captures pertinent information to support
+         migration from the TI DP83867IR/CR/CS/E/IS to the Analog Devices
+         ADIN1300 Ethernet PHY. The ADIN1300 has compelling reasons for adoption
+         versus this competitor PHY, such as reduced power consumption, lower
+         latency, and smaller footprint due to the small package size.
+         
+         .. image:: images/figure1_motivators_to_migrate_dp83867.png
+         
+         The ADIN1300 Ethernet PHY supports all the standard functions and pins
+         of an Ethernet PHY and it is very straight forward to migrate an
+         existing design to the ADIN1300. The following sections detail the
+         modifications at the schematic level required to migrate from a DP83867
+         device to the ADIN1300 device. Including a description of differences
+         corresponding to each functional group of pins and differences in the
+         hardware pin configuration of the device. A side-by-side pinout and
+         package comparison and a feature comparison table are included for easy
+         reference. The ADIN1300 datasheet provides a detailed description of
+         all functions of the device and should also be consulted for reference.
+         
+         Hardware Changes By Function
+         
+         **Power Supplies Overview**
+
+         
+         Both devices require a minimum of 2 power supply rails, where the VDDIO
+         is connected to the same power supply voltage as the MAC or as the PHY
+         analog supply AVDD_3P3 (VDDA2P5). The VDDIO supply rail powers the MAC
+         interface and MDIO blocks, this can operate from 1.8V, 2.5V or 3.3V.
+         Both devices have an on-chip voltage regulator to generate the internal
+         core supply rail. The supply requirements are listed in Table 1.
+         
+         .. image:: images/table1_overview_of_power_supply_rails_dp83867.png
+         
+         The ADIN1300 is robust to power supply sequencing and the power can be
+         applied in any order. Decoupling requirements for each device differ as
+         described in Table 2
+         
+         .. image:: images/table2_decoupling_requirements_for_each_phy_dp83867.png
+         
+         **RESET Operation**
+
+         
+         Both devices have a RESET_N pin which initializes the device and
+         latches the hardware pin configuration. To reset the device the RESET_N
+         pin should be held low for >10 μs. Deglitch circuitry is included on
+         this pin to reject pulses shorter than ~1 μs. This pin requires a 1 kΩ
+         pull-up resistor to AVDD_3P3. The ADIN1300 includes power monitoring
+         circuitry to monitor all of the supplies. At power-up, the ADIN1300 is
+         held in hardware reset until each of the supplies has crossed its
+         minimum rising threshold value.
+         
+         The hardware strapping pins are read and updated at the de-assertion of
+         reset for both devices. For the ADIN1300, the RESET_N pin resides in
+         the AVDD_3P3 voltage domain. In applications where the MAC interface is
+         powered from VDDIO of 1.8V, level shifting of the RESET_N signal
+         applied to the ADIN1300 may be required to ensure the voltage level on
+         the RESET_N pin is in excess of the minimum input high threshold level.
+         The DP83867 requires external control over the RESET_N pin during power
+         up and a much longer time to when the management registers are
+         accessible. If the RESET_N pin is connected to a host controller, then
+         the PHY must be held in reset for a minimum of 200 ms after the last
+         supply powers up. If the host controller cannot be connected to
+         RESET_N, then a 100-Ω resistor and 47-uF capacitor are required to be
+         connected in series between the RESET_N pin and ground.
+         
+         **Clocking**
+
+         
+         A 25 MHz crystal or external clock source is used to provide the
+         reference clock for both devices. A crystal can be connected to pins
+         XTAL_I/XTAL_O (XI/XO), with both devices using the same external
+         circuit. Or a 25 MHz refence clock can be provided on the input clock
+         pin CLK_IN (XI). In RMII mode, the ADIN1300 expects an external 50 MHz
+         REF_CLK provided to the XTAL_I/REF_CLK pin.
+         
+         **Bias Resistor**
+
+         
+         An external resistor is required to bias internal reference circuitry
+         for both DP83867 and ADIN1300. The ADIN1300 requires a 3.01 kΩ resistor
+         (1% tolerance, 100 ppm/°C temperature coefficient) connected to pin 10.
+         The DP83687 uses an 11 kΩ (1%) on pin 12 in QFN package or pin 15 in
+         QFP package.
+         
+         .. image:: images/table3_bias_resistor_values_dp83867.png
+         
+         **Media Dependent Interface (MDI)**
+
+         
+         The ADIN1300 has voltage mode line drivers with on-chip terminations so
+         no external termination resistors are required. Both devices use
+         voltage mode line drive for connection from the MDI_0:3_P/N
+         (TD_P/M_A:D) pins to the magnetics and RJ-45 line using the same
+         external circuit. The recommended external circuit for the interface to
+         the magnetics and RJ-45 is shown in Figure 2.
+         
+
+   
+   .. container:: half column
+
+         
+
+   
+      ..
+
+   |image1|
+
+         **MDIO/Management Interface**
+
+         
+         Both devices support the IEEE management interface using the MDIO/MDC
+         pins and require a pullup resistor on the MDIO pin (Management Data
+         Open Drain Input/Output). The recommended value for ADIN1300 is a 1.5kΩ
+         resistor connected to pin 24. The DP83867 recommends 2.2kΩ connected to
+         pin 17 (QFN) or pin 21 (QFP). Both devices provide an interrupt pin,
+         INT_N (¯INT). This pin requires a 1.5 kΩ pull-up resistor to VDDIO. The
+         DP83867 recommends 2.2kΩ pull-up resistors for their interrupt pin.
+         
+         **LED Function**
+
+         
+         The ADIN1300 support two LED pins on LED_0 and LINK_ST. The LED_0 has
+         programmability of LED functions, with different blinking operation
+         possible through MDIO configuration, the default mode is ON when Link
+         is Up, blink if activity. The LINK_ST provides static information about
+         Link up or down status. The DP83867 supports 3 LEDs pins 45, 46, 47
+         (QFN) or pins 61, 62, 63 (QFP) in addition to one GPIO pin that can be
+         configured to operate as LED_3. Both devices use these pins for
+         strapping purposes.
+         
+         **LED Circuit**
+
+         
+         The ADIN1300 LED_0 operates from the AVDD_3P3 voltage domain, therefore
+         can support driving LEDs even when the MAC interface is running at the
+         lower voltage of 1.8V. The default LED operation is on if the Link is
+         up and blinks when there is activity, this operation can be
+         reprogrammed through MDIO write. For the LED_0 of the ADIN1300, it can
+         be configured with 4-level strapping. The strapping configuration will
+         have an impact on how the LED function operates and needs to be
+         considered if the LED pins are used to directly drive an LED. If the
+         strap pin is pulled high by the strapping resistors, (MODE_3/MODE_4)
+         the output will be configured as an active low driver and conversely if
+         the strapping input is pulled low (MODE_0/MODE_1), the output will be
+         configured as active high. This LED circuit should be configured
+         accordingly.
+         
+         .. image:: images/figure3_led0_hardware_config_dp83867.png
+         
+         **Link Status, LINK_ST**
+
+         
+         The ADIN1300 has a dedicated LINK_ST pin to provide information to the
+         MAC on the status of the Link. By default, the LINK_ST pin goes high
+         indicating the link is up and low to indicate the link is down. The
+         LINK_ST polarity is programmable by setting the bit high
+         GE_LNK_STAT_INV_EN. The LINK_ST could be used to drive an LED, however
+         it resides in the VDDIO voltage domain, therefore, when driving an LED
+         in an integrated RJ45 jack where the PHY VDDIO is 1.8V, level shifting
+         will be required. This can be done using a FET.
+         
+
+   
+
+--------------
+
+.. container:: group
+
+   
+   .. container:: half column
+
+         
+         **MAC Interface**
+
+         
+         The ADIN1300 supports RGMII, MII and RMII MAC interface modes. The
+         following sections describe the RGMII, MII and RMII interfaces for both
+         devices.
+         
+         **RGMII Interface**
+
+         
+         The RGMII interface is the communication path between the PHY and MAC
+         devices. The RGMII interface has a low pin count interface supports
+         10M, 100M and Gigabit operation, with a total of 12 pins for data
+         transmission, reception and to signal errors or collision. It is the
+         most common interface for Gigabit applications and has the lowest
+         latency. Table 5 shows a pin overview of both devices for the RGMII MAC
+         interface mode. Both devices support the internal delay on the clocks.
+         By default, the ADIN1300 is configured in RGMII mode with a 2 ns delay
+         on RXC and TXC.
+         
+         .. image:: images/table4_rgmii_mac_interface_pin_mode_comparison_dp83867.png
+         
+         **MII Interface**
+
+         
+         The MII interface is the communication path between the PHY and MAC
+         devices. The MII interface has a high pin count, with a total of 15
+         pins for data transmission, reception and to signal errors or
+         collision. It is sometimes used in 100M applications as it has a lower
+         latency than RGMII and is much lower than RMII. Table 5 shows a pin
+         overview of both devices for the MII MAC interface mode. When using the
+         ADIN1300 in MII mode, the multifunction pin “LED_0/COL/TX_ER”
+         automatically becomes either COL or TX_ER. If EEE advertisement is
+         disabled the pin function is COL as full and half-duplex operation is
+         supported and TX_ER is not required as an input. If EEE advertisement
+         is enabled the pin function is TX_ER as only full duplex operation is
+         supported with EEE and the COL pin is not required. Similarly, the
+         “INT_N/CRS” becomes CRS.
+         
+
+   
+   .. container:: half column
+
+      The ADIN1300 sub-system registers provide user with ability to reconfigure
+      which pin the COL and CRS functions are provided on (option of redirecting
+      to GP_CLK, LINK_ST or INT_N). This requires a register write over MDIO
+      interface to reconfigure. Note, the DP83867IR only support MII mode with
+      the 64-QFP 12x12 mm package.
+
+         
+         .. image:: images/table5_mii_mac_interface_pin_mode_comparison_dp83867.png
+         
+         **RMII Interface**
+
+         
+         The DP83867 does not support the RMII interface. RMII is a reduced MII interface using fewer pins as shown in Table 6. The pin count for this interface is 8 pins. |image2| In RMII mode, the ADIN1300 requires an external 50MHz clock applied to XTAL_I. This clock could come from the MAC.
+         
+
+   
+
+--------------
+
+.. container:: group
+
+   
+   .. container:: half column
+
+         
+         **Output Clocks**
+
+         
+         The ADIN1300 provides a 25 MHz output reference clock on the REF_CLK
+         pin. This can be used a 25 MHz input reference clock for another PHY
+         device. The ADIN1300 can optionally provide a number of clock signals
+         on the GP_CLK pin. This is configured via MDIO writes and the clocks
+         available are a 125 MHz free running clock, 25 MHz clock and 25 MHz/125
+         MHz recovered clock.
+         
+         Hardware Configuration
+         
+         Both devices have a number of strapping options to enable managed or
+         unmanaged configurations of the PHY function such as PHY address, mode
+         of operation, Auto-Negotiation and MAC Interface. After power on, the
+         strapping pin voltages get sensed and latched upon existing from a
+         reset and the sensed voltages are used to set the personality of the
+         PHY. When configuring any strapping configurations, ensure to review
+         the default state of the MAC side, whether the pins are being driven
+         when coming out of reset or if there are internal pulls. Understanding
+         the behavior on the MAC side is key to ensuring there are no conflicts
+         with the hardware strapping implemented, or to adjust the strapping
+         resistor values if required. The DP83867 uses 4-level strapping options
+         throughout, while the ADIN1300 uses a mix of 2-level and 4-level. In
+         general, strapping pins are multi-functional and have different
+         operation after the device is brought out of reset. The ADIN1300 has
+         internal pull downs on many of its strapping pins (not all), therefore
+         it would be possible to minimize external strapping resistors.
+         
+         .. image:: images/figure4_adin1300_hardware_strapping_2and4_level_dp83867.png
+         
+         .. image:: images/table7_4level_strapping_resistor_ratios_adin_1300_dp83867.png
+         
+         Strapping configurations are very specific to the device, consult the
+         respective datasheets to determine the exact configuration for required
+         use case. The DP83867 has internal 9 kΩ pulldown resistors on all pins
+         used for strapping functions.
+         
+         .. image:: images/table8_4level_strapping_resistor_ratios_dp83867.png
+         
+         **Hardware Configuration of Speed**
+
+         
+         For the ADIN1300, speed configuration is done using two pins, PHY_CFG0
+         and PHY_CFG1. These pins do not have any internal pull resistors,
+         therefore external strapping is required. Both pins support 4-level
+         strapping, providing much flexibility in terms of the possible
+         combinations, such as Auto-neg speeds shown in Table 9 or Forced modes
+         shown in Table 10. Review the datasheet hardware configuration pin
+         section for full detail on the possible settings using these pins.
+         
+
+   
+   .. container:: half column
+
+      |image3| |image4|
+
+         
+         **Hardware Configuration of Auto-MDIX**
+
+         
+         Selection of Auto-MDIX for the ADIN1300 is done using one pin,
+         (MDIX_MODE) with 4-level strapping.
+         
+         .. image:: images/table11_auto_mdix_modes_1300_dp83867.png
+         
+         **MAC Interface Selection**
+
+         
+         The ADIN1300 uses two hardware pins, MACIF_SEL0 and MACIF_SEL1 to
+         provide user ability to select different MAC interfaces. These two pins
+         have internal weak pull downs, therefore the default operation would be
+         RGMII with delays as shown in Table 12. To configure any other MAC
+         interface mode, use 10kΩ pull up or pull down resistors to select
+         accordingly.
+
+         
+         |image5|
+
+         **Hardware Configuration of PHY Address**
+
+         
+         Both devices have a default strapping providing a PHY address of
+         0x0000. The ADIN1300 uses two-level strapping for the four PHY address
+         pins, either pull high or low to configure the PHY address, with an
+         option of 16 unique addresses possible. Two level strapping provides a
+         very robust PHY addressing scheme. The DP83867 provides four level
+         strapping for the PHY address pins, capable of 16 unique address when
+         using the QFN device or 32 when using the QFP. When configuring any
+         strapping configurations, assess the default state of the MAC side, in
+         case it conflicts with the hardware strapping implemented.
+         
+
+   
+
+.. important::
+
+   Strapping configurations are very specific to the device, consult the
+   respective datasheets to determine the exact configuration for required use
+   case.
+
+--------------
+
+.. container:: group
+
+   
+   .. container:: half column
+
+         
+         Package
+         
+         The ADIN1300 is available in a 40 lead LFCSP (6 mm x 6 mm footprint).
+         The DP83867 is available in two package options, 48 lead QFN (7 mm x 7
+         mm) and 64 pin QFP (12 mm x 12 mm). Due to the smaller package
+         footprint and differing pinout, the ADIN1300 is not a drop-in
+         replacement for the DP83867 product. It will require a re-spin of
+         schematic and board layout to achieve this exchange.
+         
+         .. image:: images/table13_package_comparrison_dp83867.png
+         
+         The DP83867 requires the 64-QFP (12 mm x 12 mm) option to support MII
+         or RMII interface.
+         
+         .. image:: images/table14_package_comparrison_dp83867.png
+         
+         The underside of the LFCSP package for the ADIN1300 includes an exposed
+         paddle which should be soldered directly to the board with an array of
+         vias for thermal purposes. There are also two exposed stripes adjacent
+         to the exposed paddle. These do not need to be soldered to the board,
+         they should be treated as a keep out area as they are connected to
+         supply rails in the device, therefore should not be tied to ground and
+         there should be no routing or traces on the PCB layer directly
+         underneath them.
+         
+         Other Pinout Considerations
+         
+         **Integrated MDI Termination**
+
+         
+         Both devices include integrated termination resistors on the MDI paths.
+         These are voltage mode PHYs, no external resistors are required for
+         biasing and no supply voltage is required at the center tap of the
+         transformer.
+         
+
+   
+   .. container:: half column
+
+         
+         **RGMII Drive/Termination resistors**
+
+         
+         The ADIN1300 provides user with ability to adjust the RGMII drive
+         current through the GE_RGMII_IO_CNTRL register.
+         
+         **MII**
+
+         
+         The ADIN1300 also supports MII MAC interface mode in the standard
+         40-QFN (6 mm x 6mm) package for 10/100M operation. The DP83867 must use
+         the 64-QFP (12 mm x 12 mm) package.
+         
+         **RMII**
+
+         
+         The ADIN1300 also supports RMII MAC interface mode for 10/100M
+         operation. The DP83867 does not support the RMII interface.
+         
+         **SGMII**
+
+         
+         The DP83867 supports SGMII interface in the CS/E/IS variants. The
+         ADIN1300 does not support SGMII interface.
+         
+         **GMII**
+
+         
+         The DP83867 supports GMII interface in the 64-lead QFP (12 mm x 12 mm)
+         package option. The ADIN1300 does not support GMII interface.
+         
+         Software Considerations
+         
+         Both devices can be hardware strapped to be used in an unmanaged
+         configuration. Alternatively, they can provide SMI/MII access over the
+         MDIO interface. - The DP83869 supports Clause 22 register access, while
+         the ADIN1300 supports both Clause 22 and Clause 45 register access
+         using both the 802.3 Clause 22 and Clause 45 management frame
+         structures. Registers 0x0 to 0xF are common across all PHYs.
+         
+         **Linux Driver**
+
+         
+         The ADIN1300 has a Linux Driver available in the Linux mainline kernel. The ADIN1300 linux driver detail is captured here: `adin <https://wiki.analog.com/resources/tools-software/linux-drivers/net-phy/adin>`_
+         
+         **Non Operating System Driver**
+
+         
+         The ADIN1300 has a Non Operating System Driver available from the devices product page here: :adi:`en/products/adin1300.html#product-requirement`
+         
+
+   
+
+.. tip::
+
+   The ADIN1300 has a Linux Driver available in the Linux mainline kernel.
+
+Side by Side Package/Pinout Comparison
+--------------------------------------
+
+The following is a side-by-side comparison of the package and pinouts, showing
+the position of the corresponding functional pins on each device
+
+|image6|
+
+--------------
+
+Feature Comparison Table
+------------------------
+
+.. image:: images/table15_feature_comparrison_table_dp83867.png
+
+Example Configuration for RGMII
+-------------------------------
+
+The following example captures how to configure the ADIN1300 for an unmanaged
+configuration with RGMII Interface, operating in Auto Negotiation mode
+advertising all speeds. The PHY will power up in this state, ready to establish
+a link with a link partner. The MAC interface configuration pins (MACIF_SEL0/1)
+are pulled to ground, setting the PHY to RGMII mode with 2ns Delay on RXC & TXC.
+GP_CLK is pulled to VDDIO to configure an automatic MDIX operation. In addition,
+the PHY_CFG0 and PHY_CFG1 pins are configured for MODE_4 and MODE_1
+respectively. The PHY_CFG0 pin is also shared with the LED_0 pin, it’s
+configuration with MODE_4 means an active low LED can be used on LED_0.
+
+The following list summarizes an RGMII auto negotiate, 10 Mbps, 100 Mbps, or
+1000 Mbps with full duplex or half duplex, with the software power-down enabled
+after reset:
+
+-  MAC Interface = RGMII with 2ns delay on RXC/TXC
+
+   -  MACIF_SEL0 = MODE_1 = 10 kΩ pull-down resistor
+   -  MACIF_SEL1 = MODE_1 = 10 kΩ pull-down resistor
+
+-  MDIX_MODE = automatic MDIX, preferred MDI
+
+   -  MDIX_MODE = MODE_4
+
+-  PHY address = 0b0001
+-  Speed selection = 10 Mbps, 100 Mbps, or 1000 Mbps with full duplex or half
+   duplex, automatic negotiate enabled
+
+   -  PHY_CFG0 = MODE_4 = 10 kΩ pull-up resistor
+
+::
+
+     *PHY_CFG1 = MODE_1 = 10 kΩ pull-down resistor
+
+.. image:: images/figure6_rmii_auto_neg_allspeeds_half_or_full_duplex_dp83867.png
+
+.. |image1| image:: images/figure2_isolating_using_discrete_magnetics_dp83867.png
+.. |image2| image:: images/table6_rmii_mac_interface_pin_mode_comparison_dp83867.png
+.. |image3| image:: images/table9_autoneg_speeds_1300_dp83867.png
+.. |image4| image:: images/table10_forced_neg_speeds_1300_dp83867.png
+.. |image5| image:: images/table12_mac_interface_selection_1300_dp83867.png
+.. |image6| image:: images/figure5_pinout_comparison_dp83867.png

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/dp83869_to_adin1300_phy_exchange_guide.rst
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/dp83869_to_adin1300_phy_exchange_guide.rst
@@ -3,21 +3,21 @@ PHY Exchange Guide, DP83869 to ADIN1300 Gb
 
 .. container:: group
 
-   
+
    .. container:: half column
 
-         
+
          **Overview**
 
-         
+
          This PHY exchange guide captures pertinent information to support
          migration from the TI DP83869 to the Analog Devices ADIN1300 Ethernet
          PHY. The ADIN1300 has compelling reasons for adoption versus this
          competitor PHY, such as reduced power consumption, lower latency, and
          smaller footprint due to the small package size.
-         
+
          .. image:: images/dp83869_motivators_to_migrate_-_figure1.png
-         
+
          The ADIN1300 Ethernet PHY supports all the standard functions and pins
          of an Ethernet PHY and it is very straight forward to migrate an
          existing design to the ADIN1300. The following sections detail the
@@ -28,29 +28,29 @@ PHY Exchange Guide, DP83869 to ADIN1300 Gb
          package comparison and a feature comparison table are included for easy
          reference. The ADIN1300 datasheet provides a detailed description of
          all functions of the device and should also be consulted for reference.
-         
+
          Hardware Changes By Function
-         
+
          **Power Supplies Overview**
 
-         
+
          Both devices require a minimum of 2 power supply rails, where the VDDIO
          is connected to the same power supply voltage as the MAC or as the PHY
          analog supply AVDD_3P3 (VDDA2P5). The VDDIO supply rail powers the MAC
          interface and MDIO blocks, this can operate from 1.8V, 2.5V or 3.3V.
          The supply requirements are listed in Table 1.
-         
+
          .. image:: images/dp83869_overview_of_power_supply_rails_table_1.png
-         
+
          The ADIN1300 is robust to power supply sequencing and the power can be
          applied in any order. Decoupling requirements for each device differ as
          described in Table 2
-         
+
          .. image:: images/dp83869_decoupling_requirements_for_each_phy_table2.png
-         
+
          **RESET Operation**
 
-         
+
          Both devices have a RESET_N pin which initializes the device and
          latches the hardware pin configuration. To reset the ADIN1300 the
          RESET_N pin should be held low for >10 μs. Deglitch circuitry is
@@ -67,7 +67,7 @@ PHY Exchange Guide, DP83869 to ADIN1300 Gb
          level shifting of the RESET_N signal applied to the ADIN1300 may be
          required to ensure the voltage level on the RESET_N pin is in excess of
          the minimum input high threshold level.
-         
+
          The DP83869 requires external control over the RESET_N pin during power
          up and a much longer time to when the management registers are
          accessible. If the RESET_N pin is connected to a host controller, then
@@ -75,10 +75,10 @@ PHY Exchange Guide, DP83869 to ADIN1300 Gb
          supply powers up. If the host controller cannot be connected to
          RESET_N, then a 100-Ω resistor and 47-uF capacitor are required to be
          connected in series between the RESET_N pin and ground.
-         
+
          **Clocking**
 
-         
+
          A 25 MHz crystal or external clock source is used to provide the
          reference clock for both devices. A crystal can be connected to pins
          XTAL_I/XTAL_O (XI/XO), with both devices using the same external
@@ -86,41 +86,41 @@ PHY Exchange Guide, DP83869 to ADIN1300 Gb
          pin CLK_IN (XI). The DP83869 does not support the RMII MAC interface.
          The ADIN1300 does support RMII and requires an external 50 MHz REF_CLK
          on the XTAL_I/REF_CLK pin in RMII mode.
-         
+
          **Bias Resistor**
 
-         
+
          An external resistor is required to bias internal reference circuitry
          for both DP83869 and ADIN1300. The ADIN1300 requires a 3.01 kΩ resistor
          (1% tolerance, 100 ppm/°C temperature coefficient) connected to pin 10.
          The DP83687 uses an 11 kΩ (1%) on pin 12.
-         
+
          .. image:: images/dp83869_bias_resistor_values_table3.png
-         
+
          **Media Dependent Interface (MDI)**
 
-         
+
          The ADIN1300 has voltage mode line drivers with on-chip terminations so
          no external termination resistors are required. Both devices use
          voltage mode line drive for connection from the MDI_0:3_P/N
          (TD_P/M_A:D) pins to the magnetics and RJ-45 line using the same
          external circuit. The recommended external circuit for the interface to
          the magnetics and RJ-45 is shown in Figure 2.
-         
 
-   
+
+
    .. container:: half column
 
-         
 
-   
+
+
       ..
 
    |image1|
 
          **MDIO/Management Interface**
 
-         
+
          Both devices support the IEEE management interface using the MDIO/MDC
          pins and require a pullup resistor on the MDIO pin (Management Data
          Open Drain Input/Output). The recommended value for ADIN1300 is a 1.5kΩ
@@ -128,10 +128,10 @@ PHY Exchange Guide, DP83869 to ADIN1300 Gb
          resistor connected to pin 41. Both devices provide an interrupt pin,
          INT_N (¯INT). This pin requires a 1.5 kΩ pull-up resistor to VDDIO. The
          DP83869 recommends 2.2kΩ pull-up resistors for their interrupt pin.
-         
+
          **LED Function**
 
-         
+
          The ADIN1300 support two LED pins on LED_0 and LINK_ST. The LED_0 has
          programmability of LED functions, with different blinking operation
          possible through MDIO configuration, the default mode is ON when Link
@@ -139,10 +139,10 @@ PHY Exchange Guide, DP83869 to ADIN1300 Gb
          Link up or down status. The DP83869 supports 3 LEDs pins 45, 46, 47 in
          addition to one GPIO pin that can be configured to operate as LED_3.
          Both devices use these pins for strapping purposes.
-         
+
          **LED Circuit**
 
-         
+
          The ADIN1300 LED_0 operates from the AVDD_3P3 voltage domain, therefore
          can support driving LEDs even when the MAC interface is running at the
          lower voltage of 1.8V. The default LED operation is on if the Link is
@@ -156,12 +156,12 @@ PHY Exchange Guide, DP83869 to ADIN1300 Gb
          the strapping input is pulled low (MODE_0/MODE_1), the output will be
          configured as active high. This LED circuit should be configured
          accordingly.
-         
+
          .. image:: images/dp83869_led_0_hardware_configuation_pin_interaction_figure3.png
-         
+
          **Link Status, LINK_ST**
 
-         
+
          The ADIN1300 has a dedicated LINK_ST pin to provide information to the
          MAC on the status of the Link. By default, the LINK_ST pin goes high
          indicating the link is up and low to indicate the link is down. The
@@ -170,28 +170,28 @@ PHY Exchange Guide, DP83869 to ADIN1300 Gb
          it resides in the VDDIO voltage domain, therefore, when driving an LED
          in an integrated RJ45 jack where the PHY VDDIO is 1.8V, level shifting
          will be required. This can be done using a FET.
-         
 
-   
+
+
 
 --------------
 
 .. container:: group
 
-   
+
    .. container:: half column
 
-         
+
          **MAC Interface**
 
-         
+
          The ADIN1300 supports RGMII, MII and RMII MAC interface modes. The
          following sections describe the RGMII, MII and RMII interfaces for both
          devices.
-         
+
          **RGMII Interface**
 
-         
+
          The RGMII interface is the communication path between the PHY and MAC
          devices. The RGMII interface has a low pin count interface supports
          10M, 100M and Gigabit operation, with a total of 12 pins for data
@@ -201,12 +201,12 @@ PHY Exchange Guide, DP83869 to ADIN1300 Gb
          interface mode. Both devices support the internal delay on the clocks.
          By default, the ADIN1300 is configured in RGMII mode with a 2 ns delay
          on RXC and TXC.
-         
+
          .. image:: images/dp83869_rgmii_mac_interface_mode_pin_comparison_table4.png
-         
+
          **MII Interface**
 
-         
+
          The MII interface is the communication path between the PHY and MAC
          devices. The MII interface has a high pin count, with a total of 15
          pins for data transmission, reception and to signal errors or
@@ -224,53 +224,53 @@ PHY Exchange Guide, DP83869 to ADIN1300 Gb
          provided on (option of redirecting to GP_CLK, LINK_ST or INT_N). This
          requires a register write over MDIO interface to reconfigure. The
          DP83869 can configure pin 21 (GPIO_0) using software as COL or CRS.
-         
 
-   
+
+
    .. container:: half column
 
-         
 
-   
+
+
       ..
 
    |image2|
 
          **RMII Interface**
 
-         
+
          The DP83869 does not support the RMII interface. RMII is a reduced MII
          interface using fewer pins as shown in Table 6. The pin count for this
          interface is 8 pins.
-         
+
          .. image:: images/dp83869_rmii_mac_interface_mode_pin_comparison_table6.png
-         
+
          In RMII mode, the ADIN1300 requires an external 50MHz clock applied to
          XTAL_I. This clock could come from the MAC.
-         
+
          **Output Clocks**
 
-         
+
          The ADIN1300 provides a 25 MHz output reference clock on the REF_CLK
          pin. This can be used a 25 MHz input reference clock for another PHY
          device. The ADIN1300 can optionally provide a number of clock signals
          on the GP_CLK pin. This is configured via MDIO writes and the clocks
          available are a 125 MHz free running clock, 25 MHz clock and 25 MHz/125
          MHz recovered clock.
-         
 
-   
+
+
 
 --------------
 
 .. container:: group
 
-   
+
    .. container:: half column
 
-         
+
          Hardware Configuration
-         
+
          Both devices have a number of strapping options to enable managed or
          unmanaged configurations of the PHY function such as PHY address, mode
          of operation, Auto-Negotiation and MAC Interface. After power on, the
@@ -287,20 +287,20 @@ PHY Exchange Guide, DP83869 to ADIN1300 Gb
          brought out of reset. The ADIN1300 has internal pull downs on many of
          its strapping pins (not all), therefore it would be possible to
          minimize external strapping resistors.
-         
+
          .. image:: images/dp83869_adin1300_hw_strapping_2_and_4_level_starpping_resistors_figure_4.png
-         
+
          .. image:: images/dp83869_4_level_strapping_resistor_ratios_adin1300_table_7.png
-         
+
          Strapping configurations are very specific to the device, consult the
          respective datasheets to determine the exact configuration for required
          use case.
-         
+
          .. image:: images/dp83869_4_level_strapping_resistor_ratios_table_8.png
-         
+
          **Hardware Configuration of Speed**
 
-         
+
          For the ADIN1300, speed configuration is done using two pins, PHY_CFG0
          and PHY_CFG1. These pins do not have any internal pull resistors,
          therefore external strapping is required. Both pins support 4-level
@@ -308,37 +308,37 @@ PHY Exchange Guide, DP83869 to ADIN1300 Gb
          combinations, such as Auto-neg speeds shown in Table 9 or Forced modes
          shown in Table 10. Review the datasheet hardware configuration pin
          section for full detail on the possible settings using these pins.
-         
 
-   
+
+
    .. container:: half column
 
       |image3| |image4|
 
-         
+
          **Hardware Configuration of Auto-MDIX**
 
-         
+
          Selection of Auto-MDIX for the ADIN1300 is done using one pin,
          (MDIX_MODE) with 4-level strapping.
-         
+
          .. image:: images/dp83869_auto_mdix_mode_adin1300_table_11.png
-         
+
          **MAC Interface Selection**
 
-         
+
          The ADIN1300 uses two hardware pins, MACIF_SEL0 and MACIF_SEL1 to
          provide user ability to select different MAC interfaces. These two pins
          have internal weak pull downs, therefore the default operation would be
          RGMII with delays as shown in Table 12. To configure any other MAC
          interface mode, use 10kΩ pull up or pull down resistors to select
          accordingly.
-         
+
          .. image:: images/dp83869_mac_interface_selection_adin1300_table_12.png
-         
+
          **Hardware Configuration of PHY Address**
 
-         
+
          Both devices have a default strapping providing a PHY address of
          0x0000. The ADIN1300 uses two-level strapping for the four PHY address
          pins, either pull high or low to configure the PHY address, with an
@@ -348,28 +348,28 @@ PHY Exchange Guide, DP83869 to ADIN1300 Gb
          configuring any strapping configurations, assess the default state of
          the MAC side, in case it conflicts with the hardware strapping
          implemented.
-         
 
-   
+
+
 
 --------------
 
 .. container:: group
 
-   
+
    .. container:: half column
 
-         
+
          Package
-         
+
          The ADIN1300 is available in a 40 lead LFCSP (6 mm x 6 mm footprint).
          The DP83869 is available in a 48 lead QFN (7 mm x 7 mm). Due to the
          smaller package footprint and differing pinout, the ADIN1300 is not a
          drop-in replacement for the DP83869 product. It will require a re-spin
          of schematic and board layout to achieve this exchange.
-         
+
          .. image:: images/dp83869_package_comparison_table_13.png
-         
+
          The underside of the LFCSP package for the ADIN1300 includes an exposed
          paddle which should be soldered directly to the board with an array of
          vias for thermal purposes. There are also two exposed stripes adjacent
@@ -378,77 +378,77 @@ PHY Exchange Guide, DP83869 to ADIN1300 Gb
          supply rails in the device, therefore should not be tied to ground and
          there should be no routing or traces on the PCB layer directly
          underneath them.
-         
+
          Other Pinout Considerations
-         
+
          **Integrated MDI Termination**
 
-         
+
          Both devices include integrated termination resistors on the MDI paths.
          These are voltage mode PHYs, no external resistors are required for
          biasing and no supply voltage is required at the center tap of the
          transformer.
-         
+
          **RGMII Drive/Termination resistors**
 
-         
+
          The ADIN1300 provides user with ability to adjust the RGMII drive
          current through the GE_RGMII_IO_CNTRL register.
-         
 
-   
+
+
    .. container:: half column
 
-         
+
          **MII**
 
-         
+
          The ADIN1300 and DP83869 both support the MII MAC interface.
-         
+
          **RMII**
 
-         
+
          The ADIN1300 supports RMII MAC interface mode for 10/100M operation.
          The DP83869 does not support the RMII interface.
-         
+
          **GMII**
 
-         
+
          The ADIN1300 and DP83869 do not support the GMII interface.
-         
+
          **SGMII**
 
-         
+
          The DP83869 supports SGMII interface. The ADIN1300 does not support
          SGMII interface.
-         
+
          **FIBER**
 
-         
+
          The DP83869 supports 1000BASE-X and 100BASE-FX Fiber protocols. The
          ADIN1300 does not support fiber protocols.
-         
+
          Software Considerations
-         
+
          Both devices can be hardware strapped to be used in an unmanaged
          configuration. Alternatively, they can provide SMI/MII access over the
          MDIO interface. The DP83869 supports Clause 22 register access, while
          the ADIN1300 supports both Clause 22 and Clause 45 register access
          using both the 802.3 Clause 22 and Clause 45 management frame
          structures. Registers 0x0 to 0xF are common across all PHYs.
-         
+
          **Linux Driver**
 
-         
+
          The ADIN1300 has a Linux Driver available in the Linux mainline kernel. The ADIN1300 linux driver detail is captured here: `adin <https://wiki.analog.com/resources/tools-software/linux-drivers/net-phy/adin>`_
-         
+
          **Non Operating System Driver**
 
-         
-         The ADIN1300 has a Non Operating System Driver available from the devices product page here: :adi:`en/products/adin1300.html#product-requirement`
-         
 
-   
+         The ADIN1300 has a Non Operating System Driver available from the devices product page here: :adi:`en/products/adin1300.html#product-requirement`
+
+
+
 
 .. tip::
 

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/dp83869_to_adin1300_phy_exchange_guide.rst
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/dp83869_to_adin1300_phy_exchange_guide.rst
@@ -1,0 +1,504 @@
+PHY Exchange Guide, DP83869 to ADIN1300 Gb
+==========================================
+
+.. container:: group
+
+   
+   .. container:: half column
+
+         
+         **Overview**
+
+         
+         This PHY exchange guide captures pertinent information to support
+         migration from the TI DP83869 to the Analog Devices ADIN1300 Ethernet
+         PHY. The ADIN1300 has compelling reasons for adoption versus this
+         competitor PHY, such as reduced power consumption, lower latency, and
+         smaller footprint due to the small package size.
+         
+         .. image:: images/dp83869_motivators_to_migrate_-_figure1.png
+         
+         The ADIN1300 Ethernet PHY supports all the standard functions and pins
+         of an Ethernet PHY and it is very straight forward to migrate an
+         existing design to the ADIN1300. The following sections detail the
+         modifications at the schematic level required to migrate from a DP83869
+         device to the ADIN1300 device. Including a description of differences
+         corresponding to each functional group of pins and differences in the
+         hardware pin configuration of the device. A side-by-side pinout and
+         package comparison and a feature comparison table are included for easy
+         reference. The ADIN1300 datasheet provides a detailed description of
+         all functions of the device and should also be consulted for reference.
+         
+         Hardware Changes By Function
+         
+         **Power Supplies Overview**
+
+         
+         Both devices require a minimum of 2 power supply rails, where the VDDIO
+         is connected to the same power supply voltage as the MAC or as the PHY
+         analog supply AVDD_3P3 (VDDA2P5). The VDDIO supply rail powers the MAC
+         interface and MDIO blocks, this can operate from 1.8V, 2.5V or 3.3V.
+         The supply requirements are listed in Table 1.
+         
+         .. image:: images/dp83869_overview_of_power_supply_rails_table_1.png
+         
+         The ADIN1300 is robust to power supply sequencing and the power can be
+         applied in any order. Decoupling requirements for each device differ as
+         described in Table 2
+         
+         .. image:: images/dp83869_decoupling_requirements_for_each_phy_table2.png
+         
+         **RESET Operation**
+
+         
+         Both devices have a RESET_N pin which initializes the device and
+         latches the hardware pin configuration. To reset the ADIN1300 the
+         RESET_N pin should be held low for >10 μs. Deglitch circuitry is
+         included on this pin to reject pulses shorter than ~1 μs. This pin
+         requires a 1 kΩ pull-up resistor to AVDD_3P3. The ADIN1300 includes
+         power monitoring circuitry to monitor all of the supplies. At power-up,
+         the ADIN1300 is held in hardware reset until each of the supplies has
+         crossed its minimum rising threshold value. The hardware strapping pins
+         are read and updated at the de-assertion of reset for both devices. For
+         the ADIN1300, the RESET_N pin resides in the AVDD_3P3 voltage domain.
+         After 5 ms from the deassertion of RESET_N, the management interface
+         registers are accessible and the device can be programmed. In
+         applications where the MAC interface is powered from VDDIO of 1.8V,
+         level shifting of the RESET_N signal applied to the ADIN1300 may be
+         required to ensure the voltage level on the RESET_N pin is in excess of
+         the minimum input high threshold level.
+         
+         The DP83869 requires external control over the RESET_N pin during power
+         up and a much longer time to when the management registers are
+         accessible. If the RESET_N pin is connected to a host controller, then
+         the PHY must be held in reset for a minimum of 200 ms after the last
+         supply powers up. If the host controller cannot be connected to
+         RESET_N, then a 100-Ω resistor and 47-uF capacitor are required to be
+         connected in series between the RESET_N pin and ground.
+         
+         **Clocking**
+
+         
+         A 25 MHz crystal or external clock source is used to provide the
+         reference clock for both devices. A crystal can be connected to pins
+         XTAL_I/XTAL_O (XI/XO), with both devices using the same external
+         circuit. Or a 25 MHz refence clock can be provided on the input clock
+         pin CLK_IN (XI). The DP83869 does not support the RMII MAC interface.
+         The ADIN1300 does support RMII and requires an external 50 MHz REF_CLK
+         on the XTAL_I/REF_CLK pin in RMII mode.
+         
+         **Bias Resistor**
+
+         
+         An external resistor is required to bias internal reference circuitry
+         for both DP83869 and ADIN1300. The ADIN1300 requires a 3.01 kΩ resistor
+         (1% tolerance, 100 ppm/°C temperature coefficient) connected to pin 10.
+         The DP83687 uses an 11 kΩ (1%) on pin 12.
+         
+         .. image:: images/dp83869_bias_resistor_values_table3.png
+         
+         **Media Dependent Interface (MDI)**
+
+         
+         The ADIN1300 has voltage mode line drivers with on-chip terminations so
+         no external termination resistors are required. Both devices use
+         voltage mode line drive for connection from the MDI_0:3_P/N
+         (TD_P/M_A:D) pins to the magnetics and RJ-45 line using the same
+         external circuit. The recommended external circuit for the interface to
+         the magnetics and RJ-45 is shown in Figure 2.
+         
+
+   
+   .. container:: half column
+
+         
+
+   
+      ..
+
+   |image1|
+
+         **MDIO/Management Interface**
+
+         
+         Both devices support the IEEE management interface using the MDIO/MDC
+         pins and require a pullup resistor on the MDIO pin (Management Data
+         Open Drain Input/Output). The recommended value for ADIN1300 is a 1.5kΩ
+         resistor connected to pin 24. The DP83869 also recommends a 1.5kΩ
+         resistor connected to pin 41. Both devices provide an interrupt pin,
+         INT_N (¯INT). This pin requires a 1.5 kΩ pull-up resistor to VDDIO. The
+         DP83869 recommends 2.2kΩ pull-up resistors for their interrupt pin.
+         
+         **LED Function**
+
+         
+         The ADIN1300 support two LED pins on LED_0 and LINK_ST. The LED_0 has
+         programmability of LED functions, with different blinking operation
+         possible through MDIO configuration, the default mode is ON when Link
+         is Up, blink if activity. The LINK_ST provides static information about
+         Link up or down status. The DP83869 supports 3 LEDs pins 45, 46, 47 in
+         addition to one GPIO pin that can be configured to operate as LED_3.
+         Both devices use these pins for strapping purposes.
+         
+         **LED Circuit**
+
+         
+         The ADIN1300 LED_0 operates from the AVDD_3P3 voltage domain, therefore
+         can support driving LEDs even when the MAC interface is running at the
+         lower voltage of 1.8V. The default LED operation is on if the Link is
+         up and blinks when there is activity, this operation can be
+         reprogrammed through MDIO write. For the LED_0 of the ADIN1300, it can
+         be configured with 4-level strapping. The strapping configuration will
+         have an impact on how the LED function operates and needs to be
+         considered if the LED pins are used to directly drive an LED. If the
+         strap pin is pulled high by the strapping resistors, (MODE_3/MODE_4)
+         the output will be configured as an active low driver and conversely if
+         the strapping input is pulled low (MODE_0/MODE_1), the output will be
+         configured as active high. This LED circuit should be configured
+         accordingly.
+         
+         .. image:: images/dp83869_led_0_hardware_configuation_pin_interaction_figure3.png
+         
+         **Link Status, LINK_ST**
+
+         
+         The ADIN1300 has a dedicated LINK_ST pin to provide information to the
+         MAC on the status of the Link. By default, the LINK_ST pin goes high
+         indicating the link is up and low to indicate the link is down. The
+         LINK_ST polarity is programmable by setting the bit high
+         GE_LNK_STAT_INV_EN. The LINK_ST could be used to drive an LED, however
+         it resides in the VDDIO voltage domain, therefore, when driving an LED
+         in an integrated RJ45 jack where the PHY VDDIO is 1.8V, level shifting
+         will be required. This can be done using a FET.
+         
+
+   
+
+--------------
+
+.. container:: group
+
+   
+   .. container:: half column
+
+         
+         **MAC Interface**
+
+         
+         The ADIN1300 supports RGMII, MII and RMII MAC interface modes. The
+         following sections describe the RGMII, MII and RMII interfaces for both
+         devices.
+         
+         **RGMII Interface**
+
+         
+         The RGMII interface is the communication path between the PHY and MAC
+         devices. The RGMII interface has a low pin count interface supports
+         10M, 100M and Gigabit operation, with a total of 12 pins for data
+         transmission, reception and to signal errors or collision. It is the
+         most common interface for Gigabit applications and has the lowest
+         latency. Table 5 shows a pin overview of both devices for the RGMII MAC
+         interface mode. Both devices support the internal delay on the clocks.
+         By default, the ADIN1300 is configured in RGMII mode with a 2 ns delay
+         on RXC and TXC.
+         
+         .. image:: images/dp83869_rgmii_mac_interface_mode_pin_comparison_table4.png
+         
+         **MII Interface**
+
+         
+         The MII interface is the communication path between the PHY and MAC
+         devices. The MII interface has a high pin count, with a total of 15
+         pins for data transmission, reception and to signal errors or
+         collision. It is sometimes used in 100M applications as it has a lower
+         latency than RGMII and is much lower than RMII. Table 5 shows a pin
+         overview of both devices for the MII MAC interface mode. When using the
+         ADIN1300 in MII mode, the multifunction pin “LED_0/COL/TX_ER”
+         automatically becomes either COL or TX_ER. If EEE advertisement is
+         disabled, the pin function is COL as full and half-duplex operation is
+         supported and TX_ER is not required as an input. If EEE advertisement
+         is enabled the pin function is TX_ER as only full duplex operation is
+         supported with EEE and the COL pin is not required. Similarly, the
+         “INT_N/CRS” becomes CRS. The ADIN1300 sub-system registers provide user
+         with ability to reconfigure which pin the COL and CRS functions are
+         provided on (option of redirecting to GP_CLK, LINK_ST or INT_N). This
+         requires a register write over MDIO interface to reconfigure. The
+         DP83869 can configure pin 21 (GPIO_0) using software as COL or CRS.
+         
+
+   
+   .. container:: half column
+
+         
+
+   
+      ..
+
+   |image2|
+
+         **RMII Interface**
+
+         
+         The DP83869 does not support the RMII interface. RMII is a reduced MII
+         interface using fewer pins as shown in Table 6. The pin count for this
+         interface is 8 pins.
+         
+         .. image:: images/dp83869_rmii_mac_interface_mode_pin_comparison_table6.png
+         
+         In RMII mode, the ADIN1300 requires an external 50MHz clock applied to
+         XTAL_I. This clock could come from the MAC.
+         
+         **Output Clocks**
+
+         
+         The ADIN1300 provides a 25 MHz output reference clock on the REF_CLK
+         pin. This can be used a 25 MHz input reference clock for another PHY
+         device. The ADIN1300 can optionally provide a number of clock signals
+         on the GP_CLK pin. This is configured via MDIO writes and the clocks
+         available are a 125 MHz free running clock, 25 MHz clock and 25 MHz/125
+         MHz recovered clock.
+         
+
+   
+
+--------------
+
+.. container:: group
+
+   
+   .. container:: half column
+
+         
+         Hardware Configuration
+         
+         Both devices have a number of strapping options to enable managed or
+         unmanaged configurations of the PHY function such as PHY address, mode
+         of operation, Auto-Negotiation and MAC Interface. After power on, the
+         strapping pin voltages get sensed and latched upon existing from a
+         reset and the sensed voltages are used to set the personality of the
+         PHY. When configuring any strapping configurations, ensure to review
+         the default state of the MAC side, whether the pins are being driven
+         when coming out of reset or if there are internal pulls. Understanding
+         the behavior on the MAC side is key to ensuring there are no conflicts
+         with the hardware strapping implemented, or to adjust the strapping
+         resistor values if required. The ADIN1300 and DP83869 both use a mix of
+         2-level and 4-level strapping options. In general, strapping pins are
+         multi-functional and have different operation after the device is
+         brought out of reset. The ADIN1300 has internal pull downs on many of
+         its strapping pins (not all), therefore it would be possible to
+         minimize external strapping resistors.
+         
+         .. image:: images/dp83869_adin1300_hw_strapping_2_and_4_level_starpping_resistors_figure_4.png
+         
+         .. image:: images/dp83869_4_level_strapping_resistor_ratios_adin1300_table_7.png
+         
+         Strapping configurations are very specific to the device, consult the
+         respective datasheets to determine the exact configuration for required
+         use case.
+         
+         .. image:: images/dp83869_4_level_strapping_resistor_ratios_table_8.png
+         
+         **Hardware Configuration of Speed**
+
+         
+         For the ADIN1300, speed configuration is done using two pins, PHY_CFG0
+         and PHY_CFG1. These pins do not have any internal pull resistors,
+         therefore external strapping is required. Both pins support 4-level
+         strapping, providing much flexibility in terms of the possible
+         combinations, such as Auto-neg speeds shown in Table 9 or Forced modes
+         shown in Table 10. Review the datasheet hardware configuration pin
+         section for full detail on the possible settings using these pins.
+         
+
+   
+   .. container:: half column
+
+      |image3| |image4|
+
+         
+         **Hardware Configuration of Auto-MDIX**
+
+         
+         Selection of Auto-MDIX for the ADIN1300 is done using one pin,
+         (MDIX_MODE) with 4-level strapping.
+         
+         .. image:: images/dp83869_auto_mdix_mode_adin1300_table_11.png
+         
+         **MAC Interface Selection**
+
+         
+         The ADIN1300 uses two hardware pins, MACIF_SEL0 and MACIF_SEL1 to
+         provide user ability to select different MAC interfaces. These two pins
+         have internal weak pull downs, therefore the default operation would be
+         RGMII with delays as shown in Table 12. To configure any other MAC
+         interface mode, use 10kΩ pull up or pull down resistors to select
+         accordingly.
+         
+         .. image:: images/dp83869_mac_interface_selection_adin1300_table_12.png
+         
+         **Hardware Configuration of PHY Address**
+
+         
+         Both devices have a default strapping providing a PHY address of
+         0x0000. The ADIN1300 uses two-level strapping for the four PHY address
+         pins, either pull high or low to configure the PHY address, with an
+         option of 16 unique addresses possible. Two level strapping provides a
+         very robust PHY addressing scheme. The DP83869 provides four level
+         strapping for the PHY address pins, capable of 16 unique address. When
+         configuring any strapping configurations, assess the default state of
+         the MAC side, in case it conflicts with the hardware strapping
+         implemented.
+         
+
+   
+
+--------------
+
+.. container:: group
+
+   
+   .. container:: half column
+
+         
+         Package
+         
+         The ADIN1300 is available in a 40 lead LFCSP (6 mm x 6 mm footprint).
+         The DP83869 is available in a 48 lead QFN (7 mm x 7 mm). Due to the
+         smaller package footprint and differing pinout, the ADIN1300 is not a
+         drop-in replacement for the DP83869 product. It will require a re-spin
+         of schematic and board layout to achieve this exchange.
+         
+         .. image:: images/dp83869_package_comparison_table_13.png
+         
+         The underside of the LFCSP package for the ADIN1300 includes an exposed
+         paddle which should be soldered directly to the board with an array of
+         vias for thermal purposes. There are also two exposed stripes adjacent
+         to the exposed paddle. These do not need to be soldered to the board,
+         they should be treated as a keep out area as they are connected to
+         supply rails in the device, therefore should not be tied to ground and
+         there should be no routing or traces on the PCB layer directly
+         underneath them.
+         
+         Other Pinout Considerations
+         
+         **Integrated MDI Termination**
+
+         
+         Both devices include integrated termination resistors on the MDI paths.
+         These are voltage mode PHYs, no external resistors are required for
+         biasing and no supply voltage is required at the center tap of the
+         transformer.
+         
+         **RGMII Drive/Termination resistors**
+
+         
+         The ADIN1300 provides user with ability to adjust the RGMII drive
+         current through the GE_RGMII_IO_CNTRL register.
+         
+
+   
+   .. container:: half column
+
+         
+         **MII**
+
+         
+         The ADIN1300 and DP83869 both support the MII MAC interface.
+         
+         **RMII**
+
+         
+         The ADIN1300 supports RMII MAC interface mode for 10/100M operation.
+         The DP83869 does not support the RMII interface.
+         
+         **GMII**
+
+         
+         The ADIN1300 and DP83869 do not support the GMII interface.
+         
+         **SGMII**
+
+         
+         The DP83869 supports SGMII interface. The ADIN1300 does not support
+         SGMII interface.
+         
+         **FIBER**
+
+         
+         The DP83869 supports 1000BASE-X and 100BASE-FX Fiber protocols. The
+         ADIN1300 does not support fiber protocols.
+         
+         Software Considerations
+         
+         Both devices can be hardware strapped to be used in an unmanaged
+         configuration. Alternatively, they can provide SMI/MII access over the
+         MDIO interface. The DP83869 supports Clause 22 register access, while
+         the ADIN1300 supports both Clause 22 and Clause 45 register access
+         using both the 802.3 Clause 22 and Clause 45 management frame
+         structures. Registers 0x0 to 0xF are common across all PHYs.
+         
+         **Linux Driver**
+
+         
+         The ADIN1300 has a Linux Driver available in the Linux mainline kernel. The ADIN1300 linux driver detail is captured here: `adin <https://wiki.analog.com/resources/tools-software/linux-drivers/net-phy/adin>`_
+         
+         **Non Operating System Driver**
+
+         
+         The ADIN1300 has a Non Operating System Driver available from the devices product page here: :adi:`en/products/adin1300.html#product-requirement`
+         
+
+   
+
+.. tip::
+
+   The ADIN1300 has a Linux Driver available in the Linux mainline kernel.
+
+Side by Side Package/Pinout Comparison
+--------------------------------------
+
+The following is a side-by-side comparison of the package and pinouts, showing
+the position of the corresponding functional pins on each device.
+
+.. image:: images/dp83869_adin1300_pinout_comparison_versus_dp83869_figure5.png
+
+--------------
+
+Feature Comparison Table
+------------------------
+
+.. image:: images/dp83869_feature_comparison_table_table_14.png
+
+Example Configuration for RGMII
+-------------------------------
+
+The following example captures how to configure the ADIN1300 for an unmanaged
+configuration with RGMII Interface, operating in Auto Negotiation mode
+advertising all speeds. The PHY will power up in this state, ready to establish
+a link with a link partner. The MAC interface configuration pins (MACIF_SEL0/1)
+are pulled to ground, setting the PHY to RGMII mode with 2ns Delay on RXC & TXC.
+GP_CLK is pulled to VDDIO to configure an automatic MDIX operation. In addition,
+the PHY_CFG0 and PHY_CFG1 pins are configured for MODE_4 and MODE_1
+respectively. The PHY_CFG0 pin is also shared with the LED_0 pin, it’s
+configuration with MODE_4 means an active low LED can be used on LED_0.
+
+The following list summarizes an RGMII auto negotiate, 10 Mbps, 100 Mbps, or
+1000 Mbps with full duplex or half duplex, with the software power-down enabled
+after reset:
+
+-  MAC Interface = RGMII with 2ns delay on RXC/TXC
+-  MACIF_SEL0 = MODE_1 = 10 kΩ pull-down resistor
+-  MACIF_SEL1 = MODE_1 = 10 kΩ pull-down resistor
+-  MDIX_MODE = automatic MDIX, preferred MDI
+-  MDIX_MODE = MODE_4
+-  PHY address = 0b0001
+-  Speed selection = 10 Mbps, 100 Mbps, or 1000 Mbps with full duplex or half duplex, automatic negotiate enabled
+-  PHY_CFG0 = MODE_4 = 10 kΩ pull-up resistor
+-  PHY_CFG1 = MODE_1 = 10 kΩ pull-down resistor
+
+.. image:: images/dp83869_rgmii_auto_negotiate_10mbps_100mbps_with_half_duple_or_full_deplex_figure6.png
+
+.. |image1| image:: images/dp83869_isolation_using_discrete_magnetics_figure_2.png
+.. |image2| image:: images/dp83869_mii_mac_interface_mode_pin_comparison_table5.png
+.. |image3| image:: images/dp83869_auto_negotiated_speeds_adin1300_table_9.png
+.. |image4| image:: images/dp83869_forced_speeds_adin1300_table_10.png

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/01_-_88e1510_motivators_to_migrate_-_figure1.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/01_-_88e1510_motivators_to_migrate_-_figure1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ff76d687c342679ab13e15f1d56aa5090c37daa5589090eb54e9451b2afb520a
+size 51317

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/01_-_88e1512_motivators_to_migrate_-_figure1.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/01_-_88e1512_motivators_to_migrate_-_figure1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f98a27fd70e43c3b32386ea7b40e29d47355ec354e69a7592f22c4110253039d
+size 60487

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/02_-_88e1510_power_supply_rails_external_-_table_1.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/02_-_88e1510_power_supply_rails_external_-_table_1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3123cfd9cb937ccd8140763c8c36c50ef61d139098e150d8144075b4558c21a6
+size 14383

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/02_-_88e1512_power_supply_rails_external_-_table_1.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/02_-_88e1512_power_supply_rails_external_-_table_1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:efa18d29bf2df7792f286b47caee05af6cc146deeebe2211e6c40a3dae049748
+size 17844

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/03_-_88e1510_power_supply_rails_external_-_table_2.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/03_-_88e1510_power_supply_rails_external_-_table_2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4579d3845356d0795f94507939bf9b88e5ff5aad98a2a4ea7982d063d2891cdb
+size 15946

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/03_-_88e1512_power_supply_rails_external_-_table_2.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/03_-_88e1512_power_supply_rails_external_-_table_2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:71d807fc4957fd04169bcb53ee4b294de3fa54d3c7424a137a1755f5c8d6036c
+size 19696

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/04_-_88e1510_decoupling_requirements_-_table_3.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/04_-_88e1510_decoupling_requirements_-_table_3.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1b779a7809fb02e6041dda7ddc3b322f6afd2499578b8f8c0690e29edd7cfe84
+size 16946

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/04_-_88e1512_decoupling_requirements_-_table_3.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/04_-_88e1512_decoupling_requirements_-_table_3.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:72024b8efd9bc2dbf7b122149e70f36690017fd9f1e4c1f8ec7ecaee88917136
+size 20682

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/05_-_88e1510_bias_resistor_values_-_table_4.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/05_-_88e1510_bias_resistor_values_-_table_4.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e0a530ee46f725eef035c5238f4ff9e678d0395a37df2d9c7e154cef189340d2
+size 6705

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/05_-_88e1512_bias_resistor_values_-_table_4.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/05_-_88e1512_bias_resistor_values_-_table_4.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:291d15c29fc514c7bdcbe5473e6ce976277967ff84c29c0a00516b3b82afec8a
+size 8314

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/06_-_88e1510_discrate_magnetics_isolation_-_figure_2.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/06_-_88e1510_discrate_magnetics_isolation_-_figure_2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:85a06809fff097b1dde815459f429c009a901289eabc4a3251cb93a662c9a36e
+size 45465

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/06_-_88e1512_discrate_magnetics_isolation_-_figure_2.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/06_-_88e1512_discrate_magnetics_isolation_-_figure_2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8e4471a827002c6ab1f71a9081fb11a63103fadd346d47cf0d04280165ce70b7
+size 49632

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/07_-_88e1510_led_hardware_config_-_figure_3.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/07_-_88e1510_led_hardware_config_-_figure_3.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f84fd18f2f377b4d1f732be0b815a0c19f44e852a62d76b709e1971bd79ed264
+size 10748

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/07_-_88e1512_led_hardware_config_-_figure_3.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/07_-_88e1512_led_hardware_config_-_figure_3.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a81e2d93943d4af63cb3668f6745f4ef1ca770bfe3970af5aba265eb953ac1b8
+size 11505

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/08_-_88e1510_rgmii_mac_interface_pin_comparison_-_table_5.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/08_-_88e1510_rgmii_mac_interface_pin_comparison_-_table_5.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a94a52b6390feffdd8c5cd98ac6ef790bb40ad66857f380a665a05a148d71dfd
+size 23043

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/08_-_88e1512_rgmii_mac_interface_pin_comparison_-_table_5.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/08_-_88e1512_rgmii_mac_interface_pin_comparison_-_table_5.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0da62c9a81c17c079ae4a3f0718ed9ee57fcafdaa9283cb9bb6fd88938ed3715
+size 23227

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/09_-_88e1510_mii_mac_interface_pin_comparison_-_table_6.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/09_-_88e1510_mii_mac_interface_pin_comparison_-_table_6.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eb06caf4303e376daaefc1f29d0213b8303419fc2e5a2f0d319916ea01a8b2ab
+size 29692

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/09_-_88e1512_mii_mac_interface_pin_comparison_-_table_6.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/09_-_88e1512_mii_mac_interface_pin_comparison_-_table_6.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9183c5fc252fe1f24649b1670f3fabf003879ad55ee15617996e3467026a539a
+size 38584

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/10_-_88e1510_rmii_mac_interface_pin_comparison_-_table_7.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/10_-_88e1510_rmii_mac_interface_pin_comparison_-_table_7.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bd52b73ccaabe29c8f3fc48ae085c9ff726fa44a207e1b8801c1738a0456e4d6
+size 16552

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/10_-_88e1512_rmii_mac_interface_pin_comparison_-_table_7.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/10_-_88e1512_rmii_mac_interface_pin_comparison_-_table_7.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e83f65aec3e9586952eb5591d39841935fed6b2497186805a120429c1ad94667
+size 21454

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/10_4_level_resistor_strapping_rations_table7.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/10_4_level_resistor_strapping_rations_table7.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:feb048537b6ef61098f06090bd77706b818928a868afb00b6bb6a5cf5c496209
+size 12026

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/10_4level_strapping_resistor_ratios_table7.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/10_4level_strapping_resistor_ratios_table7.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a48bc51b54a9c1ce0c9a5716cb1a87cd522f72c1d2e20b91bcb5aacc4087e6b4
+size 15684

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/11_-_88e1510_adin1300_hardware_strapping_levels_-_figure_4.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/11_-_88e1510_adin1300_hardware_strapping_levels_-_figure_4.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a42ebf44f3cf79196419c77450ae393a9695d95030de2a06ddc1bb76fbc8e4ae
+size 9790

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/11_-_88e1512_adin1300_hardware_strapping_levels_-_figure_4.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/11_-_88e1512_adin1300_hardware_strapping_levels_-_figure_4.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:021178f34c86bdef9fa9f6547a11420305c562430725bc4c605bed038ed02f43
+size 10672

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/11_auto_neg_speeds_adin1300_table8.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/11_auto_neg_speeds_adin1300_table8.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1da5059bce39d87791923029f24eff46e31175fec78b87f2aecbc63cf2f8131b
+size 19485

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/11_auto_negotiated_speeds_table8.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/11_auto_negotiated_speeds_table8.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9efa25823fa07702b07479a51abef7d875455b2f875e2971d501f2cb08b1e620
+size 19396

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/12.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/12.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e1780d5ab84e761d653903bc1601b0bc6de969b5e0718ccd62d6b5d9431e4e0b
+size 291525

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/1200_capcouple_transformer.jpg
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/1200_capcouple_transformer.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:21e390a3d2bed08fe60d6147da8d5ded7b3475d726d789109a7ec8d44c97c59e
+size 920525

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/12_-_88e1510_4_level_strapping_restsor_ratios_adin1300_-_table_8.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/12_-_88e1510_4_level_strapping_restsor_ratios_adin1300_-_table_8.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a0c9f910abc8bcc8a46fd421da994fc0f22ca4c99ccaa0a254bfb925bc8a4be0
+size 12729

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/12_-_88e1512_4_level_strapping_restsor_ratios_adin1300_-_table_8.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/12_-_88e1512_4_level_strapping_restsor_ratios_adin1300_-_table_8.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:555b8a78f887e0c35acf80a7435dfb9ba5248adc35b3f3db66fcf7410cabc820
+size 15834

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/12_forced_speeds_adin1300_table9.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/12_forced_speeds_adin1300_table9.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d438c20c201f9fdfcaf87cc2dfac2c4b8ee5d721d2184cbf082d7d6c045a2a39
+size 10948

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/12_forced_speeds_table9.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/12_forced_speeds_table9.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5c1a839fe9ae00993fb42e1366dad1fa62cc6a784c799d95f8df354f501669fc
+size 10947

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/13.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/13.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a7a6eb348864a2479bea503a2a74d8c7ee74234ab00092cededcf4273d947787
+size 326711

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/13_-_88e1510_adin1300_auto_neg_speeds_-_table_9.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/13_-_88e1510_adin1300_auto_neg_speeds_-_table_9.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f79c15f61fa485f037e54e29796e84605cd8f5a313e6f3427d88791c8bbec1d6
+size 15813

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/13_-_88e1512_adin1300_auto_neg_speeds_-_table_9.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/13_-_88e1512_adin1300_auto_neg_speeds_-_table_9.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2de8aeab46908a8f5c356774d67ea41fe18c1cdbe66d3e81afff361060fedf8e
+size 19480

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/13_auto_mdix_mode_table10.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/13_auto_mdix_mode_table10.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b865aabd784ab0a2c27ff212110ac47f0c6a2a1f6919ab7b37ba379e85c12e43
+size 14057

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/13_auto_mdix_more_adin_1300_table10.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/13_auto_mdix_more_adin_1300_table10.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6151716fb83c8a4506cbc6e9cfe21aef706d6b88db193c84e7e93388b252a6e5
+size 14023

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/14.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/14.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0073753c0d77b11b62be6faf15749cf69e92d4036203b985f0fe493de00470fa
+size 282002

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/14_-_88e1510_adin1300_forced_speeds_-_table_10.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/14_-_88e1510_adin1300_forced_speeds_-_table_10.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2924ffa487b658f22c989fd59c76698efcecc59aaa0f6817955179b1a72c6242
+size 8625

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/14_-_88e1512_adin1300_forced_speeds_-_table_10.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/14_-_88e1512_adin1300_forced_speeds_-_table_10.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:68bc0149caad6bf6b45fdcea81a77979b5606fd8c2c321596a0adcc360943f65
+size 11054

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/14_mac_interface_selection_adin1300_table11.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/14_mac_interface_selection_adin1300_table11.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:957856d8c77372781411dd9da69b53b301e513d386d1030d6c3c533a33499910
+size 13666

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/14_mac_interface_selection_adin_1300_table11.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/14_mac_interface_selection_adin_1300_table11.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fcce2b8ab085abb25925e11dc37d60ef4d9e830c27a48de785c7ad6afe76c53c
+size 13712

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/15.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/15.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:aa86ff0e2c2c171187ec21c866636f60352746b811c6a007caa79f1e3a1fcaa4
+size 294197

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/15_-_88e1510_auto_mdix_mode_adin1300_-_table_11.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/15_-_88e1510_auto_mdix_mode_adin1300_-_table_11.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7148e4121e09645aed9a029a7c53bd8636fc72917a63bb1ebf2089f6ca3493be
+size 11101

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/15_-_88e1512_auto_mdix_mode_adin1300_-_table_11.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/15_-_88e1512_auto_mdix_mode_adin1300_-_table_11.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3c66ce076aedfde00dd00d636126947a2010024aede300a32047f9adb2b56c61
+size 14026

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/15_ar8031_package_comparison_table12.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/15_ar8031_package_comparison_table12.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:430294e84e30933c09895c79276a69265611c607a5e0e1cac3159f82d1253d03
+size 9704

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/15_package_comparison_table12.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/15_package_comparison_table12.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f4e3764f5562ce5caa3968ca8ef746a70e1e14fc7d1f3e2c37a13e93592fcbb4
+size 9356

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/16.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/16.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ad0131a955b44b3dd3ab4b7928790b492ad9b94db4fb0d4c167584225a9bd102
+size 321219

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/16_-_88e1510_mac_interface_selection_adin1300_-_table_12.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/16_-_88e1510_mac_interface_selection_adin1300_-_table_12.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:75b3522ce9f1c2c47fa6062b6bfde55396e4b1263eadba7477309c98d712e4ec
+size 10927

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/16_-_88e1512_mac_interface_selection_adin1300_-_table_12.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/16_-_88e1512_mac_interface_selection_adin1300_-_table_12.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ac336a5b4fcbed2363babbfe29ddcbc58e549d8cccbd99e59efa108983d817c5
+size 13720

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/16_adin1300_pinout_comparison_vs_ar8031_figure4.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/16_adin1300_pinout_comparison_vs_ar8031_figure4.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f9b56b291f58a0d93dd1b3e3722dc5e5b19f6d2498b7ff9134ed7f6fa6f4d740
+size 188961

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/16_adin1300_pinout_vs_ar8035_figure_4.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/16_adin1300_pinout_vs_ar8035_figure_4.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:135a680a58c5c47920fff01e360c0ffab6aa766a83c98577f71714534b29bc51
+size 185320

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/17_-_88e1510_adin1300_package_compasrison_-_table_13.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/17_-_88e1510_adin1300_package_compasrison_-_table_13.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7f265bc942b7cea5067af6e430cc36ca1e45c044373582a5afdd07a1f12d3bfb
+size 7646

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/17_-_88e1512_adin1300_package_compasrison_-_table_13.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/17_-_88e1512_adin1300_package_compasrison_-_table_13.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:379b8ef6a987642338ffa028d0455b97c921a06de6ea068e85c4ad4669d81e51
+size 9795

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/17_ar8031_feature_comparison_table_table13.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/17_ar8031_feature_comparison_table_table13.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4a884ea6fe8f77d5facf070bc85670b1a993b048a95e9838222f0f8f99d01c13
+size 49325

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/17_feature_comparison_table_table13.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/17_feature_comparison_table_table13.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d159120dc6f73254889cae293701ad6a69e5d2a06a50a0b8ab489db1dbf82db6
+size 50277

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/18_-_88e1510_adin1300_pinout_comparison_-_figure_5.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/18_-_88e1510_adin1300_pinout_comparison_-_figure_5.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:38f0be68585b6bd6f61592710c5f9555813f335478af0712e639f32644b2b09a
+size 196998

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/18_-_88e1512_adin1300_pinout_comparison_-_figure_5.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/18_-_88e1512_adin1300_pinout_comparison_-_figure_5.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:52e0325a2d076852a7b524c9c3e1d43008c1d3448496caca3f1933d8775ce4e8
+size 206100

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/18_ar8031_rgmii_auto_neg_10_100_and_1000_mbps_with_full_and_half_duplex_figure5.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/18_ar8031_rgmii_auto_neg_10_100_and_1000_mbps_with_full_and_half_duplex_figure5.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c205223bbdb3ca401e102815c8bc52e067e73178f25e17d81fc515cfd0cafeb7
+size 39470

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/18_rgmii_auto_neg_10_100_and_1000_mbps_with_full_and_half_duplex_figure5.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/18_rgmii_auto_neg_10_100_and_1000_mbps_with_full_and_half_duplex_figure5.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7f15087e323f9de48777f52d2b6e2781fe65104dc0da590da087e4716a0f60b4
+size 44341

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/19_-_88e1510_feature_comparison_table_15.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/19_-_88e1510_feature_comparison_table_15.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d13aae3b3e68833772d33baf61a28a1a67a6181080bd00b48e63da6500d1d212
+size 36683

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/19_-_88e1512_feature_comparison_table_15.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/19_-_88e1512_feature_comparison_table_15.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ea130c1b406e9ecf5aa9e340202e2a380f779e1959e11befc308e34217570b2c
+size 33580

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/1_-1000baset_master_slave_register.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/1_-1000baset_master_slave_register.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e199493c4811d52330715342f64cb712943f04dd53e5f4286eb41316a55180e8
+size 26758

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/1_ar8031_overview_of_power_supply_rails_table1.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/1_ar8031_overview_of_power_supply_rails_table1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:88f989130dc6caaa1b9afa312f3f2dd49b78326b77f177bf19af1ad983e3446c
+size 17011

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/1_ar8035_overview_of_power_supply_rails_table1.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/1_ar8035_overview_of_power_supply_rails_table1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7a1c30a3797c4698f410d57f272edba0692c352534a0cf74c257eba6def4fc17
+size 16682

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/20_-_88e1510_adin1300_example_-_figure_6.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/20_-_88e1510_adin1300_example_-_figure_6.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:59cc185e5604cc31d823804ccadf7c0655210ea19336f33206e6a24fd12c38ff
+size 31358

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/20_-_88e1512_adin1300_example_-_figure_6.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/20_-_88e1512_adin1300_example_-_figure_6.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e9cf036fc3067e978c10dbc9f72f6dcb93e9a974c6bf8510ac54611560beb688
+size 44236

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/2_-_b100tx_tst_mode_register.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/2_-_b100tx_tst_mode_register.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5ce0deb29b3f42922bd0341972491f83fc892b9eabb5639f0fb7db6c66b0d4c3
+size 51808

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/2_ar8031_decoupling_requirements_for_each_phy_table2.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/2_ar8031_decoupling_requirements_for_each_phy_table2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dac003ab6695c5c46889eb70facf187a16cd7d02a51ef482e385e7069aaf2908
+size 17762

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/2_decoupling_requirements_for_each_phy_table2.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/2_decoupling_requirements_for_each_phy_table2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:59837209ee158176b8994cf3cc96f35ea9fe38a69897ccc6b432ebe101e6f47b
+size 17406

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/3_-_b10tx_tst_mode_register.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/3_-_b10tx_tst_mode_register.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c082b09bbced4698bfa48957e2893f1452f2cd7a175ab470ea58abf05bedca67
+size 28542

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/3_ar8031_bias_resistor_values_table3.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/3_ar8031_bias_resistor_values_table3.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:019cfcad91faf846307ba3e8573beec3a5c392bd804600d195120ee3f34c6f70
+size 8490

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/4_-_adin1200_gui_screenshot.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/4_-_adin1200_gui_screenshot.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:64e4631c90b5a02aa99b9b51471f7a5f72a5f6c359ceca8e6c1fc231de7c4c77
+size 93805

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/4_-_gui_screenshot.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/4_-_gui_screenshot.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ad40cbab791feff64752f737159e3c54e24cc0dd448c303a1c22297d72f40993
+size 90317

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/4_ar8031_iso_using_magnetics_figure1.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/4_ar8031_iso_using_magnetics_figure1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a472973016d71bf5608f96d64745e8a94f182f866a899515d81d20144fd1ec59
+size 48431

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/4_isolation_using_discrete_magnetics_figure1.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/4_isolation_using_discrete_magnetics_figure1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:94b36573c3b80a00942d4ee7264b05d31194c67e414fc7c5c20fa5eca5007976
+size 48835

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/5_ar8031_led_0_hw_config_pin_interaction_figure2.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/5_ar8031_led_0_hw_config_pin_interaction_figure2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:64138c3af1af5dd9f70439fe472e236db6309e3bd3c57032293ec5cfd44e5f02
+size 11508

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/5_ar8035_led_0_hw_config_pin_interaction_figure2.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/5_ar8035_led_0_hw_config_pin_interaction_figure2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c09b7ccce2b8d6cc491289cd8cccdc76708633474b11e4a75a1a1728ace6db5a
+size 11516

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/6_ar8035_rgmii_mac_interface_mode_pin_comparison_table4.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/6_ar8035_rgmii_mac_interface_mode_pin_comparison_table4.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4fed04e24fb3d85762e631054e7031b81662d32f258f4033c89c0d4e0b4af015
+size 26909

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/6_rgmii_mac_interface_mode_pin_comparison_table4.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/6_rgmii_mac_interface_mode_pin_comparison_table4.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f02d80a89f15e4cc7715ccd9dc48989b4719f9a94010390b8bdbaf3b08ec7a50
+size 25384

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/7_ar8035_mii_mac_interface_mode_pin_comparison_table5.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/7_ar8035_mii_mac_interface_mode_pin_comparison_table5.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8195c60df79fd8e31e27b1ee29c0a2286a6559285340cb22c36f633da728c913
+size 38615

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/7_mii_mac_interface_mode_pin_comparison_table5.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/7_mii_mac_interface_mode_pin_comparison_table5.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a1fa5d4d09456a6658b46a45902e05b54fd08224b36e018e1f0308f6435cf33d
+size 38593

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/8_ar8035_rmii_mac_interface_mode_pin_comparison_table6.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/8_ar8035_rmii_mac_interface_mode_pin_comparison_table6.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d45c2875289325c25dc792980ca5fa65d72ab99ec83a5a4edda9daf2edfe8c80
+size 21490

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/8_rmii_mac_interface_mode_pin_comparison_table6.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/8_rmii_mac_interface_mode_pin_comparison_table6.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:75b2f19478bbd288225143b0901ab97cbf94d5f3dd06a28f6404f1c23c9c214b
+size 21477

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/9_adin1300_hw_strapping_2_and_4_level_figure3.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/9_adin1300_hw_strapping_2_and_4_level_figure3.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6aaaa030255ce70b1594b47a1df612ca0acb7ee141b3b6e9c3af7a8627d5d615
+size 10513

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/adin1200_magnetics_cmchoke.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/adin1200_magnetics_cmchoke.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e2ba81a224e77e21c86e71011fa7d4ccc9fbc0b8261eb8687d2a9235df131c25
+size 48762

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/adin1300_exposed_paddle_and_keepout.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/adin1300_exposed_paddle_and_keepout.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9c13b464b733734d6de710b59fab838c60e3521ce90aecf4074acccd9d380f96
+size 183504

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/adin1300_magnetics.jpg
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/adin1300_magnetics.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c587a01d8fe281beef8fd2f043e778b3760618d0229c3d0f1622d3d4d267034e
+size 254191

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/adin1300_paddle_and_keep_out_areas.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/adin1300_paddle_and_keep_out_areas.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:438bb97200ab53c94665aa0846d10f3083a15d22377048528583a01fbd26f8f8
+size 124886

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/adin1300_stubs_and_plane_crossing_graphic.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/adin1300_stubs_and_plane_crossing_graphic.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f4fc10bff247efeeb2a8b4e439d6081fa6d13f5f20136fc4687505c598596279
+size 10642

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/ar8035_table3_bias_resistor_values.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/ar8035_table3_bias_resistor_values.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:031620ae04bbc4529f90883a66e4917cf931a1350e1de43a575ed44f8ce17f72
+size 18586

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/cap_and_magnetic.jpg
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/cap_and_magnetic.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:07b87e4502e1df4405387c4fe47546ed676eb1ef71ed8aaa387df40c37500933
+size 65354

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/cap_with_cable.jpg
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/cap_with_cable.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d0573220e56446a80cea6903fa12bcffab4ccb752f74d1511c99436e001d9978
+size 49575

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/capiso_sch.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/capiso_sch.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f55d1fb45ee50342abd842b3f7e18da0dc806dc27c5336c59ffdeba9a736b7cc
+size 60230

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/dp38322_table_4_mii_mac_interface_mode_pin_comparison.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/dp38322_table_4_mii_mac_interface_mode_pin_comparison.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9c2ba31e45c68cef06edbde7e815351ad90618969136fa6b560db2f5b14f5eed
+size 29481

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/dp38325_table_5_mii_mac_interface_mode_pin_comparison.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/dp38325_table_5_mii_mac_interface_mode_pin_comparison.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e5bde504a839a475306f2569e4dede88812dde788c497dfe7acbaded8737e62c
+size 29390

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/dp83822_magnetics_cmchoke.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/dp83822_magnetics_cmchoke.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e0e08072d2bdc9751def30ca2250c75efa097ac726a01ca3f8363060a3ec13f8
+size 60237

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/dp83822_side_by_side.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/dp83822_side_by_side.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:293e877e36054a802c9fe42b0fbd7225dc5c185b4c6028e4bc21a0d28b5b7587
+size 223668

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/dp83822_table1.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/dp83822_table1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:26b4fae466e78d4602a28a1011ae2122ef17750b14de120c78380f70095be4ac
+size 20050

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/dp83822_table14.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/dp83822_table14.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0253ebee91bc6bcd2c47cd2252200c743c3fde58a5df42ff3d906138b5a1d6bf
+size 12292

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/dp83822_table3.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/dp83822_table3.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:182fdc1a51d5c4c57c5ce62a5a340ddf79871b43dd1288ce889df6dd79500b2a
+size 12376

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/dp83822_table5.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/dp83822_table5.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e2bb28a930a69c6e5f10224f74ca3ee5a30480c3b8bd2edd7da2c19fd28aa48a
+size 31241

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/dp83822_table6.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/dp83822_table6.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0a0ce2559a4e1cbdcb9f21de1c01205d56714091faec59a96e9b4e925d8f922d
+size 47960

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/dp83822_table8_9.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/dp83822_table8_9.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2a7209f8b180ae098cd7091ab675924820cc9f1e8373a5435f5fbd51fd0e36ce
+size 49299

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/dp83822_table_comparison.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/dp83822_table_comparison.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8318a7cd891be6c1f9092e30c58f0a413e468b3c4db6bf9b6644d8077db3bddf
+size 79924

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/dp83869_4_level_strapping_resistor_ratios_adin1300_table_7.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/dp83869_4_level_strapping_resistor_ratios_adin1300_table_7.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:59a5bade990922beddb5e5e04ff925b9d595771dd0aaa8d077156b0410b1d3f3
+size 21692

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/dp83869_4_level_strapping_resistor_ratios_table_8.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/dp83869_4_level_strapping_resistor_ratios_table_8.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cf9c9dc6f1f8c8fc4e1a679fa19e909e960a42409e382e6cc7a7d44a14f7eaab
+size 21320

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/dp83869_adin1300_hw_strapping_2_and_4_level_starpping_resistors_figure_4.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/dp83869_adin1300_hw_strapping_2_and_4_level_starpping_resistors_figure_4.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0c5f43c578e9199b393842bb81f0b893eaa29a894560e88a5b1a2d30bcb100c8
+size 13508

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/dp83869_adin1300_pinout_comparison_versus_dp83869_figure5.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/dp83869_adin1300_pinout_comparison_versus_dp83869_figure5.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9401229d6eb385c18a1a3356135da162e7950e9d5515fe93104a72085cef6f4f
+size 202671

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/dp83869_auto_mdix_mode_adin1300_table_11.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/dp83869_auto_mdix_mode_adin1300_table_11.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:65f36a905048216ed8e9a357959688ddad14e9e320685589ff25545988b4600e
+size 18047

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/dp83869_auto_negotiated_speeds_adin1300_table_9.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/dp83869_auto_negotiated_speeds_adin1300_table_9.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:97c05de4041058fd1cfae8cd3bcdbeda92a77f197911066b46fef191c7ddb13b
+size 26937

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/dp83869_bias_resistor_values_table3.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/dp83869_bias_resistor_values_table3.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:974888d7b8963329820e7f6c6f0f1cd3dc0fa0698dd26a105b96f7e7a3ac811e
+size 11006

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/dp83869_decoupling_requirements_for_each_phy_table2.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/dp83869_decoupling_requirements_for_each_phy_table2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2a909f57c7c1adbac20bf009e7203f5424da4a275166d37f3e4f7147289d348d
+size 24088

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/dp83869_feature_comparison_table_table_14.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/dp83869_feature_comparison_table_table_14.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6d3a3ceb4b061abda95ae9ca2a7874b60f525485314028996fa5fb8578488fe3
+size 49861

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/dp83869_forced_speeds_adin1300_table_10.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/dp83869_forced_speeds_adin1300_table_10.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:33731c9a02c7bc315dd00fa8b72a37c1316c79c5e925a25abf8898f25afb26c3
+size 14860

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/dp83869_isolation_using_discrete_magnetics_figure_2.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/dp83869_isolation_using_discrete_magnetics_figure_2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a5689ad9f1f4f92fae6387607fcabd73a0696a8b8901fe79e5bec6e02f330ac5
+size 70233

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/dp83869_led_0_hardware_configuation_pin_interaction_figure3.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/dp83869_led_0_hardware_configuation_pin_interaction_figure3.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:10351d7f9a3412ee87c083ef26355dca3e223047afaffdc7e6e606b0fb95ef75
+size 16950

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/dp83869_mac_interface_selection_adin1300_table_12.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/dp83869_mac_interface_selection_adin1300_table_12.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c6f43a6e88f5ab9b399825f35e83dae9b12de5d3e590438e4e3de0cf09bb4a7e
+size 18191

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/dp83869_mii_mac_interface_mode_pin_comparison_table5.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/dp83869_mii_mac_interface_mode_pin_comparison_table5.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:60282250f2c8869fab5ce15dddb699432ee7f7b2e4273fd0eb6c87e43909b6a8
+size 57855

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/dp83869_motivators_to_migrate_-_figure1.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/dp83869_motivators_to_migrate_-_figure1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6ae531fffb17c9a4dfb6bd29d38173f2396604535d30993e6512ce6ae6fa55b2
+size 111164

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/dp83869_overview_of_power_supply_rails_table_1.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/dp83869_overview_of_power_supply_rails_table_1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:232b92e16506aa29e54b4c7417494f58ed3c4c05cff72b3895ccefd8339fca9a
+size 25814

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/dp83869_package_comparison_table_13.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/dp83869_package_comparison_table_13.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4e211882d6695985a72d3e00e9fcc5f83804335c79fc331d47272fb3f7e21655
+size 12397

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/dp83869_rgmii_auto_negotiate_10mbps_100mbps_with_half_duple_or_full_deplex_figure6.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/dp83869_rgmii_auto_negotiate_10mbps_100mbps_with_half_duple_or_full_deplex_figure6.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d99efd7ad7db63d48d3b9f703192a070ce6ad445172907c903b947a2927e57f8
+size 39430

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/dp83869_rgmii_mac_interface_mode_pin_comparison_table4.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/dp83869_rgmii_mac_interface_mode_pin_comparison_table4.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f96b6504f6f4e90f2f454ba2f5bdd268908cdfedf5d1c350b0d1d18408209941
+size 24403

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/dp83869_rmii_mac_interface_mode_pin_comparison_table6.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/dp83869_rmii_mac_interface_mode_pin_comparison_table6.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:45793b8d6f473b8cee163d5b8286e6af935969a1819e22ac5700006e63743280
+size 28245

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/fig_10.jpg
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/fig_10.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2c3765f837d5521e92672e2c016b56d81e44a8209a926c7476574330291fdb37
+size 136952

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/fig_7.jpg
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/fig_7.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:94616012c7c64ac71813b39c61b4dcd298a7109c33c1824079880af816cb2934
+size 141848

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/fig_8.jpg
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/fig_8.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ed7b485a8ed99f7674b8a8d29c1cc7a74795d2e5051aa134e181dd63cc224f32
+size 137192

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/fig_9.jpg
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/fig_9.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:02b7c22eefa1e4e1001575a8b4eefc870d2f6d04d1dc9710dba51f0f6ac6eb78
+size 139962

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/figure1_motivators_to_migrate_dp83867.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/figure1_motivators_to_migrate_dp83867.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:24d74e2308e6bfc863a9f63dc8f2531f0845a97b2cb3efe9100746f46158bf37
+size 69386

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/figure2_isolating_using_discrete_magnetics_dp83867.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/figure2_isolating_using_discrete_magnetics_dp83867.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:94ce844704d361cf866f8ebf0f8bbe144c535d48d96f9baf760ac2863334114e
+size 53595

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/figure3_led0_hardware_config_dp83867.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/figure3_led0_hardware_config_dp83867.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6857ec380d8cc8c7e19cf6ca173296ab9319e49f38df90e898d2a77903723fe9
+size 10587

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/figure4_adin1300_hardware_strapping_2and4_level_dp83867.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/figure4_adin1300_hardware_strapping_2and4_level_dp83867.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1f17c568bd72d5bd05b8ebb6dfd706edbfb226814a612dd184226e99d6d3576a
+size 9783

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/figure5_pinout_comparison_dp83867.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/figure5_pinout_comparison_dp83867.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8bfb124c52b7b58216619868f849b66430d17584b3a20c375180511d3b31a510
+size 222267

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/figure6_rmii_auto_neg_allspeeds_half_or_full_duplex_dp83867.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/figure6_rmii_auto_neg_allspeeds_half_or_full_duplex_dp83867.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:861bbba5a602e13abadc2b6c87896b744e0992bbf03102ee35db10eceafd1691
+size 44457

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/first_formula.jpg
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/first_formula.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:957e32228bf64b95e1adb5ea22ce255460324ffe0ab709471bdc798914a699a1
+size 12593

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/ksz8081_table_4_mii_mac_interface_mode_pin_comparison.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/ksz8081_table_4_mii_mac_interface_mode_pin_comparison.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0c093632ce84c23502fca40a8500fc0164cd8bdaeadbbb38fd5ac67883586538
+size 32945

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/ksz_table10.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/ksz_table10.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5acf417f82bc520ab416dee4e1cb94184ff1de1b87ffe4ac0d173ba2adbe226b
+size 17557

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/ksz_table13.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/ksz_table13.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:926a9e1e474c227a0f04bb83706e8222b9b40f1ed962351420b1cb4579f06c39
+size 79915

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/ksz_table5.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/ksz_table5.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ecb7134adcd7f06187b1ca639221421435a37d7aea24113671cc9207a2ec23bd
+size 36504

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/ksz_table6.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/ksz_table6.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:be7bd8e1cb017c7d8dccf00bd3ba909e7def6123ed452a4807343577c6bfc767
+size 40808

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/ksz_table7.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/ksz_table7.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:84c92316ade77cc312ca3a4787295b1ba6ed70a5e8e620dfa6e30561be0a3857
+size 21279

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/ksz_table8.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/ksz_table8.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:497edcf734bc81b0b4d2f4bfbe7b7391b6fa59a7b4e14b3886566de107b5640e
+size 24715

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/ksz_table9.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/ksz_table9.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:db7aca72cdce8b3c535bb81e1f8584e9a6027282a28706bba120c762562dea74
+size 13579

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/led.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/led.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8ec51dc3ee5b60f4d9ebb567d731b9651759f4735185c9aa298ad6980b486dcb
+size 29802

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/phy.jpg
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/phy.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c15e6b759736311d35f97e13b87b98ff47422536483f09c262af3a61d93c6cf2
+size 30041

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/phy_compare.jpg
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/phy_compare.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ad0b4f9485ffbbbd26be2f40f15177fb0ceb1b4a73eff88dfc62c608ab34c2d5
+size 129532

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/phy_exchange_dp83825_to_adin1200_fig1.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/phy_exchange_dp83825_to_adin1200_fig1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0b3453d41595eff7e984f93ec6bfda8c1713443fee88465357ef0362bcf87fb9
+size 19254

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/phy_exchange_dp83825_to_adin1200_fig2.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/phy_exchange_dp83825_to_adin1200_fig2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e8e1c009dfaa28600756b26767393996ec74cacd8b919b166c967365a1eca1e8
+size 13446

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/phy_exchange_dp83825_to_adin1200_figpinoutcomp.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/phy_exchange_dp83825_to_adin1200_figpinoutcomp.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a69ec87b98c4fb15ad30fa6dd162c076a09e784cce6469bf39a5de67ceaf6dbf
+size 285873

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/phy_exchange_dp83825_to_adin1200_figrmiiauto.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/phy_exchange_dp83825_to_adin1200_figrmiiauto.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f6e82ca3bc75ba10da88b6c16e6a920d25e0887db77f9a19bf18ed04f7065e43
+size 45520

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/phy_exchange_dp83825_to_adin1200_table1.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/phy_exchange_dp83825_to_adin1200_table1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:61e7e8a577004a57c6ef0e8cee9e1995c0507d5a1b04a0217ec89d6e0f6c606e
+size 18553

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/phy_exchange_dp83825_to_adin1200_table2.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/phy_exchange_dp83825_to_adin1200_table2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b0763d40c5f5069c0447e6ae96f5477049db2c06ee8c4768215ba1ab8f6acc81
+size 18749

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/phy_exchange_dp83825_to_adin1200_table3.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/phy_exchange_dp83825_to_adin1200_table3.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8a164d5a519c0250f06d5da97f4028255d08cf9ea3bd3183ed021df0239d40ef
+size 10562

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/phy_exchange_dp83825_to_adin1200_table5.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/phy_exchange_dp83825_to_adin1200_table5.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5f03d7d1fb682e59ee9237c6b412eb7bf23eaf3dd7563c21735617607909a3fe
+size 27600

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/phy_exchange_dp83825_to_adin1200_table6.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/phy_exchange_dp83825_to_adin1200_table6.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5a2c807d89c2cbe7e9f83e54dbe86ac731bfd3fe3018b53dc490a19112d65d14
+size 36260

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/phy_exchange_dp83825_to_adin1200_table7.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/phy_exchange_dp83825_to_adin1200_table7.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b68e24c7dbf15ee7facc00cb0ef2121ed567a4002d6c2eb700304f4120547d08
+size 12026

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/phy_exchange_dp83825_to_adin1200_tableautonegspeed.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/phy_exchange_dp83825_to_adin1200_tableautonegspeed.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:056353fba3cbf33a206d720e9630881bef8d1e9535e9f440268392a9af1ec610
+size 15932

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/phy_exchange_dp83825_to_adin1200_tableforcedspeed.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/phy_exchange_dp83825_to_adin1200_tableforcedspeed.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:94843c45c628e71f1bd1debe74e6baf5826d435d814c47d6926d68978f2631e0
+size 10750

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/phy_exchange_dp83825_to_adin1200_tablehighlevelcomp.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/phy_exchange_dp83825_to_adin1200_tablehighlevelcomp.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e276bfeb80848286fba6d6382feb8ca082ca175c82b4bcb588559a4c2c196987
+size 104271

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/phy_exchange_dp83825_to_adin1200_tablemacsel.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/phy_exchange_dp83825_to_adin1200_tablemacsel.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:35b749a065b573910f30b352224d037e743dbd8be4c83c64b70e32c4902a701a
+size 10595

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/phy_exchange_dp83825_to_adin1200_tablemdx.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/phy_exchange_dp83825_to_adin1200_tablemdx.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:765482e9468155eac01825f72ab0e1a9b6a3afb5bb267e0d07bff37ccbc19f09
+size 10796

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/phy_exchange_dp83825_to_adin1200_tablepackagecomp.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/phy_exchange_dp83825_to_adin1200_tablepackagecomp.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9bdfbd53e7a6832fa2053eeb34905467545c56f0b99141235fb3f6c3d3f24ed2
+size 8789

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/pinoutcomparison.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/pinoutcomparison.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3c496c7694bbaf09bfe6221ad79df68391935f5c742f7ce33ec5220aa622bccb
+size 234839

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/rgmii_example.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/rgmii_example.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eead3189d34fbbc2b6dd15407e50467be59f30e3e6780ba530090875eafb9760
+size 118413

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/rmii_example.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/rmii_example.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:29cd20fe368b5bc3fdd8feb4cd90ca4998aab5cbfa89c2abfe31e4097164d887
+size 115810

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/second_formula.jpg
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/second_formula.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7fc515c2944db5013baf1fa187e8e045ef87516b500c581f253d6422b02c9fea
+size 17379

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/single_cap_backplane.jpg
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/single_cap_backplane.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:029919bbdc26cc2395ae511a04ca08281c8c5d1f7f2f25683af4a50d81ff6591
+size 29791

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/soprx.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/soprx.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:98bbba8a986babcbed9cebef73de89bf2feae8bdbbf8ebc8c0b589b342a86ebe
+size 72996

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/soptx.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/soptx.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:00f71fc635bb1065b28e31b2512b5a7da1d7de668776160cb2e62208c491ab19
+size 104739

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/strapping.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/strapping.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cea088696f4515c051ac78531bbe1c211e27ec2aa9cf90eb26ffeef065a23766
+size 18816

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/table1.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/table1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c71c7ed0d1688c443053417edbbe9b83e5872ec6ba1cddbdb04518ed670551d2
+size 22127

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/table10_forced_neg_speeds_1300_dp83867.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/table10_forced_neg_speeds_1300_dp83867.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dac2b457070b7e8ed033c6876f20d8471c12cfe0115e62bde996a79cce709c3b
+size 8726

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/table11_auto_mdix_modes_1300_dp83867.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/table11_auto_mdix_modes_1300_dp83867.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b96035dafaec88336bc27bc2e4ef24f98e3b75835f333543d10109a192d141f4
+size 11100

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/table12_mac_interface_selection_1300_dp83867.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/table12_mac_interface_selection_1300_dp83867.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3e754a3e42220106690ba89f2d0794993a80b83f1b43ade9ca38d847632b7e36
+size 10931

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/table13_package_comparrison_dp83867.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/table13_package_comparrison_dp83867.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4517cec537432eab39f5c8dedadd04366713378bcf5bf981f9ef15331d9f37cf
+size 7737

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/table14_package_comparrison_dp83867.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/table14_package_comparrison_dp83867.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3154b7e68f313b9f947b9035f3809ed4f93c73213a7919509d3156d7193bedd5
+size 7953

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/table15_feature_comparrison_table_dp83867.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/table15_feature_comparrison_table_dp83867.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2488d9cedac1708bc62223e10a9eaf064892b8a18f3e12b1aef308ed87ff2414
+size 58521

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/table1_overview_of_power_supply_rails_dp83867.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/table1_overview_of_power_supply_rails_dp83867.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:22d6cf0d1f61dea3d59009e21f3d56aa87f7e5e2150ed1ab1d0ffba7290143f4
+size 12072

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/table2.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/table2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:851b8a868150ca7fa7414f30a2c6333e559c5b61fd3eded060ce48a6b0a35066
+size 22976

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/table2_decoupling_requirements_for_each_phy_dp83867.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/table2_decoupling_requirements_for_each_phy_dp83867.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f6fc043f4a09763ab567795b41fc12ecc20a494a916377eacc032382f754e6e2
+size 14531

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/table3.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/table3.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:db306d7a7d06a3e8a854585c39085340bd24acdee5a6188fd5f1b0ba810d78a8
+size 13269

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/table3_bias_resistor_values_dp83867.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/table3_bias_resistor_values_dp83867.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:20d7a82a1908f397bfe74aecb005d897c81c5577b78e4753ca05a51f6f7ce4b9
+size 7884

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/table4_rgmii_mac_interface_pin_mode_comparison_dp83867.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/table4_rgmii_mac_interface_pin_mode_comparison_dp83867.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fc28193173c7de060022df896f42d5427c0aee016f78684aea243c89b5c3bd68
+size 26968

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/table5_mii_mac_interface_pin_mode_comparison_dp83867.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/table5_mii_mac_interface_pin_mode_comparison_dp83867.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:32c398fc7382e56a5a32e4baddc2ac34d52f7c143c49f6f8b5823cfaafe7430e
+size 35608

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/table6_rmii_mac_interface_pin_mode_comparison_dp83867.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/table6_rmii_mac_interface_pin_mode_comparison_dp83867.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5c8933282cc0fdb97565996017d3dd5c9bc98e9105e414b3d1e06fbd228b9e83
+size 16707

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/table7_4level_strapping_resistor_ratios_adin_1300_dp83867.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/table7_4level_strapping_resistor_ratios_adin_1300_dp83867.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7b23f820e5f21ebf2cabaae2e983842c1f5ba2dbca845bdeec8f17a936db1634
+size 12746

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/table8_4level_strapping_resistor_ratios_dp83867.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/table8_4level_strapping_resistor_ratios_dp83867.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5ab3af79f17f7d51469447437d2562df1bc5e2e0f9956fb0a2672f5c910d6e40
+size 12795

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/table9_autoneg_speeds_1300_dp83867.png
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/table9_autoneg_speeds_1300_dp83867.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:32211295c6791d524261a7fadacd16cdd8d8e033fb66c2e302bff73685f9c00d
+size 15884

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/images/tvs_and_cmc.jpg
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/images/tvs_and_cmc.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:995882ad6bc899385fea31c340134f2a7fa95a1bb944d0af5d4fd43fb821119d
+size 31499

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/index.rst
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/index.rst
@@ -1,0 +1,21 @@
+ADIN1300 and ADIN1200 Product Wiki Page and Evaluation Documentation
+====================================================================
+
+.. toctree::
+   :titlesonly:
+
+   adin1300-and-adin1200
+   adin1200-ieee-compliance-test-mode-access
+   adin1300-ieee-compliance-test-mode-access
+   ar8031_to_adin1300_phy_exchange_guide
+   ar8035_to_adin1300_phy_exchange_guide
+   cap-coupling
+   dp83822_to_adin1200_phy_exchange_guide
+   dp83825_to_adin1200_phy_exchange_guide
+   dp83867_to_adin1300_phy_exchange_guide
+   dp83869_to_adin1300_phy_exchange_guide
+   ksz8081_to_adin1200_phy_exchange_guide
+   layout-considerations
+   marvell88e1510_to_adin1300_phy_exchange_guide
+   marvell88e1512_to_adin1300_phy_exchange_guide
+   phy_faq

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/index.rst
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/index.rst
@@ -1,8 +1,27 @@
-ADIN1300 and ADIN1200 Product Wiki Page and Evaluation Documentation
-====================================================================
+.. _adin1300_and_adin1200 eval:
+
+ADIN1300 AND ADIN1200
+===============================================================================================================================
+
+.. TODO: Add a picture of the chip/board
+
+Overview
+-------------------------------------------------------------------------------
+
+.. TODO: Describe in max 10 rows the main features and applications.
+
+Features:
+
+- feature 1
+- feature 2
+
+Applications:
+
+- application 1
+- application 2
 
 .. toctree::
-   :titlesonly:
+   :hidden:
 
    adin1300-and-adin1200
    adin1200-ieee-compliance-test-mode-access
@@ -19,3 +38,22 @@ ADIN1300 and ADIN1200 Product Wiki Page and Evaluation Documentation
    marvell88e1510_to_adin1300_phy_exchange_guide
    marvell88e1512_to_adin1300_phy_exchange_guide
    phy_faq
+
+Recommendations
+-------------------------------------------------------------------------------
+
+People who follow the flow that is outlined, have a much better experience with
+things. However, like many things, documentation is never as complete as it
+should be. If you have any questions, feel free to ask on our
+:ref:`EngineerZone forums <help-and-support>`, but before that, please make
+sure you read our documentation thoroughly.
+
+Warning
+-------------------------------------------------------------------------------
+
+.. esd-warning::
+
+Help and support
+-------------------------------------------------------------------------------
+
+Please go to :ref:`Help and Support <help-and-support>` page.

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/ksz8081_to_adin1200_phy_exchange_guide.rst
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/ksz8081_to_adin1200_phy_exchange_guide.rst
@@ -1,0 +1,443 @@
+PHY Exchange Guide, KSZ8081RNB/MNX to ADIN1200 10/100Mb
+=======================================================
+
+.. container:: group
+
+   
+   .. container:: half column
+
+         
+         **Overview**
+
+         
+         This PHY exchange guide captures pertinent information to support
+         migration from the MicroChip KSZ8081MNX/RNB to the Analog Devices
+         ADIN1200 Ethernet PHY. The ADIN1200 supports MII, RMII and RGMII MAC
+         interfaces from the same package version, while the KZS8081MNX version
+         supports a MII MAC interface and the KSZ8081RNB supports RMII. The PHYs
+         have different pinouts, therefore the ADIN1200 is not a drop-in
+         replacement for the Microchip product. This requires edits to the
+         schematic and board layout to achieve this exchange. The following
+         sections detail the modifications at the schematic level required to
+         migrate from KSZ8081 to the ADIN1200 device.
+         
+         Hardware Changes By Function
+         
+         **Power Supplies Overview**
+
+         
+         The supply requirements are listed in Table 1. Both devices can operate
+         from a minimum of one 3.3V power supply rail AVDD_3P3 (VDDA_3.3V),
+         where the VDDIO rail is connected to 3.3V. Both devices have an on chip
+         voltage regulator to generate the internal core supply rail and
+         provided to a pin for decoupling purposes.
+         
+         .. image:: images/table1.png
+            :width: 600
+         
+         The ADIN1200 is robust to power supply sequencing and the power can be
+         applied in any order. The ADIN1200 provides two pins for each supply
+         rail, whereas the Microchip device provides one power supply pin for
+         each rail. The VDDIO supply rail powers the MAC interface and MDIO
+         blocks, this can operate from 1.8V, 2.5V or 3.3V. Decoupling
+         requirements for each device differs as described in Table 2
+         
+         .. image:: images/table2.png
+            :width: 600
+         
+         **RESET Operation**
+
+         
+         An active low hardware reset pin, RESET_N (RST#) is provided on Pin 6
+         of the ADIN1200 and pin 32 of the KSZ8081. The hardware strapping pins
+         are read and updated at the de-assertion of reset for both devices. For
+         the ADIN1200, the RESET_N pin resides in the AVDD_3P3 voltage domain,
+         whereas for the Microchip device, the RST# pin is referenced to VDDIO.
+         In applications where the MAC interface is powered from VDDIO of 1.8V,
+         level shifting of the RESET_N signal applied to the ADIN1200 may be
+         required to ensure the voltage level on the RESET_N pin is in excess of
+         the minimum input high threshold level.
+         
+         **Clocking**
+
+         
+         A 25 MHz crystal or external clock source is used to provide the
+         reference clock for both devices. In RMII mode, the ADIN1200 expects an
+         external 50MHz REF_CLK provided to the XTAL_I/REF_CLK pin. The
+         KSZ8081RNB (RMII mode) can provide a 50 MHz REF_CLK to the MAC device
+         from the 25 MHz source. Alternatively, an external 50 MHz clock can be
+         provided to both the PHY and MAC.
+         
+         **Bias Resistor**
+
+         
+         An external resistor, REXT is required to bias internal reference
+         circuitry for both KSZ8081 and ADIN1200. The ADIN1200 requires a 3.01
+         kΩ resistor (1% tolerance, 100 ppm/°C temperature coefficient)
+         connected to pin 10. The KSZ8081 uses an 6.49 kΩ on pin 10.
+         
+         .. image:: images/table3.png
+            :width: 600
+         
+         **Media Dependent Interface (MDI)**
+
+         
+      The ADIN1200 has voltage mode line drivers with on-chip terminations so no external termination resistors are required and the center tap of the transformer does not require biasing to supply voltage. Both devices use voltage mode line drive for connection from the MDI_0:1_P/N (RXM/P, TXM/P) pins to the magnetics and RJ-45 line using the same external circuit. The recommended external circuit for the interface to the magnetics and RJ-45 is shown in Figure 1. The KSZ8081 is also a voltage mode PHY. |image1| **Figure 1 Isolation using Discrete Magnetics**
+
+   
+   .. container:: half column
+
+         
+         **MDIO/Management Interface**
+
+         
+         Both devices can be hardware strapped to be used in an unmanaged
+         configuration. Alternatively, they can provide SMI/MII access over the
+         two wire MDIO interface. The MDIO pin (Management Data Open Drain
+         Input/Output) for SMI/MII interface to MAC and requires an external
+         pullup resistor. The recommended value for ADIN1200 is a 1.5kΩ resistor
+         connected to pin 24. The KSZ8081 recommends 1kΩ connected to pin 11. A
+         hardware interrupt output pin INT_N (INTRP) is provided in both devices
+         and is open drain. The recommended value for ADIN1200 is a 1.5kΩ
+         resistor connected to INT_N pin 27. The KSZ8081 recommends 1kΩ
+         connected to INTRP, pin 21.
+         
+         **LED Function**
+
+         
+         Both devices support two LED pins. The ADIN1200 pins are LED_0 and
+         LINK_ST. The LED_0 has programmability of LED functions, with different
+         blinking operation possible through MDIO configuration, the default
+         mode is ON when Link is Up, blink if activity. The LINK_ST provides
+         static information about Link up or down status. The KSZ8081 pins are
+         LED0, LED1, where LED0 can be configured for On/Off and Blink if
+         activity while LED1 can be configured to indicate 10 or 100M link
+         speed. Both devices use these pins for Speed and Auto-Neg strapping
+         purposes.
+         
+         **LED Circuit**
+
+         
+         The ADIN1200 LED_0 operates from the AVDD_3P3 voltage domain, therefore can support driving LEDs even when the MAC interface is running at the lower voltage of 1.8V. The KSZ8081 LED circuits operate from the VDDIO domain. The default LED operation is on if the Link is up and blinks when there is activity, this operation can be reprogrammed through MDIO write. For the LED_0 of the ADIN1200, it can be configured with 4-level strapping. The strapping configuration will have an impact on how the LED function operates, and needs to be considered if the LED pins are used to directly drive an LED. If the strap pin is pulled high by the strapping resistors, (MODE_3/MODE_4) the output will be configured as an active low driver and conversely if the strapping input is pulled low (MODE_0/MODE_1), the output will be configured as active high. This LED circuit should be configured accordingly. |image2| Figure 2. LED_0 Hardware Configuration Pin Interaction
+         
+         **Link Status, LINK_ST**
+
+         
+         The ADIN1200 has a dedicated LINK_ST pin to provide information to the
+         MAC on the status of the Link. By default, the LINK_ST pin goes high
+         indicating the link is up and low to indicate the link is down. The
+         LINK_ST polarity is programmable by setting the bit high
+         GE_LNK_STAT_INV_EN. The LINK_ST could be used to drive an LED, however
+         it resides in the VDDIO voltage domain, therefore, when driving an LED
+         in an integrated RJ45 jack where the PHY VDDIO is 1.8V, level shifting
+         will be required.
+         
+
+   
+
+--------------
+
+.. container:: group
+
+   
+   .. container:: half column
+
+         
+         **MAC Interface**
+
+         
+         The ADIN1200 supports MII, RMII and RGMII MAC interface modes, whereas
+         the KSZ8081RNB supports RMII and the KSZ8081MNX supports MII interface.
+         The following sections describe specifically the MII and RMII
+         interfaces for both devices.
+         
+         **MII Interface**
+
+         
+         The MII interface is the communication path between the PHY and MAC
+         devices. The KSZ8081MNX version will be covered here. The MII interface
+         has a high pin count, with a total of 15 pins for data transmission,
+         reception and to signal errors or collision. It is sometimes used in
+         100M applications as it has a lower latency than RGMII and is much
+         lower than RMII. Table 4 shows a pin overview of both devices for the
+         MII MAC interface mode. When using the ADIN1200 in MII mode, the
+         multifunction pin “LED_0/COL/TX_ER” automatically becomes COL.
+         Similarly, the “INT_N/CRS” becomes CRS. The ADIN1200 sub-system
+         registers provide user with ability to reconfigure which pin the COL
+         and CRS functions are provided on (option of redirecting to GP_CLK,
+         LINK_ST or INT_N). This requires a register write over MDIO interface
+         to reconfigure.
+         
+         .. image:: images/ksz8081_table_4_mii_mac_interface_mode_pin_comparison.png
+         
+
+   
+   .. container:: half column
+
+         
+         **RMII Interface**
+
+         
+         The KSZ8081RNB model has RMII interface. RMII is a reduced MII
+         interface using fewer pins as shown in Table 5. The pin count for this
+         interface is 8 pins.
+
+         
+         |image3|
+
+         RMII mode requires a 50MHz clock, REF_CLK. The KSZ8081RNB can generate
+         a 50MHz clock internally and provide it to the MAC. Alternatively, it
+         can accept an external 50MHz clock from the MAC. In RMII mode, the
+         ADIN1200 requires an external 50MHz clock applied to XTAL_I.
+         
+         **RGMII Interface**
+
+         
+         The ADIN1200 supports an RGMII interface mode, while the KSZ8081 does
+         not. The RGMII interface has a low pin count interface support for 10M,
+         100M and Gigabit operation with a total of 12 pins for data
+         transmission, reception and to signal errors or collisions. It is the
+         most common interface used for Gigabit applications. The ADIN1200 can
+         support 10/100 M speeds over the RGMII interface. Table 6 shows a pin
+         overview of the ADIN1200 RGMII interface.
+         
+         .. image:: images/ksz_table6.png
+            :width: 600
+         
+         **Output Clocks**
+
+         
+         The ADIN1200 can optionally provide a number of clock signals on the
+         GP_CLK pin. This is configured via MDIO writes and the clocks available
+         are a 125 MHz free running clock, 25 MHz clock and 25MHz/125 MHz
+         recovered clock.
+         
+
+   
+
+--------------
+
+.. container:: group
+
+   
+   .. container:: half column
+
+         
+         Hardware Configuration
+         
+         Both devices have a number of strapping options to enable managed or unmanaged configurations of the PHY function such as PHY address, mode of operation, Auto-Negotiation and MAC Interface. After power on, the strapping pin voltages get sensed and latched upon existing from a reset and the sensed voltages are used to set the personality of the PHY. When configuring any strapping configurations, ensure to review the default state of the MAC side, whether the pins are being driven when coming out of reset or if there are internal pulls. Understanding the behavior on the MAC side is key to ensuring there are no conflicts with the hardware strapping implemented, or to adjust the strapping resistor values if required. The KSZ8081 uses 2-level strapping options throughout, while the ADIN1200 uses a mix of 2-level and 4-level. In general, strapping pins are multi-functional and have different operation after the device is brought out of reset. The ADIN1200 has internal pull downs on many of its strapping pins (not all), therefore it would be possible to minimize external strapping resistors. |image4| Figure 3. ADIN1200 Hardware Strapping, 2 and 4 level strapping resistors
+
+         
+         |image5|
+
+         Strapping configurations are very specific to the device, consult the
+         respective datasheets to determine the exact configuration for required
+         use case.
+         
+         **Hardware Configuration of Speed**
+
+         
+      For the ADIN1200, speed configuration is done using two pins, PHY_CFG0 and
+      PHY_CFG1. These pins do not have any internal pull resistors, therefore
+      external strapping is required. Both pins support 4-level strapping,
+      providing much flexibility in terms of the possible combinations, such as
+      Auto-neg speeds shown in Table 8 or Forced modes shown in Table 9. Review
+      the datasheet hardware configuration pin section for full detail on the
+      possible settings using these pins. The KSZ8081 uses pin SPEED to select
+      between 10 or 100 M speeds and pin DUPLEX to configure HD or FD.
+
+   
+   .. container:: half column
+
+   
+      ..
+
+   |image6|
+
+         .. image:: images/ksz_table9.png
+            :width: 600
+         
+         **Hardware Configuration of Auto-MDIX**
+
+         
+         Selection of Auto-MDIX for the ADIN1200 is done using one pin,
+         (MDIX_MODE) with 4-level strapping. In the KSZ8081 Auto-MDI/MDI-X is
+         enabled by default and can be disabled/configured with an MDIO write.
+
+         
+         |image7|
+
+         **MAC Interface Selection**
+
+         
+         The ADIN1200 uses two hardware pins, MACIF_SEL0 and MACIF_SEL1 to
+         provide user ability to select different MAC interfaces. These two pins
+         have internal weak pull downs, therefore the default operation would be
+         RGMII with delays as shown in Table 11. To configure any other MAC
+         interface mode, use 10kΩ pull up or pull down resistors to select
+         accordingly. The KSZ8081 MAC interface selection (RMII/MII) is chosen
+         by selecting the appropriate part version (RNB/MNX).
+         
+         **Hardware Configuration of PHY Address**
+
+         
+         Both devices have a default strapping providing a PHY address of
+         0x0000. The ADIN1200 provides four PHY address pins, allowing up to 16
+         unique addresses possible. The PHY address pins are shared with the RXD
+         output pins. The KSZ8081 provides three PHY address pins, capable of 8
+         unique addresses. Two PHY Address pins are dedicated pins, with the
+         third PHY address shared with an RXD output pin. Both devices use
+         two-level strapping, either pull high or low to configure the PHY
+         address.
+         
+
+   
+
+.. important::
+
+   Strapping configurations are very specific to the device, consult the
+   respective datasheets to determine the exact configuration for required use
+   case.
+
+--------------
+
+.. container:: group
+
+   
+   .. container:: half column
+
+         
+         Package
+         
+         Both the ADIN1200 and the KSZ8081 are available in a 32 lead QFN/LFCSP
+         package of 5 mm x 5mm body size. The devices have different pinouts,
+         therefore the ADIN1200 is not a drop-in replacement for the Microchip
+         product. This requires edits to the schematic and board layout to
+         achieve this exchange.
+         
+         The underside of the LFCSP package for the ADIN1200 includes an exposed
+         paddle which should be soldered directly to the board with an array of
+         vias for thermal purposes. There are also two exposed stripes adjacent
+         to the exposed paddle. These do not need to be soldered to the board,
+         they should be treated as a keepout area as they are connected to
+         supply rails in the device, therefore should not be tied to ground and
+         there should be no routing or traces on the PCB layer directly
+         underneath them.
+         
+         Other Pinout Considerations
+         
+         **Integrated MDI Termination**
+
+         
+         Both devices include integrated termination resistors on the MDI paths.
+         These are voltage mode PHYs, no external resistors are required for
+         biasing and no supply voltage is required at the center tap of the
+         transformer.
+         
+         **RGMII**
+
+         
+      The ADIN1200 also supports RGMII MAC interface mode.
+
+   
+   .. container:: half column
+
+         
+         Software Considerations
+         
+         Both devices can be hardware strapped to be used in an unmanaged
+         configuration. Alternatively, they can provide SMI/MII access over the
+         MDIO interface. The KSZ8081 supports Clause 22 register access, while
+         the ADIN1200 supports both Clause 22 and Clause 45 access. Registers
+         0x0 to 0xF are common across all PHYs.
+         
+         **Linux Driver**
+
+         
+         The ADIN1200 has a Linux Driver available in the Linux mainline kernel. The ADIN1200 linux driver detail is captured here: `adin <https://wiki.analog.com/resources/tools-software/linux-drivers/net-phy/adin>`_
+         
+         **Non Operating System Driver**
+
+         
+         The ADIN1200 has a Non Operating System Driver available from the devices product page here: :adi:`en/products/adin1200.html#product-requirement`
+         
+
+   
+
+.. tip::
+
+   The ADIN1200 has a Linux Driver available in the Linux mainline kernel.
+
+--------------
+
+High Level Comparison
+---------------------
+
+.. image:: images/ksz_table13.png
+   :align: center
+
+--------------
+
+Side by Side Package/Pinout Comparison
+--------------------------------------
+
+The following is a side-by-side comparison of the package and pinouts, showing
+the position of the corresponding functional pins on each device.
+
+|image8|
+
+--------------
+
+Example Configurations for RMII
+-------------------------------
+
+The following example captures how to configure the ADIN1200 for an unmanaged
+configuration with RMII Interface, operating in Auto-negotiation mode
+advertising all speeds. The PHY will power up in this state, ready to establish
+a link with a link partner. The MAC interface configuration pins (MACIF_SEL0/1)
+are pulled to VDDIO, setting the PHY to RMII mode. GP_CLK is set to MODE_3 to
+configure an automatic MDIX operation. In addition, the PHY_CFG0 and PHY_CFG1
+pins are configured for MODE_4 and MODE_1 respectively. The PHY_CFG0 pin is also
+shared with the LED_0 pin, it’s configuration with MODE_4 means an active low
+LED can be used on LED_0.
+
+The following list summarizes an RMII auto negotiate, 10 Mbps or 100 Mbps full
+duplex or half duplex:
+
+-  MAC Interface = RMII
+
+   -  MACIF_SEL0 = MODE_1 = 10 kΩ pull-up resistor
+   -  MACIF_SEL1 = MODE_1 = 10 kΩ pull-up resistor
+
+-  MDIX_MODE = automatic MDIX, preferred MDIX
+
+   -  MDIX_MODE = MODE_3
+
+-  PHY address = 0b0001
+-  Speed selection = 10 Mbps, 100 Mbps with full duplex or half duplex,
+   auto-negotiation enabled
+
+   -  PHY_CFG0 = MODE_4 = 10 kΩ pull-up resistor
+
+::
+
+     *PHY_CFG1 = MODE_1 = 10 kΩ pull-down resistor
+
+.. image:: images/rmii_example.png
+   :align: center
+
+.. |image1| image:: images/adin1200_magnetics_cmchoke.png
+   :width: 600
+.. |image2| image:: images/led.png
+   :width: 600
+.. |image3| image:: images/ksz_table5.png
+   :width: 600
+.. |image4| image:: images/strapping.png
+   :width: 600
+.. |image5| image:: images/ksz_table7.png
+   :width: 600
+.. |image6| image:: images/ksz_table8.png
+   :width: 600
+.. |image7| image:: images/ksz_table10.png
+   :width: 600
+.. |image8| image:: images/pinoutcomparison.png

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/ksz8081_to_adin1200_phy_exchange_guide.rst
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/ksz8081_to_adin1200_phy_exchange_guide.rst
@@ -3,13 +3,13 @@ PHY Exchange Guide, KSZ8081RNB/MNX to ADIN1200 10/100Mb
 
 .. container:: group
 
-   
+
    .. container:: half column
 
-         
+
          **Overview**
 
-         
+
          This PHY exchange guide captures pertinent information to support
          migration from the MicroChip KSZ8081MNX/RNB to the Analog Devices
          ADIN1200 Ethernet PHY. The ADIN1200 supports MII, RMII and RGMII MAC
@@ -20,34 +20,34 @@ PHY Exchange Guide, KSZ8081RNB/MNX to ADIN1200 10/100Mb
          schematic and board layout to achieve this exchange. The following
          sections detail the modifications at the schematic level required to
          migrate from KSZ8081 to the ADIN1200 device.
-         
+
          Hardware Changes By Function
-         
+
          **Power Supplies Overview**
 
-         
+
          The supply requirements are listed in Table 1. Both devices can operate
          from a minimum of one 3.3V power supply rail AVDD_3P3 (VDDA_3.3V),
          where the VDDIO rail is connected to 3.3V. Both devices have an on chip
          voltage regulator to generate the internal core supply rail and
          provided to a pin for decoupling purposes.
-         
+
          .. image:: images/table1.png
             :width: 600
-         
+
          The ADIN1200 is robust to power supply sequencing and the power can be
          applied in any order. The ADIN1200 provides two pins for each supply
          rail, whereas the Microchip device provides one power supply pin for
          each rail. The VDDIO supply rail powers the MAC interface and MDIO
          blocks, this can operate from 1.8V, 2.5V or 3.3V. Decoupling
          requirements for each device differs as described in Table 2
-         
+
          .. image:: images/table2.png
             :width: 600
-         
+
          **RESET Operation**
 
-         
+
          An active low hardware reset pin, RESET_N (RST#) is provided on Pin 6
          of the ADIN1200 and pin 32 of the KSZ8081. The hardware strapping pins
          are read and updated at the de-assertion of reset for both devices. For
@@ -57,40 +57,40 @@ PHY Exchange Guide, KSZ8081RNB/MNX to ADIN1200 10/100Mb
          level shifting of the RESET_N signal applied to the ADIN1200 may be
          required to ensure the voltage level on the RESET_N pin is in excess of
          the minimum input high threshold level.
-         
+
          **Clocking**
 
-         
+
          A 25 MHz crystal or external clock source is used to provide the
          reference clock for both devices. In RMII mode, the ADIN1200 expects an
          external 50MHz REF_CLK provided to the XTAL_I/REF_CLK pin. The
          KSZ8081RNB (RMII mode) can provide a 50 MHz REF_CLK to the MAC device
          from the 25 MHz source. Alternatively, an external 50 MHz clock can be
          provided to both the PHY and MAC.
-         
+
          **Bias Resistor**
 
-         
+
          An external resistor, REXT is required to bias internal reference
          circuitry for both KSZ8081 and ADIN1200. The ADIN1200 requires a 3.01
          kΩ resistor (1% tolerance, 100 ppm/°C temperature coefficient)
          connected to pin 10. The KSZ8081 uses an 6.49 kΩ on pin 10.
-         
+
          .. image:: images/table3.png
             :width: 600
-         
+
          **Media Dependent Interface (MDI)**
 
-         
+
       The ADIN1200 has voltage mode line drivers with on-chip terminations so no external termination resistors are required and the center tap of the transformer does not require biasing to supply voltage. Both devices use voltage mode line drive for connection from the MDI_0:1_P/N (RXM/P, TXM/P) pins to the magnetics and RJ-45 line using the same external circuit. The recommended external circuit for the interface to the magnetics and RJ-45 is shown in Figure 1. The KSZ8081 is also a voltage mode PHY. |image1| **Figure 1 Isolation using Discrete Magnetics**
 
-   
+
    .. container:: half column
 
-         
+
          **MDIO/Management Interface**
 
-         
+
          Both devices can be hardware strapped to be used in an unmanaged
          configuration. Alternatively, they can provide SMI/MII access over the
          two wire MDIO interface. The MDIO pin (Management Data Open Drain
@@ -101,10 +101,10 @@ PHY Exchange Guide, KSZ8081RNB/MNX to ADIN1200 10/100Mb
          and is open drain. The recommended value for ADIN1200 is a 1.5kΩ
          resistor connected to INT_N pin 27. The KSZ8081 recommends 1kΩ
          connected to INTRP, pin 21.
-         
+
          **LED Function**
 
-         
+
          Both devices support two LED pins. The ADIN1200 pins are LED_0 and
          LINK_ST. The LED_0 has programmability of LED functions, with different
          blinking operation possible through MDIO configuration, the default
@@ -114,15 +114,15 @@ PHY Exchange Guide, KSZ8081RNB/MNX to ADIN1200 10/100Mb
          activity while LED1 can be configured to indicate 10 or 100M link
          speed. Both devices use these pins for Speed and Auto-Neg strapping
          purposes.
-         
+
          **LED Circuit**
 
-         
+
          The ADIN1200 LED_0 operates from the AVDD_3P3 voltage domain, therefore can support driving LEDs even when the MAC interface is running at the lower voltage of 1.8V. The KSZ8081 LED circuits operate from the VDDIO domain. The default LED operation is on if the Link is up and blinks when there is activity, this operation can be reprogrammed through MDIO write. For the LED_0 of the ADIN1200, it can be configured with 4-level strapping. The strapping configuration will have an impact on how the LED function operates, and needs to be considered if the LED pins are used to directly drive an LED. If the strap pin is pulled high by the strapping resistors, (MODE_3/MODE_4) the output will be configured as an active low driver and conversely if the strapping input is pulled low (MODE_0/MODE_1), the output will be configured as active high. This LED circuit should be configured accordingly. |image2| Figure 2. LED_0 Hardware Configuration Pin Interaction
-         
+
          **Link Status, LINK_ST**
 
-         
+
          The ADIN1200 has a dedicated LINK_ST pin to provide information to the
          MAC on the status of the Link. By default, the LINK_ST pin goes high
          indicating the link is up and low to indicate the link is down. The
@@ -131,29 +131,29 @@ PHY Exchange Guide, KSZ8081RNB/MNX to ADIN1200 10/100Mb
          it resides in the VDDIO voltage domain, therefore, when driving an LED
          in an integrated RJ45 jack where the PHY VDDIO is 1.8V, level shifting
          will be required.
-         
 
-   
+
+
 
 --------------
 
 .. container:: group
 
-   
+
    .. container:: half column
 
-         
+
          **MAC Interface**
 
-         
+
          The ADIN1200 supports MII, RMII and RGMII MAC interface modes, whereas
          the KSZ8081RNB supports RMII and the KSZ8081MNX supports MII interface.
          The following sections describe specifically the MII and RMII
          interfaces for both devices.
-         
+
          **MII Interface**
 
-         
+
          The MII interface is the communication path between the PHY and MAC
          devices. The KSZ8081MNX version will be covered here. The MII interface
          has a high pin count, with a total of 15 pins for data transmission,
@@ -167,32 +167,32 @@ PHY Exchange Guide, KSZ8081RNB/MNX to ADIN1200 10/100Mb
          and CRS functions are provided on (option of redirecting to GP_CLK,
          LINK_ST or INT_N). This requires a register write over MDIO interface
          to reconfigure.
-         
-         .. image:: images/ksz8081_table_4_mii_mac_interface_mode_pin_comparison.png
-         
 
-   
+         .. image:: images/ksz8081_table_4_mii_mac_interface_mode_pin_comparison.png
+
+
+
    .. container:: half column
 
-         
+
          **RMII Interface**
 
-         
+
          The KSZ8081RNB model has RMII interface. RMII is a reduced MII
          interface using fewer pins as shown in Table 5. The pin count for this
          interface is 8 pins.
 
-         
+
          |image3|
 
          RMII mode requires a 50MHz clock, REF_CLK. The KSZ8081RNB can generate
          a 50MHz clock internally and provide it to the MAC. Alternatively, it
          can accept an external 50MHz clock from the MAC. In RMII mode, the
          ADIN1200 requires an external 50MHz clock applied to XTAL_I.
-         
+
          **RGMII Interface**
 
-         
+
          The ADIN1200 supports an RGMII interface mode, while the KSZ8081 does
          not. The RGMII interface has a low pin count interface support for 10M,
          100M and Gigabit operation with a total of 12 pins for data
@@ -200,43 +200,43 @@ PHY Exchange Guide, KSZ8081RNB/MNX to ADIN1200 10/100Mb
          most common interface used for Gigabit applications. The ADIN1200 can
          support 10/100 M speeds over the RGMII interface. Table 6 shows a pin
          overview of the ADIN1200 RGMII interface.
-         
+
          .. image:: images/ksz_table6.png
             :width: 600
-         
+
          **Output Clocks**
 
-         
+
          The ADIN1200 can optionally provide a number of clock signals on the
          GP_CLK pin. This is configured via MDIO writes and the clocks available
          are a 125 MHz free running clock, 25 MHz clock and 25MHz/125 MHz
          recovered clock.
-         
 
-   
+
+
 
 --------------
 
 .. container:: group
 
-   
+
    .. container:: half column
 
-         
+
          Hardware Configuration
-         
+
          Both devices have a number of strapping options to enable managed or unmanaged configurations of the PHY function such as PHY address, mode of operation, Auto-Negotiation and MAC Interface. After power on, the strapping pin voltages get sensed and latched upon existing from a reset and the sensed voltages are used to set the personality of the PHY. When configuring any strapping configurations, ensure to review the default state of the MAC side, whether the pins are being driven when coming out of reset or if there are internal pulls. Understanding the behavior on the MAC side is key to ensuring there are no conflicts with the hardware strapping implemented, or to adjust the strapping resistor values if required. The KSZ8081 uses 2-level strapping options throughout, while the ADIN1200 uses a mix of 2-level and 4-level. In general, strapping pins are multi-functional and have different operation after the device is brought out of reset. The ADIN1200 has internal pull downs on many of its strapping pins (not all), therefore it would be possible to minimize external strapping resistors. |image4| Figure 3. ADIN1200 Hardware Strapping, 2 and 4 level strapping resistors
 
-         
+
          |image5|
 
          Strapping configurations are very specific to the device, consult the
          respective datasheets to determine the exact configuration for required
          use case.
-         
+
          **Hardware Configuration of Speed**
 
-         
+
       For the ADIN1200, speed configuration is done using two pins, PHY_CFG0 and
       PHY_CFG1. These pins do not have any internal pull resistors, therefore
       external strapping is required. Both pins support 4-level strapping,
@@ -246,30 +246,30 @@ PHY Exchange Guide, KSZ8081RNB/MNX to ADIN1200 10/100Mb
       possible settings using these pins. The KSZ8081 uses pin SPEED to select
       between 10 or 100 M speeds and pin DUPLEX to configure HD or FD.
 
-   
+
    .. container:: half column
 
-   
+
       ..
 
    |image6|
 
          .. image:: images/ksz_table9.png
             :width: 600
-         
+
          **Hardware Configuration of Auto-MDIX**
 
-         
+
          Selection of Auto-MDIX for the ADIN1200 is done using one pin,
          (MDIX_MODE) with 4-level strapping. In the KSZ8081 Auto-MDI/MDI-X is
          enabled by default and can be disabled/configured with an MDIO write.
 
-         
+
          |image7|
 
          **MAC Interface Selection**
 
-         
+
          The ADIN1200 uses two hardware pins, MACIF_SEL0 and MACIF_SEL1 to
          provide user ability to select different MAC interfaces. These two pins
          have internal weak pull downs, therefore the default operation would be
@@ -277,10 +277,10 @@ PHY Exchange Guide, KSZ8081RNB/MNX to ADIN1200 10/100Mb
          interface mode, use 10kΩ pull up or pull down resistors to select
          accordingly. The KSZ8081 MAC interface selection (RMII/MII) is chosen
          by selecting the appropriate part version (RNB/MNX).
-         
+
          **Hardware Configuration of PHY Address**
 
-         
+
          Both devices have a default strapping providing a PHY address of
          0x0000. The ADIN1200 provides four PHY address pins, allowing up to 16
          unique addresses possible. The PHY address pins are shared with the RXD
@@ -289,9 +289,9 @@ PHY Exchange Guide, KSZ8081RNB/MNX to ADIN1200 10/100Mb
          third PHY address shared with an RXD output pin. Both devices use
          two-level strapping, either pull high or low to configure the PHY
          address.
-         
 
-   
+
+
 
 .. important::
 
@@ -303,18 +303,18 @@ PHY Exchange Guide, KSZ8081RNB/MNX to ADIN1200 10/100Mb
 
 .. container:: group
 
-   
+
    .. container:: half column
 
-         
+
          Package
-         
+
          Both the ADIN1200 and the KSZ8081 are available in a 32 lead QFN/LFCSP
          package of 5 mm x 5mm body size. The devices have different pinouts,
          therefore the ADIN1200 is not a drop-in replacement for the Microchip
          product. This requires edits to the schematic and board layout to
          achieve this exchange.
-         
+
          The underside of the LFCSP package for the ADIN1200 includes an exposed
          paddle which should be soldered directly to the board with an array of
          vias for thermal purposes. There are also two exposed stripes adjacent
@@ -323,46 +323,46 @@ PHY Exchange Guide, KSZ8081RNB/MNX to ADIN1200 10/100Mb
          supply rails in the device, therefore should not be tied to ground and
          there should be no routing or traces on the PCB layer directly
          underneath them.
-         
+
          Other Pinout Considerations
-         
+
          **Integrated MDI Termination**
 
-         
+
          Both devices include integrated termination resistors on the MDI paths.
          These are voltage mode PHYs, no external resistors are required for
          biasing and no supply voltage is required at the center tap of the
          transformer.
-         
+
          **RGMII**
 
-         
+
       The ADIN1200 also supports RGMII MAC interface mode.
 
-   
+
    .. container:: half column
 
-         
+
          Software Considerations
-         
+
          Both devices can be hardware strapped to be used in an unmanaged
          configuration. Alternatively, they can provide SMI/MII access over the
          MDIO interface. The KSZ8081 supports Clause 22 register access, while
          the ADIN1200 supports both Clause 22 and Clause 45 access. Registers
          0x0 to 0xF are common across all PHYs.
-         
+
          **Linux Driver**
 
-         
+
          The ADIN1200 has a Linux Driver available in the Linux mainline kernel. The ADIN1200 linux driver detail is captured here: `adin <https://wiki.analog.com/resources/tools-software/linux-drivers/net-phy/adin>`_
-         
+
          **Non Operating System Driver**
 
-         
-         The ADIN1200 has a Non Operating System Driver available from the devices product page here: :adi:`en/products/adin1200.html#product-requirement`
-         
 
-   
+         The ADIN1200 has a Non Operating System Driver available from the devices product page here: :adi:`en/products/adin1200.html#product-requirement`
+
+
+
 
 .. tip::
 

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/layout-considerations.rst
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/layout-considerations.rst
@@ -1,0 +1,153 @@
+ADIN1300 and ADIN1200 Layout Considerations
+===========================================
+
+The ADIN1300 and ADIN1200 need specific layout guidelines and hardware
+considerations for designing a physical layer device. This user guide will cover
+details on the ADIN1300 and ADIN1200 layout recommendations. The sections within
+this user guide provide a high-level overview, and the document must be used in
+conjunction with the ADIN1200/1200 datasheets and additional apps notes found
+through the ADIN1200 and ADIN1300 product pages.
+
+Layout Considerations
+---------------------
+
+This section is an overview of the key areas of interest during placement and
+layout of the PHY and corresponding support components. Take care when routing
+high speed interface signals to maximize signal performance and ensure optimum
+EMC performance, with a view to ensure critical signal traces are kept as short
+as possible to minimize noise coupling.
+
+PHY Package Layout
+~~~~~~~~~~~~~~~~~~
+
+The LFCSP has an exposed pad underneath the package that must be soldered to the
+PCB ground for mechanical and thermal reasons. For thermal impedance performance
+and to maximize heat removal, use of a 4 × 4 array of thermal vias beneath the
+exposed ground pad is recommended.
+
+There are also two bus bars on either side of the exposed pad, these bus bars
+are connected to internal voltage rails and are not intended or required to be
+soldered to the board. The PCB land pattern must incorporate the exposed ground
+paddle with vias and two keep out areas around the bus bars in the footprint. No
+PCB traces or vias can be used in either of the keep out areas. The
+EVAL-ADIN1300FMCZ uses an array of 4 × 4 vias on a 0.75 mm grid arrangement, as
+shown below. The via pad diameter dimension is 0.02 in. (0.5015 mm) and the
+finished drill hole diameter is 0.01 in. (0.2489 mm).
+
+.. image:: images/adin1300_exposed_paddle_and_keepout.png
+   :align: center
+
+Component Placement
+~~~~~~~~~~~~~~~~~~~
+
+Prioritization of the critical traces and components helps simplify the routing
+exercise. Place and orient the critical traces and components first to ensure an
+effective layout with minimal turns, vias, and crossing traces. For an Ethernet
+PHY layout, the important components are the crystal and load capacitors, the
+transformer on the MDI lines, and all bypass capacitors local to the device.
+Prioritize these components and the routing to them. Keep the PHY chip at least
+1 in. away from the edge of the board. The following sections provide more
+detail for each of the areas.
+
+MDI Lines
+~~~~~~~~~
+
+The MDI interface runs from the ADIN1300 PHY to the transformer, and from there
+to the RJ45 connector. Traces running from the MDI_x_x pins of the ADIN1300 to
+the magnetics must be on the same side of the board, kept as short as possible
+(ideally less than 1 inch in length), but more importantly they should be length
+matched, for the MDI traces, the intra differential pairs these should be length
+matched within 20 mils for 1G operation and within 50 mils for 100M or 10M
+operation. The inter differential pairs are not as critical and should be length
+matched as close as possible, but within 1000 mils. The individual trace
+impedance of these tracks kept below 50 Ω, with differential impedance of 100 Ω
+for each pair. The same recommendations apply for traces running from the
+magnetics to the RJ45 connector. Keep impedances constant throughout because any
+discontinuities may affect signal integrity.
+
+Each pair must be routed together, trace widths kept the same throughout, trace
+lengths kept equal where possible, and avoid any right angles on these traces
+(use curves in traces or 45° angles). Avoid stubs on all signal traces. Where
+possible, route traces on the same layer. By taking these guidelines into
+account the difference in latency between each pair is minimized and this will
+also help in avoiding an increase in common mode noise.
+
+Route traces over a continuous reference plane with no interruptions to reduce
+inductance.
+
+Where possible, ensure a solid return path underneath all signal traces. Avoid
+routing signal traces across plane splits.
+
+.. image:: images/adin1300_stubs_and_plane_crossing_graphic.png
+   :align: center
+
+MAC Interface Pins
+~~~~~~~~~~~~~~~~~~
+
+All signals within TX group should be length matched, similarly for all signals
+within RX group. Where possible route these interface pins on the same side as
+component pins. Keep trace lengths as short as possible. Route traces with an
+impedance of 50 Ω to ground.
+
+The ADIN1300 has the capability to program the drive current of the RGMII pins
+to help improve signal integrity and minimize ringing. Alternatively, series
+termination resistors can be placed in all RGMII output pins if further tuning
+is required.
+
+Crystal Oscillator
+~~~~~~~~~~~~~~~~~~
+
+To ensure minimum current consumption and to minimize stray capacitances, make
+connections between the crystal, capacitors, and ground as close to the ADIN1300
+as possible and preferably on the same side as the ADIN1300 device. Caps should
+be tuned to adjust for pin capacitance and trace capacitance.
+
+Power and Ground Planes
+~~~~~~~~~~~~~~~~~~~~~~~
+
+From a PCB layout point of view, it is important to place the decoupling
+capacitors as close as possible to the power and GND pins to minimize the
+inductance.
+
+Magnetics Module Grounding
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A split ground plane under the transformer minimizes noise coupling across the
+transformer and between adjacent coils within. Ensure a physical separation of
+the ground planes underneath the transformer. Make the width of this separation
+at least 100 mil.
+
+Transformer Layout
+~~~~~~~~~~~~~~~~~~
+
+No metal layers can be directly underneath the transformer to minimize any noise
+coupling across the transformer.
+
+RJ45 Module Grounding
+~~~~~~~~~~~~~~~~~~~~~
+
+For optimal EMC performance, it is recommended to use a metal shielded RJ45
+connector with the shield connected to chassis ground. There must be an
+isolation gap between the chassis ground and the PHY IC ground with consistent
+isolation across all layers.
+
+Placement of TVS
+~~~~~~~~~~~~~~~~
+
+It is recommended to place the TVS diode close to the ADIN1300 device to ensure
+minimal track inductance between the external protection and internal protection
+within the device.
+
+Thermal Considerations
+~~~~~~~~~~~~~~~~~~~~~~
+
+The ADIN1300 is packaged in an LFCSP package. This package is designed with an
+exposed paddle which must be soldered to the PCB for mechanical and thermal
+reasons. The exposed paddle acts to conduct heat away from the package and into
+the PCB. By incorporating an array of thermal vias in the PCB thermal paddle,
+heat is dissipated more effectively into the inner metal layers of the PCB. When
+designing the PCB layout for optimum thermal performance, use a 4 mm × 4 mm
+array of vias under the paddle. This LFCSP device includes two exposed power
+bars adjacent to the exposed pad at the top and bottom. These bars are connected
+to internal power rails and the area around them is a keep out zone. Keep these
+areas clear of traces or vias.

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/marvell88e1510_to_adin1300_phy_exchange_guide.rst
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/marvell88e1510_to_adin1300_phy_exchange_guide.rst
@@ -3,44 +3,44 @@ PHY Exchange Guide, Marvell Alaska 88E1510 to ADIN1300 Gb
 
 .. container:: group
 
-   
+
    .. container:: half column
 
-         
+
          **Overview**
 
-         
+
          This PHY exchange guide captures pertinent information to support
          migration from the Marvell 88E1510 to the Analog Devices ADIN1300
          Ethernet PHY.
-         
+
          The ADIN1300 has compelling reasons for adoption versus this competitor
          PHY, such as reduced power consumption, lower latency, and smaller
          footprint due to the small package size.
-         
+
          .. image:: images/01_-_88e1510_motivators_to_migrate_-_figure1.png
             :alt: !!ENTER FIGURE HERE!!
             :align: right
-         
+
          The ADIN1300 Ethernet PHY supports all the standard functions and pins
          of an Ethernet PHY and it is very straight forward to migrate an
          existing design to the ADIN1300.
-         
+
          The following sections detail the modifications at the schematic level
          required to migrate from an 88E1510 device to the ADIN1300 device.
          Including a description of differences corresponding to each functional
          group of pins and differences in the hardware pin configuration of the
          device. A side-by-side pinout and package comparison and a feature
          comparison table are included for easy reference.
-         
+
          The ADIN1300 datasheet provides a detailed description of all functions
          of the device and should also be consulted for reference.
-         
+
          Hardware Changes By Function
-         
+
          **Power Supplies Overview**
 
-         
+
          The ADIN1300 requires a minimum of 2 power supply rails, where the
          VDDIO is connected to the same power supply voltage as the MAC or as
          the PHY analog supply AVDD_3P3 (VDDA2P5). The 88E1510 can be powered
@@ -49,131 +49,131 @@ PHY Exchange Guide, Marvell Alaska 88E1510 to ADIN1300 Gb
          powers the MAC interface and MDIO blocks, this can operate from 1.8V,
          2.5V or 3.3V. The supply requirements are listed in Table 1 and Table
          2.
-         
+
          .. image:: images/02_-_88e1510_power_supply_rails_external_-_table_1.png
             :align: right
-         
+
          .. image:: images/03_-_88e1510_power_supply_rails_external_-_table_2.png
             :align: right
-         
+
          The ADIN1300 is robust to power supply sequencing and the power can be
          applied in any order.
-         
+
          Decoupling requirements for each device differ as described in Table 3.
          This table shows the decoupling for Analog, Digital and Core power
          supply pins for each device. For the different 88E1510 configurations
          and additional pins that require decoupling when the internal
          regulators are in use, see the datasheet.
-         
+
          .. image:: images/04_-_88e1510_decoupling_requirements_-_table_3.png
             :align: right
-         
+
          **RESET Operation**
 
-         
+
          Both devices have a RESET_N pin which initializes the device and
          latches the hardware pin configuration. To reset the ADIN1300 the
          RESET_N pin should be held low for >10 μs. Deglitch circuitry is
          included on this pin to reject pulses shorter than ~1 μs. This pin
          requires a 1 kΩ pull-up resistor to AVDD_3P3.
-         
+
          The ADIN1300 includes power monitoring circuitry to monitor all of the
          supplies. At power-up, the ADIN1300 is held in hardware reset until
          each of the supplies has crossed its minimum rising threshold value.
-         
+
          The hardware strapping pins are read and updated at the de-assertion of
          reset for both devices. For the ADIN1300, the RESET_N pin resides in
          the AVDD_3P3 voltage domain. After 5 ms from the deassertion of
          RESET_N, the management interface registers are accessible and the
          device can be programmed.
-         
+
          In applications where the MAC interface is powered from VDDIO of 1.8V,
          level shifting of the RESET_N signal applied to the ADIN1300 may be
          required to ensure the voltage level on the RESET_N pin is in excess of
          the minimum input high threshold level.
-         
+
          The 88E1510 will be hardware configured after the de assertion of
          RESETn. The valid power to RESETn de-assertion time is 10mS. To reset
          the 88E1510 the RESET_N pin should be held low for a minimum of 10 ms.
-         
+
          **Clocking**
 
-         
+
          A 25 MHz crystal or external clock source is used to provide the
          reference clock for both devices. A crystal can be connected to pins
          XTAL_I/XTAL_O (XI/XO), with both devices using the same external
          circuit. Or a 25 MHz refence clock can be provided on the input clock
          pin CLK_IN (XI).
-         
+
          The ADIN1300 supports RMII and requires an external 50 MHz REF_CLK on
          the XTAL_I/REF_CLK pin in RMII mode. The 88E1510 does not support the
          RMII MAC interface.
-         
+
          **Bias Resistor**
 
-         
+
          An external resistor is required to bias internal reference circuitry
          for both 88E1510 and ADIN1300. The ADIN1300 requires a 3.01 kΩ resistor
          (1% tolerance, 100 ppm/°C temperature coefficient) connected to pin 10.
          The 88E1510 uses a 4.99 kΩ (1%) on pin 25.
-         
+
          .. image:: images/05_-_88e1510_bias_resistor_values_-_table_4.png
             :align: right
-         
 
-   
+
+
    .. container:: half column
 
-         
+
          **Media Dependent Interface (MDI)**
 
-         
+
          The ADIN1300 has voltage mode line drivers with on-chip terminations so
          no external termination resistors are required. Both devices use
          voltage mode line drive for connection from the MDI_0:3_P/N
          (TD_P/M_A:D) pins to the magnetics and RJ-45 line using the same
          external circuit.
-         
+
          The recommended external circuit for the interface to the magnetics and
          RJ-45 is shown in Figure 2.
-         
+
          .. image:: images/06_-_88e1510_discrate_magnetics_isolation_-_figure_2.png
             :align: right
-         
+
          **MDIO/Management Interface**
 
-         
+
          Both devices support the IEEE management interface using the MDIO/MDC
          pins and require a pullup resistor on the MDIO pin (Management Data
          Open Drain Input/Output). The recommended value for ADIN1300 is a 1.5kΩ
          resistor connected to pin 24. The 88E1510 recommends a 1.5kΩ to 10 kΩ
          resistor connected to pin 5.
-         
+
          Both devices provide an interrupt pin, INT_N (¯INT). For the ADIN1300
          this pin requires a 1.5 kΩ pull-up resistor to VDDIO. The 88E1510 INT_N
          (¯INT) is shared with the LED[2] pin and is register programmable.
-         
+
          **LED Function**
 
-         
+
          The ADIN1300 supports two LED pins, one on LED_0 and one on LINK_ST.
          The LED_0 has programmability of LED functions, with different blinking
          operation possible through MDIO configuration, the default mode is ON
          when Link is Up, blink if activity. The LINK_ST provides static
          information about Link up or down status.
-         
+
          The 88E1510 supports 3 LED pins 8, 9 and 10.
-         
+
          **LED Circuit**
 
-         
+
          The ADIN1300 LED_0 operates from the AVDD_3P3 voltage domain, therefore
          can support driving LEDs even when the MAC interface is running at the
          lower voltage of 1.8V.
-         
+
          The default LED operation is on if the Link is up and blinks when there
          is activity, this operation can be reprogrammed through MDIO write.
-         
+
          For the LED_0 of the ADIN1300, it can be configured with 4-level
          strapping. The strapping configuration will have an impact on how the
          LED function operates and needs to be considered if the LED pins are
@@ -182,45 +182,45 @@ PHY Exchange Guide, Marvell Alaska 88E1510 to ADIN1300 Gb
          an active low driver and conversely if the strapping input is pulled
          low (MODE_0/MODE_1), the output will be configured as active high. This
          LED circuit should be configured accordingly.
-         
+
          .. image:: images/07_-_88e1510_led_hardware_config_-_figure_3.png
             :align: right
-         
+
          **Link Status, LINK_ST**
 
-         
+
          The ADIN1300 has a dedicated LINK_ST pin to provide information to the
          MAC on the status of the Link. By default, the LINK_ST pin goes high
          indicating the link is up and low to indicate the link is down. The
          LINK_ST polarity is programmable by setting the bit high
          GE_LNK_STAT_INV_EN.
-         
+
          The LINK_ST could be used to drive an LED, however it resides in the
          VDDIO voltage domain, therefore, when driving an LED in an integrated
          RJ45 jack where the PHY VDDIO is 1.8V, level shifting will be required.
          This can be done using a FET.
-         
 
-   
+
+
 
 --------------
 
 .. container:: group
 
-   
+
    .. container:: half column
 
-         
+
          **MAC Interface**
 
-         
+
          The ADIN1300 supports RGMII, MII and RMII MAC interface modes. The
          following sections describe the RGMII interface for both devices and
          the MII and RMII interfaces for the ADIN1300.
-         
+
          **RGMII Interface**
 
-         
+
          The RGMII interface is the communication path between the PHY and MAC
          devices. The RGMII interface has a low pin count interface supports
          10M, 100M and Gigabit operation, with a total of 12 pins for data
@@ -228,24 +228,24 @@ PHY Exchange Guide, Marvell Alaska 88E1510 to ADIN1300 Gb
          most common interface for Gigabit applications and has the lowest
          latency. Table 5 shows a pin overview of both devices for the RGMII MAC
          interface mode.
-         
+
          Both devices support the internal delay on the clocks. By default, the
          ADIN1300 is configured in RGMII mode with a 2 ns delay on RXC and TXC.
-         
+
          .. image:: images/08_-_88e1510_rgmii_mac_interface_pin_comparison_-_table_5.png
-         
+
          **MII Interface**
 
-         
+
          The 88E1510 does not support the MII interface.
-         
+
          The MII interface is the communication path between the PHY and MAC
          devices. The MII interface has a high pin count, with a total of 15
          pins for data transmission, reception and to signal errors or
          collision. It is sometimes used in 100M applications as it has a lower
          latency than RGMII and is much lower than RMII. Table 6 shows a pin
          overview for the ADIN1300 for the MII MAC interface mode.
-         
+
          When using the ADIN1300 in MII mode, the multifunction pin
          “LED_0/COL/TX_ER” automatically becomes either COL or TX_ER. If EEE
          advertisement is disabled, the pin function is COL as full and
@@ -253,92 +253,92 @@ PHY Exchange Guide, Marvell Alaska 88E1510 to ADIN1300 Gb
          input. If EEE advertisement is enabled the pin function is TX_ER as
          only full duplex operation is supported with EEE and the COL pin is not
          required. Similarly, the “INT_N/CRS” becomes CRS.
-         
 
-   
+
+
    .. container:: half column
 
-         
+
          The ADIN1300 sub-system registers provide user with ability to
          reconfigure which pin the COL and CRS functions are provided on (option
          of redirecting to GP_CLK, LINK_ST or INT_N). This requires a register
          write over MDIO interface to reconfigure.
-         
+
          .. image:: images/09_-_88e1510_mii_mac_interface_pin_comparison_-_table_6.png
             :align: right
-         
+
          **RMII Interface**
 
-         
+
          The 88E1510 does not support the RMII interface. RMII is a Reduced MII
          interface using fewer pins as shown in Table 7. The pin count for this
          interface is 8 pins.
-         
+
          .. image:: images/10_-_88e1510_rmii_mac_interface_pin_comparison_-_table_7.png
             :align: right
-         
+
          In RMII mode, the ADIN1300 requires an external 50MHz clock applied to
          XTAL_I. This clock could come from the MAC.
-         
 
-   
+
+
 
 --------------
 
 .. container:: group
 
-   
+
    .. container:: half column
 
-         
+
          **Output Clocks**
 
-         
+
          The ADIN1300 provides a 25 MHz output reference clock on the REF_CLK
          pin. This can be used a 25 MHz input reference clock for another PHY
          device.
-         
+
          The ADIN1300 can optionally provide a number of clock signals on the
          GP_CLK pin. This is configured via MDIO writes and the clocks available
          are a 125 MHz free running clock, 25 MHz clock and 25 MHz/125 MHz
          recovered clock.
-         
+
          Hardware Configuration
-         
+
          Both devices have a number of strapping options to enable managed or
          unmanaged configurations of the PHY function such as PHY address, mode
          of operation, Auto-Negotiation and MAC Interface.
-         
+
          After power on, the strapping pin voltages get sensed and latched upon
          existing from a reset and the sensed voltages are used to set the
          personality of the PHY.
-         
+
          When configuring any strapping configurations, ensure to review the
          default state of the MAC side, whether the pins are being driven when
          coming out of reset or if there are internal pulls. Understanding the
          behavior on the MAC side is key to ensuring there are no conflicts with
          the hardware strapping implemented, or to adjust the strapping resistor
          values if required.
-         
+
          The ADIN1300 uses a mix of 2-level and 4-level strapping options. In
          general, strapping pins are multi-functional and have different
          operation after the device is brought out of reset. The ADIN1300 has
          internal pull downs on many of its strapping pins (not all), therefore
          it would be possible to minimize external strapping resistors.
-         
+
          .. image:: images/11_-_88e1510_adin1300_hardware_strapping_levels_-_figure_4.png
             :align: right
-         
+
          .. image:: images/12_-_88e1510_4_level_strapping_restsor_ratios_adin1300_-_table_8.png
             :align: right
-         
+
          Strapping configurations are very specific to the device, consult the
          respective datasheet to determine the exact configuration required for
          each use case with the 88E1510.
-         
+
          **Hardware Configuration of Speed**
 
-         
+
          For the ADIN1300, speed configuration is done using two pins, PHY_CFG0
          and PHY_CFG1. These pins do not have any internal pull resistors,
          therefore external strapping is required. Both pins support 4-level
@@ -346,62 +346,62 @@ PHY Exchange Guide, Marvell Alaska 88E1510 to ADIN1300 Gb
          combinations, such as Auto-neg speeds shown in Table 9 or Forced modes
          shown in Table 10. Review the datasheet hardware configuration pin
          section for full detail on the possible settings using these pins.
-         
 
-   
+
+
    .. container:: half column
 
-         
 
-   
+
+
       ..
 
    |image1|
 
          .. image:: images/14_-_88e1510_adin1300_forced_speeds_-_table_10.png
             :align: right
-         
+
          **Hardware Configuration of Auto-MDIX**
 
-         
+
          Selection of Auto-MDIX for the ADIN1300 is done using one pin,
          (MDIX_MODE) with 4-level strapping.
-         
+
          .. image:: images/15_-_88e1510_auto_mdix_mode_adin1300_-_table_11.png
             :align: right
-         
+
          **MAC Interface Selection**
 
-         
+
          The ADIN1300 uses two hardware pins, MACIF_SEL0 and MACIF_SEL1 to
          provide user ability to select different MAC interfaces. These two pins
          have internal weak pull downs, therefore the default operation would be
          RGMII with delays as shown in Table 12. To configure any other MAC
          interface mode, use 10kΩ pull up or pull down resistors to select
          accordingly.
-         
+
          .. image:: images/16_-_88e1510_mac_interface_selection_adin1300_-_table_12.png
             :align: right
-         
+
          **Hardware Configuration of PHY Address**
 
-         
+
          The ADIN1300 has a default strapping providing a PHY address of 0x0000.
          For the 88E1510 Bit 0 of the PHY address is configured during the
          hardware reset sequence. PHY address bits[4:1] are set to “0000”
          internally in the device.
-         
+
          The ADIN1300 uses two-level strapping for the four PHY address pins,
          either pull high or low to configure the PHY address, with an option of
          16 unique addresses possible. Two level strapping provides a very
          robust PHY addressing scheme.
-         
+
          When configuring any strapping configurations, assess the default state
          of the MAC side, in case it conflicts with the hardware strapping
          implemented.
-         
 
-   
+
+
 
 .. important::
 
@@ -413,21 +413,21 @@ PHY Exchange Guide, Marvell Alaska 88E1510 to ADIN1300 Gb
 
 .. container:: group
 
-   
+
    .. container:: half column
 
-         
+
          Package
-         
+
          The ADIN1300 is available in a 40 lead LFCSP (6 mm x 6 mm footprint).
          The 88E1510 is available in a 48 lead QFN (7 mm x 7 mm). Due to the
          smaller package footprint and differing pinout, the ADIN1300 is not a
          drop-in replacement for the 88E1510 product. It will require a re-spin
          of schematic and board layout to achieve this exchange.
-         
+
          .. image:: images/17_-_88e1510_adin1300_package_compasrison_-_table_13.png
             :align: right
-         
+
          The underside of the LFCSP package for the ADIN1300 includes an exposed
          paddle which should be soldered directly to the board with an array of
          vias for thermal purposes. There are also two exposed stripes adjacent
@@ -436,76 +436,76 @@ PHY Exchange Guide, Marvell Alaska 88E1510 to ADIN1300 Gb
          they are connected to supply rails in the device, therefore should not
          be tied to ground and there should be no routing or traces on the PCB
          layer directly underneath them.
-         
+
          Other Pinout Considerations
-         
+
          **Integrated MDI Termination**
 
-         
+
          Both devices include integrated termination resistors on the MDI paths.
          These are voltage mode PHYs, no external resistors are required for
          biasing and no supply voltage is required at the center tap of the
          transformer.
-         
+
          **RGMII Drive/Termination resistors**
 
-         
+
          The ADIN1300 provides user with ability to adjust the RGMII drive
          current through the GE_RGMII_IO_CNTRL register.
-         
 
-   
+
+
    .. container:: half column
 
-         
+
          **MII**
 
-         
+
          The ADIN1300 supports the MII MAC interface and the 88E1510 does not.
-         
+
          **RMII**
 
-         
+
          The ADIN1300 supports RMII MAC interface mode for 10/100M operation.
          The 88E1510 does not support the RMII interface.
-         
+
          **GMII**
 
-         
+
          The ADIN1300 and 88E1510 do not support the GMII interface.
-         
+
          **SGMII**
 
-         
+
          Neither of the two devices support SGMII interface.
-         
+
          **FIBER**
 
-         
+
          Neither of the two devices support fiber protocols.
-         
+
          Software Considerations
-         
+
          Both devices can be hardware strapped to be used in an unmanaged
          configuration. Alternatively, they can provide access over the MDIO
          interface. Both devices support both Clause 22 and Clause 45 register
          access using both the 802.3 Clause 22 and Clause 45 management frame
          structures.
-         
+
          Registers 0x0 to 0xF are common across all PHYs.
-         
+
          **Linux Driver**
 
-         
+
          The ADIN1300 has a Linux Driver available in the Linux mainline kernel. The ADIN1300 linux driver detail is captured here: `adin <https://wiki.analog.com/resources/tools-software/linux-drivers/net-phy/adin>`_
-         
+
          **Non Operating System Driver**
 
-         
-         The ADIN1300 has a Non Operating System Driver available from the devices product page here: :adi:`en/products/adin1300.html#product-requirement`
-         
 
-   
+         The ADIN1300 has a Non Operating System Driver available from the devices product page here: :adi:`en/products/adin1300.html#product-requirement`
+
+
+
 
 .. tip::
 

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/marvell88e1510_to_adin1300_phy_exchange_guide.rst
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/marvell88e1510_to_adin1300_phy_exchange_guide.rst
@@ -1,0 +1,576 @@
+PHY Exchange Guide, Marvell Alaska 88E1510 to ADIN1300 Gb
+=========================================================
+
+.. container:: group
+
+   
+   .. container:: half column
+
+         
+         **Overview**
+
+         
+         This PHY exchange guide captures pertinent information to support
+         migration from the Marvell 88E1510 to the Analog Devices ADIN1300
+         Ethernet PHY.
+         
+         The ADIN1300 has compelling reasons for adoption versus this competitor
+         PHY, such as reduced power consumption, lower latency, and smaller
+         footprint due to the small package size.
+         
+         .. image:: images/01_-_88e1510_motivators_to_migrate_-_figure1.png
+            :alt: !!ENTER FIGURE HERE!!
+            :align: right
+         
+         The ADIN1300 Ethernet PHY supports all the standard functions and pins
+         of an Ethernet PHY and it is very straight forward to migrate an
+         existing design to the ADIN1300.
+         
+         The following sections detail the modifications at the schematic level
+         required to migrate from an 88E1510 device to the ADIN1300 device.
+         Including a description of differences corresponding to each functional
+         group of pins and differences in the hardware pin configuration of the
+         device. A side-by-side pinout and package comparison and a feature
+         comparison table are included for easy reference.
+         
+         The ADIN1300 datasheet provides a detailed description of all functions
+         of the device and should also be consulted for reference.
+         
+         Hardware Changes By Function
+         
+         **Power Supplies Overview**
+
+         
+         The ADIN1300 requires a minimum of 2 power supply rails, where the
+         VDDIO is connected to the same power supply voltage as the MAC or as
+         the PHY analog supply AVDD_3P3 (VDDA2P5). The 88E1510 can be powered
+         with between 1 and 4 power supply rails depending on the configuration
+         of using internal or external regulators. The VDDIO / VDDO supply rail
+         powers the MAC interface and MDIO blocks, this can operate from 1.8V,
+         2.5V or 3.3V. The supply requirements are listed in Table 1 and Table
+         2.
+         
+         .. image:: images/02_-_88e1510_power_supply_rails_external_-_table_1.png
+            :align: right
+         
+         .. image:: images/03_-_88e1510_power_supply_rails_external_-_table_2.png
+            :align: right
+         
+         The ADIN1300 is robust to power supply sequencing and the power can be
+         applied in any order.
+         
+         Decoupling requirements for each device differ as described in Table 3.
+         This table shows the decoupling for Analog, Digital and Core power
+         supply pins for each device. For the different 88E1510 configurations
+         and additional pins that require decoupling when the internal
+         regulators are in use, see the datasheet.
+         
+         .. image:: images/04_-_88e1510_decoupling_requirements_-_table_3.png
+            :align: right
+         
+         **RESET Operation**
+
+         
+         Both devices have a RESET_N pin which initializes the device and
+         latches the hardware pin configuration. To reset the ADIN1300 the
+         RESET_N pin should be held low for >10 μs. Deglitch circuitry is
+         included on this pin to reject pulses shorter than ~1 μs. This pin
+         requires a 1 kΩ pull-up resistor to AVDD_3P3.
+         
+         The ADIN1300 includes power monitoring circuitry to monitor all of the
+         supplies. At power-up, the ADIN1300 is held in hardware reset until
+         each of the supplies has crossed its minimum rising threshold value.
+         
+         The hardware strapping pins are read and updated at the de-assertion of
+         reset for both devices. For the ADIN1300, the RESET_N pin resides in
+         the AVDD_3P3 voltage domain. After 5 ms from the deassertion of
+         RESET_N, the management interface registers are accessible and the
+         device can be programmed.
+         
+         In applications where the MAC interface is powered from VDDIO of 1.8V,
+         level shifting of the RESET_N signal applied to the ADIN1300 may be
+         required to ensure the voltage level on the RESET_N pin is in excess of
+         the minimum input high threshold level.
+         
+         The 88E1510 will be hardware configured after the de assertion of
+         RESETn. The valid power to RESETn de-assertion time is 10mS. To reset
+         the 88E1510 the RESET_N pin should be held low for a minimum of 10 ms.
+         
+         **Clocking**
+
+         
+         A 25 MHz crystal or external clock source is used to provide the
+         reference clock for both devices. A crystal can be connected to pins
+         XTAL_I/XTAL_O (XI/XO), with both devices using the same external
+         circuit. Or a 25 MHz refence clock can be provided on the input clock
+         pin CLK_IN (XI).
+         
+         The ADIN1300 supports RMII and requires an external 50 MHz REF_CLK on
+         the XTAL_I/REF_CLK pin in RMII mode. The 88E1510 does not support the
+         RMII MAC interface.
+         
+         **Bias Resistor**
+
+         
+         An external resistor is required to bias internal reference circuitry
+         for both 88E1510 and ADIN1300. The ADIN1300 requires a 3.01 kΩ resistor
+         (1% tolerance, 100 ppm/°C temperature coefficient) connected to pin 10.
+         The 88E1510 uses a 4.99 kΩ (1%) on pin 25.
+         
+         .. image:: images/05_-_88e1510_bias_resistor_values_-_table_4.png
+            :align: right
+         
+
+   
+   .. container:: half column
+
+         
+         **Media Dependent Interface (MDI)**
+
+         
+         The ADIN1300 has voltage mode line drivers with on-chip terminations so
+         no external termination resistors are required. Both devices use
+         voltage mode line drive for connection from the MDI_0:3_P/N
+         (TD_P/M_A:D) pins to the magnetics and RJ-45 line using the same
+         external circuit.
+         
+         The recommended external circuit for the interface to the magnetics and
+         RJ-45 is shown in Figure 2.
+         
+         .. image:: images/06_-_88e1510_discrate_magnetics_isolation_-_figure_2.png
+            :align: right
+         
+         **MDIO/Management Interface**
+
+         
+         Both devices support the IEEE management interface using the MDIO/MDC
+         pins and require a pullup resistor on the MDIO pin (Management Data
+         Open Drain Input/Output). The recommended value for ADIN1300 is a 1.5kΩ
+         resistor connected to pin 24. The 88E1510 recommends a 1.5kΩ to 10 kΩ
+         resistor connected to pin 5.
+         
+         Both devices provide an interrupt pin, INT_N (¯INT). For the ADIN1300
+         this pin requires a 1.5 kΩ pull-up resistor to VDDIO. The 88E1510 INT_N
+         (¯INT) is shared with the LED[2] pin and is register programmable.
+         
+         **LED Function**
+
+         
+         The ADIN1300 supports two LED pins, one on LED_0 and one on LINK_ST.
+         The LED_0 has programmability of LED functions, with different blinking
+         operation possible through MDIO configuration, the default mode is ON
+         when Link is Up, blink if activity. The LINK_ST provides static
+         information about Link up or down status.
+         
+         The 88E1510 supports 3 LED pins 8, 9 and 10.
+         
+         **LED Circuit**
+
+         
+         The ADIN1300 LED_0 operates from the AVDD_3P3 voltage domain, therefore
+         can support driving LEDs even when the MAC interface is running at the
+         lower voltage of 1.8V.
+         
+         The default LED operation is on if the Link is up and blinks when there
+         is activity, this operation can be reprogrammed through MDIO write.
+         
+         For the LED_0 of the ADIN1300, it can be configured with 4-level
+         strapping. The strapping configuration will have an impact on how the
+         LED function operates and needs to be considered if the LED pins are
+         used to directly drive an LED. If the strap pin is pulled high by the
+         strapping resistors, (MODE_3/MODE_4) the output will be configured as
+         an active low driver and conversely if the strapping input is pulled
+         low (MODE_0/MODE_1), the output will be configured as active high. This
+         LED circuit should be configured accordingly.
+         
+         .. image:: images/07_-_88e1510_led_hardware_config_-_figure_3.png
+            :align: right
+         
+         **Link Status, LINK_ST**
+
+         
+         The ADIN1300 has a dedicated LINK_ST pin to provide information to the
+         MAC on the status of the Link. By default, the LINK_ST pin goes high
+         indicating the link is up and low to indicate the link is down. The
+         LINK_ST polarity is programmable by setting the bit high
+         GE_LNK_STAT_INV_EN.
+         
+         The LINK_ST could be used to drive an LED, however it resides in the
+         VDDIO voltage domain, therefore, when driving an LED in an integrated
+         RJ45 jack where the PHY VDDIO is 1.8V, level shifting will be required.
+         This can be done using a FET.
+         
+
+   
+
+--------------
+
+.. container:: group
+
+   
+   .. container:: half column
+
+         
+         **MAC Interface**
+
+         
+         The ADIN1300 supports RGMII, MII and RMII MAC interface modes. The
+         following sections describe the RGMII interface for both devices and
+         the MII and RMII interfaces for the ADIN1300.
+         
+         **RGMII Interface**
+
+         
+         The RGMII interface is the communication path between the PHY and MAC
+         devices. The RGMII interface has a low pin count interface supports
+         10M, 100M and Gigabit operation, with a total of 12 pins for data
+         transmission, reception and to signal errors or collision. It is the
+         most common interface for Gigabit applications and has the lowest
+         latency. Table 5 shows a pin overview of both devices for the RGMII MAC
+         interface mode.
+         
+         Both devices support the internal delay on the clocks. By default, the
+         ADIN1300 is configured in RGMII mode with a 2 ns delay on RXC and TXC.
+         
+         .. image:: images/08_-_88e1510_rgmii_mac_interface_pin_comparison_-_table_5.png
+         
+         **MII Interface**
+
+         
+         The 88E1510 does not support the MII interface.
+         
+         The MII interface is the communication path between the PHY and MAC
+         devices. The MII interface has a high pin count, with a total of 15
+         pins for data transmission, reception and to signal errors or
+         collision. It is sometimes used in 100M applications as it has a lower
+         latency than RGMII and is much lower than RMII. Table 6 shows a pin
+         overview for the ADIN1300 for the MII MAC interface mode.
+         
+         When using the ADIN1300 in MII mode, the multifunction pin
+         “LED_0/COL/TX_ER” automatically becomes either COL or TX_ER. If EEE
+         advertisement is disabled, the pin function is COL as full and
+         half-duplex operation is supported and TX_ER is not required as an
+         input. If EEE advertisement is enabled the pin function is TX_ER as
+         only full duplex operation is supported with EEE and the COL pin is not
+         required. Similarly, the “INT_N/CRS” becomes CRS.
+         
+
+   
+   .. container:: half column
+
+         
+         The ADIN1300 sub-system registers provide user with ability to
+         reconfigure which pin the COL and CRS functions are provided on (option
+         of redirecting to GP_CLK, LINK_ST or INT_N). This requires a register
+         write over MDIO interface to reconfigure.
+         
+         .. image:: images/09_-_88e1510_mii_mac_interface_pin_comparison_-_table_6.png
+            :align: right
+         
+         **RMII Interface**
+
+         
+         The 88E1510 does not support the RMII interface. RMII is a Reduced MII
+         interface using fewer pins as shown in Table 7. The pin count for this
+         interface is 8 pins.
+         
+         .. image:: images/10_-_88e1510_rmii_mac_interface_pin_comparison_-_table_7.png
+            :align: right
+         
+         In RMII mode, the ADIN1300 requires an external 50MHz clock applied to
+         XTAL_I. This clock could come from the MAC.
+         
+
+   
+
+--------------
+
+.. container:: group
+
+   
+   .. container:: half column
+
+         
+         **Output Clocks**
+
+         
+         The ADIN1300 provides a 25 MHz output reference clock on the REF_CLK
+         pin. This can be used a 25 MHz input reference clock for another PHY
+         device.
+         
+         The ADIN1300 can optionally provide a number of clock signals on the
+         GP_CLK pin. This is configured via MDIO writes and the clocks available
+         are a 125 MHz free running clock, 25 MHz clock and 25 MHz/125 MHz
+         recovered clock.
+         
+         Hardware Configuration
+         
+         Both devices have a number of strapping options to enable managed or
+         unmanaged configurations of the PHY function such as PHY address, mode
+         of operation, Auto-Negotiation and MAC Interface.
+         
+         After power on, the strapping pin voltages get sensed and latched upon
+         existing from a reset and the sensed voltages are used to set the
+         personality of the PHY.
+         
+         When configuring any strapping configurations, ensure to review the
+         default state of the MAC side, whether the pins are being driven when
+         coming out of reset or if there are internal pulls. Understanding the
+         behavior on the MAC side is key to ensuring there are no conflicts with
+         the hardware strapping implemented, or to adjust the strapping resistor
+         values if required.
+         
+         The ADIN1300 uses a mix of 2-level and 4-level strapping options. In
+         general, strapping pins are multi-functional and have different
+         operation after the device is brought out of reset. The ADIN1300 has
+         internal pull downs on many of its strapping pins (not all), therefore
+         it would be possible to minimize external strapping resistors.
+         
+         .. image:: images/11_-_88e1510_adin1300_hardware_strapping_levels_-_figure_4.png
+            :align: right
+         
+         .. image:: images/12_-_88e1510_4_level_strapping_restsor_ratios_adin1300_-_table_8.png
+            :align: right
+         
+         Strapping configurations are very specific to the device, consult the
+         respective datasheet to determine the exact configuration required for
+         each use case with the 88E1510.
+         
+         **Hardware Configuration of Speed**
+
+         
+         For the ADIN1300, speed configuration is done using two pins, PHY_CFG0
+         and PHY_CFG1. These pins do not have any internal pull resistors,
+         therefore external strapping is required. Both pins support 4-level
+         strapping, providing much flexibility in terms of the possible
+         combinations, such as Auto-neg speeds shown in Table 9 or Forced modes
+         shown in Table 10. Review the datasheet hardware configuration pin
+         section for full detail on the possible settings using these pins.
+         
+
+   
+   .. container:: half column
+
+         
+
+   
+      ..
+
+   |image1|
+
+         .. image:: images/14_-_88e1510_adin1300_forced_speeds_-_table_10.png
+            :align: right
+         
+         **Hardware Configuration of Auto-MDIX**
+
+         
+         Selection of Auto-MDIX for the ADIN1300 is done using one pin,
+         (MDIX_MODE) with 4-level strapping.
+         
+         .. image:: images/15_-_88e1510_auto_mdix_mode_adin1300_-_table_11.png
+            :align: right
+         
+         **MAC Interface Selection**
+
+         
+         The ADIN1300 uses two hardware pins, MACIF_SEL0 and MACIF_SEL1 to
+         provide user ability to select different MAC interfaces. These two pins
+         have internal weak pull downs, therefore the default operation would be
+         RGMII with delays as shown in Table 12. To configure any other MAC
+         interface mode, use 10kΩ pull up or pull down resistors to select
+         accordingly.
+         
+         .. image:: images/16_-_88e1510_mac_interface_selection_adin1300_-_table_12.png
+            :align: right
+         
+         **Hardware Configuration of PHY Address**
+
+         
+         The ADIN1300 has a default strapping providing a PHY address of 0x0000.
+         For the 88E1510 Bit 0 of the PHY address is configured during the
+         hardware reset sequence. PHY address bits[4:1] are set to “0000”
+         internally in the device.
+         
+         The ADIN1300 uses two-level strapping for the four PHY address pins,
+         either pull high or low to configure the PHY address, with an option of
+         16 unique addresses possible. Two level strapping provides a very
+         robust PHY addressing scheme.
+         
+         When configuring any strapping configurations, assess the default state
+         of the MAC side, in case it conflicts with the hardware strapping
+         implemented.
+         
+
+   
+
+.. important::
+
+   Strapping configurations are very specific to the device, consult the
+   respective datasheets to determine the exact configuration for required use
+   case.
+
+--------------
+
+.. container:: group
+
+   
+   .. container:: half column
+
+         
+         Package
+         
+         The ADIN1300 is available in a 40 lead LFCSP (6 mm x 6 mm footprint).
+         The 88E1510 is available in a 48 lead QFN (7 mm x 7 mm). Due to the
+         smaller package footprint and differing pinout, the ADIN1300 is not a
+         drop-in replacement for the 88E1510 product. It will require a re-spin
+         of schematic and board layout to achieve this exchange.
+         
+         .. image:: images/17_-_88e1510_adin1300_package_compasrison_-_table_13.png
+            :align: right
+         
+         The underside of the LFCSP package for the ADIN1300 includes an exposed
+         paddle which should be soldered directly to the board with an array of
+         vias for thermal purposes. There are also two exposed stripes adjacent
+         to the exposed paddle. These are not intended to and do not need to be
+         soldered to the board, they should be treated as a keep out area as
+         they are connected to supply rails in the device, therefore should not
+         be tied to ground and there should be no routing or traces on the PCB
+         layer directly underneath them.
+         
+         Other Pinout Considerations
+         
+         **Integrated MDI Termination**
+
+         
+         Both devices include integrated termination resistors on the MDI paths.
+         These are voltage mode PHYs, no external resistors are required for
+         biasing and no supply voltage is required at the center tap of the
+         transformer.
+         
+         **RGMII Drive/Termination resistors**
+
+         
+         The ADIN1300 provides user with ability to adjust the RGMII drive
+         current through the GE_RGMII_IO_CNTRL register.
+         
+
+   
+   .. container:: half column
+
+         
+         **MII**
+
+         
+         The ADIN1300 supports the MII MAC interface and the 88E1510 does not.
+         
+         **RMII**
+
+         
+         The ADIN1300 supports RMII MAC interface mode for 10/100M operation.
+         The 88E1510 does not support the RMII interface.
+         
+         **GMII**
+
+         
+         The ADIN1300 and 88E1510 do not support the GMII interface.
+         
+         **SGMII**
+
+         
+         Neither of the two devices support SGMII interface.
+         
+         **FIBER**
+
+         
+         Neither of the two devices support fiber protocols.
+         
+         Software Considerations
+         
+         Both devices can be hardware strapped to be used in an unmanaged
+         configuration. Alternatively, they can provide access over the MDIO
+         interface. Both devices support both Clause 22 and Clause 45 register
+         access using both the 802.3 Clause 22 and Clause 45 management frame
+         structures.
+         
+         Registers 0x0 to 0xF are common across all PHYs.
+         
+         **Linux Driver**
+
+         
+         The ADIN1300 has a Linux Driver available in the Linux mainline kernel. The ADIN1300 linux driver detail is captured here: `adin <https://wiki.analog.com/resources/tools-software/linux-drivers/net-phy/adin>`_
+         
+         **Non Operating System Driver**
+
+         
+         The ADIN1300 has a Non Operating System Driver available from the devices product page here: :adi:`en/products/adin1300.html#product-requirement`
+         
+
+   
+
+.. tip::
+
+   The ADIN1300 has a Linux Driver available in the Linux mainline kernel.
+
+--------------
+
+Side by Side Package/Pinout Comparison
+--------------------------------------
+
+The following is a side-by-side comparison of the package and pinouts, showing
+the position of the corresponding functional pins on each device
+
+.. image:: images/18_-_88e1510_adin1300_pinout_comparison_-_figure_5.png
+   :align: right
+
+--------------
+
+Feature Comparison Table
+------------------------
+
+.. image:: images/19_-_88e1510_feature_comparison_table_15.png
+   :align: center
+
+--------------
+
+Example Configuration for RGMII
+-------------------------------
+
+The following example captures how to configure the ADIN1300 for an unmanaged
+configuration with RGMII Interface, operating in Auto Negotiation mode
+advertising all speeds. The PHY will power up in this state, ready to establish
+a link with a link partner. The MAC interface configuration pins (MACIF_SEL0/1)
+are pulled to ground, setting the PHY to RGMII mode with 2ns Delay on RXC & TXC.
+GP_CLK is pulled to VDDIO to configure an automatic MDIX operation. In addition,
+the PHY_CFG0 and PHY_CFG1 pins are configured for MODE_4 and MODE_1
+respectively. The PHY_CFG0 pin is also shared with the LED_0 pin, it’s
+configuration with MODE_4 means an active low LED can be used on LED_0.
+
+The following list summarizes an RGMII auto negotiate, 10 Mbps, 100 Mbps, or
+1000 Mbps with full duplex or half duplex, with the software power-down enabled
+after reset:
+
+-  MAC Interface = RGMII with 2ns delay on RXC/TXC
+
+   -  MACIF_SEL0 = MODE_1 = 10 kΩ pull-down resistor
+   -  MACIF_SEL1 = MODE_1 = 10 kΩ pull-down resistor
+
+-  MDIX_MODE = automatic MDIX, preferred MDI
+
+   -  MDIX_MODE = MODE_4
+
+-  PHY address = 0b0001
+-  Speed selection = 10 Mbps, 100 Mbps, or 1000 Mbps with full duplex or half
+   duplex, automatic negotiate enabled
+
+   -  PHY_CFG0 = MODE_4 = 10 kΩ pull-up resistor
+
+::
+
+     *PHY_CFG1 = MODE_1 = 10 kΩ pull-down resistor
+
+.. image:: images/20_-_88e1510_adin1300_example_-_figure_6.png
+   :align: right
+
+--------------
+
+.. |image1| image:: images/13_-_88e1510_adin1300_auto_neg_speeds_-_table_9.png

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/marvell88e1512_to_adin1300_phy_exchange_guide.rst
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/marvell88e1512_to_adin1300_phy_exchange_guide.rst
@@ -3,42 +3,42 @@ PHY Exchange Guide, Marvell Alaska 88E1512 to ADIN1300 Gb
 
 .. container:: group
 
-   
+
    .. container:: half column
 
-         
+
          **Overview**
 
-         
+
          This PHY exchange guide captures pertinent information to support
          migration from the Marvell 88E1512 to the Analog Devices ADIN1300
          Ethernet PHY.
-         
+
          The ADIN1300 has compelling reasons for adoption versus this competitor
          PHY, such as reduced power consumption, lower latency, and smaller
          footprint due to the small package size.
-         
+
          .. image:: images/01_-_88e1512_motivators_to_migrate_-_figure1.png
-         
+
          The ADIN1300 Ethernet PHY supports all the standard functions and pins
          of an Ethernet PHY and it is very straight forward to migrate an
          existing design to the ADIN1300.
-         
+
          The following sections detail the modifications at the schematic level
          required to migrate from an 88E1512 device to the ADIN1300 device.
          Including a description of differences corresponding to each functional
          group of pins and differences in the hardware pin configuration of the
          device. A side-by-side pinout and package comparison and a feature
          comparison table are included for easy reference.
-         
+
          The ADIN1300 datasheet provides a detailed description of all functions
          of the device and should also be consulted for reference.
-         
+
          Hardware Changes By Function
-         
+
          **Power Supplies Overview**
 
-         
+
          The ADIN1300 requires a minimum of 2 power supply rails, where the
          VDDIO is connected to the same power supply voltage as the MAC or as
          the PHY analog supply AVDD_3P3 (VDDA2P5). The 88E1512 can be powered
@@ -47,127 +47,127 @@ PHY Exchange Guide, Marvell Alaska 88E1512 to ADIN1300 Gb
          powers the MAC interface and MDIO blocks, this can operate from 1.8V,
          2.5V or 3.3V. The supply requirements are listed in Table 1 and Table
          2.
-         
+
          .. image:: images/02_-_88e1512_power_supply_rails_external_-_table_1.png
-         
+
          .. image:: images/03_-_88e1512_power_supply_rails_external_-_table_2.png
-         
+
          The ADIN1300 is robust to power supply sequencing and the power can be
          applied in any order.
-         
+
          Decoupling requirements for each device differ as described in Table 3.
          This table shows the decoupling for Analog, Digital and Core power
          supply pins for each device. For the different 88E1512 configurations
          and additional pins that require decoupling when the internal
          regulators are in use, see the datasheet.
-         
+
          .. image:: images/04_-_88e1512_decoupling_requirements_-_table_3.png
-         
+
          **RESET Operation**
 
-         
+
          Both devices have a RESET_N pin which initializes the device and
          latches the hardware pin configuration. To reset the ADIN1300 the
          RESET_N pin should be held low for >10 μs. Deglitch circuitry is
          included on this pin to reject pulses shorter than ~1 μs. This pin
          requires a 1 kΩ pull-up resistor to AVDD_3P3.
-         
+
          The ADIN1300 includes power monitoring circuitry to monitor all of the
          supplies. At power-up, the ADIN1300 is held in hardware reset until
          each of the supplies has crossed its minimum rising threshold value.
-         
+
          The hardware strapping pins are read and updated at the de-assertion of
          reset for both devices. For the ADIN1300, the RESET_N pin resides in
          the AVDD_3P3 voltage domain. After 5 ms from the deassertion of
          RESET_N, the management interface registers are accessible and the
          device can be programmed.
-         
+
          In applications where the MAC interface is powered from VDDIO of 1.8V,
          level shifting of the RESET_N signal applied to the ADIN1300 may be
          required to ensure the voltage level on the RESET_N pin is in excess of
          the minimum input high threshold level.
-         
+
          The 88E1512 will be hardware configured after the de assertion of
          RESETn. The valid power to RESETn de-assertion time is 10mS. To reset
          the 88E1512 the RESET_N pin should be held low for a minimum of 10 ms.
-         
+
          **Clocking**
 
-         
+
          A 25 MHz crystal or external clock source is used to provide the
          reference clock for both devices. A crystal can be connected to pins
          XTAL_I/XTAL_O (XI/XO), with both devices using the same external
          circuit. Or a 25 MHz refence clock can be provided on the input clock
          pin CLK_IN (XI).
-         
+
          The ADIN1300 supports RMII and requires an external 50 MHz REF_CLK on
          the XTAL_I/REF_CLK pin in RMII mode. The 88E1512 does not support the
          RMII MAC interface.
-         
+
          **Bias Resistor**
 
-         
+
          An external resistor is required to bias internal reference circuitry
          for both 88E1512 and ADIN1300. The ADIN1300 requires a 3.01 kΩ resistor
          (1% tolerance, 100 ppm/°C temperature coefficient) connected to pin 10.
          The 88E1512 uses a 4.99 kΩ (1%) on pin 30.
-         
-         .. image:: images/05_-_88e1512_bias_resistor_values_-_table_4.png
-         
 
-   
+         .. image:: images/05_-_88e1512_bias_resistor_values_-_table_4.png
+
+
+
    .. container:: half column
 
-         
+
          **Media Dependent Interface (MDI)**
 
-         
+
          The ADIN1300 has voltage mode line drivers with on-chip terminations so
          no external termination resistors are required. Both devices use
          voltage mode line drive for connection from the MDI_0:3_P/N
          (TD_P/M_A:D) pins to the magnetics and RJ-45 line using the same
          external circuit.
-         
+
          The recommended external circuit for the interface to the magnetics and
          RJ-45 is shown in Figure 2.
-         
+
          .. image:: images/06_-_88e1512_discrate_magnetics_isolation_-_figure_2.png
-         
+
          **MDIO/Management Interface**
 
-         
+
          Both devices support the IEEE management interface using the MDIO/MDC
          pins and require a pullup resistor on the MDIO pin (Management Data
          Open Drain Input/Output). The recommended value for ADIN1300 is a 1.5kΩ
          resistor connected to pin 24. The 88E1512 recommends a 1.5kΩ to 10 kΩ
          resistor connected to pin 8.
-         
+
          Both devices provide an interrupt pin, INT_N (¯INT). For the ADIN1300
          this pin requires a 1.5 kΩ pull-up resistor to VDDIO. The 88E1512 INT_N
          (¯INT) is shared with the LED[2] pin and is register programmable. This
          is pin 12 on the Marvell 88E1512.
-         
+
          **LED Function**
 
-         
+
          The ADIN1300 supports two LED pins, one on LED_0 and one on LINK_ST.
          The LED_0 has programmability of LED functions, with different blinking
          operation possible through MDIO configuration, the default mode is ON
          when Link is Up, blink if activity. The LINK_ST provides static
          information about Link up or down status.
-         
+
          The 88E1512 supports 3 LED pins 12, 13 and 14.
-         
+
          **LED Circuit**
 
-         
+
          The ADIN1300 LED_0 operates from the AVDD_3P3 voltage domain, therefore
          can support driving LEDs even when the MAC interface is running at the
          lower voltage of 1.8V.
-         
+
          The default LED operation is on if the Link is up and blinks when there
          is activity, this operation can be reprogrammed through MDIO write.
-         
+
          For the LED_0 of the ADIN1300, it can be configured with 4-level
          strapping. The strapping configuration will have an impact on how the
          LED function operates and needs to be considered if the LED pins are
@@ -176,45 +176,45 @@ PHY Exchange Guide, Marvell Alaska 88E1512 to ADIN1300 Gb
          an active low driver and conversely if the strapping input is pulled
          low (MODE_0/MODE_1), the output will be configured as active high. This
          LED circuit should be configured accordingly.
-         
+
          .. image:: images/07_-_88e1512_led_hardware_config_-_figure_3.png
-         
+
          **Link Status, LINK_ST**
 
-         
+
          The ADIN1300 has a dedicated LINK_ST pin to provide information to the
          MAC on the status of the Link. By default, the LINK_ST pin goes high
          indicating the link is up and low to indicate the link is down. The
          LINK_ST polarity is programmable by setting the bit high
          GE_LNK_STAT_INV_EN.
-         
+
          The LINK_ST could be used to drive an LED, however it resides in the
          VDDIO voltage domain, therefore, when driving an LED in an integrated
          RJ45 jack where the PHY VDDIO is 1.8V, level shifting will be required.
          This can be done using a FET.
-         
 
-   
+
+
 
 --------------
 
 .. container:: group
 
-   
+
    .. container:: half column
 
-         
+
          **MAC Interface**
 
-         
+
          The ADIN1300 supports RGMII, MII and RMII MAC interface modes. The
          Marvell 88E1512 supports RGMII and SGMII. The following sections
          describe the RGMII interface for both devices and the MII and RMII
          interfaces for the ADIN1300.
-         
+
          **RGMII Interface**
 
-         
+
          The RGMII interface is the communication path between the PHY and MAC
          devices. The RGMII interface has a low pin count interface supports
          10M, 100M and Gigabit operation, with a total of 12 pins for data
@@ -222,24 +222,24 @@ PHY Exchange Guide, Marvell Alaska 88E1512 to ADIN1300 Gb
          most common interface for Gigabit applications and has the lowest
          latency. Table 5 shows a pin overview of both devices for the RGMII MAC
          interface mode.
-         
+
          Both devices support the internal delay on the clocks. By default, the
          ADIN1300 is configured in RGMII mode with a 2 ns delay on RXC and TXC.
-         
+
          .. image:: images/08_-_88e1512_rgmii_mac_interface_pin_comparison_-_table_5.png
-         
+
          **MII Interface**
 
-         
+
          The 88E1512 does not support the MII interface.
-         
+
          The MII interface is the communication path between the PHY and MAC
          devices. The MII interface has a high pin count, with a total of 15
          pins for data transmission, reception and to signal errors or
          collision. It is sometimes used in 100M applications as it has a lower
          latency than RGMII and is much lower than RMII. Table 6 shows a pin
          overview for the ADIN1300 for the MII MAC interface mode.
-         
+
          When using the ADIN1300 in MII mode, the multifunction pin
          “LED_0/COL/TX_ER” automatically becomes either COL or TX_ER. If EEE
          advertisement is disabled, the pin function is COL as full and
@@ -247,88 +247,88 @@ PHY Exchange Guide, Marvell Alaska 88E1512 to ADIN1300 Gb
          input. If EEE advertisement is enabled the pin function is TX_ER as
          only full duplex operation is supported with EEE and the COL pin is not
          required. Similarly, the “INT_N/CRS” becomes CRS.
-         
 
-   
+
+
    .. container:: half column
 
-         
+
          The ADIN1300 sub-system registers provide user with ability to
          reconfigure which pin the COL and CRS functions are provided on (option
          of redirecting to GP_CLK, LINK_ST or INT_N). This requires a register
          write over MDIO interface to reconfigure.
-         
+
          .. image:: images/09_-_88e1512_mii_mac_interface_pin_comparison_-_table_6.png
-         
+
          **RMII Interface**
 
-         
+
          The 88E1512 does not support the RMII interface. RMII is a Reduced MII
          interface using fewer pins as shown in Table 7. The pin count for this
          interface is 8 pins.
-         
+
          .. image:: images/10_-_88e1512_rmii_mac_interface_pin_comparison_-_table_7.png
-         
+
          In RMII mode, the ADIN1300 requires an external 50MHz clock applied to
          XTAL_I. This clock could come from the MAC.
-         
 
-   
+
+
 
 --------------
 
 .. container:: group
 
-   
+
    .. container:: half column
 
-         
+
          **Output Clocks**
 
-         
+
          The ADIN1300 provides a 25 MHz output reference clock on the REF_CLK
          pin. This can be used a 25 MHz input reference clock for another PHY
          device.
-         
+
          The ADIN1300 can optionally provide a number of clock signals on the
          GP_CLK pin. This is configured via MDIO writes and the clocks available
          are a 125 MHz free running clock, 25 MHz clock and 25 MHz/125 MHz
          recovered clock.
-         
+
          Hardware Configuration
-         
+
          Both devices have a number of strapping options to enable managed or
          unmanaged configurations of the PHY function such as PHY address, mode
          of operation, Auto-Negotiation and MAC Interface.
-         
+
          After power on, the strapping pin voltages get sensed and latched upon
          existing from a reset and the sensed voltages are used to set the
          personality of the PHY.
-         
+
          When configuring any strapping configurations, ensure to review the
          default state of the MAC side, whether the pins are being driven when
          coming out of reset or if there are internal pulls. Understanding the
          behavior on the MAC side is key to ensuring there are no conflicts with
          the hardware strapping implemented, or to adjust the strapping resistor
          values if required.
-         
+
          The ADIN1300 uses a mix of 2-level and 4-level strapping options. In
          general, strapping pins are multi-functional and have different
          operation after the device is brought out of reset. The ADIN1300 has
          internal pull downs on many of its strapping pins (not all), therefore
          it would be possible to minimize external strapping resistors.
-         
+
          .. image:: images/11_-_88e1512_adin1300_hardware_strapping_levels_-_figure_4.png
-         
+
          .. image:: images/12_-_88e1512_4_level_strapping_restsor_ratios_adin1300_-_table_8.png
-         
+
          Strapping configurations are very specific to the device, consult the
          respective datasheet to determine the exact configuration required for
          each use case with the 88E1512.
-         
+
          **Hardware Configuration of Speed**
 
-         
+
          For the ADIN1300, speed configuration is done using two pins, PHY_CFG0
          and PHY_CFG1. These pins do not have any internal pull resistors,
          therefore external strapping is required. Both pins support 4-level
@@ -336,59 +336,59 @@ PHY Exchange Guide, Marvell Alaska 88E1512 to ADIN1300 Gb
          combinations, such as Auto-neg speeds shown in Table 9 or Forced modes
          shown in Table 10. Review the datasheet hardware configuration pin
          section for full detail on the possible settings using these pins.
-         
 
-   
+
+
    .. container:: half column
 
-         
 
-   
+
+
       ..
 
    |image1|
 
          .. image:: images/14_-_88e1512_adin1300_forced_speeds_-_table_10.png
-         
+
          **Hardware Configuration of Auto-MDIX**
 
-         
+
          Selection of Auto-MDIX for the ADIN1300 is done using one pin,
          (MDIX_MODE) with 4-level strapping.
-         
+
          .. image:: images/15_-_88e1512_auto_mdix_mode_adin1300_-_table_11.png
-         
+
          **MAC Interface Selection**
 
-         
+
          The ADIN1300 uses two hardware pins, MACIF_SEL0 and MACIF_SEL1 to
          provide user ability to select different MAC interfaces. These two pins
          have internal weak pull downs, therefore the default operation would be
          RGMII with delays as shown in Table 12. To configure any other MAC
          interface mode, use 10kΩ pull up or pull down resistors to select
          accordingly.
-         
+
          .. image:: images/16_-_88e1512_mac_interface_selection_adin1300_-_table_12.png
-         
+
          **Hardware Configuration of PHY Address**
 
-         
+
          The ADIN1300 has a default strapping providing a PHY address of 0x0000.
          For the 88E1512 Bit 0 of the PHY address is configured during the
          hardware reset sequence. PHY address bits[4:1] are set to “0000”
          internally in the device.
-         
+
          The ADIN1300 uses two-level strapping for the four PHY address pins,
          either pull high or low to configure the PHY address, with an option of
          16 unique addresses possible. Two level strapping provides a very
          robust PHY addressing scheme.
-         
+
          When configuring any strapping configurations, assess the default state
          of the MAC side, in case it conflicts with the hardware strapping
          implemented.
-         
 
-   
+
+
 
 .. important::
 
@@ -400,20 +400,20 @@ PHY Exchange Guide, Marvell Alaska 88E1512 to ADIN1300 Gb
 
 .. container:: group
 
-   
+
    .. container:: half column
 
-         
+
          Package
-         
+
          The ADIN1300 is available in a 40 lead LFCSP (6 mm x 6 mm footprint).
          The 88E1512 is available in a 56 Pin QFN (8 mm x 8 mm). Due to the
          smaller package footprint and differing pinout, the ADIN1300 is not a
          drop-in replacement for the 88E1512 product. It will require a re-spin
          of schematic and board layout to achieve this exchange.
-         
+
          .. image:: images/17_-_88e1512_adin1300_package_compasrison_-_table_13.png
-         
+
          The underside of the LFCSP package for the ADIN1300 includes an exposed
          paddle which should be soldered directly to the board with an array of
          vias for thermal purposes. There are also two exposed stripes adjacent
@@ -422,78 +422,78 @@ PHY Exchange Guide, Marvell Alaska 88E1512 to ADIN1300 Gb
          they are connected to supply rails in the device, therefore should not
          be tied to ground and there should be no routing or traces on the PCB
          layer directly underneath them.
-         
+
          Other Pinout Considerations
-         
+
          **Integrated MDI Termination**
 
-         
+
          Both devices include integrated termination resistors on the MDI paths.
          These are voltage mode PHYs, no external resistors are required for
          biasing and no supply voltage is required at the center tap of the
          transformer.
-         
+
          **RGMII Drive/Termination resistors**
 
-         
+
          The ADIN1300 provides user with ability to adjust the RGMII drive
          current through the GE_RGMII_IO_CNTRL register.
-         
 
-   
+
+
    .. container:: half column
 
-         
+
          **MII**
 
-         
+
          The ADIN1300 supports the MII MAC interface and the 88E1512 does not.
-         
+
          **RMII**
 
-         
+
          The ADIN1300 supports RMII MAC interface mode for 10/100M operation.
          The 88E1512 does not support the RMII interface.
-         
+
          **GMII**
 
-         
+
          The ADIN1300 and 88E1512 do not support the GMII interface.
-         
+
          **SGMII**
 
-         
+
          The Marvell 88E1512 supports SGMII, and the ADIN1300 does not support
          SGMII.
-         
+
          **FIBER**
 
-         
+
          The Marvell 88E1512 does support fiber protocols, while the ADIN1300
          does not. See the Marvell Datasheet for more information.
-         
+
          Software Considerations
-         
+
          Both devices can be hardware strapped to be used in an unmanaged
          configuration. Alternatively, they can provide access over the MDIO
          interface. Both devices support both Clause 22 and Clause 45 register
          access using both the 802.3 Clause 22 and Clause 45 management frame
          structures.
-         
+
          Registers 0x0 to 0xF are common across all PHYs.
-         
+
          **Linux Driver**
 
-         
+
          The ADIN1300 has a Linux Driver available in the Linux mainline kernel. The ADIN1300 linux driver detail is captured here: `adin <https://wiki.analog.com/resources/tools-software/linux-drivers/net-phy/adin>`_
-         
+
          **Non Operating System Driver**
 
-         
-         The ADIN1300 has a Non Operating System Driver available from the devices product page here: :adi:`en/products/adin1300.html#product-requirement`
-         
 
-   
+         The ADIN1300 has a Non Operating System Driver available from the devices product page here: :adi:`en/products/adin1300.html#product-requirement`
+
+
+
 
 .. tip::
 

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/marvell88e1512_to_adin1300_phy_exchange_guide.rst
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/marvell88e1512_to_adin1300_phy_exchange_guide.rst
@@ -1,0 +1,564 @@
+PHY Exchange Guide, Marvell Alaska 88E1512 to ADIN1300 Gb
+=========================================================
+
+.. container:: group
+
+   
+   .. container:: half column
+
+         
+         **Overview**
+
+         
+         This PHY exchange guide captures pertinent information to support
+         migration from the Marvell 88E1512 to the Analog Devices ADIN1300
+         Ethernet PHY.
+         
+         The ADIN1300 has compelling reasons for adoption versus this competitor
+         PHY, such as reduced power consumption, lower latency, and smaller
+         footprint due to the small package size.
+         
+         .. image:: images/01_-_88e1512_motivators_to_migrate_-_figure1.png
+         
+         The ADIN1300 Ethernet PHY supports all the standard functions and pins
+         of an Ethernet PHY and it is very straight forward to migrate an
+         existing design to the ADIN1300.
+         
+         The following sections detail the modifications at the schematic level
+         required to migrate from an 88E1512 device to the ADIN1300 device.
+         Including a description of differences corresponding to each functional
+         group of pins and differences in the hardware pin configuration of the
+         device. A side-by-side pinout and package comparison and a feature
+         comparison table are included for easy reference.
+         
+         The ADIN1300 datasheet provides a detailed description of all functions
+         of the device and should also be consulted for reference.
+         
+         Hardware Changes By Function
+         
+         **Power Supplies Overview**
+
+         
+         The ADIN1300 requires a minimum of 2 power supply rails, where the
+         VDDIO is connected to the same power supply voltage as the MAC or as
+         the PHY analog supply AVDD_3P3 (VDDA2P5). The 88E1512 can be powered
+         with between 1 and 4 power supply rails depending on the configuration
+         of using internal or external regulators. The VDDIO / VDDO supply rail
+         powers the MAC interface and MDIO blocks, this can operate from 1.8V,
+         2.5V or 3.3V. The supply requirements are listed in Table 1 and Table
+         2.
+         
+         .. image:: images/02_-_88e1512_power_supply_rails_external_-_table_1.png
+         
+         .. image:: images/03_-_88e1512_power_supply_rails_external_-_table_2.png
+         
+         The ADIN1300 is robust to power supply sequencing and the power can be
+         applied in any order.
+         
+         Decoupling requirements for each device differ as described in Table 3.
+         This table shows the decoupling for Analog, Digital and Core power
+         supply pins for each device. For the different 88E1512 configurations
+         and additional pins that require decoupling when the internal
+         regulators are in use, see the datasheet.
+         
+         .. image:: images/04_-_88e1512_decoupling_requirements_-_table_3.png
+         
+         **RESET Operation**
+
+         
+         Both devices have a RESET_N pin which initializes the device and
+         latches the hardware pin configuration. To reset the ADIN1300 the
+         RESET_N pin should be held low for >10 μs. Deglitch circuitry is
+         included on this pin to reject pulses shorter than ~1 μs. This pin
+         requires a 1 kΩ pull-up resistor to AVDD_3P3.
+         
+         The ADIN1300 includes power monitoring circuitry to monitor all of the
+         supplies. At power-up, the ADIN1300 is held in hardware reset until
+         each of the supplies has crossed its minimum rising threshold value.
+         
+         The hardware strapping pins are read and updated at the de-assertion of
+         reset for both devices. For the ADIN1300, the RESET_N pin resides in
+         the AVDD_3P3 voltage domain. After 5 ms from the deassertion of
+         RESET_N, the management interface registers are accessible and the
+         device can be programmed.
+         
+         In applications where the MAC interface is powered from VDDIO of 1.8V,
+         level shifting of the RESET_N signal applied to the ADIN1300 may be
+         required to ensure the voltage level on the RESET_N pin is in excess of
+         the minimum input high threshold level.
+         
+         The 88E1512 will be hardware configured after the de assertion of
+         RESETn. The valid power to RESETn de-assertion time is 10mS. To reset
+         the 88E1512 the RESET_N pin should be held low for a minimum of 10 ms.
+         
+         **Clocking**
+
+         
+         A 25 MHz crystal or external clock source is used to provide the
+         reference clock for both devices. A crystal can be connected to pins
+         XTAL_I/XTAL_O (XI/XO), with both devices using the same external
+         circuit. Or a 25 MHz refence clock can be provided on the input clock
+         pin CLK_IN (XI).
+         
+         The ADIN1300 supports RMII and requires an external 50 MHz REF_CLK on
+         the XTAL_I/REF_CLK pin in RMII mode. The 88E1512 does not support the
+         RMII MAC interface.
+         
+         **Bias Resistor**
+
+         
+         An external resistor is required to bias internal reference circuitry
+         for both 88E1512 and ADIN1300. The ADIN1300 requires a 3.01 kΩ resistor
+         (1% tolerance, 100 ppm/°C temperature coefficient) connected to pin 10.
+         The 88E1512 uses a 4.99 kΩ (1%) on pin 30.
+         
+         .. image:: images/05_-_88e1512_bias_resistor_values_-_table_4.png
+         
+
+   
+   .. container:: half column
+
+         
+         **Media Dependent Interface (MDI)**
+
+         
+         The ADIN1300 has voltage mode line drivers with on-chip terminations so
+         no external termination resistors are required. Both devices use
+         voltage mode line drive for connection from the MDI_0:3_P/N
+         (TD_P/M_A:D) pins to the magnetics and RJ-45 line using the same
+         external circuit.
+         
+         The recommended external circuit for the interface to the magnetics and
+         RJ-45 is shown in Figure 2.
+         
+         .. image:: images/06_-_88e1512_discrate_magnetics_isolation_-_figure_2.png
+         
+         **MDIO/Management Interface**
+
+         
+         Both devices support the IEEE management interface using the MDIO/MDC
+         pins and require a pullup resistor on the MDIO pin (Management Data
+         Open Drain Input/Output). The recommended value for ADIN1300 is a 1.5kΩ
+         resistor connected to pin 24. The 88E1512 recommends a 1.5kΩ to 10 kΩ
+         resistor connected to pin 8.
+         
+         Both devices provide an interrupt pin, INT_N (¯INT). For the ADIN1300
+         this pin requires a 1.5 kΩ pull-up resistor to VDDIO. The 88E1512 INT_N
+         (¯INT) is shared with the LED[2] pin and is register programmable. This
+         is pin 12 on the Marvell 88E1512.
+         
+         **LED Function**
+
+         
+         The ADIN1300 supports two LED pins, one on LED_0 and one on LINK_ST.
+         The LED_0 has programmability of LED functions, with different blinking
+         operation possible through MDIO configuration, the default mode is ON
+         when Link is Up, blink if activity. The LINK_ST provides static
+         information about Link up or down status.
+         
+         The 88E1512 supports 3 LED pins 12, 13 and 14.
+         
+         **LED Circuit**
+
+         
+         The ADIN1300 LED_0 operates from the AVDD_3P3 voltage domain, therefore
+         can support driving LEDs even when the MAC interface is running at the
+         lower voltage of 1.8V.
+         
+         The default LED operation is on if the Link is up and blinks when there
+         is activity, this operation can be reprogrammed through MDIO write.
+         
+         For the LED_0 of the ADIN1300, it can be configured with 4-level
+         strapping. The strapping configuration will have an impact on how the
+         LED function operates and needs to be considered if the LED pins are
+         used to directly drive an LED. If the strap pin is pulled high by the
+         strapping resistors, (MODE_3/MODE_4) the output will be configured as
+         an active low driver and conversely if the strapping input is pulled
+         low (MODE_0/MODE_1), the output will be configured as active high. This
+         LED circuit should be configured accordingly.
+         
+         .. image:: images/07_-_88e1512_led_hardware_config_-_figure_3.png
+         
+         **Link Status, LINK_ST**
+
+         
+         The ADIN1300 has a dedicated LINK_ST pin to provide information to the
+         MAC on the status of the Link. By default, the LINK_ST pin goes high
+         indicating the link is up and low to indicate the link is down. The
+         LINK_ST polarity is programmable by setting the bit high
+         GE_LNK_STAT_INV_EN.
+         
+         The LINK_ST could be used to drive an LED, however it resides in the
+         VDDIO voltage domain, therefore, when driving an LED in an integrated
+         RJ45 jack where the PHY VDDIO is 1.8V, level shifting will be required.
+         This can be done using a FET.
+         
+
+   
+
+--------------
+
+.. container:: group
+
+   
+   .. container:: half column
+
+         
+         **MAC Interface**
+
+         
+         The ADIN1300 supports RGMII, MII and RMII MAC interface modes. The
+         Marvell 88E1512 supports RGMII and SGMII. The following sections
+         describe the RGMII interface for both devices and the MII and RMII
+         interfaces for the ADIN1300.
+         
+         **RGMII Interface**
+
+         
+         The RGMII interface is the communication path between the PHY and MAC
+         devices. The RGMII interface has a low pin count interface supports
+         10M, 100M and Gigabit operation, with a total of 12 pins for data
+         transmission, reception and to signal errors or collision. It is the
+         most common interface for Gigabit applications and has the lowest
+         latency. Table 5 shows a pin overview of both devices for the RGMII MAC
+         interface mode.
+         
+         Both devices support the internal delay on the clocks. By default, the
+         ADIN1300 is configured in RGMII mode with a 2 ns delay on RXC and TXC.
+         
+         .. image:: images/08_-_88e1512_rgmii_mac_interface_pin_comparison_-_table_5.png
+         
+         **MII Interface**
+
+         
+         The 88E1512 does not support the MII interface.
+         
+         The MII interface is the communication path between the PHY and MAC
+         devices. The MII interface has a high pin count, with a total of 15
+         pins for data transmission, reception and to signal errors or
+         collision. It is sometimes used in 100M applications as it has a lower
+         latency than RGMII and is much lower than RMII. Table 6 shows a pin
+         overview for the ADIN1300 for the MII MAC interface mode.
+         
+         When using the ADIN1300 in MII mode, the multifunction pin
+         “LED_0/COL/TX_ER” automatically becomes either COL or TX_ER. If EEE
+         advertisement is disabled, the pin function is COL as full and
+         half-duplex operation is supported and TX_ER is not required as an
+         input. If EEE advertisement is enabled the pin function is TX_ER as
+         only full duplex operation is supported with EEE and the COL pin is not
+         required. Similarly, the “INT_N/CRS” becomes CRS.
+         
+
+   
+   .. container:: half column
+
+         
+         The ADIN1300 sub-system registers provide user with ability to
+         reconfigure which pin the COL and CRS functions are provided on (option
+         of redirecting to GP_CLK, LINK_ST or INT_N). This requires a register
+         write over MDIO interface to reconfigure.
+         
+         .. image:: images/09_-_88e1512_mii_mac_interface_pin_comparison_-_table_6.png
+         
+         **RMII Interface**
+
+         
+         The 88E1512 does not support the RMII interface. RMII is a Reduced MII
+         interface using fewer pins as shown in Table 7. The pin count for this
+         interface is 8 pins.
+         
+         .. image:: images/10_-_88e1512_rmii_mac_interface_pin_comparison_-_table_7.png
+         
+         In RMII mode, the ADIN1300 requires an external 50MHz clock applied to
+         XTAL_I. This clock could come from the MAC.
+         
+
+   
+
+--------------
+
+.. container:: group
+
+   
+   .. container:: half column
+
+         
+         **Output Clocks**
+
+         
+         The ADIN1300 provides a 25 MHz output reference clock on the REF_CLK
+         pin. This can be used a 25 MHz input reference clock for another PHY
+         device.
+         
+         The ADIN1300 can optionally provide a number of clock signals on the
+         GP_CLK pin. This is configured via MDIO writes and the clocks available
+         are a 125 MHz free running clock, 25 MHz clock and 25 MHz/125 MHz
+         recovered clock.
+         
+         Hardware Configuration
+         
+         Both devices have a number of strapping options to enable managed or
+         unmanaged configurations of the PHY function such as PHY address, mode
+         of operation, Auto-Negotiation and MAC Interface.
+         
+         After power on, the strapping pin voltages get sensed and latched upon
+         existing from a reset and the sensed voltages are used to set the
+         personality of the PHY.
+         
+         When configuring any strapping configurations, ensure to review the
+         default state of the MAC side, whether the pins are being driven when
+         coming out of reset or if there are internal pulls. Understanding the
+         behavior on the MAC side is key to ensuring there are no conflicts with
+         the hardware strapping implemented, or to adjust the strapping resistor
+         values if required.
+         
+         The ADIN1300 uses a mix of 2-level and 4-level strapping options. In
+         general, strapping pins are multi-functional and have different
+         operation after the device is brought out of reset. The ADIN1300 has
+         internal pull downs on many of its strapping pins (not all), therefore
+         it would be possible to minimize external strapping resistors.
+         
+         .. image:: images/11_-_88e1512_adin1300_hardware_strapping_levels_-_figure_4.png
+         
+         .. image:: images/12_-_88e1512_4_level_strapping_restsor_ratios_adin1300_-_table_8.png
+         
+         Strapping configurations are very specific to the device, consult the
+         respective datasheet to determine the exact configuration required for
+         each use case with the 88E1512.
+         
+         **Hardware Configuration of Speed**
+
+         
+         For the ADIN1300, speed configuration is done using two pins, PHY_CFG0
+         and PHY_CFG1. These pins do not have any internal pull resistors,
+         therefore external strapping is required. Both pins support 4-level
+         strapping, providing much flexibility in terms of the possible
+         combinations, such as Auto-neg speeds shown in Table 9 or Forced modes
+         shown in Table 10. Review the datasheet hardware configuration pin
+         section for full detail on the possible settings using these pins.
+         
+
+   
+   .. container:: half column
+
+         
+
+   
+      ..
+
+   |image1|
+
+         .. image:: images/14_-_88e1512_adin1300_forced_speeds_-_table_10.png
+         
+         **Hardware Configuration of Auto-MDIX**
+
+         
+         Selection of Auto-MDIX for the ADIN1300 is done using one pin,
+         (MDIX_MODE) with 4-level strapping.
+         
+         .. image:: images/15_-_88e1512_auto_mdix_mode_adin1300_-_table_11.png
+         
+         **MAC Interface Selection**
+
+         
+         The ADIN1300 uses two hardware pins, MACIF_SEL0 and MACIF_SEL1 to
+         provide user ability to select different MAC interfaces. These two pins
+         have internal weak pull downs, therefore the default operation would be
+         RGMII with delays as shown in Table 12. To configure any other MAC
+         interface mode, use 10kΩ pull up or pull down resistors to select
+         accordingly.
+         
+         .. image:: images/16_-_88e1512_mac_interface_selection_adin1300_-_table_12.png
+         
+         **Hardware Configuration of PHY Address**
+
+         
+         The ADIN1300 has a default strapping providing a PHY address of 0x0000.
+         For the 88E1512 Bit 0 of the PHY address is configured during the
+         hardware reset sequence. PHY address bits[4:1] are set to “0000”
+         internally in the device.
+         
+         The ADIN1300 uses two-level strapping for the four PHY address pins,
+         either pull high or low to configure the PHY address, with an option of
+         16 unique addresses possible. Two level strapping provides a very
+         robust PHY addressing scheme.
+         
+         When configuring any strapping configurations, assess the default state
+         of the MAC side, in case it conflicts with the hardware strapping
+         implemented.
+         
+
+   
+
+.. important::
+
+   Strapping configurations are very specific to the device, consult the
+   respective datasheets to determine the exact configuration for required use
+   case.
+
+--------------
+
+.. container:: group
+
+   
+   .. container:: half column
+
+         
+         Package
+         
+         The ADIN1300 is available in a 40 lead LFCSP (6 mm x 6 mm footprint).
+         The 88E1512 is available in a 56 Pin QFN (8 mm x 8 mm). Due to the
+         smaller package footprint and differing pinout, the ADIN1300 is not a
+         drop-in replacement for the 88E1512 product. It will require a re-spin
+         of schematic and board layout to achieve this exchange.
+         
+         .. image:: images/17_-_88e1512_adin1300_package_compasrison_-_table_13.png
+         
+         The underside of the LFCSP package for the ADIN1300 includes an exposed
+         paddle which should be soldered directly to the board with an array of
+         vias for thermal purposes. There are also two exposed stripes adjacent
+         to the exposed paddle. These are not intended to and do not need to be
+         soldered to the board, they should be treated as a keep out area as
+         they are connected to supply rails in the device, therefore should not
+         be tied to ground and there should be no routing or traces on the PCB
+         layer directly underneath them.
+         
+         Other Pinout Considerations
+         
+         **Integrated MDI Termination**
+
+         
+         Both devices include integrated termination resistors on the MDI paths.
+         These are voltage mode PHYs, no external resistors are required for
+         biasing and no supply voltage is required at the center tap of the
+         transformer.
+         
+         **RGMII Drive/Termination resistors**
+
+         
+         The ADIN1300 provides user with ability to adjust the RGMII drive
+         current through the GE_RGMII_IO_CNTRL register.
+         
+
+   
+   .. container:: half column
+
+         
+         **MII**
+
+         
+         The ADIN1300 supports the MII MAC interface and the 88E1512 does not.
+         
+         **RMII**
+
+         
+         The ADIN1300 supports RMII MAC interface mode for 10/100M operation.
+         The 88E1512 does not support the RMII interface.
+         
+         **GMII**
+
+         
+         The ADIN1300 and 88E1512 do not support the GMII interface.
+         
+         **SGMII**
+
+         
+         The Marvell 88E1512 supports SGMII, and the ADIN1300 does not support
+         SGMII.
+         
+         **FIBER**
+
+         
+         The Marvell 88E1512 does support fiber protocols, while the ADIN1300
+         does not. See the Marvell Datasheet for more information.
+         
+         Software Considerations
+         
+         Both devices can be hardware strapped to be used in an unmanaged
+         configuration. Alternatively, they can provide access over the MDIO
+         interface. Both devices support both Clause 22 and Clause 45 register
+         access using both the 802.3 Clause 22 and Clause 45 management frame
+         structures.
+         
+         Registers 0x0 to 0xF are common across all PHYs.
+         
+         **Linux Driver**
+
+         
+         The ADIN1300 has a Linux Driver available in the Linux mainline kernel. The ADIN1300 linux driver detail is captured here: `adin <https://wiki.analog.com/resources/tools-software/linux-drivers/net-phy/adin>`_
+         
+         **Non Operating System Driver**
+
+         
+         The ADIN1300 has a Non Operating System Driver available from the devices product page here: :adi:`en/products/adin1300.html#product-requirement`
+         
+
+   
+
+.. tip::
+
+   The ADIN1300 has a Linux Driver available in the Linux mainline kernel.
+
+--------------
+
+Side by Side Package/Pinout Comparison
+--------------------------------------
+
+The following is a side-by-side comparison of the package and pinouts, showing
+the position of the corresponding functional pins on each device.
+
+.. image:: images/18_-_88e1512_adin1300_pinout_comparison_-_figure_5.png
+
+--------------
+
+Feature Comparison Table
+------------------------
+
+.. image:: images/19_-_88e1512_feature_comparison_table_15.png
+   :align: center
+
+--------------
+
+Example Configuration for RGMII
+-------------------------------
+
+The following example captures how to configure the ADIN1300 for an unmanaged
+configuration with RGMII Interface, operating in Auto Negotiation mode
+advertising all speeds. The PHY will power up in this state, ready to establish
+a link with a link partner.
+
+The MAC interface configuration pins (MACIF_SEL0/1) are pulled to ground,
+setting the PHY to RGMII mode with 2ns Delay on RXC & TXC. GP_CLK is pulled to
+VDDIO to configure an automatic MDIX operation. In addition, the PHY_CFG0 and
+PHY_CFG1 pins are configured for MODE_4 and MODE_1 respectively. The PHY_CFG0
+pin is also shared with the LED_0 pin, it’s configuration with MODE_4 means an
+active low LED can be used on LED_0.
+
+The following list summarizes an RGMII auto negotiate, 10 Mbps, 100 Mbps, or
+1000 Mbps with full duplex or half duplex, with the software power-down enabled
+after reset:
+
+-  MAC Interface = RGMII with 2ns delay on RXC/TXC
+
+   -  MACIF_SEL0 = MODE_1 = 10 kΩ pull-down resistor
+   -  MACIF_SEL1 = MODE_1 = 10 kΩ pull-down resistor
+
+-  MDIX_MODE = automatic MDIX, preferred MDI
+
+   -  MDIX_MODE = MODE_4
+
+-  PHY address = 0b0001
+-  Speed selection = 10 Mbps, 100 Mbps, or 1000 Mbps with full duplex or half
+   duplex, automatic negotiate enabled
+
+   -  PHY_CFG0 = MODE_4 = 10 kΩ pull-up resistor
+
+::
+
+     *PHY_CFG1 = MODE_1 = 10 kΩ pull-down resistor
+
+.. image:: images/20_-_88e1512_adin1300_example_-_figure_6.png
+
+--------------
+
+.. |image1| image:: images/13_-_88e1512_adin1300_auto_neg_speeds_-_table_9.png

--- a/docs/solutions/reference-designs/adin1300-and-adin1200/phy_faq.rst
+++ b/docs/solutions/reference-designs/adin1300-and-adin1200/phy_faq.rst
@@ -1,0 +1,366 @@
+ADIN1200/ADIN1300 Frequently Asked Questions
+============================================
+
+.. image:: images/phy.jpg
+   :align: center
+   :width: 400
+
+Key Considerations when selecting an Industrial PHY
+---------------------------------------------------
+
+In automation applications there are a few critical features required to ensure
+high reliability and network resilience.
+
+-  **Latency Performance** The network cycle time is the communication time required by the controller to both collect and update the data memories of all devices. A low latency PHY reduces network cycle time, improving network refresh time and allows more devices to the connected to the network. Many Industrial Ethernet Network topologies are typically LINE or RING, device connections requiring two ports for data in and out. This means PHY latency is doubled and therefore the impact of this specification can be very significant in determining the overall network cycle time. The ADIN1300 PHY has significantly lower latency compared to the competition 290ns Tx & Rx (RGMII)
+-  **Robustness** to external radiated and conducted noise sources given the harsh operating environment. Select products who have been tested and adhere to EMI/EMC standards like CISPR 32, IEC 61000-4-2/4/5/6. This will prevent lengthy redesign cycles to secure certification later in the development flow. The customer evaluation board has been used for the various EMC tests to prove its robustness.
+-  **Low Power** Devices in Industrial Applications are typically IP65/66 sealed from dust and moisture and therefore have restricted airflow and limited power dissipation capability. Similarly, devices are often exposed to high ambient temperature in industrial environments. Like the case for latency, 2 ports are needed for Line and Ring topologies and therefore 2 PHY’s so the effective is a doubling in the power dissipated for data In and Out. The ADIN1300 PHY offers on the order of 30% saving in power versus the competition with 330mW of power at 100% data throughput.
+
+--------------
+
+Differences between ADIN1200 & ADIN1300
+---------------------------------------
+
+The key differences are package size, speed, supply rails and feature set.
+
+|image1|
+
+--------------
+
+Hardware Strapping Features
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The PHYs hardware configuration pins allow user predefine the personality of the
+PHY for unmanaged applications. The features that can be configured by
+bootstrapping are as follows:
+
+-  PHY Address
+-  Forced/Advertised mode
+-  PHY Speed
+-  Software Powerdown Mode after Reset
+-  Downspeed Enable
+-  Energy Detect Powerdown Mode
+-  EEE Enable
+-  Auto-MDIX
+-  MAC Interface Selection (RGMII/RMII/MII)
+-  Review the datasheet section on Hardware configuration pins for full details.
+
+Note that some pins use 4-level strapping (Mode 1-4), whereas other pins only
+use two level strapping (high & low). The PHY address pins use two level
+strapping.
+
+--------------
+
+MII 100M Latency
+~~~~~~~~~~~~~~~~
+
+The Latency in MII mode is a fixed number, dependent on clock cycles. There is
+no FIFO in MII and therefore no variation on this figure. For 1000M mode, there
+is a FIFO and there will be an 8ns uncertainty, this is captured in the
+datasheet latency specs.
+
+--------------
+
+Timing / Latency Maximum Receive Time
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The Receive latency numbers quoted in Table 1 from the Datasheet are measured
+from start of data at MDI to the positive edge from RGMII.RXCLK. These are
+following the MDI to MII/GMII delay constraint definitions in Table 24-2/3 in
+IEEE Std 802.3 for 100BASE-TX and Table 40-14 for 1000BASE-T, extended to
+10BASE-T and RMII/RGMII using the same reference points, i.e.
+
+-  TX_EN/TX_CTL sampled with the rising edge of TX_CLK/TXC/REF_CLK to 1st
+   bit/symbol on MDI
+
+-  1st bit/symbol on MDI to RX_DV sampled with the rising edge of
+   RX_CLK/RXC/REF_CLK
+
+--------------
+
+Resistor Values for Hardware pin config
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The datasheet contains information on the recommended resistors to use on the
+various strapping pins. For the four level strapping resistor values of 10k/56k
+are recommended and chosen to minimize the power consumption from the resistor
+ladder. User could adjust the values of resistor if needed, but should retain
+similar ratio. User should also review if there is extra loading on each pin
+from external circuitry and adjust as needed. Note that some pins use 4-level
+strapping (Mode 1-4), whereas other pins only use two level strapping (high &
+low). The PHY address pins use two level strapping.
+
+--------------
+
+IO Voltage for MAC interface
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ADIN1200 and ADIN1300 support VDDIO voltage range of 1.8V, 2.5V or 3.3V.
+Power consumption will increase with increased VDDIO voltage, see datasheet
+specifications for more details which includes plots showing typical data.
+
+--------------
+
+Typical Link time vs Speed
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Example Gigabit PHY Speed Configurations (assume local & remote node are
+configured the same):
+
+-  Advertise All Speeds, Auto-Neg enabled, Auto-MDIX enabled .~4-5 sec
+-  Advertise All Speeds, Auto-Neg enabled, Manual MDI/MDI-X.~3-4 sec
+-  Force 1 Speed, Auto-Neg disabled, Manual MDI/MDI-X < 200ms
+
+.. important::
+
+   Forced Mode
+
+Forced mode is always going to be the fastest mode to bring up a link. The
+auto-negotiation process is always going to take longer for the link to resolve.
+If user is sensitive to the link time, then forced mode is recommended.
+
+--------------
+
+Does the PHYs support JTAG?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+No, the ADIN1300 or ADIN1200 do not support JTAG
+
+--------------
+
+Any power sequencing requirements?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+There are no power up or down sequencing requirements.
+
+--------------
+
+Software tools for evaluation of the PHYs?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When using the ADI evaluation board with the ADuCM3029 MDIO interface dongle,
+there is an accompanying Software GUI which provides the user with easy access
+to all registers in the PHY and allows user do an initial evaluation of the part
+prior to developing own hardware and software. There is also a Linux driver for
+the ADIN1200 and ADIN1300, available in Linux mainline.
+
+--------------
+
+Exposed Paddle Keepout areas
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The package has a standard exposed paddle, which should be soldered to the board
+for thermal reasons, ideally the solder pattern will have a full via array for
+best thermal performance. The extra exposed strips seen above and below the
+exposed padded are exposed bus bars, they are connected to internal voltages, so
+should not be grounded, there should be no vias directly underneath these areas,
+they should be treated as keepout areas. They do not need to be soldered down.
+
+--------------
+
+WoL (Wake on LAN)?
+~~~~~~~~~~~~~~~~~~
+
+WoL is primarily a MAC function. In a PC / LOM application a MAC-PHY is commonly
+used and WoL is implemented in the MAC-PHY and a processor / PC system can be
+put in a sleep mode and is woken by the receipt of a WoL packet.
+
+Some PHYs include the detection of the magic packet so that the MAC can also be
+put in a sleep mode. The ADIN1300 does not include the magic packet detection
+function. In fact, WoL is not a low power mode from the PHY point of view as it
+still has to be up and is consuming power all the time, even in idle with no
+data transmission. An alternative approach and one that enables more efficient
+power consumption would be to use the PHY Energy Efficient Ethernet mode (EEE).
+If EEE is used, the link can be left in Gigabit EEE mode, the PHY power
+consumption is ~50 mW. So a significant saving vs Gb idle (330mW). Now when a
+packet is received, the PHY wakes up in 20 us (micro seconds) and wakes up the
+MAC. The MAC can process the packets to decide if a WoL packet and can wake up
+the system or ignore. A switch will usually only send packets destined for the
+device on that link. There will be occasional broadcast packets, so you will
+have some spurious wakes of the MAC, but overall the power should be lower using
+EEE than WoL.
+
+--------------
+
+SGMII interface?
+~~~~~~~~~~~~~~~~
+
+No, the ADIN1300 or ADIN1200 do not support SGMII interface. They supports MII,
+RMII & RGMII MAC interface modes.
+
+--------------
+
+C driver code for the PHYs?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+No, currently we have a Linux driver which is available upstream in the kernel. Further detail around the driver is available on our `Wiki page <https://wiki.analog.com/resources/tools-software/linux-drivers/net-phy/adin>`_
+
+--------------
+
+Conformance testing
+~~~~~~~~~~~~~~~~~~~
+
+Yes, UNH have performed conformance testing on our PHY test chip. In addition,
+we also performed internal testing using Tektronix TDSET compliance software. A
+summary report is available on request.
+
+--------------
+
+Back to back or repeater mode of operation?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Yes, when using the RGMII interface the PHY RX/TX are fully compatible, so they
+can be connected back to back. The only caution is to ensure to implement the
+internal delay on one side (typically the RX side for each side of link), this
+can be done either with hardware strapping or with a register write over the
+MDIO interface.
+
+Note that the RMII PHY TX/RX interfaces are not functionally compatible, so
+cannot be connected back to back by default, instead a register write is
+required to support this mode of operation. Refer to the detail in the datasheet
+for specific details of the register involved.
+
+--------------
+
+IEEE1588 PTP support
+~~~~~~~~~~~~~~~~~~~~
+
+IEEE1588 enables high accuracy synchronization of clocks over Ethernet. To
+eliminate variability in the delay of timing packets between devices, PTP
+compliant Ethernet hardware records the time that PTP packets enter and exit the
+device and makes these time stamps available to PTP software, enabling the PTP
+application to use timing packets to accurately synchronize two clocks.
+
+The ADIN1200 and ADIN1300 help to support IEEE1588 timestamping by providing
+start of packet indication to the MAC using hardware pins (programmable which
+pins). The PHYs do not timestamp the data directly. The MAC would timestamp
+based on the hardware pin indication from the PHY. Refer to the Start of Packet
+section in the PHY datasheets.
+
+--------------
+
+Synchronous Ethernet (SyncE)?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Yes, the ADIN1200 & ADIN1300 support Synchronous Ethernet. Synchronous Ethernet
+is the ability to output a clock synchronous to the recovered receive clock. A
+Master clock would exist at a local PHY in Gigabit Master mode. The remote PHY
+in Slave mode recovers the clock and outputs it on the GP_CLK pin. This clock
+source is then used to generate a local clock for any PHYs or switches beside
+this remote PHY. While SyncE is used in some applications, it has primarily been
+superseded by 1588.
+
+--------------
+
+Longer cable length?
+~~~~~~~~~~~~~~~~~~~~
+
+The ADIN1300 can support cable lengths up to 150 meters at Gigabit speeds and
+180 meters when operating at 100 Mbps or 10 Mbps. The ADIN1200 supports cable
+lengths as long as 180m. Limited additional experimental data with the ADIN1200
+suggests it can operate out to 210 meters (at 100 Mbps) over CAT5 cable with the
+default configuration settings.
+
+--------------
+
+1588 Start of Packet Programmable Delays
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ADIN1200 & ADIN1300 provide hardware pins for Start of Packet indication
+based on the SFD in the ethernet frame. This function is programmable in terms
+of which pins are used to provide the indication for Tx and Rx side. See
+datasheet for full detail on register programmability. One element of
+programmability is the delay
+
+SopTxDelay Delay Register
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The SopTxDel delay register is provided to align the TX_SOP signal on the chip
+pins to the TX SOP on the MDI pins. Jitter should be within ± 4ns by design for
+all speeds. Using TX_SOP makes more sense for the TX path since it would remove
+any variable PHY delays, which would happen depending on the speed/MAC interface
+mode, e.g., in the ADIN1300/1200:
+
+-  In 1000BASE-T for any MAC interface (GMII/RGMII).
+-  In 100BASE-TX and 10BASE-T for RGMII interface.
+
+The recommended SopTxDel values (called out in the datasheet register
+documentation) would align the TX_SOP signal to the SOP signal on the MDI pins.
+
+.. image:: images/soptx.png
+   :align: center
+   :width: 600
+
+SopRxDelay Delay Register
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+RX_SOP is less useful in general, since there is only a variable PHY delay in
+the RX path in ADIN1300/1200 when the RMII interface is used (100BASE-TX or
+10BASE-T). In all other cases, there is no variable delay in the RX path, and
+therefore the SOP signal can be extracted at the MAC side. The timing between
+RX_SOP and the MAC side RX SOP (RX_DV=1, RXD = 0xD5) sampled on the rising edge
+of RX_CLK) would be fixed (See figure below). But since the RX MAC interface
+signals are synchronous to RX_CLK, while RX_SOP is not, the later would have to
+be re-synchronized to the MAC clock, so it might have in fact less precision
+(depending on the MAC implementation). The t1 value would be independent of the
+MAC interface (MII/GMII/RGMII/RMII). The values (from simulation) are:
+
+- In 100BASE-TX: t1 = 260 ns - In 1000BASE-T: t1 = 212 ns The RX_SOP signal at
+  the chip pin will have some additional delay, due to the internal routing and
+  the I/O cell delay, which will be heavily dependent on the loading and PVT,
+  estimate for that delay to be somewhere between 2 ns and 6 ns. The SopRxDel
+  delay does not make so much sense in general for ADIN1200/1300. Given that the
+  RX SOP on the MDI pins will happen before the RX_SOP signal on the chip pin,
+  to align both signals (as done in the TX side), it would be required to
+  advance the RX_SOP signal rather than delay it, but that is obviously not
+  possible. Therefore, the SopRxDel delay was intended for a different purpose,
+  it is provided for cases where there may be a very long latency in the MAC
+  interface (for example if the PHY had an SGMII interface) to ensure that the
+  RX_SOP signal is received at the MAC side during the corresponding frame, as
+  if that was not the case it might cause problems.
+
+|image2|
+
+--------------
+
+Voltage Mode Line Drive
+~~~~~~~~~~~~~~~~~~~~~~~
+
+The ADIN1200 & ADIN1300 are voltage mode with on chip terminations. Therefore,
+there is no need for external termination resistors from the center tap of the
+transformer to the supply as required in current mode line drivers. In addition
+to reducing components, Voltage mode driver also manifests a significant
+reduction in power consumption versus current mode.
+
+When comparing PHY devices, ensure to check whether the output stage is voltage
+mode or current mode and also review whether the power consumption figures for
+current mode include the current dissipated in the transformer as a result of
+termination resistors.
+
+--------------
+
+Connecting a Cable to an Unpowered Device
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ADIN1300 and ADIN1200 have internal protection circuitry on the MDI pins
+that will protect them from damage when standard ethernet traffic is sent into
+an unpowered device from a remote active device.
+
+--------------
+
+Do the Exposed Pad and Bus Bars have to be soldered down?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The LFCSP has an exposed pad underneath the package that must be soldered to the
+PCB ground for electrical, mechanical and thermal reasons. For thermal impedance
+performance and to maximize heat removal, use of a 4 × 4 array of thermal vias
+beneath the exposed ground pad is recommended.
+
+There are also two bus bars on either side of the exposed pad, these bus bars are connected to internal voltage rails and are **not** intended to, and should **not** be soldered to the board. The PCB land pattern must incorporate the exposed ground paddle with vias and two keep out areas around the bus bars in the footprint. No PCB traces or vias can be used in either of the keep out areas. The EVAL-ADIN1300FMCZ uses an array of 4 × 4 vias on a 0.75 mm grid arrangement, as shown in the figure below. The via pad diameter dimension is 0.02 in. (0.5015 mm) and the finished drill hole diameter is 0.01 in. (0.2489 mm). This also applies to the exposed pad and bus bars for the ADIN1200. See the ADIN1200 Datasheet for the equivalent figure relating to the different package size.
+
+.. image:: images/adin1300_paddle_and_keep_out_areas.png
+   :align: center
+
+.. |image1| image:: images/phy_compare.jpg
+   :width: 800
+.. |image2| image:: images/soprx.png
+   :width: 600


### PR DESCRIPTION
## Summary
- Move adin1300-and-adin1200 wiki documentation to `solutions/reference-designs/adin1300-and-adin1200/`
- 16 RST files with 190 localized images
- Generated stub `index.rst` with toctree

## Test plan
- [ ] Sphinx build passes without errors
- [ ] All toctree entries resolve correctly
- [ ] Images render properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)