### PR TITLE
reference-designs/admx3: Add admx3 documentation

### DIFF
--- a/docs/solutions/reference-designs/admx3/admx3652.rst
+++ b/docs/solutions/reference-designs/admx3/admx3652.rst
@@ -1,0 +1,370 @@
+EVAL-ADMX3652Z, 6 ½-digit ±20V Dual channel Digital Voltmeter User Guide
+========================================================================
+
+Features
+--------
+
+-  90 days accuracy: up to 17ppm of reading at 2V range
+-  Manual and auto range selection, auto zero function
+-  Power sequence monitor & input protection
+-  UART communication interface, SCPI protocol
+-  5V power supply
+
+Package Contents
+----------------
+
+-  EVAL-ADMX3652Z Evaluation board
+
+Additional Equipment Needed
+---------------------------
+
+-  EVAL-ADMX3652Z-INT interface board
+-  PC running Windows 7 or newer
+-  Male USB A to Male USB B Cable
+-  Voltmeter test leads
+
+Software Needed
+---------------
+
+-  ADMX3652 Evaluation GUI
+
+General Description
+===================
+
+The EVAL-ADMX3652Z is a 6 ½ digit ±20V dual channel digital voltage meter.
+Selection within the 3 measurement ranges can be done manually, or through the
+auto range function. With EVAL-ADMX3652’s small form factor, it can be easily
+integrated into a system, or can also serve as a benchtop voltmeter when
+connected with the EVAL-ADMX3652Z-INT, an interface board that enables the
+EVAL-ADMX3652Z be used with an intuitive GUI for evaluation. This interface
+communicates from the EVAL-ADMX3652Z via USB to UART with a Windows PC and has 2
+voltage measurement channels using banana jack connectors.
+
+DC Accuracy Specifications
+--------------------------
+
+.. container:: centeralign
+
+   *Table 1. DC Voltage ± (% of reading + % of range)\ :sup:`1`*
+
++-----------------+------------+-------------------------------------+------------------------------+--------------------------------------+
+| Range\ :sup:`2` | Resolution | 24Hr\ :sup:`3` (T\ :sub:`CAL` ±1°C) | 90 days (T\ :sub:`CAL` ±5°C) | Temperature coefficient/°C\ :sup:`4` |
++=================+============+=====================================+==============================+======================================+
+| 200mV           | 200nV      | 0.0017+0.0017                       | 0.0098+0.0040                | 0.0005+0.0005                        |
++-----------------+------------+-------------------------------------+------------------------------+--------------------------------------+
+| 2V              | 2uV        | 0.0005+0.0002                       | 0.0017+0.0008                | 0.0001+0.0001                        |
++-----------------+------------+-------------------------------------+------------------------------+--------------------------------------+
+| 20V             | 20uV       | 0.0006+0.0001                       | 0.0012+0.0004                | 0.0005+0.0001                        |
++-----------------+------------+-------------------------------------+------------------------------+--------------------------------------+
+
+-  Specifications are for 60-minute warm up, aperture time of 100NPLC, and auto-zero.
+-  10% overrange on all ranges.
+-  Relative to calibration standards.
+-  Add this for each °C outside T\ :sub:`CAL` ±5°C.
+
+Quick Start Guide
+=================
+
+The EVAL-ADMX3652Z Evaluation board directly ties its 5V input to the power rail
+of the EVAL-ADMX3652Z-INT interface board, which eliminates the need for
+external power supply in the system. To setup for evaluation, use the following
+sequence:
+
+-  Mount the EVAL-ADMX3652Z firmly together with the EVAL-ADMX3652Z-INT Interface Board
+-  Connect the voltage measurement test leads to the Interface Board
+-  Connect the Interface board to the host Windows PC thru a USB A to USB B cable
+-  Download and install the FTDI Driver and ADMX3652Z Evaluation GUI
+-  Launch the GUI
+
+Evaluation Setup
+================
+
+Evaluation Board Hardware
+-------------------------
+
+.. container:: centeralign
+
+   \ |image1|\
+
+.. container:: centeralign
+
+   \ *Figure 1. EVAL-ADMX3652Z*\
+
+.. container:: centeralign
+
+   |image2|\
+
+.. container:: centeralign
+
+   \ *Figure 2. EVAL-ADMX3652Z-INT*\
+
+Hardware Setup
+--------------
+
+.. container:: centeralign
+
+   \ |image3|\
+
+.. container:: centeralign
+
+   \ *Figure 3. ADMX3652Z Hardware Setup*\
+
+Figure 3 illustrates the evaluation system components. To use the system
+properly, make sure to firmly mount the EVAL-ADMX3652Z to the EVAL-ADMX3652Z-INT
+board. Next, connect the interface board to the host PC through a USB A to USB B
+cable. Connect the voltmeter test leads to the banana jack connectors on the
+interface board, and apply an input stimulus to one or both the interface board
+measurement channels. Both channels 1 and 2 have a dedicated measurement display
+on the Software GUI, and contains functions the user can adjust depending on the
+measurement needs.
+
+Software Setup
+--------------
+
+Getting Started
+---------------
+
+From the EVAL-ADMX3652Z webpage the Software pack is available for download.
+Inside the downloadable zip file should contain 2 installers, the CDM212364
+driver and the ADMX3652Z installer. Figure 4 shows the required files for the
+GUI to be extracted and installed.
+
+.. container:: centeralign
+
+   \ |gui_installers.png|\
+
+.. container:: centeralign
+
+   \ *Figure 4. ADMX3652Z GUI Driver and Installer*\
+
+Software Installation Procedures
+--------------------------------
+
+Installing the Software Driver
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+After downloading the files, double-click on the CDM212364 Driver. Run the
+installer and it will prompt you to extract the driver package, then launch the
+installer. See Figure 5 for reference.
+
+.. container:: centeralign
+
+   \ |image4|\
+
+.. container:: centeralign
+
+   \ *Figure 5. Extract the package then Install*\
+
+Next, the License Agreement would appear. Tick “I accept this agreement” then
+click “Next”. The driver package will then be extracted and installed to your
+host PC. After it completes the process, click “Finish”. See Figure 6 for
+reference.
+
+.. container:: centeralign
+
+   \ |image5|\
+
+.. container:: centeralign
+
+   \ *Figure 6. Accept License Agreement then click Finish*\
+
+This completes the installation of the driver, which will enable the
+EVAL-ADMX3652Z setup to be automatically detected whenever connected to the host
+PC.
+
+Installing the ADMX3652Z GUI
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+After downloading the Software pack from the ADMX3652Z webpage, double-click on
+the ADMX3652Z installer. Run the installer and tick the “I accept the agreement”
+then click Next. Refer to figure 7.
+
+.. container:: centeralign
+
+   \ |image6|\
+
+.. container:: centeralign
+
+   \ *Figure 7. Run the Installer then Accept License Agreement*\
+
+Next, select a location where the ADMX3652Z GUI would be installed, then click
+Finish. Refer to Figure 8.
+
+.. container:: centeralign
+
+   \ |image7|\
+
+.. container:: centeralign
+
+   \ *Figure 8. Select Installation location then click Finish*\
+
+The software installation is now complete and the ADMX3652 Evaluation GUI is now
+ready for use.
+
+Software Operation
+~~~~~~~~~~~~~~~~~~
+
+Figure 9 shows the default setup of the ADMX3652Z GUI after installation and
+startup.
+
+.. container:: centeralign
+
+   \ |Figure X. ADMX3652Z Evaluation GUI|\
+
+.. container:: centeralign
+
+   \ *Figure 9. ADMX3652Z Evaluation GUI in Light Mode(left) and Dark Mode(right)*\
+
+To start using the GUI, click “Connect”. It will prompt the port selection
+dialog and will automatically detect the serial port that ADMX3652Z will be
+using. Click “Confirm”. Refer to Figure 10.
+
+.. container:: centeralign
+
+   \ |image8|\
+
+.. container:: centeralign
+
+   \ *Figure 10. Serial Port Confirmation*\
+
+.. note::
+
+   Note: There is around 5s loading time for the software to be ready to
+   measure.
+
+Interface Functions
+~~~~~~~~~~~~~~~~~~~
+
+The different functions found within the GUI are the following:
+
+Connect / Disconnect Button
+---------------------------
+
+| |image9|
+| The Connect button changes to Disconnect button when the user has properly established connection with the device. Use this button to disconnect the communication of the GUI with the device. Once disconnected, settings will be disabled and cannot be changed.
+
+Reset Button
+------------
+
+| |image10|
+| If connected, use reset button to change the settings to default and send a signal to the board to reset the EVAL-ADMX3652Z to its default factory settings. Once reset, loading screen willappear (same as the first run) and settings will be disabled.
+
+Power Line Frequency Selection
+------------------------------
+
+| |image11|
+| Set the Power Line frequency depending on standard AC line frequency used where user is located.
+
+.. note::
+
+   Note: Power Line Frequency = 50Hz is set as the default.
+
+Light / Dark Mode
+-----------------
+
+| |image12|
+| Set the user interface's appearance based on user's preference.
+
+Voltage Display
+---------------
+
+| |image13|
+| Measurement within the +/- 20V range is shown, and above the 10% tolerance of any measurement range, the OVERLOAD display is shown.
+
+Status Bar
+----------
+
+| The status bar displays the status of the GUI, whether it is connected or disconnected. During measurement, it shows the measurement done in one or both the channels. |image14|
+| The measurements displayed in the status bar are also logged into a logs.txt file and can be found on the location where the ADMX3652Z software is installed.
+
+Channel Measurement Configurations
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The following measurement configurations are separately available for both
+channels 1 and 2 of the EVAL-ADMX3652Z. These settings can be configured
+differently and independently based on user's measurement needs.
+
+Range Selection
+---------------
+
+| The measurement range for EVAL-ADMX3652Z can be set manually, or can be used with the Auto range function. |image15|
+| Three ranges are available to be set manually: 0.2V, 2.0V or 20V.
+
+.. note::
+
+   Note: Measurement range = 2.0V is set as the default.
+
+Aperture / NPLC
+---------------
+
+| Aperture time is the period of time used for reading the input signal. Larger aperture times means better resolution. Select short aperture times for faster measurement speed. The unit used for specifying aperture time with the EVAL-ADMX3652Z is in number of power line cycles (NPLC). |image16|
+| Aperture time can be set and selected either 0.05, 0.1, 0.25, 0.5, 1, 10, or 100.
+
+.. note::
+
+   Note: Aperture = 10 is set as the default.
+
+Single Button
+-------------
+
+| |image17|
+| Use single button to do a single measurement. It will also act as stop button if measurement is set as continuously running.
+
+Run / Stop Button
+-----------------
+
+| |image18|
+| Use the Run button to continuously measure voltage. It will change to Stop button when continuously running.
+
+.. note::
+
+   Note: CH1 set on Run button while CH2 set on Stop button are set as the
+   default.
+
+EVAL-ADMX3652Z Support
+======================
+
+Calibration reports are available upon request for EVAL-ADMX3652Z, and technical
+support for hardware and software concerns can be sent to the following e-mail
+address: admx3652-support@analog.com.
+
+.. |image1| image:: images/dvm.png
+   :width: 600
+.. |image2| image:: images/interface_board_redblack.png
+   :width: 400
+.. |image3| image:: images/dvm_setup.png
+   :width: 600
+.. |gui_installers.png| image:: images/gui_installers.png
+   :width: 400
+.. |image4| image:: images/driver_1_2.png
+   :width: 800
+.. |image5| image:: images/driver_3_4.png
+   :width: 800
+.. |image6| image:: images/installer_1_2.png
+   :width: 800
+.. |image7| image:: images/installer_3_4.png
+   :width: 800
+.. |Figure X. ADMX3652Z Evaluation GUI| image:: images/gui.png
+   :width: 1400
+.. |image8| image:: images/connect_comport.png
+   :width: 400
+.. |image9| image:: images/connect_disconnect.png
+   :width: 400
+.. |image10| image:: images/reset.png
+   :width: 100
+.. |image11| image:: images/plf.png
+   :width: 250
+.. |image12| image:: images/darklight.png
+   :width: 300
+.. |image13| image:: images/display.png
+   :width: 400
+.. |image14| image:: images/logwindow.png
+   :width: 600
+.. |image15| image:: images/range.png
+   :width: 250
+.. |image16| image:: images/aperture.png
+   :width: 250
+.. |image17| image:: images/single.png
+   :width: 100
+.. |image18| image:: images/runstop.png
+   :width: 200

--- a/docs/solutions/reference-designs/admx3/admx3652.rst
+++ b/docs/solutions/reference-designs/admx3/admx3652.rst
@@ -29,7 +29,7 @@ Software Needed
 -  ADMX3652 Evaluation GUI
 
 General Description
-===================
+-------------------
 
 The EVAL-ADMX3652Z is a 6 ½ digit ±20V dual channel digital voltage meter.
 Selection within the 3 measurement ranges can be done manually, or through the
@@ -57,57 +57,60 @@ DC Accuracy Specifications
 | 20V             | 20uV       | 0.0006+0.0001                       | 0.0012+0.0004                | 0.0005+0.0001                        |
 +-----------------+------------+-------------------------------------+------------------------------+--------------------------------------+
 
--  Specifications are for 60-minute warm up, aperture time of 100NPLC, and auto-zero.
+-  Specifications are for 60-minute warm up, aperture time of 100NPLC, and
+   auto-zero.
 -  10% overrange on all ranges.
 -  Relative to calibration standards.
 -  Add this for each °C outside T\ :sub:`CAL` ±5°C.
 
 Quick Start Guide
-=================
+-----------------
 
 The EVAL-ADMX3652Z Evaluation board directly ties its 5V input to the power rail
 of the EVAL-ADMX3652Z-INT interface board, which eliminates the need for
 external power supply in the system. To setup for evaluation, use the following
 sequence:
 
--  Mount the EVAL-ADMX3652Z firmly together with the EVAL-ADMX3652Z-INT Interface Board
+-  Mount the EVAL-ADMX3652Z firmly together with the EVAL-ADMX3652Z-INT
+   Interface Board
 -  Connect the voltage measurement test leads to the Interface Board
--  Connect the Interface board to the host Windows PC thru a USB A to USB B cable
+-  Connect the Interface board to the host Windows PC thru a USB A to USB B
+   cable
 -  Download and install the FTDI Driver and ADMX3652Z Evaluation GUI
 -  Launch the GUI
 
 Evaluation Setup
-================
+----------------
 
 Evaluation Board Hardware
--------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. container:: centeralign
 
-   \ |image1|\
+   |image1|
 
 .. container:: centeralign
 
-   \ *Figure 1. EVAL-ADMX3652Z*\
+   *Figure 1. EVAL-ADMX3652Z*
 
 .. container:: centeralign
 
-   |image2|\
+   |image2|
 
 .. container:: centeralign
 
-   \ *Figure 2. EVAL-ADMX3652Z-INT*\
+   *Figure 2. EVAL-ADMX3652Z-INT*
 
 Hardware Setup
---------------
+~~~~~~~~~~~~~~
 
 .. container:: centeralign
 
-   \ |image3|\
+   |image3|
 
 .. container:: centeralign
 
-   \ *Figure 3. ADMX3652Z Hardware Setup*\
+   *Figure 3. ADMX3652Z Hardware Setup*
 
 Figure 3 illustrates the evaluation system components. To use the system
 properly, make sure to firmly mount the EVAL-ADMX3652Z to the EVAL-ADMX3652Z-INT
@@ -119,10 +122,10 @@ on the Software GUI, and contains functions the user can adjust depending on the
 measurement needs.
 
 Software Setup
---------------
+~~~~~~~~~~~~~~
 
 Getting Started
----------------
+~~~~~~~~~~~~~~~
 
 From the EVAL-ADMX3652Z webpage the Software pack is available for download.
 Inside the downloadable zip file should contain 2 installers, the CDM212364
@@ -131,17 +134,17 @@ GUI to be extracted and installed.
 
 .. container:: centeralign
 
-   \ |gui_installers.png|\
+   |gui_installers.png|
 
 .. container:: centeralign
 
-   \ *Figure 4. ADMX3652Z GUI Driver and Installer*\
+   *Figure 4. ADMX3652Z GUI Driver and Installer*
 
 Software Installation Procedures
---------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Installing the Software Driver
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 After downloading the files, double-click on the CDM212364 Driver. Run the
 installer and it will prompt you to extract the driver package, then launch the
@@ -149,11 +152,11 @@ installer. See Figure 5 for reference.
 
 .. container:: centeralign
 
-   \ |image4|\
+   |image4|
 
 .. container:: centeralign
 
-   \ *Figure 5. Extract the package then Install*\
+   *Figure 5. Extract the package then Install*
 
 Next, the License Agreement would appear. Tick “I accept this agreement” then
 click “Next”. The driver package will then be extracted and installed to your
@@ -162,18 +165,18 @@ reference.
 
 .. container:: centeralign
 
-   \ |image5|\
+   |image5|
 
 .. container:: centeralign
 
-   \ *Figure 6. Accept License Agreement then click Finish*\
+   *Figure 6. Accept License Agreement then click Finish*
 
 This completes the installation of the driver, which will enable the
 EVAL-ADMX3652Z setup to be automatically detected whenever connected to the host
 PC.
 
 Installing the ADMX3652Z GUI
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 After downloading the Software pack from the ADMX3652Z webpage, double-click on
 the ADMX3652Z installer. Run the installer and tick the “I accept the agreement”
@@ -181,22 +184,22 @@ then click Next. Refer to figure 7.
 
 .. container:: centeralign
 
-   \ |image6|\
+   |image6|
 
 .. container:: centeralign
 
-   \ *Figure 7. Run the Installer then Accept License Agreement*\
+   *Figure 7. Run the Installer then Accept License Agreement*
 
 Next, select a location where the ADMX3652Z GUI would be installed, then click
 Finish. Refer to Figure 8.
 
 .. container:: centeralign
 
-   \ |image7|\
+   |image7|
 
 .. container:: centeralign
 
-   \ *Figure 8. Select Installation location then click Finish*\
+   *Figure 8. Select Installation location then click Finish*
 
 The software installation is now complete and the ADMX3652 Evaluation GUI is now
 ready for use.
@@ -209,11 +212,11 @@ startup.
 
 .. container:: centeralign
 
-   \ |Figure X. ADMX3652Z Evaluation GUI|\
+   |Figure X. ADMX3652Z Evaluation GUI|
 
 .. container:: centeralign
 
-   \ *Figure 9. ADMX3652Z Evaluation GUI in Light Mode(left) and Dark Mode(right)*\
+   *Figure 9. ADMX3652Z Evaluation GUI in Light Mode(left) and Dark Mode(right)*
 
 To start using the GUI, click “Connect”. It will prompt the port selection
 dialog and will automatically detect the serial port that ADMX3652Z will be
@@ -221,15 +224,15 @@ using. Click “Confirm”. Refer to Figure 10.
 
 .. container:: centeralign
 
-   \ |image8|\
+   |image8|
 
 .. container:: centeralign
 
-   \ *Figure 10. Serial Port Confirmation*\
+   *Figure 10. Serial Port Confirmation*
 
 .. note::
 
-   Note: There is around 5s loading time for the software to be ready to
+   There is around 5s loading time for the software to be ready to
    measure.
 
 Interface Functions
@@ -238,41 +241,41 @@ Interface Functions
 The different functions found within the GUI are the following:
 
 Connect / Disconnect Button
----------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 | |image9|
 | The Connect button changes to Disconnect button when the user has properly established connection with the device. Use this button to disconnect the communication of the GUI with the device. Once disconnected, settings will be disabled and cannot be changed.
 
 Reset Button
-------------
+^^^^^^^^^^^^
 
 | |image10|
-| If connected, use reset button to change the settings to default and send a signal to the board to reset the EVAL-ADMX3652Z to its default factory settings. Once reset, loading screen willappear (same as the first run) and settings will be disabled.
+| If connected, use reset button to change the settings to default and send a signal to the board to reset the EVAL-ADMX3652Z to its default factory settings. Once reset, loading screen will appear (same as the first run) and settings will be disabled.
 
 Power Line Frequency Selection
-------------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 | |image11|
 | Set the Power Line frequency depending on standard AC line frequency used where user is located.
 
 .. note::
 
-   Note: Power Line Frequency = 50Hz is set as the default.
+   Power Line Frequency = 50Hz is set as the default.
 
 Light / Dark Mode
------------------
+^^^^^^^^^^^^^^^^^
 
 | |image12|
 | Set the user interface's appearance based on user's preference.
 
 Voltage Display
----------------
+^^^^^^^^^^^^^^^
 
 | |image13|
 | Measurement within the +/- 20V range is shown, and above the 10% tolerance of any measurement range, the OVERLOAD display is shown.
 
 Status Bar
-----------
+^^^^^^^^^^
 
 | The status bar displays the status of the GUI, whether it is connected or disconnected. During measurement, it shows the measurement done in one or both the channels. |image14|
 | The measurements displayed in the status bar are also logged into a logs.txt file and can be found on the location where the ADMX3652Z software is installed.
@@ -285,44 +288,44 @@ channels 1 and 2 of the EVAL-ADMX3652Z. These settings can be configured
 differently and independently based on user's measurement needs.
 
 Range Selection
----------------
+^^^^^^^^^^^^^^^
 
 | The measurement range for EVAL-ADMX3652Z can be set manually, or can be used with the Auto range function. |image15|
 | Three ranges are available to be set manually: 0.2V, 2.0V or 20V.
 
 .. note::
 
-   Note: Measurement range = 2.0V is set as the default.
+   Measurement range = 2.0V is set as the default.
 
 Aperture / NPLC
----------------
+^^^^^^^^^^^^^^^
 
 | Aperture time is the period of time used for reading the input signal. Larger aperture times means better resolution. Select short aperture times for faster measurement speed. The unit used for specifying aperture time with the EVAL-ADMX3652Z is in number of power line cycles (NPLC). |image16|
 | Aperture time can be set and selected either 0.05, 0.1, 0.25, 0.5, 1, 10, or 100.
 
 .. note::
 
-   Note: Aperture = 10 is set as the default.
+   Aperture = 10 is set as the default.
 
 Single Button
--------------
+^^^^^^^^^^^^^
 
 | |image17|
 | Use single button to do a single measurement. It will also act as stop button if measurement is set as continuously running.
 
 Run / Stop Button
------------------
+^^^^^^^^^^^^^^^^^
 
 | |image18|
 | Use the Run button to continuously measure voltage. It will change to Stop button when continuously running.
 
 .. note::
 
-   Note: CH1 set on Run button while CH2 set on Stop button are set as the
+   CH1 set on Run button while CH2 set on Stop button are set as the
    default.
 
 EVAL-ADMX3652Z Support
-======================
+----------------------
 
 Calibration reports are available upon request for EVAL-ADMX3652Z, and technical
 support for hardware and software concerns can be sent to the following e-mail

--- a/docs/solutions/reference-designs/admx3/images/aperture.png
+++ b/docs/solutions/reference-designs/admx3/images/aperture.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a21f7c3e1abac932fa8eeaee0024636a8fb16210c986e0cd1d0a7c03a26898f5
+size 50227

--- a/docs/solutions/reference-designs/admx3/images/connect_comport.png
+++ b/docs/solutions/reference-designs/admx3/images/connect_comport.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5a45b7d506f0f2a7291ddca44bfb5cfa93960b95c2d6b976f119e9864078c2a2
+size 42659

--- a/docs/solutions/reference-designs/admx3/images/connect_disconnect.png
+++ b/docs/solutions/reference-designs/admx3/images/connect_disconnect.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:100059e5f5871eee5e1bb8e683bca246baa581361c022c001d892aca0f854e35
+size 43010

--- a/docs/solutions/reference-designs/admx3/images/darklight.png
+++ b/docs/solutions/reference-designs/admx3/images/darklight.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7c6b126234a7f31085811f22920c2093a7b081c8c134d140f2923ad1cb3d1bfc
+size 2995

--- a/docs/solutions/reference-designs/admx3/images/display.png
+++ b/docs/solutions/reference-designs/admx3/images/display.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c25786e2769d36652b3a06315f9955317f3af18ade2d8f42392ef90e2ae1421e
+size 22293

--- a/docs/solutions/reference-designs/admx3/images/driver_1_2.png
+++ b/docs/solutions/reference-designs/admx3/images/driver_1_2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c08b289559916369f330b076e7f8266b8420c3ecb4493516598c27bc5d9ef12d
+size 352029

--- a/docs/solutions/reference-designs/admx3/images/driver_3_4.png
+++ b/docs/solutions/reference-designs/admx3/images/driver_3_4.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4d5b509fb79fad1de20043dfe10629c5c2372a33bc72e41021edfd34ec57f23b
+size 321651

--- a/docs/solutions/reference-designs/admx3/images/dvm.png
+++ b/docs/solutions/reference-designs/admx3/images/dvm.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3380e8f6fd9877c175fdceba81de143c33598e23df8015219f114d5d692e2f9c
+size 925533

--- a/docs/solutions/reference-designs/admx3/images/dvm_setup.png
+++ b/docs/solutions/reference-designs/admx3/images/dvm_setup.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5fb48690a392973a0158e7654a356b35ed4b24dcbc26380f8717d1db77a2f52f
+size 1697805

--- a/docs/solutions/reference-designs/admx3/images/gui.png
+++ b/docs/solutions/reference-designs/admx3/images/gui.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:209602e759584473f41878e430af7d52a2b4287e3d004b12ff6d591c10fd35e0
+size 161269

--- a/docs/solutions/reference-designs/admx3/images/gui_installers.png
+++ b/docs/solutions/reference-designs/admx3/images/gui_installers.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:36a8bb7fd2c6f862702d86fac5a96bad850c795f20fcb99e2216118c4a4612b5
+size 27987

--- a/docs/solutions/reference-designs/admx3/images/installer_1_2.png
+++ b/docs/solutions/reference-designs/admx3/images/installer_1_2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4a9152e07825b1d7f46e29db8e0546a2cecbbab44e799e24de6a7a928fa56ae8
+size 384526

--- a/docs/solutions/reference-designs/admx3/images/installer_3_4.png
+++ b/docs/solutions/reference-designs/admx3/images/installer_3_4.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c35f5b9fccc5f47800c1e3b74e3f1f9e58d452cdb315c8bec152511f2f38203a
+size 253802

--- a/docs/solutions/reference-designs/admx3/images/interface_board_redblack.png
+++ b/docs/solutions/reference-designs/admx3/images/interface_board_redblack.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f649c8edb9be146fecc216b213ed71f32ba19259e70395dd4374e274d07bd3f3
+size 396785

--- a/docs/solutions/reference-designs/admx3/images/logwindow.png
+++ b/docs/solutions/reference-designs/admx3/images/logwindow.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:634aab430bb95f21a47d88a090e42de717ec033052d1ddad677b1f03afc42752
+size 30743

--- a/docs/solutions/reference-designs/admx3/images/plf.png
+++ b/docs/solutions/reference-designs/admx3/images/plf.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:01700a9e8cb8353f32ad6c02f31a7bd3046bc61f1e1a5e90788aa1af3b55c1e5
+size 2452

--- a/docs/solutions/reference-designs/admx3/images/range.png
+++ b/docs/solutions/reference-designs/admx3/images/range.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b17c5345093b4881409e7e3a64e50b5ed64d9b17ad3a967f6ee8b702981f9b52
+size 55786

--- a/docs/solutions/reference-designs/admx3/images/reset.png
+++ b/docs/solutions/reference-designs/admx3/images/reset.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:386b3cbd4fa887505019e8e36f13e60edbd1b6d40e967efc0b968d6987c213e1
+size 1111

--- a/docs/solutions/reference-designs/admx3/images/runstop.png
+++ b/docs/solutions/reference-designs/admx3/images/runstop.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2cdb6904e685d7135b5a54974931878a5735373bd92ae7081d8fc83597c0810f
+size 12512

--- a/docs/solutions/reference-designs/admx3/images/single.png
+++ b/docs/solutions/reference-designs/admx3/images/single.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e6e670059dfb6c54152dfa226b041d3c0fc005ea0f5323e9cdb58d18dc066bf1
+size 5792

--- a/docs/solutions/reference-designs/admx3/index.rst
+++ b/docs/solutions/reference-designs/admx3/index.rst
@@ -1,7 +1,45 @@
+.. _admx3 eval:
+
 ADMX3
-=====
+===============================
+
+.. TODO: Add a picture of the chip/board
+
+Overview
+-------------------------------------------------------------------------------
+
+.. TODO: Describe in max 10 rows the main features and applications.
+
+Features:
+
+- feature 1
+- feature 2
+
+Applications:
+
+- application 1
+- application 2
 
 .. toctree::
-   :titlesonly:
+   :hidden:
 
    admx3652
+
+Recommendations
+-------------------------------------------------------------------------------
+
+People who follow the flow that is outlined, have a much better experience with
+things. However, like many things, documentation is never as complete as it
+should be. If you have any questions, feel free to ask on our
+:ref:`EngineerZone forums <help-and-support>`, but before that, please make
+sure you read our documentation thoroughly.
+
+Warning
+-------------------------------------------------------------------------------
+
+.. esd-warning::
+
+Help and support
+-------------------------------------------------------------------------------
+
+Please go to :ref:`Help and Support <help-and-support>` page.

--- a/docs/solutions/reference-designs/admx3/index.rst
+++ b/docs/solutions/reference-designs/admx3/index.rst
@@ -1,0 +1,7 @@
+ADMX3
+=====
+
+.. toctree::
+   :titlesonly:
+
+   admx3652


### PR DESCRIPTION
## Summary
- Move admx3 wiki documentation to `solutions/reference-designs/admx3/`
- 2 RST files with 20 localized images
- Generated stub `index.rst` with toctree

## Test plan
- [ ] Sphinx build passes without errors
- [ ] All toctree entries resolve correctly
- [ ] Images render properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)