### PR TITLE
reference-designs/adrv2crr-fmc: Add adrv2crr-fmc documentation

### DIFF
--- a/docs/solutions/reference-designs/adrv2crr-fmc/images/adrv2crr-crr-switch.jpg
+++ b/docs/solutions/reference-designs/adrv2crr-fmc/images/adrv2crr-crr-switch.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:10e243c731f2833b1bfebd5afe5b16bcacdcec83435fc6a34905dd86e8b73fe2
+size 14269

--- a/docs/solutions/reference-designs/adrv2crr-fmc/images/adrv2crr-fmc-boot2.png
+++ b/docs/solutions/reference-designs/adrv2crr-fmc/images/adrv2crr-fmc-boot2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4dda1e239aa7132d18ad4fd345423745a14dd1e0cbbe1627899a914252875cb6
+size 395186

--- a/docs/solutions/reference-designs/adrv2crr-fmc/images/adrv2crr-o20-p18-jumpers.jpg
+++ b/docs/solutions/reference-designs/adrv2crr-fmc/images/adrv2crr-o20-p18-jumpers.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:70940bada250e6546e199c3c6afc007c418f205b994c056747d932a39c448b14
+size 79997

--- a/docs/solutions/reference-designs/adrv2crr-fmc/images/adrv2crr-switch-pins-position.png
+++ b/docs/solutions/reference-designs/adrv2crr-fmc/images/adrv2crr-switch-pins-position.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9d91e527f92fe789512bb9557e935f476a01ce27bda2422d06c0f3f78ede5da9
+size 1179134

--- a/docs/solutions/reference-designs/adrv2crr-fmc/images/boot-pi-eth-conn.png
+++ b/docs/solutions/reference-designs/adrv2crr-fmc/images/boot-pi-eth-conn.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d0b586c1a1fb4c07d0733994583f8afd7bc25667158196e3a269a10e54e28e74
+size 196302

--- a/docs/solutions/reference-designs/adrv2crr-fmc/images/boot-pi-screen.png
+++ b/docs/solutions/reference-designs/adrv2crr-fmc/images/boot-pi-screen.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4d00cd9f6b6c96343c65f777b7eecff0c1cda570b87c83e997b4ab1c97f36843
+size 196268

--- a/docs/solutions/reference-designs/adrv2crr-fmc/images/test_failed_screen.jpg
+++ b/docs/solutions/reference-designs/adrv2crr-fmc/images/test_failed_screen.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ddd4c7311bdf18491b7f6765565354f8b09342dcba060f81d075411574e2f65c
+size 128195

--- a/docs/solutions/reference-designs/adrv2crr-fmc/images/test_passed_screen.jpg
+++ b/docs/solutions/reference-designs/adrv2crr-fmc/images/test_passed_screen.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b7789cd509db5f5a083a9b3b7f91066db7ba86783d37f2f30e8f6c03394235fa
+size 238957

--- a/docs/solutions/reference-designs/adrv2crr-fmc/images/zu11eg-prod-test-setup.jpg
+++ b/docs/solutions/reference-designs/adrv2crr-fmc/images/zu11eg-prod-test-setup.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d1c03741d58bdc9c0b0cb42707d201eb02e6580052bc1240e61c79ce73994487
+size 502672

--- a/docs/solutions/reference-designs/adrv2crr-fmc/index.rst
+++ b/docs/solutions/reference-designs/adrv2crr-fmc/index.rst
@@ -1,0 +1,7 @@
+ADRV2CRR-FMC
+============
+
+.. toctree::
+   :titlesonly:
+
+   testing

--- a/docs/solutions/reference-designs/adrv2crr-fmc/index.rst
+++ b/docs/solutions/reference-designs/adrv2crr-fmc/index.rst
@@ -1,7 +1,45 @@
-ADRV2CRR-FMC
-============
+.. _adrv2crr_fmc eval:
+
+ADRV2CRR FMC
+=========================================================================
+
+.. TODO: Add a picture of the chip/board
+
+Overview
+-------------------------------------------------------------------------------
+
+.. TODO: Describe in max 10 rows the main features and applications.
+
+Features:
+
+- feature 1
+- feature 2
+
+Applications:
+
+- application 1
+- application 2
 
 .. toctree::
-   :titlesonly:
+   :hidden:
 
    testing
+
+Recommendations
+-------------------------------------------------------------------------------
+
+People who follow the flow that is outlined, have a much better experience with
+things. However, like many things, documentation is never as complete as it
+should be. If you have any questions, feel free to ask on our
+:ref:`EngineerZone forums <help-and-support>`, but before that, please make
+sure you read our documentation thoroughly.
+
+Warning
+-------------------------------------------------------------------------------
+
+.. esd-warning::
+
+Help and support
+-------------------------------------------------------------------------------
+
+Please go to :ref:`Help and Support <help-and-support>` page.

--- a/docs/solutions/reference-designs/adrv2crr-fmc/testing.rst
+++ b/docs/solutions/reference-designs/adrv2crr-fmc/testing.rst
@@ -1,0 +1,224 @@
+ADRV2CRR-FMC Production Testing
+===============================
+
+Overview
+--------
+
+Production tests for ADRV9009-ZU11EG are composed of a series of Bash scripts
+that run both on Raspberry Pi and DUT (Device Under Test). The test procedure
+requires a Raspberry Pi 4 board (host) connected via Ethernet cable to the DUT.
+The Raspberry Pi board requires to have a HDMI monitor and USB keyboard
+connected. All test sequences are selected and started from the GUI interface
+displayed by Raspberry Pi on the monitor. Please find the required equipment
+list below:
+
+Required Hardware
+-----------------
+
+-  Raspberry Pi4: Is strictly required to be version 4 or newer. USB 3.0 connection is required during testing.
+-  HDMI monitor: monitor should be connected to Raspberry Pi to display the testing sequence and the testing results
+-  USB keyboard: keyboard should be connected to Raspberry Pi USB 2.0 port (black). It is required to interact with the testing SW.
+-  USB A-USB type C cable: It is required to be connected between Raspberry Pi USB 3.0 port (blue) and USB-C connector of DUT when USB device mode of DUT is tested. Will be displayed on test monitor
+-  USB A – Micro USB cable: Should be connected between Raspberry Pi USB 2.0 port and DUT microUSB UART connector (P8). This is required for UART over USB interface testing
+-  Raspberry Pi microSD card: A minimum 8GB Class 10 microSD card prepared for testing sequence as presented bellow should be inserted in Raspberry Pi.
+-  DUT SD card: A minimum 8GB Class 10 SD card prepared for testing sequence as presented bellow should be inserted in ADRV2CRR-FMC P15 slot.
+-  CAT5 ethernet cable: Using ethernet cable communication between Raspberry Pi and DUT is performed. On DUT side the ethernet cable should be connected on M2 port (Ethernet RGMII)
+-  I2C programming cable: This cable is required to be connected between Raspberry Pi I2C port (pins 3 - SDA, 2 - SCL and 6 – GND) and ADRV2CRR-FMC P19 pin header. Using this connection and item 1 from Raspberry Pi menu the ADM1266 sequencer can be programmed
+-  USB-C power supply is required for powering up the Raspberry Pi
+-  ADRV2CRR-FMC: is the carrier board that can be tested selecting item 3 on the test menu. It can be considered device under test or should be used as requirement when SOM is tested as support carrier for ADRV9009-ZU11EG RF-SOM
+-  ADRV9009-ZU11EG RF-SOM: can be tested selecting item 4 from test menu. It can be tested or used when testing ADRV2CRR-FMC
+-  QSFP loopback: should be connected to P3 on ADRV2CRR-FMC
+-  SFP loopback: should be connected to P4 on ADRV2CRR-FMC
+-  FMC loopback: should be connected to P1 on ADRV2CRR-FMC (Apissys AF101)
+-  PCI-Express loopback: should be powered on using an USB A – microUSB cable and connected to P17 on ADRV2CRR-FMC (Whizz Systems - PCIe Loopback Card)
+-  Ethernet loopback: should be connected on M1 port (Ethernet SGMII) on ADRV2CRR-FMC
+-  Audio loopback: should be connected to P6 and P5 connectors on ADRV2CRR-FMC
+-  U.FL loopback cables: required for RF testing of ADRV9009-ZU11EG RF-SOM
+-  Display Port to HDMI cable: should be connected to P2 video output on ADRV2CRR-FMC
+-  USB-C OTG cable: should be connected when USB host mode is tested
+-  USB 3.0 memory stick: should be FAT formatted and connected through USB-C OTG cable to ADRV2CRR-FMC when USB host mode is tested
+-  12V power supply: connected to P11 on ADRV2CRR-FMC.
+
+The complete test jig should look like:
+
+.. image:: images/zu11eg-prod-test-setup.jpg
+   :align: center
+   :width: 600
+
+Required Software
+~~~~~~~~~~~~~~~~~
+
+ADRV9009-ZU11EG SD card
+^^^^^^^^^^^^^^^^^^^^^^^
+
+The SD card image used for production testing is based on official release of
+Zynq images and can be downloaded from :
+
+.. admonition:: Download
+   :class: download
+
+   
+   -  **28 May 2020 release**
+   -   `Actual file <https://swdownloads.analog.com/cse/prod_test_rel/talise_test/adrv9009_fmcomms8_test_card_28_05.img.tar.xz>`_
+   -  Checksum ``9d3455a071f4151b9c320282abcb2f04``
+   
+
+.. admonition:: Download
+   :class: download
+
+   
+   -  **27 May 2020 release**
+   -   `Actual file <https://swdownloads.analog.com/cse/prod_test_rel/talise_test/adrv9009_som_test_card_27_05.img.tar.xz>`_
+   -  Checksum ``4efbaa39928f2f36b7b462156e6d00f6``
+   
+
+.. note::
+
+   To write it on SD card can follow the instructions for: `linux hosts <https://wiki.analog.com/resources/tools-software/linux-software/zynq_images/linux_hosts>`_ or `windows hosts <https://wiki.analog.com/resources/tools-software/linux-software/zynq_images/windows_hosts>`_
+
+Raspberry PI SD card
+^^^^^^^^^^^^^^^^^^^^
+
+The SD image used is based on Raspbian with desktop. On top of that are
+installed the testing scripts. The image can be created starting from vanilla
+Raspbian or downloaded from:
+
+.. admonition:: Download
+   :class: download
+
+   
+   -  **02 Nov 2021 release**
+   -  `Actual file <https://swdownloads.analog.com/cse/prod_test_rel/talise_test/adrv9009_pi_test_card_02_11.tar.xz>`_
+   -  Checksum ``080fb8771e12195eba7196f9de05ec1c``
+   
+
+.. admonition:: Download
+   :class: download
+
+   
+   -  **27 May 2020 release - outdated, do not use!**
+   -  `Actual file <https://swdownloads.analog.com/cse/prod_test_rel/talise_test/adrv9009_pi_test_card_27_05.img.tar.xz>`_
+   -  Checksum ``cf5b55f2a874ef43e47f269b4c534c9d``
+   
+
+.. note::
+
+   To write it on SD card can follow the instructions: `Installing PI images <https://www.raspberrypi.org/documentation/installation/installing-images/>`_
+
+Required setup steps
+~~~~~~~~~~~~~~~~~~~~
+
+-  Place the jumpers and switches in the following positions:
+
+   -  P22 in 2 and 3
+   -  P23, P24 in 1 and 2
+   -  S14, S15, S16 in 1
+   -  S13 in 0
+
+   |image1|
+
+-  P20, P18 in 1 and 2
+
+|image2|
+
+-  S9 in “Carrier”
+
+|image3|
+
+-  Connect HDMI cable to Raspberry Pi
+-  Connect USB keyboard to Raspberry Pi
+-  Insert Raspberry Pi microSD card
+-  Connect power supply to Raspberry Pi
+-  Connect all loopbacks to DUT
+-  Connect Ethernet cable between Raspberry Pi and DUT
+-  Connect USB cables between Raspberry Pi and DUT
+-  Insert SD card in DUT
+-  Connect DisplayPort cable to DUT
+-  Power on DUT
+
+Test process
+~~~~~~~~~~~~
+
+First make sure all the required setup explained above is completed. Once the
+test setup is ready, SOM testing should be done using the following steps:
+
+-  Power on both DUT and Raspberry Pi
+-  The following screen should be visible after Raspberry Pi booted:
+
+.. image:: images/boot-pi-screen.png
+   :align: center
+   :width: 800
+
+.. important::
+
+   When testing the ADRV2CRR-FMC the following test needs to be run: Test 3\
+
+-  Testing sequence can be started by selecting one of the menu items. In order
+   to start testing an Ethernet cable should be connected between Raspberry Pi
+   and DUT. At the beginning of every test the correct connection with DUT is
+   checked. If the connection cannot be established the following error message
+   will be printed:
+
+.. image:: images/boot-pi-eth-conn.png
+   :align: center
+   :width: 800
+
+.. tip::
+
+   Make sure that Ethernet cable is connected, DUT is powered up, DUT SD card is
+   inserted and boot mode switches (S13-S16) are configured for SD boot.
+
+-  If connection is OK the test will start. Below is an example of test 3
+   running:
+
+.. image:: images/adrv2crr-fmc-boot2.png
+   :align: center
+   :width: 800
+
+-  Follow on-screen instructions to complete the test.
+-  If test completed successfully the PASSED message will be printed in green
+   like in the screen bellow. This means that DUT passed all the assigned tests.
+
+.. image:: images/test_passed_screen.jpg
+   :align: center
+   :width: 600
+
+-  If one of the tests failed, the FAIL message will be printed like in the
+   screen capture bellow:
+
+.. image:: images/test_failed_screen.jpg
+   :align: center
+   :width: 600
+
+-  In case of a failed test the program will ask if the tester wants to repeat that test immediately. The test can be repeated by an undefined number of times.
+-  If the problem is persistent and the test failing continuously the test
+   engineer can decide to not repeat it anymore.
+
+.. tip::
+
+   In this situation it will be asked if user wants to close the test sequence
+   and declare the DUT tested failed or can respond NO(n) to question “Do you
+   want to close the test?” and in this way mark the test as passed and bypass
+   it.
+
+   
+   .. warning::
+
+      This is not recommended!
+
+   
+
+.. important::
+
+   When testing is finished ADRV and Raspberry PI should always be powered off
+   before power is unplugged otherwise the SD cards can be corrupted. First
+   should be selected item 9 to power off ADRV. The test engineer should wait
+   until LEDs DS6 and DS7 are off. Now the power can be disconnected from ADRV.
+   After ADRV is off the Raspberry PI can be turned off by selecting item 8.
+
+.. |image1| image:: images/adrv2crr-switch-pins-position.png
+   :width: 400
+.. |image2| image:: images/adrv2crr-o20-p18-jumpers.jpg
+   :width: 300
+.. |image3| image:: images/adrv2crr-crr-switch.jpg
+   :width: 300


### PR DESCRIPTION
## Summary
- Move adrv2crr-fmc wiki documentation to `solutions/reference-designs/adrv2crr-fmc/`
- 2 RST files with 9 localized images
- Generated stub `index.rst` with toctree

## Test plan
- [ ] Sphinx build passes without errors
- [ ] All toctree entries resolve correctly
- [ ] Images render properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)