### PR TITLE
reference-designs/adrv9002: Add adrv9002 documentation

### DIFF
--- a/docs/solutions/reference-designs/adrv9002/common.rst
+++ b/docs/solutions/reference-designs/adrv9002/common.rst
@@ -1,0 +1,28 @@
+More Information
+================
+
+-  :doc:`ADRV9001/2 Quick Start Guides </solutions/reference-designs/adrv9002/quickstart>`
+
+   -  :doc:`ADRV9002 Zynq UltraScale+ MPSoC ZCU102 Quick Start Guide </solutions/reference-designs/adrv9002/quickstart/zynqmp>`
+   -  :doc:`ADRV9002 Zynq SoC ZC706 Quick Start Guide </solutions/reference-designs/adrv9002/quickstart/zynq>`
+   -  :doc:`ADRV9002 Zynq Zed Board Quick Start Guide </solutions/reference-designs/adrv9002/quickstart/zed>`
+   -  :doc:`ADRV9002 Arria10 SoC Quick Start Guide </solutions/reference-designs/adrv9002/quickstart/a10soc>`
+
+-  :doc:`ADRV9001/ADRV9002 HDL Reference Design </solutions/reference-designs/adrv9002/reference_hdl>`
+
+   -  :doc:`AXI_ADRV9001/AXI_ADRV9002 Interface Core </solutions/reference-designs/adrv9002/axi_adrv9002>`
+   -  `Building HDL how-to, ADI Reference Designs HDL User Guide <https://wiki.analog.com/resources/fpga/docs/hdl>`_
+
+-  `ADRV9002 Device Driver Customization <https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9002-customization>`_
+-  `ADRV9002 Integrated Dual RF Transceiver Linux device driver <https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9002>`_
+
+Support
+=======
+
+Analog Devices will provide limited online support for anyone using the reference design with Analog Devices components via the :ez:`EngineerZone <community/fpga>`.
+
+Software resources
+==================
+
+-  `ADRV9002 Device Driver Customization <https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9002-customization>`_
+-  `ADRV9002 Integrated Dual RF Transceiver Linux device driver <https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9002>`_

--- a/docs/solutions/reference-designs/adrv9002/images/9002_blockdiagram.png
+++ b/docs/solutions/reference-designs/adrv9002/images/9002_blockdiagram.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9de6e6f7fc73902d30a6479f0664cf0feae57c0183f90523846c61ca85c39aad
+size 102599

--- a/docs/solutions/reference-designs/adrv9002/images/a10soc_fmc_rework.jpg
+++ b/docs/solutions/reference-designs/adrv9002/images/a10soc_fmc_rework.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c5bbfed82cd098e607e1d6a999df9a885897cd0ecb939afa4f91f90713d9e9e0
+size 610109

--- a/docs/solutions/reference-designs/adrv9002/images/adrv9002_a10soc_quickstart.png
+++ b/docs/solutions/reference-designs/adrv9002/images/adrv9002_a10soc_quickstart.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d073bb7fefaad8edf5e9c78f16a12f41117f957d8ad0fe70b3c22485f95c70d0
+size 2162452

--- a/docs/solutions/reference-designs/adrv9002/images/adrv9002_a10soc_vadj_jumper.png
+++ b/docs/solutions/reference-designs/adrv9002/images/adrv9002_a10soc_vadj_jumper.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:548836aafc7c78b0dbe5302c4e0e9443713747a07b393ed88c3394ba04151f58
+size 837961

--- a/docs/solutions/reference-designs/adrv9002/images/adrv9002_b0_np_w1.png
+++ b/docs/solutions/reference-designs/adrv9002/images/adrv9002_b0_np_w1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6cba210c3d95c5f8085cee7a052e8724ef6bf8b9b0dd1541500d1b3f7647fc78
+size 5614

--- a/docs/solutions/reference-designs/adrv9002/images/adrv9002_b0_np_w2.png
+++ b/docs/solutions/reference-designs/adrv9002/images/adrv9002_b0_np_w2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:00ff75e08159c5f70b177f4b0c6feae41a15dd887303027b84ed7ae31e1c185c
+size 5115

--- a/docs/solutions/reference-designs/adrv9002/images/adrv9002_vadj_led.png
+++ b/docs/solutions/reference-designs/adrv9002/images/adrv9002_vadj_led.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:00c00aa4e386e67e01b197e42803d22c5dd065a1a6636a0d9d410fe045bd3508
+size 1433377

--- a/docs/solutions/reference-designs/adrv9002/images/adrv9002_zc706_quickstart.png
+++ b/docs/solutions/reference-designs/adrv9002/images/adrv9002_zc706_quickstart.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e62cb9dd7d043c473da5ea0bbb0a4b2840b78ecc152e56ed45bb0ba65d5582ab
+size 1864367

--- a/docs/solutions/reference-designs/adrv9002/images/adrv9002_zcu102_quickstart.png.png
+++ b/docs/solutions/reference-designs/adrv9002/images/adrv9002_zcu102_quickstart.png.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e1b8fe4b6b10bcf088303c9dbbc12ef885ec060250faa54501c5fefbfb4ded27
+size 648928

--- a/docs/solutions/reference-designs/adrv9002/images/adrv9002_zed_quickstart.png
+++ b/docs/solutions/reference-designs/adrv9002/images/adrv9002_zed_quickstart.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ae2c28b6378fae7adc71367b69f2b3c696b1ff7dacb862d867032f2eff0ef408
+size 1841233

--- a/docs/solutions/reference-designs/adrv9002/images/adrv9002xbcz_c0_np_w1.png
+++ b/docs/solutions/reference-designs/adrv9002/images/adrv9002xbcz_c0_np_w1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:69a048a52e37da0e029b1ad4aa31b1a6e9ec81b1fb73c7839272d3b97264ad55
+size 6107

--- a/docs/solutions/reference-designs/adrv9002/images/adrv9002xbcz_c0_np_w2.png
+++ b/docs/solutions/reference-designs/adrv9002/images/adrv9002xbcz_c0_np_w2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5c2b8b5ee03d6cdcffe92e6942a656911ae95474b72bcff7cfaba41cdc31630d
+size 5871

--- a/docs/solutions/reference-designs/adrv9002/images/axi_9002.png
+++ b/docs/solutions/reference-designs/adrv9002/images/axi_9002.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3aced92bed250c5f71194b96fc806b5bff8b43db7e8023111d5fc61fec56edaa
+size 43711

--- a/docs/solutions/reference-designs/adrv9002/images/navassa-tinyiiod.jpg
+++ b/docs/solutions/reference-designs/adrv9002/images/navassa-tinyiiod.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b772cb72b23a453f39ca7914ac6bf0ee662cd3cca9486938dae95231627bfccb
+size 398411

--- a/docs/solutions/reference-designs/adrv9002/images/rxcomponentmodephy.png
+++ b/docs/solutions/reference-designs/adrv9002/images/rxcomponentmodephy.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4fb1ac8e3e05d800098dcf77e69745fb79b6c12c3b8da11fcdffa6e2bdf6b014
+size 32815

--- a/docs/solutions/reference-designs/adrv9002/images/shutdown.png
+++ b/docs/solutions/reference-designs/adrv9002/images/shutdown.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:239c1de88af1c7fd88912b7fb9428345dc12c0a2434048d37a5ba9b066e01868
+size 18524

--- a/docs/solutions/reference-designs/adrv9002/images/txcomponentmodephy.png
+++ b/docs/solutions/reference-designs/adrv9002/images/txcomponentmodephy.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:aebebb5e74c48d3377e6dd6be2eb1e0a22656a3f8e7113d23ef43671a8f0762e
+size 33870

--- a/docs/solutions/reference-designs/adrv9002/images/zc706plusfmcjesdadc1.png
+++ b/docs/solutions/reference-designs/adrv9002/images/zc706plusfmcjesdadc1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ca6dc7f0ed2798f76da52416bcdcf58bbceeff558f4f785fc33f564687b96c66
+size 2856257

--- a/docs/solutions/reference-designs/adrv9002/images/zcu102.jpg
+++ b/docs/solutions/reference-designs/adrv9002/images/zcu102.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:33c025c605ac9b4c1646be6d3cf4e18a7cff90c661f745f1ae0e752b1e4c091f
+size 227473

--- a/docs/solutions/reference-designs/adrv9002/images/zcu102_1p0_bootmode.jpg
+++ b/docs/solutions/reference-designs/adrv9002/images/zcu102_1p0_bootmode.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:92bce7183ea990bff071d450757147107f41852588aa73341cba1ee1ae7885ba
+size 1003634

--- a/docs/solutions/reference-designs/adrv9002/images/zed_sw.png
+++ b/docs/solutions/reference-designs/adrv9002/images/zed_sw.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:42ad20c2aa135651b8810995de9894daf017b86cd4beab809c20160a5cc54adb
+size 4079732

--- a/docs/solutions/reference-designs/adrv9002/index.rst
+++ b/docs/solutions/reference-designs/adrv9002/index.rst
@@ -1,8 +1,27 @@
+.. _adrv9002 eval:
+
 ADRV9002
-========
+=================================================
+
+.. TODO: Add a picture of the chip/board
+
+Overview
+-------------------------------------------------------------------------------
+
+.. TODO: Describe in max 10 rows the main features and applications.
+
+Features:
+
+- feature 1
+- feature 2
+
+Applications:
+
+- application 1
+- application 2
 
 .. toctree::
-   :titlesonly:
+   :hidden:
 
    axi_adrv9002
    common
@@ -14,3 +33,22 @@ ADRV9002
    quickstart/zynq
    quickstart/zynqmp
    reference_hdl
+
+Recommendations
+-------------------------------------------------------------------------------
+
+People who follow the flow that is outlined, have a much better experience with
+things. However, like many things, documentation is never as complete as it
+should be. If you have any questions, feel free to ask on our
+:ref:`EngineerZone forums <help-and-support>`, but before that, please make
+sure you read our documentation thoroughly.
+
+Warning
+-------------------------------------------------------------------------------
+
+.. esd-warning::
+
+Help and support
+-------------------------------------------------------------------------------
+
+Please go to :ref:`Help and Support <help-and-support>` page.

--- a/docs/solutions/reference-designs/adrv9002/index.rst
+++ b/docs/solutions/reference-designs/adrv9002/index.rst
@@ -1,0 +1,16 @@
+ADRV9002
+========
+
+.. toctree::
+   :titlesonly:
+
+   axi_adrv9002
+   common
+   no-os-setup
+   prerequisites
+   quickstart
+   quickstart/a10soc
+   quickstart/zed
+   quickstart/zynq
+   quickstart/zynqmp
+   reference_hdl

--- a/docs/solutions/reference-designs/adrv9002/no-os-setup.rst
+++ b/docs/solutions/reference-designs/adrv9002/no-os-setup.rst
@@ -1,0 +1,106 @@
+ADRV9002 No-OS System Level Design Setup
+========================================
+
+Supported devices
+-----------------
+
+-  :adi:`ADRV9002`
+
+Supported carriers
+------------------
+
+-  `ZCU102 <https://www.xilinx.com/ZCU102>`_
+-  `ZC706 <https://www.xilinx.com/ZC706>`_
+-  `Zed Board <http://zedboard.org/content/overview>`_
+
+Naming conventions
+------------------
+
+The ADRV9001 is family designator assigned to the System Development User Guide
+(UG-1828 for new ADRV9002, ADRV9003, ADRV9004, and upcoming additional family
+members). Thus, throughout this document, ADRV9001 designator may be used to
+refer to either ADRV9002, ADRV9003 or ADRV9004.
+
+Project layout and HDL generation
+---------------------------------
+
+This is how the adrv9001 no-OS project looks like as a file tree.
+
+::
+
+   no-OS/projects/adrv9001
+   ├── Makefile
+   ├── src
+   │   ├── app
+   │   │   ├── app_iio.c
+   │   │   ├── app_iio.h
+   │   │   ├── headless.c
+   │   │   ├── ORxGainTable.h
+   │   │   ├── RxGainTable.h
+   │   │   └── TxAttenTable.h
+   │   ├── firmware
+   │   │   ├── Navassa_EvaluationFw.h
+   │   │   └── Navassa_Stream.h
+   │   └── hal
+   │       ├── adi_platform.h
+   │       ├── adi_platform_types.h
+   │       ├── no_os_platform.c
+   │       ├── no_os_platform.h
+   │       └── parameters.h
+   ├── src.mk
+   └── system_top.xsa / system_top.hdf
+
+Note the presence of the system_top.xsa or system_top.hdf file. In order to build this no-OS project, you need such an .xsa or .hdf file present in the project directory, as shown above. In case you don't have one, either obtain a pre-built file or build it yourself by following the `Building HDL <https://wiki.analog.com/resources/fpga/docs/build>`_ guide.
+
+See more about Navassa's HDL and options for building an HDL for CMOS or LVDS interface :doc:`here </solutions/reference-designs/adrv9002/reference_hdl>`.
+
+And this is how the corresponding drivers section looks like as a file tree (the
+Navassa API can be found under common, devices and third_party directories):
+
+::
+
+   no-OS/drivers/rf-transceiver/navassa/
+   ├── adrv9002.c
+   ├── adrv9002_conv.c
+   ├── adrv9002.h
+   ├── common
+   ├── devices
+   └── third_party
+
+Building
+--------
+
+.. note::
+
+   See `Build <https://wiki.analog.com/resources/no-os/build>`_.
+
+By default, the digital interface is CMOS. In case a LVDS digital interface is
+used, this has to be specified in the make command:
+
+::
+
+   make LVDS=y
+
+Demo Applications
+-----------------
+
+Make sure to connect your adrv9002 evaluation board to the correct FMC connector
+or the carrier you use:
+
+-  :doc:`ZCU102 </solutions/reference-designs/adrv9002/quickstart/zynqmp>`
+-  :doc:`ZC706 </solutions/reference-designs/adrv9002/quickstart/zynq>`
+-  :doc:`Zed Board </solutions/reference-designs/adrv9002/quickstart/zed>`
+
+.. note::
+
+   See `Dac Dma Example <https://wiki.analog.com/resources/no-os/dac_dma_example>`_.
+
+.. note::
+
+   See `Iiod Demo <https://wiki.analog.com/resources/no-os/iiod_demo>`_.
+
+Here's an example of iio-oscilloscope connected to a NO-OS Navassa IIOD demo
+with electrical loopbacks between TX1-RX1 and TX2-RX2.
+
+.. image:: images/navassa-tinyiiod.jpg
+   :width: 400

--- a/docs/solutions/reference-designs/adrv9002/prerequisites.rst
+++ b/docs/solutions/reference-designs/adrv9002/prerequisites.rst
@@ -1,0 +1,40 @@
+Prerequisites for ADRV9001/2 based boards
+=========================================
+
+What you need, depends on what you are trying to do. As a minimum, you need to
+start out with:
+
+-  The ADRV9001 based card.
+-  A carrier platform. ADI does not offer these boards for sale or loan, getting
+   one yourself is normal part of development or evaluation of the ADRV9001. Our
+   recommended carriers (the ones we use all the time) are either:
+
+   -  The `Xilinx ZCU102 <https://www.xilinx.com/zcu102>`_. The fabric on this device is much larger, and if you are looking at targeting - this is the recommended option.
+   -  There are a few more boards, which do work, but are currently not yet
+      supported. The experience of the fabric only solutions is very close to
+      the ARM/FPGA SoC based solutions, but the GUI runs on a host PC (Windows
+      or Linux).
+
+::
+
+     *
+
+.. note::
+
+   See `quickstart <https://wiki.analog.com/quickstart#supported_carriers>`_
+
+-   some way to interact with the platform,
+
+   -  for the ARM/FPGA SoC platforms, this normally includes:
+
+      -  DisplayPort monitor
+      -  USB Keyboard
+      -  USB Mouse
+
+   -  for the FPGA only solutions, this includes:
+
+      -  LAN cable (Ethernet)
+      -  Host PC (Windows or Linux)
+
+-  Internet connection (without proxies makes things much easier) to update the scripts/binaries on the SD Card that came with the ADI FMC Card. (Firewalls are OK, proxies make things a pain).
+-  RF Test equipment

--- a/docs/solutions/reference-designs/adrv9002/quickstart.rst
+++ b/docs/solutions/reference-designs/adrv9002/quickstart.rst
@@ -1,0 +1,154 @@
+ADRV9001/2 Quick Start Guides
+=============================
+
+The Quick Start Guides provide a simple step by step instruction on how to do an initial system setup for the :adi:`ADRV9002NP/W1/PCBZ <EVAL-ADRV9002>` and :adi:`ADRV9002NP/W2/PCBZ <EVAL-ADRV9002>` boards on various FPGA development boards. They will discuss how to program the bitstream, run a no-OS program or boot a Linux distribution.
+
+Supported Carriers
+------------------
+
+The :adi:`ADRV9002NP/W1/PCBZ <EVAL-ADRV9002>` and :adi:`ADRV9002NP/W2/PCBZ <EVAL-ADRV9002>` is, by definition a "FPGA mezzanine card" (FMC), that means it needs a carrier to plug into. The carriers we support are:
+
++----------------------------------------------------------------------------------------------------------------------+--------------------+--------------------+
+| Board                                                                                                                | ADRV9002NP         |                    |
++======================================================================================================================+====================+====================+
+|                                                                                                                      | **CMOS inteface**  | **LVDS interface** |
++----------------------------------------------------------------------------------------------------------------------+--------------------+--------------------+
+| `ZCU102 <https://www.xilinx.com/ZCU102>`_                                                                            | √                  | √                  |
++----------------------------------------------------------------------------------------------------------------------+--------------------+--------------------+
+| `ZC706 <https://www.xilinx.com/ZC706>`_                                                                              | √ **VADJ 1.8V**\ ¹ | N/A²               |
++----------------------------------------------------------------------------------------------------------------------+--------------------+--------------------+
+| `Zed Board <http://zedboard.org/product/zedboard>`_                                                                  | √ **VADJ 1.8V**    | N/A²               |
++----------------------------------------------------------------------------------------------------------------------+--------------------+--------------------+
+| `Arria 10 SoC <https://www.altera.com/products/boards_and_kits/dev-kits/altera/arria-10-soc-development-kit.html>`_  | √                  | N/A³               |
++----------------------------------------------------------------------------------------------------------------------+--------------------+--------------------+
+
+¹ Instruction for reprogramming the VADJ can be found `here <https://www.xilinx.com/Attachment/ZC706_Power_Controllers_Reprogramming_Steps.pdf>`_ and `here <https://forums.xilinx.com/t5/Xilinx-Evaluation-Boards/ZC706-Doesn-t-work-with-VADJ-at-1-8v/td-p/430086>`_ ² See :doc:`Cmos only operation </solutions/reference-designs/adrv9002/quickstart>` section ³ Not supported due sub-optimal mapping of the clock pins from the source synchronous interfaces.
+
+CMOS only operation
+-------------------
+
+On the ZC706 / ZedBoard platforms the FMC connectors map to HR IO banks. The HR banks have a limitation that when using LVDS I/O standard you must set the bank VCCO voltage to 2.5V, however the ADRV9001 evaluation board is using IO supplies of 1.8V and does not have level shifters for the single ended lines. Therefore the VCCO of the banks must be set to 1.8 V (VADJ) and limiting the operation to CMOS mode only. More information on the limitation see `7 Series Select IO guide <https://www.xilinx.com/support/documentation/user_guides/ug471_7Series_SelectIO.pdf>`_ section 'LVDS and LVDS_25' and Table 1-43
+
+Supported Environments
+----------------------
+
+The supported OS are:
+
++----------------------------------------------------------------------------------------------------------------------+-----+----------------+----------------+--------------------------+
+| Board                                                                                                                | HDL | Linux Software | No-OS Software | Required Minimum Release |
++======================================================================================================================+=====+================+================+==========================+
+| `ZCU102 <https://www.xilinx.com/ZCU102>`_                                                                            | √   | √              | √              | 2019-R2                  |
++----------------------------------------------------------------------------------------------------------------------+-----+----------------+----------------+--------------------------+
+| `ZC706 <https://www.xilinx.com/ZC706>`_                                                                              | √   | √              | √              | 2020-R1                  |
++----------------------------------------------------------------------------------------------------------------------+-----+----------------+----------------+--------------------------+
+| `Zed Board <http://zedboard.org/product/zedboard>`_                                                                  | √   | √              | √              | 2019-R2                  |
++----------------------------------------------------------------------------------------------------------------------+-----+----------------+----------------+--------------------------+
+| `Arria 10 SoC <https://www.altera.com/products/boards_and_kits/dev-kits/altera/arria-10-soc-development-kit.html>`_  | √   | √              | N/A            | 2020-R1                  |
++----------------------------------------------------------------------------------------------------------------------+-----+----------------+----------------+--------------------------+
+
+Hardware Setup
+--------------
+
+In most carriers, the :adi:`ADRV9002NP/W1/PCBZ <EVAL-ADRV9002>` and :adi:`ADRV9002NP/W2/PCBZ <EVAL-ADRV9002>` boards connects to the HPC1 connector (unless otherwise noted). The carrier setup requires power, UART (115200), ethernet (Linux), DisplayPort or HDMI (if available) and/or JTAG (no-OS) connections. A few typical setups are shown below.
+
+Identify your hardware
+~~~~~~~~~~~~~~~~~~~~~~
+
+Evaluation boards were equipped with different silicon revisions. All boards
+built since the middle of December 2020 have C0 silicon, older ones use B0
+silicon these are no longer shipped. You can identify the board you have based
+on its label.
+
+======== ================
+Label    Silicon Revision
+======== ================
+|image1| **B0**
+|image2| **B0**
+|image3| **C0**
+|image4| **C0**
+======== ================
+
+.. tip::
+
+   Each revision of silicon requires its corresponding software support files in
+   the later steps.
+
+ZCU102 + ADRV9002NP
+-------------------
+
+:doc:`ADRV9002 Zynq UltraScale+ MPSoC ZCU102 Quick Start Guide </solutions/reference-designs/adrv9002/quickstart/zynqmp>`
+
+ZC706 + ADRV9002NP
+------------------
+
+:doc:`ADRV9002 Zynq SoC ZC706 Quick Start Guide </solutions/reference-designs/adrv9002/quickstart/zynq>`
+
+Zed Board + ADRV9002NP
+----------------------
+
+:doc:`ADRV9002 Zynq Zed Board Quick Start Guide </solutions/reference-designs/adrv9002/quickstart/zed>`
+
+============
+
+More Information
+================
+
+-  :doc:`ADRV9001/2 Quick Start Guides </solutions/reference-designs/adrv9002/quickstart>`
+
+   -  :doc:`ADRV9002 Zynq UltraScale+ MPSoC ZCU102 Quick Start Guide </solutions/reference-designs/adrv9002/quickstart/zynqmp>`
+   -  :doc:`ADRV9002 Zynq SoC ZC706 Quick Start Guide </solutions/reference-designs/adrv9002/quickstart/zynq>`
+   -  :doc:`ADRV9002 Zynq Zed Board Quick Start Guide </solutions/reference-designs/adrv9002/quickstart/zed>`
+   -  :doc:`ADRV9002 Arria10 SoC Quick Start Guide </solutions/reference-designs/adrv9002/quickstart/a10soc>`
+
+-  :doc:`ADRV9001/ADRV9002 HDL Reference Design </solutions/reference-designs/adrv9002/reference_hdl>`
+
+   -  :doc:`AXI_ADRV9001/AXI_ADRV9002 Interface Core </solutions/reference-designs/adrv9002/axi_adrv9002>`
+   -  `Building HDL how-to, ADI Reference Designs HDL User Guide <https://wiki.analog.com/resources/fpga/docs/hdl>`_
+
+-  `ADRV9002 Device Driver Customization <https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9002-customization>`_
+-  `ADRV9002 Integrated Dual RF Transceiver Linux device driver <https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9002>`_
+
+Support
+=======
+
+Analog Devices will provide limited online support for anyone using the reference design with Analog Devices components via the :ez:`EngineerZone <community/fpga>`.
+
+Software resources
+==================
+
+-  `ADRV9002 Device Driver Customization <https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9002-customization>`_
+-  `ADRV9002 Integrated Dual RF Transceiver Linux device driver <https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9002>`_
+
+More Information
+================
+
+-  :doc:`ADRV9001/2 Quick Start Guides </solutions/reference-designs/adrv9002/quickstart>`
+
+   -  :doc:`ADRV9002 Zynq UltraScale+ MPSoC ZCU102 Quick Start Guide </solutions/reference-designs/adrv9002/quickstart/zynqmp>`
+   -  :doc:`ADRV9002 Zynq SoC ZC706 Quick Start Guide </solutions/reference-designs/adrv9002/quickstart/zynq>`
+   -  :doc:`ADRV9002 Zynq Zed Board Quick Start Guide </solutions/reference-designs/adrv9002/quickstart/zed>`
+   -  :doc:`ADRV9002 Arria10 SoC Quick Start Guide </solutions/reference-designs/adrv9002/quickstart/a10soc>`
+
+-  :doc:`ADRV9001/ADRV9002 HDL Reference Design </solutions/reference-designs/adrv9002/reference_hdl>`
+
+   -  :doc:`AXI_ADRV9001/AXI_ADRV9002 Interface Core </solutions/reference-designs/adrv9002/axi_adrv9002>`
+   -  `Building HDL how-to, ADI Reference Designs HDL User Guide <https://wiki.analog.com/resources/fpga/docs/hdl>`_
+
+-  `ADRV9002 Device Driver Customization <https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9002-customization>`_
+-  `ADRV9002 Integrated Dual RF Transceiver Linux device driver <https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9002>`_
+
+Support
+=======
+
+Analog Devices will provide limited online support for anyone using the reference design with Analog Devices components via the :ez:`EngineerZone <community/fpga>`.
+
+Software resources
+==================
+
+-  `ADRV9002 Device Driver Customization <https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9002-customization>`_
+-  `ADRV9002 Integrated Dual RF Transceiver Linux device driver <https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9002>`_
+
+.. |image1| image:: images/adrv9002_b0_np_w1.png
+.. |image2| image:: images/adrv9002_b0_np_w2.png
+.. |image3| image:: images/adrv9002xbcz_c0_np_w1.png
+.. |image4| image:: images/adrv9002xbcz_c0_np_w2.png

--- a/docs/solutions/reference-designs/adrv9002/quickstart/a10soc.rst
+++ b/docs/solutions/reference-designs/adrv9002/quickstart/a10soc.rst
@@ -1,0 +1,645 @@
+ADRV9002 Arria10 SoC Quick Start Guide
+======================================
+
+.. image:: ../images/adrv9002_a10soc_quickstart.png
+   :align: center
+   :width: 600
+
+This guide provides some quick instructions (still takes awhile to download, and set things up) on how to setup the :adi:`ADRV9002NP/W1/PCBZ <EVAL-ADRV9002>` and :adi:`ADRV9002NP/W2/PCBZ <EVAL-ADRV9002>` on:
+
+-  `Arria10 SoC Development Kit <https://www.altera.com/products/boards_and_kits/dev-kits/altera/arria-10-soc-development-kit.html>`_ Rev. C or later
+
+Instructions on how to build the Zynq Linux kernel and devicetrees from source
+can be found here:
+
+-  `AD-FMC-SDCARD for Zynq & Altera SoC Quick Start Guide <https://wiki.analog.com/resources/tools-software/linux-software/kuiper-linux>`_
+-  `Altera SOC - Build Preloader and Bootloader Image <https://wiki.analog.com/resources/tools-software/linux-software/altera_soc_images>`_
+
+Required Software
+-----------------
+
+-  SD Card 16GB image using the instructions here: `SDCARD for Zynq & Altera SoC Quick Start Guide <https://wiki.analog.com/resources/tools-software/linux-software/kuiper-linux>`_. Use 2020_r1 or later release. (Pre-released files, built using Vivado 2020.1 can be downloaded from `here <https://swdownloads.analog.com/cse/prebuilt/socfpga_arria10_socdk_adrv9002_rx2tx2.zip>`_)
+-   Copy next boot files from ``socfpga_arria10_socdk_adrv9002`` directory directly on SD Card ``BOOT`` partition :
+
+   -  ``socfpga_arria10_socdk.rbf``
+   -  ``socfpga_arria10_socdk_sdmmc.dtb``
+   -  ``zImage`` (from ``socfpga_arria10-common`` folder)
+
+-  Write preloader_bootloader.bin from ``socfpga_arria10_socdk_adrv9002`` folder on third SD Card partition:
+
+::
+
+       root@raspberrypi:~# lsblk
+       NAME        MAJ:MIN RM  SIZE RO TYPE MOUNTPOINT
+       sda           8:0    1 14.9G  0 disk
+       ├─sda1        8:1    1    1G  0 part /media/pi/BOOT
+       ├─sda2        8:2    1  7.6G  0 part /media/pi/rootfs
+       └─sda3        8:3    1    4M  0 part
+       root@raspberrypi:~# dd if="./preloader_bootloader.bin" of="/dev/sda3" bs=512
+       2048+0 records in
+       2048+0 records out
+       1048576 bytes (1.0 MB, 1.0 MiB) copied, 0.25035 s, 4.2 MB/s
+
+-  A UART terminal (Putty/Tera Term/Minicom, etc.), Baud rate 115200 (8N1).
+
+Required Hardware
+-----------------
+
+-  `Arria10 SoC Development Kit <https://www.altera.com/products/boards_and_kits/dev-kits/altera/arria-10-soc-development-kit.html>`_ Rev. C or later
+-  :adi:`ADRV9002NP/W2/PCBZ <EVAL-ADRV9002>` daughterboard
+-  Reference clock source
+-  Mini-USB cable
+-  Ethernet cable
+-  Optionally USB keyboard, mouse and a Display Port compatible monitor
+
+.. esd-warning::
+
+FMC Pin Connection Configuration Change
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. important::
+
+   To be compatible with the :adi:`ADRV9002NP/W2/PCBZ <EVAL-ADRV9002>` the Arria10 SoC Development Kit requires a minor rework.
+
+   
+   In the default configuration of the Arria10 SoC Development Kit some of the FMC header pins are connected to a dedicated clock chip. To be compatible with the :adi:`ADRV9002NP/W2/PCBZ <EVAL-ADRV9002>` these pins need to be connected directly to the FPGA.
+
+The connection of those pins can be changed by moving the position of four zero
+Ohm resistors:
+
+-  R612 to R610
+-  R613 to R611
+-  R621 to R620
+-  R633 to R632
+
+These resistors can be found on the backside of the Arria10 SoC Development Kit
+underneath the FMC A connector (J29). The following picture shows the required
+configuration to be compatible with the AD-FMCDAQ2-EBZ.
+
+.. image:: ../images/a10soc_fmc_rework.jpg
+   :align: center
+   :width: 400
+
+Testing
+=======
+
+.. warning::
+
+   Before executing below steps, VADJ for FMCA must be set to 1.8V.
+
+   
+   This can be done by changing VADJ FMCA Voltage using J42 (see below picture).
+   
+   On an ADRV9002 Card, there is a red LED close to the FMC connector. The role
+   of this LED is to indicate if VADJ voltage exceeded 2.0V level. If that was
+   the case this LED will be ON. If this LED does not turn off after few seconds
+   after boot, then there is an issue and while the board might still operate
+   this is exceeding the recommended level for VADJ, decreasing board lifetime
+   and can lead to permanent damage of the IC in the worst case.
+
+.. image:: ../images/adrv9002_a10soc_vadj_jumper.png
+   :align: center
+
+-  Connect the :adi:`ADRV9002NP/W1/PCBZ <EVAL-ADRV9002>` or :adi:`ADRV9002NP/W2/PCBZ <EVAL-ADRV9002>` FMC board to the FMCA carrier socket -.
+-  On the FMC card set switch to select clock source between:
+
+.. image:: ../images/adrv9002_vadj_led.png
+   :align: right
+   :width: 200
+
+::
+
+     * an on-board 38.4MHz VCTCXO (default)
+     * external (thru J501) 10MHz to 1000MHz / +13dBm
+     * Connect USB UART (Mini USB) to your host PC.
+     * Insert SD card into socket.
+     * Configure`Arria10 SoC Development Kit <https://www.altera.com/products/boards_and_kits/dev-kits/altera/arria-10-soc-development-kit.html>`_ for SD Card booting (Set the Jumpers and Switches accordingly).
+     * Turn on the power switch on the FPGA board.
+     * Observe kernel and serial console messages on your terminal.
+
+Messages
+--------
+
+.. collapsible:: Complete kernel boot log (Click to expand)
+
+   .. container:: box bggreen
+
+      This specifies any shell prompt running on the target
+
+      ::
+
+         U-Boot 2014.10-00334-gf7a7e26-dirty (Jun 30 2021 - 18:30:00), Build: jenkins-master-hdl_jobs_for_linux-projects-adrv9001.a10soc-14
+
+         CPU   : Altera SOCFPGA Arria 10 Platform
+         BOARD : Altera SOCFPGA Arria 10 Dev Kit
+         I2C:   ready
+         DRAM:  WARNING: Caches not enabled
+         SOCFPGA DWMMC: 0
+         FPGA: writing socfpga_arria10_socdk.rbf ...
+         Full Configuration Succeeded.
+         DDRCAL: Success
+         INFO  : Skip relocation as SDRAM is non secure memory
+         Reserving 2048 Bytes for IRQ stack at: ffe386e8
+         DRAM  : 1 GiB
+         WARNING: Caches not enabled
+         MMC:   ** Warning - bad CRC, using default environment
+
+         In:    serial
+         Out:   serial
+         Err:   serial
+         Model: SOCFPGA Arria10 Dev Kit
+         Net:   dwmac.ff800000
+         Hit any key to stop autoboot:  0
+         FPGA must be in Early Release mode to program core.
+         fpga - loadable FPGA image support
+
+          Unable to read file u-boot.scr 
+         7699728 bytes read in 353 ms (20.8 MiB/s)
+         22104 bytes read in 4 ms (5.3 MiB/s)
+         FPGA BRIDGES: enable
+         Kernel image @ 0x010000 [ 0x000000 - 0x757d10 ]
+         ## Flattened Device Tree blob at 00000100
+            Booting using the fdt blob at 0x000100
+            Loading Device Tree to 01ff7000, end 01fff657 ... OK
+
+         Starting kernel ...
+
+         [    0.000000] Booting Linux on physical CPU 0x0
+         [    0.000000] Linux version 5.4.0-00475-gc588ee4bed9a (dragos@debian) (gcc version 10.2.1 20201103 (GNU Toolchain for the A-profile Architecture 10.2-2020.11 (arm-10.16))) #12 SMP Fri Jul 2 19:31:54 EEST 2021
+         [    0.000000] CPU: ARMv7 Processor [414fc091] revision 1 (ARMv7), cr=10c5387d
+         [    0.000000] CPU: PIPT / VIPT nonaliasing data cache, VIPT aliasing instruction cache
+         [    0.000000] OF: fdt: Machine model: Altera SOCFPGA Arria 10
+         [    0.000000] Memory policy: Data cache writealloc
+         [    0.000000] cma: Reserved 128 MiB at 0x38000000
+         [    0.000000] percpu: Embedded 19 pages/cpu s45196 r8192 d24436 u77824
+         [    0.000000] Built 1 zonelists, mobility grouping on.  Total pages: 260608
+         [    0.000000] Kernel command line: console=ttyS0,115200 root=/dev/mmcblk0p2 rw rootwait
+         [    0.000000] Dentry cache hash table entries: 131072 (order: 7, 524288 bytes, linear)
+         [    0.000000] Inode-cache hash table entries: 65536 (order: 6, 262144 bytes, linear)
+         [    0.000000] mem auto-init: stack:off, heap alloc:off, heap free:off
+         [    0.000000] Memory: 885444K/1048576K available (12288K kernel code, 1132K rwdata, 7180K rodata, 1024K init, 173K bss, 32060K reserved, 131072K cma-reserved, 131072K highmem)
+         [    0.000000] SLUB: HWalign=64, Order=0-3, MinObjects=0, CPUs=2, Nodes=1
+         [    0.000000] ftrace: allocating 38575 entries in 76 pages
+         [    0.000000] rcu: Hierarchical RCU implementation.
+         [    0.000000] rcu:     RCU event tracing is enabled.
+         [    0.000000] rcu: RCU calculated value of scheduler-enlistment delay is 10 jiffies.
+         [    0.000000] NR_IRQS: 16, nr_irqs: 16, preallocated irqs: 16
+         [    0.000000] L2C-310 erratum 769419 enabled
+         [    0.000000] L2C-310 enabling early BRESP for Cortex-A9
+         [    0.000000] L2C-310: enabling full line of zeros but not enabled in Cortex-A9
+         [    0.000000] L2C-310 ID prefetch enabled, offset 1 lines
+         [    0.000000] L2C-310 dynamic clock gating enabled, standby mode enabled
+         [    0.000000] L2C-310 cache controller enabled, 8 ways, 512 kB
+         [    0.000000] L2C-310: CACHE_ID 0x410030c9, AUX_CTRL 0x76460001
+         [    0.000000] random: get_random_bytes called from start_kernel+0x32c/0x4e4 with crng_init=0
+         [    0.000000] clocksource: timer1: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 19112604467 ns
+         [    0.000005] sched_clock: 32 bits at 100MHz, resolution 10ns, wraps every 21474836475ns
+         [    0.000013] Switching to timer-based delay loop, resolution 10ns
+         [    0.000181] Console: colour dummy device 80x30
+         [    0.000210] Calibrating delay loop (skipped), value calculated using timer frequency.. 200.00 BogoMIPS (lpj=1000000)
+         [    0.000221] pid_max: default: 32768 minimum: 301
+         [    0.000328] Mount-cache hash table entries: 2048 (order: 1, 8192 bytes, linear)
+         [    0.000341] Mountpoint-cache hash table entries: 2048 (order: 1, 8192 bytes, linear)
+         [    0.000882] CPU: Testing write buffer coherency: ok
+         [    0.000909] CPU0: Spectre v2: using BPIALL workaround
+         [    0.001127] CPU0: thread -1, cpu 0, socket 0, mpidr 80000000
+         [    0.001626] Setting up static identity map for 0x100000 - 0x100060
+         [    0.001744] rcu: Hierarchical SRCU implementation.
+         [    0.001996] smp: Bringing up secondary CPUs ...
+         [    0.002591] CPU1: thread -1, cpu 1, socket 0, mpidr 80000001
+         [    0.002597] CPU1: Spectre v2: using BPIALL workaround
+         [    0.002702] smp: Brought up 1 node, 2 CPUs
+         [    0.002711] SMP: Total of 2 processors activated (400.00 BogoMIPS).
+         [    0.002716] CPU: All CPU(s) started in SVC mode.
+         [    0.003186] devtmpfs: initialized
+         [    0.006718] VFP support v0.3: implementor 41 architecture 3 part 30 variant 9 rev 4
+         [    0.006897] clocksource: jiffies: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 19112604462750000 ns
+         [    0.006913] futex hash table entries: 512 (order: 3, 32768 bytes, linear)
+         [    0.010752] NET: Registered protocol family 16
+         [    0.012595] DMA: preallocated 256 KiB pool for atomic coherent allocations
+         [    0.013335] hw-breakpoint: found 5 (+1 reserved) breakpoint and 1 watchpoint registers.
+         [    0.013343] hw-breakpoint: maximum watchpoint size is 4 bytes.
+         [    0.027402] vgaarb: loaded
+         [    0.027688] SCSI subsystem initialized
+         [    0.027859] usbcore: registered new interface driver usbfs
+         [    0.027894] usbcore: registered new interface driver hub
+         [    0.027939] usbcore: registered new device driver usb
+         [    0.028065] usb_phy_generic soc:usbphy: soc:usbphy supply vcc not found, using dummy regulator
+         [    0.028903] mc: Linux media interface: v0.10
+         [    0.028938] videodev: Linux video capture interface: v2.00
+         [    0.028995] pps_core: LinuxPPS API ver. 1 registered
+         [    0.029000] pps_core: Software ver. 5.3.6 - Copyright 2005-2007 Rodolfo Giometti <giometti@linux.it>
+         [    0.029017] PTP clock support registered
+         [    0.029225] jesd204: found 0 devices and 0 topologies
+         [    0.029263] FPGA manager framework
+         [    0.029332] Advanced Linux Sound Architecture Driver Initialized.
+         [    0.030073] clocksource: Switched to clocksource timer1
+         [    0.427376] NET: Registered protocol family 2
+         [    0.427876] tcp_listen_portaddr_hash hash table entries: 512 (order: 0, 6144 bytes, linear)
+         [    0.427900] TCP established hash table entries: 8192 (order: 3, 32768 bytes, linear)
+         [    0.427960] TCP bind hash table entries: 8192 (order: 4, 65536 bytes, linear)
+         [    0.428057] TCP: Hash tables configured (established 8192 bind 8192)
+         [    0.428159] UDP hash table entries: 512 (order: 2, 16384 bytes, linear)
+         [    0.428205] UDP-Lite hash table entries: 512 (order: 2, 16384 bytes, linear)
+         [    0.428370] NET: Registered protocol family 1
+         [    0.428781] RPC: Registered named UNIX socket transport module.
+         [    0.428789] RPC: Registered udp transport module.
+         [    0.428793] RPC: Registered tcp transport module.
+         [    0.428798] RPC: Registered tcp NFSv4.1 backchannel transport module.
+         [    0.428809] PCI: CLS 0 bytes, default 64
+         [    0.430041] workingset: timestamp_bits=30 max_order=18 bucket_order=0
+         [    0.435557] NFS: Registering the id_resolver key type
+         [    0.435581] Key type id_resolver registered
+         [    0.435587] Key type id_legacy registered
+         [    0.435598] Installing knfsd (copyright (C) 1996 okir@monad.swb.de).
+         [    0.436174] ntfs: driver 2.1.32 [Flags: R/W].
+         [    0.436410] jffs2: version 2.2. (NAND) © 2001-2006 Red Hat, Inc.
+         [    0.463586] bounce: pool size: 64 pages
+         [    0.463602] io scheduler mq-deadline registered
+         [    0.463608] io scheduler kyber registered
+         [    0.467968] dma-pl330 ffda1000.pdma: Loaded driver for PL330 DMAC-341330
+         [    0.467982] dma-pl330 ffda1000.pdma:     DBUFF-512x8bytes Num_Chans-8 Num_Peri-32 Num_Events-8
+         [    0.470420] Serial: 8250/16550 driver, 2 ports, IRQ sharing disabled
+         [    0.471244] printk: console [ttyS0] disabled
+         [    0.471289] ffc02100.serial1: ttyS0 at MMIO 0xffc02100 (irq = 37, base_baud = 6250000) is a 16550A
+         [    1.067467] printk: console [ttyS0] enabled
+         [    1.073097] brd: module loaded
+         [    1.102849] spi_altera ff200040.spi: base (ptrval), irq 40
+         [    1.109054] altr_a10sr_gpio altr_a10sr_gpio.0.auto: DMA mask not set
+         [    1.116166] libphy: Fixed MDIO Bus: probed
+         [    1.120690] CAN device driver interface
+         [    1.124727] socfpga-dwmac ff800000.ethernet: IRQ eth_wake_irq not found
+         [    1.131331] socfpga-dwmac ff800000.ethernet: IRQ eth_lpi not found
+         [    1.137572] socfpga-dwmac ff800000.ethernet: PTP uses main clock
+         [    1.143578] socfpga-dwmac ff800000.ethernet: No sysmgr-syscon node found
+         [    1.150254] socfpga-dwmac ff800000.ethernet: Unable to parse OF data
+         [    1.156600] socfpga-dwmac: probe of ff800000.ethernet failed with error -524
+         [    1.163769] stmmaceth ff800000.ethernet: IRQ eth_wake_irq not found
+         [    1.170009] stmmaceth ff800000.ethernet: IRQ eth_lpi not found
+         [    1.175893] stmmaceth ff800000.ethernet: PTP uses main clock
+         [    1.181680] stmmaceth ff800000.ethernet: User ID: 0x10, Synopsys ID: 0x37
+         [    1.188442] stmmaceth ff800000.ethernet:     DWMAC1000
+         [    1.193311] stmmaceth ff800000.ethernet: DMA HW capability register supported
+         [    1.200424] stmmaceth ff800000.ethernet: RX Checksum Offload Engine supported
+         [    1.207526] stmmaceth ff800000.ethernet: COE Type 2
+         [    1.212387] stmmaceth ff800000.ethernet: TX Checksum insertion supported
+         [    1.219056] stmmaceth ff800000.ethernet: Enhanced/Alternate descriptors
+         [    1.225643] stmmaceth ff800000.ethernet: Enabled extended descriptors
+         [    1.232058] stmmaceth ff800000.ethernet: Ring mode enabled
+         [    1.237518] stmmaceth ff800000.ethernet: Enable RX Mitigation via HW Watchdog Timer
+         [    1.252854] libphy: stmmac: probed
+         [    1.256250] Micrel KSZ9031 Gigabit PHY stmmac-0:07: attached PHY driver [Micrel KSZ9031 Gigabit PHY] (mii_bus:phy_addr=stmmac-0:07, irq=POLL)
+         [    1.269549] usbcore: registered new interface driver asix
+         [    1.274986] usbcore: registered new interface driver ax88179_178a
+         [    1.281080] usbcore: registered new interface driver cdc_ether
+         [    1.286904] usbcore: registered new interface driver net1080
+         [    1.292565] usbcore: registered new interface driver cdc_subset
+         [    1.298473] usbcore: registered new interface driver zaurus
+         [    1.304075] usbcore: registered new interface driver cdc_ncm
+         [    1.310173] dwc2 ffb00000.usb: ffb00000.usb supply vusb_d not found, using dummy regulator
+         [    1.318465] dwc2 ffb00000.usb: ffb00000.usb supply vusb_a not found, using dummy regulator
+         [    1.326911] dwc2 ffb00000.usb: EPs: 16, dedicated fifos, 8064 entries in SPRAM
+         [    1.334682] dwc2 ffb00000.usb: DWC OTG Controller
+         [    1.339385] dwc2 ffb00000.usb: new USB bus registered, assigned bus number 1
+         [    1.346455] dwc2 ffb00000.usb: irq 38, io mem 0xffb00000
+         [    1.351892] usb usb1: New USB device found, idVendor=1d6b, idProduct=0002, bcdDevice= 5.04
+         [    1.360135] usb usb1: New USB device strings: Mfr=3, Product=2, SerialNumber=1
+         [    1.367325] usb usb1: Product: DWC OTG Controller
+         [    1.372017] usb usb1: Manufacturer: Linux 5.4.0-00475-gc588ee4bed9a dwc2_hsotg
+         [    1.379205] usb usb1: SerialNumber: ffb00000.usb
+         [    1.384214] hub 1-0:1.0: USB hub found
+         [    1.387973] hub 1-0:1.0: 1 port detected
+         [    1.392470] ehci_hcd: USB 2.0 'Enhanced' Host Controller (EHCI) Driver
+         [    1.398968] ehci-pci: EHCI PCI platform driver
+         [    1.403713] usbcore: registered new interface driver uas
+         [    1.409051] usbcore: registered new interface driver usb-storage
+         [    1.415122] usbcore: registered new interface driver usbserial_generic
+         [    1.421653] usbserial: USB Serial support registered for generic
+         [    1.427654] usbcore: registered new interface driver ftdi_sio
+         [    1.433400] usbserial: USB Serial support registered for FTDI USB Serial Device
+         [    1.440742] usbcore: registered new interface driver upd78f0730
+         [    1.446650] usbserial: USB Serial support registered for upd78f0730
+         [    1.454450] rtc-ds1307: probe of 0-0068 failed with error -121
+         [    1.460330] i2c /dev entries driver
+         [    1.464473] usbcore: registered new interface driver uvcvideo
+         [    1.470219] USB Video Class driver (1.1.1)
+         [    1.476836] ltc2978: probe of 0-005c failed with error -121
+         [    1.482999] Synopsys Designware Multimedia Card Interface Driver
+         [    1.489172] dw_mmc ff808000.dwmmc0: IDMAC supports 32-bit address mode.
+         [    1.495848] dw_mmc ff808000.dwmmc0: Using internal DMA controller.
+         [    1.502034] dw_mmc ff808000.dwmmc0: Version ID is 270a
+         [    1.507188] dw_mmc ff808000.dwmmc0: DW MMC controller at irq 31,32 bit host data width,1024 deep fifo
+         [    1.516467] mmc_host mmc0: card is polling.
+         [    1.533255] mmc_host mmc0: Bus speed (slot 0) = 50000000Hz (slot req 400000Hz, actual 396825HZ div = 63)
+         [    1.622641] mmc_host mmc0: Bus speed (slot 0) = 50000000Hz (slot req 50000000Hz, actual 50000000HZ div = 0)
+         [    1.632388] mmc0: new high speed SDHC card at address aaaa
+         [    1.638528] mmcblk0: mmc0:aaaa SB16G 14.8 GiB
+         [    1.649483]  mmcblk0: p1 p2 p3
+         [    2.431855] ledtrig-cpu: registered to indicate activity on CPUs
+         [    2.437975] usbcore: registered new interface driver usbhid
+         [    2.443541] usbhid: USB HID core driver
+         [    2.468407] fpga_manager fpga0: SoCFPGA Arria10 FPGA Manager registered
+         [    2.475657] usbcore: registered new interface driver snd-usb-audio
+         [    2.483273] oprofile: no performance counters
+         [    2.487701] oprofile: using timer interrupt.
+         [    2.492051] drop_monitor: Initializing network drop monitor service
+         [    2.498933] NET: Registered protocol family 10
+         [    2.504117] Segment Routing with IPv6
+         [    2.507817] sit: IPv6, IPv4 and MPLS over IPv4 tunneling driver
+         [    2.514189] NET: Registered protocol family 17
+         [    2.518630] NET: Registered protocol family 15
+         [    2.523205] can: controller area network core (rev 20170425 abi 9)
+         [    2.529410] NET: Registered protocol family 29
+         [    2.533860] can: raw protocol (rev 20170425)
+         [    2.538111] can: broadcast manager protocol (rev 20170425 t)
+         [    2.543760] can: netlink gateway (rev 20190810) max_hops=1
+         [    2.549372] 8021q: 802.1Q VLAN Support v1.8
+         [    2.553586] NET: Registered protocol family 36
+         [    2.558031] Key type dns_resolver registered
+         [    2.562347] ThumbEE CPU extension supported.
+         [    2.566603] Registering SWP/SWPB emulation handler
+         [    2.595815] random: fast init done
+         [    2.634372] random: crng init done
+         [   11.982155] adrv9002 spi0.0: adrv9002-phy Rev 12.0, Firmware 0.16.3.8,  Stream 0.7.3.0,  API version: 48.8.7 successfully initialized
+         [   11.995290] cf_axi_adc ff220000.axi-adrv9002-rx-lpc: ADI AIM (10.01.b) at 0xFF220000 mapped to 0x6a138419, probed ADC ADRV9002 as MASTER
+         [   12.030682] cf_axi_dds ff22a000.axi-adrv9002-tx-lpc: Analog Devices CF_AXI_DDS_DDS MASTER (9.01.b) at 0xFF22A000 mapped to 0x913a51ba, probed DDS ADRV9002
+         [   12.044681] of_cfs_init
+         [   12.047142] of_cfs_init: OK
+         [   12.050103] ALSA device list:
+         [   12.053059]   No soundcards found.
+         [   12.056640] ttyS0 - failed to request DMA
+         [   12.276053] EXT4-fs (mmcblk0p2): recovery complete
+         [   12.284520] EXT4-fs (mmcblk0p2): mounted filesystem with ordered data mode. Opts: (null)
+         [   12.292644] VFS: Mounted root (ext4 filesystem) on device 179:2.
+         [   12.302364] devtmpfs: mounted
+         [   12.309448] Freeing unused kernel memory: 1024K
+         [   12.314357] Run /sbin/init as init process
+         [   12.897820] systemd[1]: System time before build time, advancing clock.
+         [   12.965398] systemd[1]: systemd 241 running in system mode. (+PAM +AUDIT +SELINUX +IMA +APPARMOR +SMACK +SYSVINIT +UTMP +LIBCRYPTSETUP +GCRYPT +GNUTLS +ACL +XZ +LZ4 +SECCOMP +BLKID +ELFUTILS +KMOD -IDN2 +IDN -PCRE2 default-hierarchy=hybrid)
+         [   12.987283] systemd[1]: Detected architecture arm.
+
+         Welcome to Kuiper GNU/Linux 10 (buster)!
+
+         [   13.074023] systemd[1]: Set hostname to <analog>.
+         [   13.442796] systemd[1]: File /lib/systemd/system/systemd-journald.service:12 configures an IP firewall (IPAddressDeny=any), but the local system does not support BPF/cgroup based firewalling.
+         [   13.459883] systemd[1]: Proceeding WITHOUT firewalling in effect! (This warning is only shown for the first loaded unit using IP firewalling.)
+         [   13.642873] systemd[1]: /etc/systemd/system/tof-server.service:1: Assignment outside of section. Ignoring.
+         [   13.652554] systemd[1]: /etc/systemd/system/tof-server.service:2: Assignment outside of section. Ignoring.
+         [   13.883412] systemd[1]: Listening on fsck to fsckd communication Socket.
+         [  OK  ] Listening on fsck to fsckd communication Socket.
+         [   13.920646] systemd[1]: Listening on udev Kernel Socket.
+         [  OK  ] Listening on udev Kernel Socket.
+         [   13.950781] systemd[1]: Listening on Journal Socket.
+         [  OK  ] Listening on Journal Socket.
+         [  OK  ] Created slice system-systemd\x2dfsck.slice.
+                  Starting Load Kernel Modules...
+         [  OK  ] Listening on initctl Compatibility Named Pipe.
+                  Starting Set the console keyboard layout...
+         [  OK  ] Started Forward Password R…uests to Wall Directory Watch.
+         [  OK  ] Listening on Journal Socket (/dev/log).
+         [  OK  ] Created slice system-serial\x2dgetty.slice.
+                  Mounting Kernel Debug File System...
+         [  OK  ] Listening on udev Control Socket.
+         [  OK  ] Listening on Syslog Socket.
+                  Starting Restore / save the current clock...
+                  Starting Journal Service...
+         [  OK  ] Created slice User and Session Slice.
+         [  OK  ] Reached target Slices.
+         [  OK  ] Reached target Swap.
+                  Mounting RPC Pipe File System...
+                  Starting udev Coldplug all Devices...
+         [  OK  ] Created slice system-getty.slice.
+         [  OK  ] Started Journal Service.
+         [FAILED] Failed to start Load Kernel Modules.
+         See 'systemctl status systemd-modules-load.service' for details.
+         [  OK  ] Started Set the console keyboard layout.
+         [  OK  ] Mounted Kernel Debug File System.
+         [  OK  ] Started Restore / save the current clock.
+         [  OK  ] Mounted RPC Pipe File System.
+                  Starting Remount Root and Kernel File Systems...
+                  Starting Apply Kernel Variables...
+                  Mounting Kernel Configuration File System...
+         [  OK  ] Mounted Kernel Configuration File System.
+         [  OK  ] Started Apply Kernel Variables.
+         [  OK  ] Started udev Coldplug all Devices.
+                  Starting Helper to synchronize boot up for ifupdown...
+         [  OK  ] Started Remount Root and Kernel File Systems.
+         [  OK  ] Started Helper to synchronize boot up for ifupdown.
+                  Starting Flush Journal to Persistent Storage...
+                  Starting Create System Users...
+                  Starting Load/Save Random Seed...
+         [  OK  ] Started Create System Users.
+         [  OK  ] Started Load/Save Random Seed.
+                  Starting Create Static Device Nodes in /dev...
+         [  OK  ] Started Flush Journal to Persistent Storage.
+         [  OK  ] Started Create Static Device Nodes in /dev.
+         [  OK  ] Reached target Local File Systems (Pre).
+                  Starting udev Kernel Device Manager...
+         [  OK  ] Started udev Kernel Device Manager.
+                  Starting Show Plymouth Boot Screen...
+         [  OK  ] Started Show Plymouth Boot Screen.
+         [  OK  ] Started Forward Password R…s to Plymouth Directory Watch.
+         [  OK  ] Reached target Local Encrypted Volumes.
+         [  OK  ] Found device /dev/ttyS0.
+         [  OK  ] Found device /dev/disk/by-partuuid/9bdcdc9c-01.
+                  Starting File System Check…isk/by-partuuid/9bdcdc9c-01...
+         [  OK  ] Started File System Check Daemon to report status.
+         [  OK  ] Started File System Check …/disk/by-partuuid/9bdcdc9c-01.
+                  Mounting /boot...
+         [  OK  ] Mounted /boot.
+         [  OK  ] Reached target Local File Systems.
+                  Starting Raise network interfaces...
+                  Starting Create Volatile Files and Directories...
+                  Starting Tell Plymouth To Write Out Runtime Data...
+                  Starting Preprocess NFS configuration...
+                  Starting Set console font and keymap...
+         [  OK  ] Started Tell Plymouth To Write Out Runtime Data.
+         [  OK  ] Started Preprocess NFS configuration.
+         [  OK  ] Reached target NFS client services.
+         [  OK  ] Reached target Remote File Systems (Pre).
+         [  OK  ] Reached target Remote File Systems.
+         [  OK  ] Started Set console font and keymap.
+         [  OK  ] Started Create Volatile Files and Directories.
+                  Starting Update UTMP about System Boot/Shutdown...
+                  Starting Network Time Synchronization...
+         [  OK  ] Started Update UTMP about System Boot/Shutdown.
+         [  OK  ] Started Network Time Synchronization.
+         [  OK  ] Reached target System Time Synchronized.
+         [  OK  ] Reached target System Initialization.
+         [  OK  ] Listening on Avahi mDNS/DNS-SD Stack Activation Socket.
+         [  OK  ] Listening on CUPS Scheduler.
+         [  OK  ] Started CUPS Scheduler.
+         [  OK  ] Reached target Paths.
+         [  OK  ] Started Daily Cleanup of Temporary Directories.
+         [  OK  ] Started Daily apt download activities.
+         [  OK  ] Listening on GPS (Global P…ioning System) Daemon Sockets.
+         [  OK  ] Listening on triggerhappy.socket.
+         [  OK  ] Listening on D-Bus System Message Bus Socket.
+         [  OK  ] Reached target Sockets.
+         [  OK  ] Reached target Basic System.
+                  Starting Check for Raspberry Pi EEPROM updates...
+         [  OK  ] Started Regular background program processing daemon.
+                  Starting Disk Manager...
+         [  OK  ] Started CUPS Scheduler.
+         [  OK  ] Started tof-server.service.
+                  Starting System Logging Service...
+                  Starting Avahi mDNS/DNS-SD Stack...
+                  Starting dhcpcd on all interfaces...
+                  Starting rng-tools.service...
+                  Starting Login Service...
+         [  OK  ] Started D-Bus System Message Bus.
+                  Starting WPA supplicant...
+                  Starting LSB: Switch to on…nless shift key is pressed)...
+         [  OK  ] Started Daily man-db regeneration.
+                  Starting dphys-swapfile - …unt, and delete a swap file...
+                  Starting Modem Manager...
+                  Starting triggerhappy global hotkey daemon...
+         [  OK  ] Started Daily apt upgrade and clean activities.
+         [  OK  ] Started Daily rotation of log files.
+         [  OK  ] Reached target Timers.
+         [  OK  ] Started Check for Raspberry Pi EEPROM updates.
+         [FAILED] Failed to start rng-tools.service.
+         See 'systemctl status rng-tools.service' for details.
+         [  OK  ] Started Login Service.
+         [  OK  ] Started triggerhappy global hotkey daemon.
+         [  OK  ] Started System Logging Service.
+         [  OK  ] Started dhcpcd on all interfaces.
+         [  OK  ] Started Avahi mDNS/DNS-SD Stack.
+         [  OK  ] Started WPA supplicant.
+         [  OK  ] Started Raise network interfaces.
+         [  OK  ] Started LSB: Switch to ond…(unless shift key is pressed).
+                  Starting Authorization Manager...
+         [  OK  ] Started Make remote CUPS printers available locally.
+         [  OK  ] Reached target Network.
+                  Starting /etc/rc.local Compatibility...
+                  Starting OpenBSD Secure Shell server...
+                  Starting Permit User Sessions...
+                  Starting HTTP based time synchronization tool...
+         [  OK  ] Started IIO Daemon.
+         [  OK  ] Started dphys-swapfile - s…mount, and delete a swap file.
+         [  OK  ] Started /etc/rc.local Compatibility.
+         [  OK  ] Started Permit User Sessions.
+         [  OK  ] Started HTTP based time synchronization tool.
+                  Starting Light Display Manager...
+                  Starting Manage, Install and Generate Color Profiles...
+                  Starting Hold until boot process finishes up...
+         [  OK  ] Started OpenBSD Secure Shell server.
+         [  OK  ] Started Authorization Manager.
+         [  OK  ] Started Manage, Install and Generate Color Profiles.
+
+         Raspbian GNU/Linux 10 analog ttyS0
+
+         analog login: root (automatic login)
+
+         Last login: Wed Jun 30 17:58:11 BST 2021 on ttyS0
+         Linux analog 5.4.0-00475-gc588ee4bed9a #12 SMP Fri Jul 2 19:31:54 EEST 2021 armv7l
+
+         The programs included with the Debian GNU/Linux system are free software;
+         the exact distribution terms for each program are described in the
+         individual files in /usr/share/doc/*/copyright.
+
+         Debian GNU/Linux comes with ABSOLUTELY NO WARRANTY, to the extent
+         permitted by applicable law.
+         root@analog:~#
+These devices should be present:
+
+.. container:: box bggreen
+
+   This specifies any shell prompt running on the target
+
+   
+   ::
+   
+
+   
+      root@analog:~#  iio_info | grep ':device'
+          iio:device0: adrv9002-phy
+          iio:device1: axi-adrv9002-rx-lpc (buffer capable)
+          iio:device2: axi-adrv9002-tx-lpc (buffer capable)
+
+For more on device modes, check `device modes. <https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9002>`_
+
+Pyadi-iio Example
+-----------------
+
+Pyadi-iio is a python abstraction module for ADI hardware with IIO drivers to make them easier to use. For more check `Pyadi-iio <https://github.com/analogdevicesinc/pyadi-iio>`_. An example of using adrv9002 can be checked :git-pyadi-iio:`here <examples/adrv9002_example.py>`
+
+IIO Oscilloscope Remote
+-----------------------
+
+Please see also here:`Oscilloscope <https://wiki.analog.com/resources/tools-software/linux-software/iio_oscilloscope>`_
+
+The IIO Oscilloscope application can be used to connect to another platform that
+has a connected device in order to configure the device and read data from it.
+
+Build and start osc on a network enabled Linux host.
+
+Once the application is launched goto Settings -> Connect and enter the IP
+address of the target in the popup window.
+
+.. important::
+
+   Even thought this is Linux, this is a persistent file systems. Care should be taken not to corrupt the file system -- please shut down things, don't just turn off the power switch. Depending on your monitor, the standard power off could be hiding. You can do this from the terminal as well with ``sudo shutdown -h now``
+
+   |image1|
+
+More Information
+----------------
+
+-  :doc:`ADRV9001/2 Quick Start Guides </solutions/reference-designs/adrv9002/quickstart>`
+
+   -  :doc:`ADRV9002 Zynq UltraScale+ MPSoC ZCU102 Quick Start Guide </solutions/reference-designs/adrv9002/quickstart/zynqmp>`
+   -  :doc:`ADRV9002 Zynq SoC ZC706 Quick Start Guide </solutions/reference-designs/adrv9002/quickstart/zynq>`
+   -  :doc:`ADRV9002 Zynq Zed Board Quick Start Guide </solutions/reference-designs/adrv9002/quickstart/zed>`
+   -  :doc:`ADRV9002 Arria10 SoC Quick Start Guide </solutions/reference-designs/adrv9002/quickstart/a10soc>`
+
+-  :doc:`ADRV9001/ADRV9002 HDL Reference Design </solutions/reference-designs/adrv9002/reference_hdl>`
+
+   -  :doc:`AXI_ADRV9001/AXI_ADRV9002 Interface Core </solutions/reference-designs/adrv9002/axi_adrv9002>`
+   -  `Building HDL how-to, ADI Reference Designs HDL User Guide <https://wiki.analog.com/resources/fpga/docs/hdl>`_
+
+-  `ADRV9002 Device Driver Customization <https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9002-customization>`_
+-  `ADRV9002 Integrated Dual RF Transceiver Linux device driver <https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9002>`_
+
+Support
+-------
+
+Analog Devices will provide limited online support for anyone using the reference design with Analog Devices components via the :ez:`EngineerZone <community/fpga>`.
+
+Software resources
+------------------
+
+-  `ADRV9002 Device Driver Customization <https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9002-customization>`_
+-  `ADRV9002 Integrated Dual RF Transceiver Linux device driver <https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9002>`_
+
+More Information
+----------------
+
+-  :doc:`ADRV9001/2 Quick Start Guides </solutions/reference-designs/adrv9002/quickstart>`
+
+   -  :doc:`ADRV9002 Zynq UltraScale+ MPSoC ZCU102 Quick Start Guide </solutions/reference-designs/adrv9002/quickstart/zynqmp>`
+   -  :doc:`ADRV9002 Zynq SoC ZC706 Quick Start Guide </solutions/reference-designs/adrv9002/quickstart/zynq>`
+   -  :doc:`ADRV9002 Zynq Zed Board Quick Start Guide </solutions/reference-designs/adrv9002/quickstart/zed>`
+   -  :doc:`ADRV9002 Arria10 SoC Quick Start Guide </solutions/reference-designs/adrv9002/quickstart/a10soc>`
+
+-  :doc:`ADRV9001/ADRV9002 HDL Reference Design </solutions/reference-designs/adrv9002/reference_hdl>`
+
+   -  :doc:`AXI_ADRV9001/AXI_ADRV9002 Interface Core </solutions/reference-designs/adrv9002/axi_adrv9002>`
+   -  `Building HDL how-to, ADI Reference Designs HDL User Guide <https://wiki.analog.com/resources/fpga/docs/hdl>`_
+
+-  `ADRV9002 Device Driver Customization <https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9002-customization>`_
+-  `ADRV9002 Integrated Dual RF Transceiver Linux device driver <https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9002>`_
+
+Support
+-------
+
+Analog Devices will provide limited online support for anyone using the reference design with Analog Devices components via the :ez:`EngineerZone <community/fpga>`.
+
+Software resources
+------------------
+
+-  `ADRV9002 Device Driver Customization <https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9002-customization>`_
+-  `ADRV9002 Integrated Dual RF Transceiver Linux device driver <https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9002>`_
+
+.. |image1| image:: ../images/shutdown.png
+   :width: 300

--- a/docs/solutions/reference-designs/adrv9002/quickstart/a10soc.rst
+++ b/docs/solutions/reference-designs/adrv9002/quickstart/a10soc.rst
@@ -541,6 +541,7 @@ Messages
          Debian GNU/Linux comes with ABSOLUTELY NO WARRANTY, to the extent
          permitted by applicable law.
          root@analog:~#
+
 These devices should be present:
 
 .. container:: box bggreen

--- a/docs/solutions/reference-designs/adrv9002/quickstart/zed.rst
+++ b/docs/solutions/reference-designs/adrv9002/quickstart/zed.rst
@@ -1,0 +1,1595 @@
+ADRV9002 Zynq ZedBoard Quick Start Guide
+========================================
+
+.. image:: ../images/adrv9002_zed_quickstart.png
+   :align: center
+   :width: 600
+
+This guide provides some quick instructions (still takes a while to download, and set things up) on how to setup the :adi:`ADRV9002NP/W1/PCBZ <EVAL-ADRV9002>` and :adi:`ADRV9002NP/W2/PCBZ <EVAL-ADRV9002>` on:
+
+-  `ZED Board <http://zedboard.org/product/zedboard/>`_ The supported revision is C or higher.
+
+Instructions on how to build the Zynq Linux kernel and devicetrees from source
+can be found here:
+
+-  `Building the Zynq Linux kernel and devicetrees from source <https://wiki.analog.com/resources/tools-software/linux-build/generic/zynq>`_
+-  `How to build the Zynq boot image BOOT.BIN <https://wiki.analog.com/resources/tools-software/linux-software/build-the-zynq-boot-image>`_
+
+ADRV9002 Zynq SoC ZC706 Quick Start Guide
+=========================================
+
+.. image:: ../images/adrv9002_zc706_quickstart.png
+   :align: center
+   :width: 600
+
+This guide provides some quick instructions (still takes awhile to download, and set things up) on how to setup the :adi:`ADRV9002NP/W1/PCBZ <EVAL-ADRV9002>` and :adi:`ADRV9002NP/W2/PCBZ <EVAL-ADRV9002>` on:
+
+-  `ZC706 <https://www.xilinx.com/ZC706>`_ The revision that is supported is 1.2 or higher.
+
+Instructions on how to build the Zynq Linux kernel and devicetrees from source
+can be found here:
+
+-  `Building the Zynq Linux kernel and devicetrees from source <https://wiki.analog.com/resources/tools-software/linux-build/generic/zynq>`_
+-  `How to build the Zynq boot image BOOT.BIN <https://wiki.analog.com/resources/tools-software/linux-software/build-the-zynq-boot-image>`_
+
+LVDS support
+------------
+
+According to `7 Series Select IO guide <https://www.xilinx.com/support/documentation/user_guides/ug471_7Series_SelectIO.pdf>`_ section 'LVDS and LVDS_25' and Table 1-43 the LVDS I/O standard (VADJ 1.8V) is not supported on High Range banks.
+
+Since the evaluation board can operate only with <fc #ff0000>\ **VADJ set to 1.8V**\ </fc> and the FMC connector on the carrier (ZC706, Zedborad) is mapped to HR banks the **<fc #ff0000>LVDS interface is not supported</fc>**.
+
+Required Software
+-----------------
+
+-  SD Card 16GB imaged using the instructions here: `SDCARD for Zynq & Altera SoC Quick Start Guide <https://wiki.analog.com/resources/tools-software/linux-software/kuiper-linux>`_. Use 2020_r1 or newer release. (Pre-released files, built using Vivado 2020.1 can be downloaded from `here <https://swdownloads.analog.com/cse/prebuilt/zynq-zc706-adv7511-adrv9002-master-2021_05_13-08_13_21.zip>`_ )
+-  Copy next boot files from ``zynq-zc706-adv7511-adrv9002`` directory directly on sdcard ``BOOT`` partition :
+
+::
+
+      * ''BOOT.bin''
+      * ''uImage''
+      * ''devicetree.dtb''
+
+-  A UART terminal (Putty/Tera Term/Minicom, etc.), Baud rate 115200 (8N1).
+
+Required Hardware
+-----------------
+
+-  Xilinx `ZC706 <https://www.xilinx.com/ZC706>`_ board - Rev 1.2 or higher
+-  :adi:`ADRV9002NP/W2/PCBZ <EVAL-ADRV9002>` dautherboard
+-  Reference clock source
+-  Mini-USB cable
+-  Ethernet cable
+-  **<fc #ff0000>Specific HW for setting VADJ to 1.8 V</fc>**
+-  Optionally USB keyboard, mouse and a HDMI compatible monitor
+
+ADRV9001/2 Quick Start Guides
+-----------------------------
+
+The Quick Start Guides provide a simple step by step instruction on how to do an initial system setup for the :adi:`ADRV9002NP/W1/PCBZ <EVAL-ADRV9002>` and :adi:`ADRV9002NP/W2/PCBZ <EVAL-ADRV9002>` boards on various FPGA development boards. They will discuss how to program the bitstream, run a no-OS program or boot a Linux distribution.
+
+Supported Carriers
+~~~~~~~~~~~~~~~~~~
+
+The :adi:`ADRV9002NP/W1/PCBZ <EVAL-ADRV9002>` and :adi:`ADRV9002NP/W2/PCBZ <EVAL-ADRV9002>` is, by definition a "FPGA mezzanine card" (FMC), that means it needs a carrier to plug into. The carriers we support are:
+
++----------------------------------------------------------------------------------------------------------------------+-------------------------------------+--------------------+
+| Board                                                                                                                | ADRV9002NP                          |                    |
++======================================================================================================================+=====================================+====================+
+|                                                                                                                      | **CMOS inteface**                   | **LVDS interface** |
++----------------------------------------------------------------------------------------------------------------------+-------------------------------------+--------------------+
+| `ZCU102 <https://www.xilinx.com/ZCU102>`_                                                                            | √                                   | √                  |
++----------------------------------------------------------------------------------------------------------------------+-------------------------------------+--------------------+
+| `ZC706 <https://www.xilinx.com/ZC706>`_                                                                              | √ **<fc #ff0000>VADJ 1.8V</fc>**\ ¹ | N/A²               |
++----------------------------------------------------------------------------------------------------------------------+-------------------------------------+--------------------+
+| `Zed Board <http://zedboard.org/product/zedboard>`_                                                                  | √ **<fc #ff0000>VADJ 1.8V</fc>**    | N/A²               |
++----------------------------------------------------------------------------------------------------------------------+-------------------------------------+--------------------+
+| `Arria 10 SoC <https://www.altera.com/products/boards_and_kits/dev-kits/altera/arria-10-soc-development-kit.html>`_  | √                                   | N/A³               |
++----------------------------------------------------------------------------------------------------------------------+-------------------------------------+--------------------+
+
+| ¹ Instruction for reprogramming the VADJ can be found `here <https://www.xilinx.com/Attachment/ZC706_Power_Controllers_Reprogramming_Steps.pdf>`_ and `here <https://forums.xilinx.com/t5/Xilinx-Evaluation-Boards/ZC706-Doesn-t-work-with-VADJ-at-1-8v/td-p/430086>`_
+| ² See :doc:`Cmos only operation </solutions/reference-designs/adrv9002/quickstart>` section
+| ³ Not supported due sub-optimal mapping of the clock pins from the source synchronous interfaces.
+
+CMOS only operation
+~~~~~~~~~~~~~~~~~~~
+
+On the ZC706 / ZedBoard platforms the FMC connectors map to HR IO banks. The HR banks have a limitation that when using LVDS I/O standard you must set the bank VCCO voltage to 2.5V, however the ADRV9001 evaluation board is using IO supplies of 1.8V and does not have level shifters for the single ended lines. Therefore the VCCO of the banks must be set to 1.8 V (VADJ) and limiting the operation to CMOS mode only. More information on the limitation see `7 Series Select IO guide <https://www.xilinx.com/support/documentation/user_guides/ug471_7Series_SelectIO.pdf>`_ section 'LVDS and LVDS_25' and Table 1-43
+
+Supported Environments
+~~~~~~~~~~~~~~~~~~~~~~
+
+The supported OS are:
+
++----------------------------------------------------------------------------------------------------------------------+-----+----------------+----------------+--------------------------+
+| Board                                                                                                                | HDL | Linux Software | No-OS Software | Required Minimum Release |
++======================================================================================================================+=====+================+================+==========================+
+| `ZCU102 <https://www.xilinx.com/ZCU102>`_                                                                            | √   | √              | √              | 2019-R2                  |
++----------------------------------------------------------------------------------------------------------------------+-----+----------------+----------------+--------------------------+
+| `ZC706 <https://www.xilinx.com/ZC706>`_                                                                              | √   | √              | √              | 2020-R1                  |
++----------------------------------------------------------------------------------------------------------------------+-----+----------------+----------------+--------------------------+
+| `Zed Board <http://zedboard.org/product/zedboard>`_                                                                  | √   | √              | √              | 2019-R2                  |
++----------------------------------------------------------------------------------------------------------------------+-----+----------------+----------------+--------------------------+
+| `Arria 10 SoC <https://www.altera.com/products/boards_and_kits/dev-kits/altera/arria-10-soc-development-kit.html>`_  | √   | √              | N/A            | 2020-R1                  |
++----------------------------------------------------------------------------------------------------------------------+-----+----------------+----------------+--------------------------+
+
+Hardware Setup
+~~~~~~~~~~~~~~
+
+In most carriers, the :adi:`ADRV9002NP/W1/PCBZ <EVAL-ADRV9002>` and :adi:`ADRV9002NP/W2/PCBZ <EVAL-ADRV9002>` boards connects to the HPC1 connector (unless otherwise noted). The carrier setup requires power, UART (115200), ethernet (Linux), DisplayPort or HDMI (if available) and/or JTAG (no-OS) connections. A few typical setups are shown below.
+
+Identify your hardware
+^^^^^^^^^^^^^^^^^^^^^^
+
+Evaluation boards were equipped with different silicon revisions. All boards
+built since the middle of December 2020 have C0 silicon, older ones use B0
+silicon these are no longer shipped. You can identify the board you have based
+on its label.
+
+======== ================
+Label    Silicon Revision
+======== ================
+|image1| **B0**
+|image2| **B0**
+|image3| **C0**
+|image4| **C0**
+======== ================
+
+.. tip::
+
+   Each revision of silicon requires its corresponding software support files in
+   the later steps.
+
+ZCU102 + ADRV9002NP
+~~~~~~~~~~~~~~~~~~~
+
+:doc:`ADRV9002 Zynq UltraScale+ MPSoC ZCU102 Quick Start Guide </solutions/reference-designs/adrv9002/quickstart/zynqmp>`
+
+ZC706 + ADRV9002NP
+~~~~~~~~~~~~~~~~~~
+
+:doc:`ADRV9002 Zynq SoC ZC706 Quick Start Guide </solutions/reference-designs/adrv9002/quickstart/zynq>`
+
+Zed Board + ADRV9002NP
+~~~~~~~~~~~~~~~~~~~~~~
+
+:doc:`ADRV9002 Zynq Zed Board Quick Start Guide </solutions/reference-designs/adrv9002/quickstart/zed>`
+
+============
+
+More Information
+----------------
+
+-  :doc:`ADRV9001/2 Quick Start Guides </solutions/reference-designs/adrv9002/quickstart>`
+
+   -  :doc:`ADRV9002 Zynq UltraScale+ MPSoC ZCU102 Quick Start Guide </solutions/reference-designs/adrv9002/quickstart/zynqmp>`
+   -  :doc:`ADRV9002 Zynq SoC ZC706 Quick Start Guide </solutions/reference-designs/adrv9002/quickstart/zynq>`
+   -  :doc:`ADRV9002 Zynq Zed Board Quick Start Guide </solutions/reference-designs/adrv9002/quickstart/zed>`
+   -  :doc:`ADRV9002 Arria10 SoC Quick Start Guide </solutions/reference-designs/adrv9002/quickstart/a10soc>`
+
+-  :doc:`ADRV9001/ADRV9002 HDL Reference Design </solutions/reference-designs/adrv9002/reference_hdl>`
+
+   -  :doc:`AXI_ADRV9001/AXI_ADRV9002 Interface Core </solutions/reference-designs/adrv9002/axi_adrv9002>`
+   -  `Building HDL how-to, ADI Reference Designs HDL User Guide <https://wiki.analog.com/resources/fpga/docs/hdl>`_
+
+-  `ADRV9002 Device Driver Customization <https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9002-customization>`_
+-  `ADRV9002 Integrated Dual RF Transceiver Linux device driver <https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9002>`_
+
+Support
+-------
+
+Analog Devices will provide limited online support for anyone using the reference design with Analog Devices components via the :ez:`EngineerZone <community/fpga>`.
+
+Software resources
+------------------
+
+-  `ADRV9002 Device Driver Customization <https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9002-customization>`_
+-  `ADRV9002 Integrated Dual RF Transceiver Linux device driver <https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9002>`_
+
+More Information
+----------------
+
+-  :doc:`ADRV9001/2 Quick Start Guides </solutions/reference-designs/adrv9002/quickstart>`
+
+   -  :doc:`ADRV9002 Zynq UltraScale+ MPSoC ZCU102 Quick Start Guide </solutions/reference-designs/adrv9002/quickstart/zynqmp>`
+   -  :doc:`ADRV9002 Zynq SoC ZC706 Quick Start Guide </solutions/reference-designs/adrv9002/quickstart/zynq>`
+   -  :doc:`ADRV9002 Zynq Zed Board Quick Start Guide </solutions/reference-designs/adrv9002/quickstart/zed>`
+   -  :doc:`ADRV9002 Arria10 SoC Quick Start Guide </solutions/reference-designs/adrv9002/quickstart/a10soc>`
+
+-  :doc:`ADRV9001/ADRV9002 HDL Reference Design </solutions/reference-designs/adrv9002/reference_hdl>`
+
+   -  :doc:`AXI_ADRV9001/AXI_ADRV9002 Interface Core </solutions/reference-designs/adrv9002/axi_adrv9002>`
+   -  `Building HDL how-to, ADI Reference Designs HDL User Guide <https://wiki.analog.com/resources/fpga/docs/hdl>`_
+
+-  `ADRV9002 Device Driver Customization <https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9002-customization>`_
+-  `ADRV9002 Integrated Dual RF Transceiver Linux device driver <https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9002>`_
+
+Support
+-------
+
+Analog Devices will provide limited online support for anyone using the reference design with Analog Devices components via the :ez:`EngineerZone <community/fpga>`.
+
+Software resources
+------------------
+
+-  `ADRV9002 Device Driver Customization <https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9002-customization>`_
+-  `ADRV9002 Integrated Dual RF Transceiver Linux device driver <https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9002>`_
+
+.. |image1| image:: ../images/adrv9002_b0_np_w1.png
+.. |image2| image:: ../images/adrv9002_b0_np_w2.png
+.. |image3| image:: ../images/adrv9002xbcz_c0_np_w1.png
+.. |image4| image:: ../images/adrv9002xbcz_c0_np_w2.png
+
+Testing
+=======
+
+.. esd-warning::
+
+.. image:: http://www.xilinx.com/images/product-images/zc706-base-board.jpg
+   :alt: http://www.xilinx.com/images/product-images/zc706-base-board.jpg
+
+.. warning::
+
+   <fc #ff0000>Before executing below steps, VADJ must be set to 1.8V.</fc>
+
+   
+   Instruction for reprogramming the VADJ can be found `here <https://e2e.ti.com/support/power-management-group/power-management/f/power-management-forum/960099/configure-zc706-evaluation-board-vadj-for-3-3v>`_ and `here <https://support.xilinx.com/s/article/56811?language=en_US>`_.
+   
+   On an ADRV9002 Card, there is a red LED close to the FMC connector. The role
+   of this LED is to indicate if VADJ voltage exceeded 2.0V level. If that was
+   the case this LED will be ON. If this LED does not turn off after few seconds
+   after boot, then there is an issue and while the board might still operate
+   this is exceeding the recommended level for VADJ, decreasing board lifetime
+   and can lead to permanent damage of the IC in the worst case.
+
+.. image:: ../images/adrv9002_vadj_led.png
+   :align: center
+   :width: 200
+
+-  Connect the :adi:`ADRV9002NP/W1/PCBZ <EVAL-ADRV9002>` or :adi:`ADRV9002NP/W2/PCBZ <EVAL-ADRV9002>` FMC board to the FPGA carrier **LPC FMC** socket.
+-  On the FMC card set switch to select clock source between:
+
+   -  an on-board 38.4MHz VCTCXO (default)
+   -  external (thru J501) 10MHz to 1000MHz / +13dBm
+
+-  Connect USB UART (Mini USB) to your host PC.
+-  Insert SD card into socket.
+-  Configure ZC706 for SD BOOT (Set the jumpers: The main one is: SW11 - Big
+   Blue Switch in the middle, which controls the Boot Mode, it needs to be set:
+   1: Down, 2: Down, 3: Up, 4: Up, 5: Down. Other Jumpers can be checked via
+   looking at the picture. (click the picture to make it bigger)).
+
+|zc706plusfmcjesdadc1.png|
+
+-  Turn on the power switch on the FPGA board.
+-  Observe kernel and serial console messages on your terminal.
+-  <fc #ff0000>*\* There is supported CMOS interface only.**</fc>
+
+::
+
+   * 
+
+Messages
+--------
+
+.. collapsible:: Complete kernel boot log (Click to expand)
+
+   .. container:: box bggreen
+
+      .. note::
+
+         This specifies any shell prompt running on the target
+
+      ::
+
+         U-Boot 2014.07-dirty (Nov 20 2014 - 17:07:55)
+
+         Board:  Xilinx Zynq
+         I2C:   ready
+         DRAM:  ECC disabled 1 GiB
+         MMC:   zynq_sdhci: 0
+         SF: Detected S25FL128S_64K with page size 512 Bytes, erase size 128 KiB, total 32 MiB
+         ** Warning - bad CRC, using default environment
+
+         In:    serial
+         Out:   serial
+         Err:   serial
+         Net:   Gem.e000b000
+         Hit any key to stop autoboot:  0
+         Device: zynq_sdhci
+         Manufacturer ID: 3
+         OEM: 5344
+         Name: SL16G
+         Tran Speed: 50000000
+         Rd Block Len: 512
+         SD version 3.0
+         High Capacity: Yes
+         Capacity: 14.8 GiB
+         Bus Width: 4-bit
+         reading uEnv.txt
+         389 bytes read in 24 ms (15.6 KiB/s)
+         Loaded environment from uEnv.txt
+         Importing environment from SD ...
+         Running uenvcmd ...
+         Copying Linux from SD to RAM...
+         reading uImage
+         6513112 bytes read in 560 ms (11.1 MiB/s)
+         reading devicetree.dtb
+         18382 bytes read in 28 ms (640.6 KiB/s)
+         reading uramdisk.image.gz
+          Unable to read file uramdisk.image.gz 
+         ## Booting kernel from Legacy Image at 03000000 ...
+            Image Name:   Linux-5.4.0-g2d38bef770bc-dirty
+            Image Type:   ARM Linux Kernel Image (uncompressed)
+            Data Size:    6513048 Bytes = 6.2 MiB
+            Load Address: 00008000
+            Entry Point:  00008000
+            Verifying Checksum ... OK
+         ## Flattened Device Tree blob at 02a00000
+            Booting using the fdt blob at 0x2a00000
+            Loading Kernel Image ... OK
+            Loading Device Tree to 1fff8000, end 1ffff7cd ... OK
+
+         Starting kernel ...
+
+         Booting Linux on physical CPU 0x0
+         Linux version 5.4.0-g2d38bef770bc-dirty (dragos@debian) (gcc version 10.2.1 20201103 (GNU Toolchain for the A-profile Architecture 10.2-2020.11 (arm-10.16))) #22 SMP PREEMPT Thu Mar 11 17:55:04 EET 2021
+         CPU: ARMv7 Processor [413fc090] revision 0 (ARMv7), cr=18c5387d
+         CPU: PIPT / VIPT nonaliasing data cache, VIPT aliasing instruction cache
+         OF: fdt: Machine model: Xilinx Zynq ZED
+         OF: fdt: earlycon: stdout-path /amba@0/uart@E0001000 not found
+         Memory policy: Data cache writealloc
+         cma: Reserved 128 MiB at 0x17c00000
+         percpu: Embedded 15 pages/cpu s29516 r8192 d23732 u61440
+         Built 1 zonelists, mobility grouping on.  Total pages: 130048
+         Kernel command line: console=ttyPS0,115200 root=/dev/mmcblk0p2 rw earlycon rootfstype=ext4 rootwait cpuidle.off=1
+         Dentry cache hash table entries: 65536 (order: 6, 262144 bytes, linear)
+         Inode-cache hash table entries: 32768 (order: 5, 131072 bytes, linear)
+         mem auto-init: stack:off, heap alloc:off, heap free:off
+         Memory: 368404K/524288K available (9216K kernel code, 744K rwdata, 7000K rodata, 1024K init, 162K bss, 24812K reserved, 131072K cma-reserved, 0K highmem)
+         rcu: Preemptible hierarchical RCU implementation.
+         rcu:    RCU restricting CPUs from NR_CPUS=4 to nr_cpu_ids=2.
+                 Tasks RCU enabled.
+         rcu: RCU calculated value of scheduler-enlistment delay is 10 jiffies.
+         rcu: Adjusting geometry for rcu_fanout_leaf=16, nr_cpu_ids=2
+         NR_IRQS: 16, nr_irqs: 16, preallocated irqs: 16
+         efuse mapped to (ptrval)
+         slcr mapped to (ptrval)
+         L2C: platform modifies aux control register: 0x72360000 -> 0x72760000
+         L2C: DT/platform modifies aux control register: 0x72360000 -> 0x72760000
+         L2C-310 erratum 769419 enabled
+         L2C-310 enabling early BRESP for Cortex-A9
+         L2C-310 full line of zeros enabled for Cortex-A9
+         L2C-310 ID prefetch enabled, offset 1 lines
+         L2C-310 dynamic clock gating enabled, standby mode enabled
+         L2C-310 cache controller enabled, 8 ways, 512 kB
+         L2C-310: CACHE_ID 0x410000c8, AUX_CTRL 0x76760001
+         random: get_random_bytes called from start_kernel+0x2c8/0x464 with crng_init=0
+         zynq_clock_init: clkc starts at (ptrval)
+         Zynq clock init
+         sched_clock: 64 bits at 333MHz, resolution 3ns, wraps every 4398046511103ns
+         clocksource: arm_global_timer: mask: 0xffffffffffffffff max_cycles: 0x4ce07af025, max_idle_ns: 440795209040 ns
+         Switching to timer-based delay loop, resolution 3ns
+         clocksource: ttc_clocksource: mask: 0xffff max_cycles: 0xffff, max_idle_ns: 537538477 ns
+         timer #0 at (ptrval), irq=17
+         Console: colour dummy device 80x30
+         Calibrating delay loop (skipped), value calculated using timer frequency.. 666.66 BogoMIPS (lpj=3333333)
+         pid_max: default: 32768 minimum: 301
+         Mount-cache hash table entries: 1024 (order: 0, 4096 bytes, linear)
+         Mountpoint-cache hash table entries: 1024 (order: 0, 4096 bytes, linear)
+         CPU: Testing write buffer coherency: ok
+         CPU0: Spectre v2: using BPIALL workaround
+         CPU0: thread -1, cpu 0, socket 0, mpidr 80000000
+         Setting up static identity map for 0x100000 - 0x100060
+         rcu: Hierarchical SRCU implementation.
+         smp: Bringing up secondary CPUs ...
+         CPU1: thread -1, cpu 1, socket 0, mpidr 80000001
+         CPU1: Spectre v2: using BPIALL workaround
+         smp: Brought up 1 node, 2 CPUs
+         SMP: Total of 2 processors activated (1333.33 BogoMIPS).
+         CPU: All CPU(s) started in SVC mode.
+         devtmpfs: initialized
+         VFP support v0.3: implementor 41 architecture 3 part 30 variant 9 rev 4
+         clocksource: jiffies: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 19112604462750000 ns
+         futex hash table entries: 512 (order: 3, 32768 bytes, linear)
+         pinctrl core: initialized pinctrl subsystem
+         NET: Registered protocol family 16
+         DMA: preallocated 256 KiB pool for atomic coherent allocations
+         hw-breakpoint: found 5 (+1 reserved) breakpoint and 1 watchpoint registers.
+         hw-breakpoint: maximum watchpoint size is 4 bytes.
+         zynq-ocm f800c000.ocmc: ZYNQ OCM pool: 256 KiB @ 0x(ptrval)
+         e0001000.serial: ttyPS0 at MMIO 0xe0001000 (irq = 25, base_baud = 3125000) is a xuartps
+         printk: console [ttyPS0] enabled
+         SCSI subsystem initialized
+         usbcore: registered new interface driver usbfs
+         usbcore: registered new interface driver hub
+         usbcore: registered new device driver usb
+         mc: Linux media interface: v0.10
+         videodev: Linux video capture interface: v2.00
+         jesd204: found 0 devices and 0 topologies
+         FPGA manager framework
+         Advanced Linux Sound Architecture Driver Initialized.
+         clocksource: Switched to clocksource arm_global_timer
+         thermal_sys: Registered thermal governor 'step_wise'
+         NET: Registered protocol family 2
+         tcp_listen_portaddr_hash hash table entries: 512 (order: 0, 6144 bytes, linear)
+         TCP established hash table entries: 4096 (order: 2, 16384 bytes, linear)
+         TCP bind hash table entries: 4096 (order: 3, 32768 bytes, linear)
+         TCP: Hash tables configured (established 4096 bind 4096)
+         UDP hash table entries: 256 (order: 1, 8192 bytes, linear)
+         UDP-Lite hash table entries: 256 (order: 1, 8192 bytes, linear)
+         NET: Registered protocol family 1
+         hw perfevents: no interrupt-affinity property for /pmu@f8891000, guessing.
+         hw perfevents: enabled with armv7_cortex_a9 PMU driver, 7 counters available
+         workingset: timestamp_bits=30 max_order=17 bucket_order=0
+         io scheduler mq-deadline registered
+         io scheduler kyber registered
+         zynq-pinctrl 700.pinctrl: zynq pinctrl initialized
+         dma-pl330 f8003000.dmac: Loaded driver for PL330 DMAC-241330
+         dma-pl330 f8003000.dmac:        DBUFF-128x8bytes Num_Chans-8 Num_Peri-4 Num_Events-16
+         brd: module loaded
+         loop: module loaded
+         Registered mathworks_ip class
+         spi-nor spi1.0: found s25fl128s1, expected n25q128a11
+         random: fast init done
+         spi-nor spi1.0: s25fl128s1 (16384 Kbytes)
+         5 fixed-partitions partitions found on MTD device spi1.0
+         Creating 5 MTD partitions on "spi1.0":
+         0x000000000000-0x000000500000 : "boot"
+         0x000000500000-0x000000520000 : "bootenv"
+         0x000000520000-0x000000540000 : "config"
+         0x000000540000-0x000000fc0000 : "image"
+         0x000000fc0000-0x000001000000 : "spare"
+         MACsec IEEE 802.1AE
+         libphy: Fixed MDIO Bus: probed
+         tun: Universal TUN/TAP device driver, 1.6
+         libphy: MACB_mii_bus: probed
+         mdio_bus e000b000.ethernet-ffffffff: MDIO device at address 0 is missing.
+         usbcore: registered new interface driver asix
+         usbcore: registered new interface driver ax88179_178a
+         usbcore: registered new interface driver cdc_ether
+         usbcore: registered new interface driver net1080
+         usbcore: registered new interface driver cdc_subset
+         usbcore: registered new interface driver zaurus
+         usbcore: registered new interface driver cdc_ncm
+         ehci_hcd: USB 2.0 'Enhanced' Host Controller (EHCI) Driver
+         usbcore: registered new interface driver uas
+         usbcore: registered new interface driver usb-storage
+         usbcore: registered new interface driver usbserial_generic
+         usbserial: USB Serial support registered for generic
+         usbcore: registered new interface driver ftdi_sio
+         usbserial: USB Serial support registered for FTDI USB Serial Device
+         usbcore: registered new interface driver upd78f0730
+         usbserial: USB Serial support registered for upd78f0730
+         chipidea-usb2 e0002000.usb: e0002000.usb supply vbus not found, using dummy regulator
+         ULPI transceiver vendor/product ID 0x0424/0x0007
+         Found SMSC USB3320 ULPI transceiver.
+         ULPI integrity check: passed.
+         ci_hdrc ci_hdrc.0: EHCI Host Controller
+         ci_hdrc ci_hdrc.0: new USB bus registered, assigned bus number 1
+         ci_hdrc ci_hdrc.0: USB 2.0 started, EHCI 1.00
+         usb usb1: New USB device found, idVendor=1d6b, idProduct=0002, bcdDevice= 5.04
+         usb usb1: New USB device strings: Mfr=3, Product=2, SerialNumber=1
+         usb usb1: Product: EHCI Host Controller
+         usb usb1: Manufacturer: Linux 5.4.0-g2d38bef770bc-dirty ehci_hcd
+         usb usb1: SerialNumber: ci_hdrc.0
+         hub 1-0:1.0: USB hub found
+         hub 1-0:1.0: 1 port detected
+         i2c /dev entries driver
+         adv7511 0-0039: 0-0039 supply avdd not found, using dummy regulator
+         adv7511 0-0039: 0-0039 supply dvdd not found, using dummy regulator
+         adv7511 0-0039: 0-0039 supply pvdd not found, using dummy regulator
+         adv7511 0-0039: 0-0039 supply bgvdd not found, using dummy regulator
+         adv7511 0-0039: 0-0039 supply dvdd-3v not found, using dummy regulator
+         adv7511: probe of 0-0039 failed with error -5
+         xiic-i2c 41620000.i2c: IRQ index 0 not found
+         usbcore: registered new interface driver uvcvideo
+         USB Video Class driver (1.1.1)
+         gspca_main: v2.14.0 registered
+         cdns-wdt f8005000.watchdog: Xilinx Watchdog Timer with timeout 10s
+         Xilinx Zynq CpuIdle Driver started
+         failed to register cpuidle driver
+         sdhci: Secure Digital Host Controller Interface driver
+         sdhci: Copyright(c) Pierre Ossman
+         sdhci-pltfm: SDHCI platform and OF driver helper
+         mmc0: SDHCI controller on e0100000.mmc [e0100000.mmc] using ADMA
+         ledtrig-cpu: registered to indicate activity on CPUs
+         hidraw: raw HID events driver (C) Jiri Kosina
+         usbcore: registered new interface driver usbhid
+         usbhid: USB HID core driver
+         axi_sysid 45000000.axi-sysid-0: AXI System ID core version (1.01.a) found
+         axi_sysid 45000000.axi-sysid-0: [adrv9001] [CMOS_LVDS_N=1] on [zc706] git branch <dev_adrv9001_a10soc_zc706> git <9331186e2289103cfb641d9991c4ca809fe57476> clean [2021-02-26 08:58:42] UTC
+         fpga_manager fpga0: Xilinx Zynq FPGA Manager registered
+         usbcore: registered new interface driver snd-usb-audio
+         axi-i2s 77600000.axi-i2s: probed, capture enabled, playback enabled
+         NET: Registered protocol family 10
+         Segment Routing with IPv6
+         mmc0: new high speed SDHC card at address aaaa
+         sit: IPv6, IPv4 and MPLS over IPv4 tunneling driver
+         mmcblk0: mmc0:aaaa SL16G 14.8 GiB
+         NET: Registered protocol family 17
+          mmcblk0: p1 p2 p3
+         NET: Registered protocol family 36
+         Registering SWP/SWPB emulation handler
+         random: crng init done
+         adrv9002 spi0.0: adrv9002-phy Rev 11.0, Firmware 0.13.6.7,  Stream 0.5.18.0,  API version: 39.0.7 successfully initialized
+         cf_axi_adc 44a00000.axi-adrv9002-rx-lpc: ADI AIM (10.01.b) at 0x44A00000 mapped to 0xe9f1d723, probed ADC ADRV9002 as MASTER
+         cf_axi_tdd 44a0c800.axi-adrv9002-core-tdd-lpc: Analog Devices CF_AXI_TDD MASTER (1.00.a)
+         cf_axi_dds 44a0a000.axi-adrv9002-tx-lpc: Analog Devices CF_AXI_DDS_DDS MASTER (9.01.b) at 0x44A0A000 mapped to 0x1b2fbc4a, probed DDS ADRV9002
+         asoc-simple-card zed_sound: adau-hifi <-> 77600000.axi-i2s mapping ok
+         adau1761 0-003b: Unable to sync registers 0x4002-0x4002. -5
+         hctosys: unable to open rtc device (rtc0)
+         ALSA device list:
+           #0: ZED ADAU1761
+         EXT4-fs (mmcblk0p2): mounted filesystem with ordered data mode. Opts: (null)
+         VFS: Mounted root (ext4 filesystem) on device 179:2.
+         devtmpfs: mounted
+         Freeing unused kernel memory: 1024K
+         Run /sbin/init as init process
+         systemd[1]: System time before build time, advancing clock.
+         systemd[1]: Failed to lookup module alias 'autofs4': Function not implemented
+         systemd[1]: systemd 241 running in system mode. (+PAM +AUDIT +SELINUX +IMA +APPARMOR +SMACK +SYSVINIT +UTMP +LIBCRYPTSETUP +GCRYPT +GNUTLS +ACL +XZ +LZ4 +SECCOMP +BLKID +ELFUTILS +KMOD -IDN2 +IDN -PCRE2 default-hierarchy=hybrid)
+         systemd[1]: Detected architecture arm.
+
+         Welcome to Kuiper GNU/Linux 10 (buster)!
+
+         systemd[1]: Set hostname to <analog>.
+         systemd[1]: File /lib/systemd/system/systemd-journald.service:12 configures an IP firewall (IPAddressDeny=any), but the local system does not support BPF/cgroup based firewalling.
+         systemd[1]: Proceeding WITHOUT firewalling in effect! (This warning is only shown for the first loaded unit using IP firewalling.)
+         systemd[1]: Listening on Journal Socket (/dev/log).
+         [  OK  ] Listening on Journal Socket (/dev/log).
+         systemd[1]: Listening on fsck to fsckd communication Socket.
+         [  OK  ] Listening on fsck to fsckd communication Socket.
+         systemd[1]: Created slice system-serial\x2dgetty.slice.
+         [  OK  ] Created slice system-serial\x2dgetty.slice.
+         systemd[1]: Listening on Journal Socket.
+         [  OK  ] Listening on Journal Socket.
+         systemd[1]: Mounting RPC Pipe File System...
+                  Mounting RPC Pipe File System...
+         [  OK  ] Created slice User and Session Slice.
+         [  OK  ] Created slice system-systemd\x2dfsck.slice.
+         [  OK  ] Started Forward Password R…uests to Wall Directory Watch.
+                  Starting Load Kernel Modules...
+         [  OK  ] Listening on udev Kernel Socket.
+         [  OK  ] Listening on Syslog Socket.
+         [  OK  ] Listening on udev Control Socket.
+                  Starting udev Coldplug all Devices...
+                  Mounting Kernel Debug File System...
+                  Starting Journal Service...
+                  Starting Restore / save the current clock...
+         [  OK  ] Reached target Slices.
+         [  OK  ] Created slice system-getty.slice.
+                  Starting Set the console keyboard layout...
+         [  OK  ] Listening on initctl Compatibility Named Pipe.
+         [  OK  ] Reached target Swap.
+         [  OK  ] Started Journal Service.
+         [FAILED] Failed to mount RPC Pipe File System.
+         See 'systemctl status run-rpc_pipefs.mount' for details.
+         [DEPEND] Dependency failed for RPC …ice for NFS client and server.
+         [DEPEND] Dependency failed for RPC …curity service for NFS server.
+         [FAILED] Failed to start Load Kernel Modules.
+         See 'systemctl status systemd-modules-load.service' for details.
+         [  OK  ] Mounted Kernel Debug File System.
+         [  OK  ] Started Restore / save the current clock.
+                  Starting Remount Root and Kernel File Systems...
+                  Mounting Kernel Configuration File System...
+                  Starting Apply Kernel Variables...
+         [  OK  ] Reached target NFS client services.
+         [  OK  ] Reached target Remote File Systems (Pre).
+         [  OK  ] Reached target Remote File Systems.
+         [  OK  ] Started Set the console keyboard layout.
+         [  OK  ] Mounted Kernel Configuration File System.
+         [  OK  ] Started Apply Kernel Variables.
+         [  OK  ] Started udev Coldplug all Devices.
+                  Starting Helper to synchronize boot up for ifupdown...
+         [  OK  ] Started Helper to synchronize boot up for ifupdown.
+         [  OK  ] Started Remount Root and Kernel File Systems.
+                  Starting Load/Save Random Seed...
+                  Starting Flush Journal to Persistent Storage...
+                  Starting Create System Users...
+         [  OK  ] Started Load/Save Random Seed.
+         [  OK  ] Started Create System Users.
+         [  OK  ] Started Flush Journal to Persistent Storage.
+                  Starting Create Static Device Nodes in /dev...
+         [  OK  ] Started Create Static Device Nodes in /dev.
+                  Starting udev Kernel Device Manager...
+         [  OK  ] Reached target Local File Systems (Pre).
+         [  OK  ] Started udev Kernel Device Manager.
+                  Starting Show Plymouth Boot Screen...
+         [  OK  ] Started Show Plymouth Boot Screen.
+         [  OK  ] Reached target Local Encrypted Volumes.
+         [  OK  ] Started Forward Password R…s to Plymouth Directory Watch.
+         [  OK  ] Found device /dev/ttyPS0.
+         [  OK  ] Found device /dev/disk/by-partuuid/0e0f8290-01.
+                  Starting Load Kernel Modules...
+                  Starting File System Check…isk/by-partuuid/0e0f8290-01...
+         [FAILED] Failed to start Load Kernel Modules.
+         See 'systemctl status systemd-modules-load.service' for details.
+         [  OK  ] Started File System Check Daemon to report status.
+         [  OK  ] Started File System Check …/disk/by-partuuid/0e0f8290-01.
+                  Mounting /boot...
+         [  OK  ] Mounted /boot.
+         [  OK  ] Reached target Local File Systems.
+                  Starting Set console font and keymap...
+                  Starting Raise network interfaces...
+                  Starting Create Volatile Files and Directories...
+                  Starting Preprocess NFS configuration...
+                  Starting Tell Plymouth To Write Out Runtime Data...
+         [  OK  ] Started Set console font and keymap.
+         [  OK  ] Started Preprocess NFS configuration.
+         [  OK  ] Started Tell Plymouth To Write Out Runtime Data.
+         [  OK  ] Started Create Volatile Files and Directories.
+                  Starting Network Time Synchronization...
+                  Starting Update UTMP about System Boot/Shutdown...
+         [  OK  ] Started Update UTMP about System Boot/Shutdown.
+         [  OK  ] Started Network Time Synchronization.
+         [  OK  ] Reached target System Time Synchronized.
+         [  OK  ] Reached target System Initialization.
+         [  OK  ] Listening on triggerhappy.socket.
+         [  OK  ] Listening on D-Bus System Message Bus Socket.
+         [  OK  ] Listening on CUPS Scheduler.
+         [  OK  ] Started Daily rotation of log files.
+         [  OK  ] Started CUPS Scheduler.
+         [  OK  ] Reached target Paths.
+         [  OK  ] Started Daily man-db regeneration.
+         [  OK  ] Started Daily Cleanup of Temporary Directories.
+         [  OK  ] Listening on GPS (Global P…ioning System) Daemon Sockets.
+         [  OK  ] Listening on Avahi mDNS/DNS-SD Stack Activation Socket.
+         [  OK  ] Reached target Sockets.
+         [  OK  ] Reached target Basic System.
+                  Starting Modem Manager...
+                  Starting System Logging Service...
+                  Starting triggerhappy global hotkey daemon...
+                  Starting Login Service...
+                  Starting Check for Raspberry Pi EEPROM updates...
+                  Starting rng-tools.service...
+         [  OK  ] Started Regular background program processing daemon.
+         [  OK  ] Started Manage Sound Card State (restore and store).
+                  Starting Save/Restore Sound Card State...
+         [  OK  ] Started D-Bus System Message Bus.
+                  Starting WPA supplicant...
+                  Starting dhcpcd on all interfaces...
+                  Starting Disk Manager...
+                  Starting LSB: Switch to on…nless shift key is pressed)...
+                  Starting Avahi mDNS/DNS-SD Stack...
+         [  OK  ] Started CUPS Scheduler.
+         [  OK  ] Started Daily apt download activities.
+         [  OK  ] Started Daily apt upgrade and clean activities.
+         [  OK  ] Reached target Timers.
+                  Starting dphys-swapfile - …unt, and delete a swap file...
+         [  OK  ] Started triggerhappy global hotkey daemon.
+         [  OK  ] Started System Logging Service.
+         [  OK  ] Started Raise network interfaces.
+         [  OK  ] Started Check for Raspberry Pi EEPROM updates.
+         [FAILED] Failed to start rng-tools.service.
+         See 'systemctl status rng-tools.service' for details.
+         [  OK  ] Started Login Service.
+         [  OK  ] Started Save/Restore Sound Card State.
+         [  OK  ] Started dhcpcd on all interfaces.
+         [  OK  ] Started Avahi mDNS/DNS-SD Stack.
+         [  OK  ] Started WPA supplicant.
+                  Starting Authorization Manager...
+         [  OK  ] Started Make remote CUPS printers available locally.
+         [  OK  ] Reached target Network.
+                  Starting OpenBSD Secure Shell server...
+                  Starting Permit User Sessions...
+                  Starting /etc/rc.local Compatibility...
+         [  OK  ] Started IIO Daemon.
+         [  OK  ] Reached target Sound Card.
+         [  OK  ] Started LSB: Switch to ond…(unless shift key is pressed).
+         [  OK  ] Started dphys-swapfile - s…mount, and delete a swap file.
+         [  OK  ] Started /etc/rc.local Compatibility.
+         [  OK  ] Started Permit User Sessions.
+                  Starting Hold until boot process finishes up...
+                  Starting Light Display Manager...
+         [  OK  ] Started OpenBSD Secure Shell server.
+         [  OK  ] Started Authorization Manager.
+
+         Raspbian GNU/Linux 10 analog ttyPS0
+
+         analog login:
+These devices should be present:
+
+.. container:: box bggreen
+
+   
+   .. note::
+
+      This specifies any shell prompt running on the target
+
+   
+   ::
+   
+   
+
+   
+      analog@analog:~$ iio_info | grep iio:device
+              iio:device0: adrv9002-phy
+              iio:device1: xadc
+              iio:device2: axi-adrv9002-rx-lpc (buffer capable)
+              iio:device3: axi-adrv9002-core-tdd-lpc
+              iio:device4: axi-adrv9002-tx-lpc (buffer capable)
+
+For more on device modes, check `device modes. <https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9002>`_
+
+Pyadi-iio Example
+-----------------
+
+Pyadi-iio is a python abstraction module for ADI hardware with IIO drivers to make them easier to use. For more check `Pyadi-iio <https://github.com/analogdevicesinc/pyadi-iio>`_. An example of using adrv9002 can be checked :git-pyadi-iio:`here <examples/adrv9002_example.py>`
+
+IIO Oscilloscope Remote
+-----------------------
+
+Please see also here:`Oscilloscope <https://wiki.analog.com/resources/tools-software/linux-software/iio_oscilloscope>`_
+
+The IIO Oscilloscope application can be used to connect to another platform that
+has a connected device in order to configure the device and read data from it.
+
+Build and start osc on a network enabled Linux host.
+
+Once the application is launched goto Settings -> Connect and enter the IP
+address of the target in the popup window.
+
+Shut down
+---------
+
+.. important::
+
+   Even thought this is Linux, this is a persistent file systems. Care should be taken not to corrupt the file system -- please shut down things, don't just turn off the power switch. Depending on your monitor, the standard power off could be hiding. You can do this from the terminal as well with ``sudo shutdown -h now``
+
+   |image1_2|
+
+More Information
+----------------
+
+-  :doc:`ADRV9001/2 Quick Start Guides </solutions/reference-designs/adrv9002/quickstart>`
+
+   -  :doc:`ADRV9002 Zynq UltraScale+ MPSoC ZCU102 Quick Start Guide </solutions/reference-designs/adrv9002/quickstart/zynqmp>`
+   -  :doc:`ADRV9002 Zynq SoC ZC706 Quick Start Guide </solutions/reference-designs/adrv9002/quickstart/zynq>`
+   -  :doc:`ADRV9002 Zynq Zed Board Quick Start Guide </solutions/reference-designs/adrv9002/quickstart/zed>`
+   -  :doc:`ADRV9002 Arria10 SoC Quick Start Guide </solutions/reference-designs/adrv9002/quickstart/a10soc>`
+
+-  :doc:`ADRV9001/ADRV9002 HDL Reference Design </solutions/reference-designs/adrv9002/reference_hdl>`
+
+   -  :doc:`AXI_ADRV9001/AXI_ADRV9002 Interface Core </solutions/reference-designs/adrv9002/axi_adrv9002>`
+   -  `Building HDL how-to, ADI Reference Designs HDL User Guide <https://wiki.analog.com/resources/fpga/docs/hdl>`_
+
+-  `ADRV9002 Device Driver Customization <https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9002-customization>`_
+-  `ADRV9002 Integrated Dual RF Transceiver Linux device driver <https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9002>`_
+
+Support
+-------
+
+Analog Devices will provide limited online support for anyone using the reference design with Analog Devices components via the :ez:`EngineerZone <community/fpga>`.
+
+Software resources
+------------------
+
+-  `ADRV9002 Device Driver Customization <https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9002-customization>`_
+-  `ADRV9002 Integrated Dual RF Transceiver Linux device driver <https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9002>`_
+
+More Information
+----------------
+
+-  :doc:`ADRV9001/2 Quick Start Guides </solutions/reference-designs/adrv9002/quickstart>`
+
+   -  :doc:`ADRV9002 Zynq UltraScale+ MPSoC ZCU102 Quick Start Guide </solutions/reference-designs/adrv9002/quickstart/zynqmp>`
+   -  :doc:`ADRV9002 Zynq SoC ZC706 Quick Start Guide </solutions/reference-designs/adrv9002/quickstart/zynq>`
+   -  :doc:`ADRV9002 Zynq Zed Board Quick Start Guide </solutions/reference-designs/adrv9002/quickstart/zed>`
+   -  :doc:`ADRV9002 Arria10 SoC Quick Start Guide </solutions/reference-designs/adrv9002/quickstart/a10soc>`
+
+-  :doc:`ADRV9001/ADRV9002 HDL Reference Design </solutions/reference-designs/adrv9002/reference_hdl>`
+
+   -  :doc:`AXI_ADRV9001/AXI_ADRV9002 Interface Core </solutions/reference-designs/adrv9002/axi_adrv9002>`
+   -  `Building HDL how-to, ADI Reference Designs HDL User Guide <https://wiki.analog.com/resources/fpga/docs/hdl>`_
+
+-  `ADRV9002 Device Driver Customization <https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9002-customization>`_
+-  `ADRV9002 Integrated Dual RF Transceiver Linux device driver <https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9002>`_
+
+Support
+-------
+
+Analog Devices will provide limited online support for anyone using the reference design with Analog Devices components via the :ez:`EngineerZone <community/fpga>`.
+
+Software resources
+------------------
+
+-  `ADRV9002 Device Driver Customization <https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9002-customization>`_
+-  `ADRV9002 Integrated Dual RF Transceiver Linux device driver <https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9002>`_
+
+.. |zc706plusfmcjesdadc1.png| image:: ../images/zc706plusfmcjesdadc1.png
+   :width: 200
+
+.. |image1_2| image:: ../images/shutdown.png
+   :width: 300
+
+Required Software
+-----------------
+
+-  SD Card 16GB imaged using the instructions here: `SDCARD for Zynq & Altera SoC Quick Start Guide <https://wiki.analog.com/resources/tools-software/linux-software/kuiper-linux>`_. Use 2019_r2 or later release. Copy next boot files from ``zynq-zed-adrv9002`` directory directly on sdcard ``BOOT`` partition:
+
+   -  ``BOOT.bin``
+   -  ``uImage``
+   -  ``devicetree.dtb``
+
+-  A UART terminal (Putty/Tera Term/Minicom, etc.), Baud rate 115200 (8N1).
+
+Required Hardware
+-----------------
+
+-  Xilinx `ZED Board <http://zedboard.org/product/zedboard/>`_ board - Revision C or higher.
+-  :adi:`ADRV9002NP/W2/PCBZ <EVAL-ADRV9002>` dautherboard
+-  Reference clock source
+-  Micro-USB cable
+-  Ethernet cable
+-  Optionally USB keyboard, mouse and a HDMI compatible monitor
+
+.. esd-warning::
+
+ADRV9001/2 Quick Start Guides
+-----------------------------
+
+The Quick Start Guides provide a simple step by step instruction on how to do an initial system setup for the :adi:`ADRV9002NP/W1/PCBZ <EVAL-ADRV9002>` and :adi:`ADRV9002NP/W2/PCBZ <EVAL-ADRV9002>` boards on various FPGA development boards. They will discuss how to program the bitstream, run a no-OS program or boot a Linux distribution.
+
+Supported Carriers
+~~~~~~~~~~~~~~~~~~
+
+The :adi:`ADRV9002NP/W1/PCBZ <EVAL-ADRV9002>` and :adi:`ADRV9002NP/W2/PCBZ <EVAL-ADRV9002>` is, by definition a "FPGA mezzanine card" (FMC), that means it needs a carrier to plug into. The carriers we support are:
+
++----------------------------------------------------------------------------------------------------------------------+-------------------------------------+--------------------+
+| Board                                                                                                                | ADRV9002NP                          |                    |
++======================================================================================================================+=====================================+====================+
+|                                                                                                                      | **CMOS inteface**                   | **LVDS interface** |
++----------------------------------------------------------------------------------------------------------------------+-------------------------------------+--------------------+
+| `ZCU102 <https://www.xilinx.com/ZCU102>`_                                                                            | √                                   | √                  |
++----------------------------------------------------------------------------------------------------------------------+-------------------------------------+--------------------+
+| `ZC706 <https://www.xilinx.com/ZC706>`_                                                                              | √ **<fc #ff0000>VADJ 1.8V</fc>**\ ¹ | N/A²               |
++----------------------------------------------------------------------------------------------------------------------+-------------------------------------+--------------------+
+| `Zed Board <http://zedboard.org/product/zedboard>`_                                                                  | √ **<fc #ff0000>VADJ 1.8V</fc>**    | N/A²               |
++----------------------------------------------------------------------------------------------------------------------+-------------------------------------+--------------------+
+| `Arria 10 SoC <https://www.altera.com/products/boards_and_kits/dev-kits/altera/arria-10-soc-development-kit.html>`_  | √                                   | N/A³               |
++----------------------------------------------------------------------------------------------------------------------+-------------------------------------+--------------------+
+
+| ¹ Instruction for reprogramming the VADJ can be found `here <https://www.xilinx.com/Attachment/ZC706_Power_Controllers_Reprogramming_Steps.pdf>`_ and `here <https://forums.xilinx.com/t5/Xilinx-Evaluation-Boards/ZC706-Doesn-t-work-with-VADJ-at-1-8v/td-p/430086>`_
+| ² See :doc:`Cmos only operation </solutions/reference-designs/adrv9002/quickstart>` section
+| ³ Not supported due sub-optimal mapping of the clock pins from the source synchronous interfaces.
+
+CMOS only operation
+~~~~~~~~~~~~~~~~~~~
+
+On the ZC706 / ZedBoard platforms the FMC connectors map to HR IO banks. The HR banks have a limitation that when using LVDS I/O standard you must set the bank VCCO voltage to 2.5V, however the ADRV9001 evaluation board is using IO supplies of 1.8V and does not have level shifters for the single ended lines. Therefore the VCCO of the banks must be set to 1.8 V (VADJ) and limiting the operation to CMOS mode only. More information on the limitation see `7 Series Select IO guide <https://www.xilinx.com/support/documentation/user_guides/ug471_7Series_SelectIO.pdf>`_ section 'LVDS and LVDS_25' and Table 1-43
+
+Supported Environments
+~~~~~~~~~~~~~~~~~~~~~~
+
+The supported OS are:
+
++----------------------------------------------------------------------------------------------------------------------+-----+----------------+----------------+--------------------------+
+| Board                                                                                                                | HDL | Linux Software | No-OS Software | Required Minimum Release |
++======================================================================================================================+=====+================+================+==========================+
+| `ZCU102 <https://www.xilinx.com/ZCU102>`_                                                                            | √   | √              | √              | 2019-R2                  |
++----------------------------------------------------------------------------------------------------------------------+-----+----------------+----------------+--------------------------+
+| `ZC706 <https://www.xilinx.com/ZC706>`_                                                                              | √   | √              | √              | 2020-R1                  |
++----------------------------------------------------------------------------------------------------------------------+-----+----------------+----------------+--------------------------+
+| `Zed Board <http://zedboard.org/product/zedboard>`_                                                                  | √   | √              | √              | 2019-R2                  |
++----------------------------------------------------------------------------------------------------------------------+-----+----------------+----------------+--------------------------+
+| `Arria 10 SoC <https://www.altera.com/products/boards_and_kits/dev-kits/altera/arria-10-soc-development-kit.html>`_  | √   | √              | N/A            | 2020-R1                  |
++----------------------------------------------------------------------------------------------------------------------+-----+----------------+----------------+--------------------------+
+
+Hardware Setup
+~~~~~~~~~~~~~~
+
+In most carriers, the :adi:`ADRV9002NP/W1/PCBZ <EVAL-ADRV9002>` and :adi:`ADRV9002NP/W2/PCBZ <EVAL-ADRV9002>` boards connects to the HPC1 connector (unless otherwise noted). The carrier setup requires power, UART (115200), ethernet (Linux), DisplayPort or HDMI (if available) and/or JTAG (no-OS) connections. A few typical setups are shown below.
+
+Identify your hardware
+^^^^^^^^^^^^^^^^^^^^^^
+
+Evaluation boards were equipped with different silicon revisions. All boards
+built since the middle of December 2020 have C0 silicon, older ones use B0
+silicon these are no longer shipped. You can identify the board you have based
+on its label.
+
+========== ================
+Label      Silicon Revision
+========== ================
+|image1_3| **B0**
+|image2_2| **B0**
+|image3_2| **C0**
+|image4_2| **C0**
+========== ================
+
+.. tip::
+
+   Each revision of silicon requires its corresponding software support files in
+   the later steps.
+
+ZCU102 + ADRV9002NP
+~~~~~~~~~~~~~~~~~~~
+
+:doc:`ADRV9002 Zynq UltraScale+ MPSoC ZCU102 Quick Start Guide </solutions/reference-designs/adrv9002/quickstart/zynqmp>`
+
+ZC706 + ADRV9002NP
+~~~~~~~~~~~~~~~~~~
+
+:doc:`ADRV9002 Zynq SoC ZC706 Quick Start Guide </solutions/reference-designs/adrv9002/quickstart/zynq>`
+
+Zed Board + ADRV9002NP
+~~~~~~~~~~~~~~~~~~~~~~
+
+:doc:`ADRV9002 Zynq Zed Board Quick Start Guide </solutions/reference-designs/adrv9002/quickstart/zed>`
+
+============
+
+More Information
+----------------
+
+-  :doc:`ADRV9001/2 Quick Start Guides </solutions/reference-designs/adrv9002/quickstart>`
+
+   -  :doc:`ADRV9002 Zynq UltraScale+ MPSoC ZCU102 Quick Start Guide </solutions/reference-designs/adrv9002/quickstart/zynqmp>`
+   -  :doc:`ADRV9002 Zynq SoC ZC706 Quick Start Guide </solutions/reference-designs/adrv9002/quickstart/zynq>`
+   -  :doc:`ADRV9002 Zynq Zed Board Quick Start Guide </solutions/reference-designs/adrv9002/quickstart/zed>`
+   -  :doc:`ADRV9002 Arria10 SoC Quick Start Guide </solutions/reference-designs/adrv9002/quickstart/a10soc>`
+
+-  :doc:`ADRV9001/ADRV9002 HDL Reference Design </solutions/reference-designs/adrv9002/reference_hdl>`
+
+   -  :doc:`AXI_ADRV9001/AXI_ADRV9002 Interface Core </solutions/reference-designs/adrv9002/axi_adrv9002>`
+   -  `Building HDL how-to, ADI Reference Designs HDL User Guide <https://wiki.analog.com/resources/fpga/docs/hdl>`_
+
+-  `ADRV9002 Device Driver Customization <https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9002-customization>`_
+-  `ADRV9002 Integrated Dual RF Transceiver Linux device driver <https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9002>`_
+
+Support
+-------
+
+Analog Devices will provide limited online support for anyone using the reference design with Analog Devices components via the :ez:`EngineerZone <community/fpga>`.
+
+Software resources
+------------------
+
+-  `ADRV9002 Device Driver Customization <https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9002-customization>`_
+-  `ADRV9002 Integrated Dual RF Transceiver Linux device driver <https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9002>`_
+
+More Information
+----------------
+
+-  :doc:`ADRV9001/2 Quick Start Guides </solutions/reference-designs/adrv9002/quickstart>`
+
+   -  :doc:`ADRV9002 Zynq UltraScale+ MPSoC ZCU102 Quick Start Guide </solutions/reference-designs/adrv9002/quickstart/zynqmp>`
+   -  :doc:`ADRV9002 Zynq SoC ZC706 Quick Start Guide </solutions/reference-designs/adrv9002/quickstart/zynq>`
+   -  :doc:`ADRV9002 Zynq Zed Board Quick Start Guide </solutions/reference-designs/adrv9002/quickstart/zed>`
+   -  :doc:`ADRV9002 Arria10 SoC Quick Start Guide </solutions/reference-designs/adrv9002/quickstart/a10soc>`
+
+-  :doc:`ADRV9001/ADRV9002 HDL Reference Design </solutions/reference-designs/adrv9002/reference_hdl>`
+
+   -  :doc:`AXI_ADRV9001/AXI_ADRV9002 Interface Core </solutions/reference-designs/adrv9002/axi_adrv9002>`
+   -  `Building HDL how-to, ADI Reference Designs HDL User Guide <https://wiki.analog.com/resources/fpga/docs/hdl>`_
+
+-  `ADRV9002 Device Driver Customization <https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9002-customization>`_
+-  `ADRV9002 Integrated Dual RF Transceiver Linux device driver <https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9002>`_
+
+Support
+-------
+
+Analog Devices will provide limited online support for anyone using the reference design with Analog Devices components via the :ez:`EngineerZone <community/fpga>`.
+
+Software resources
+------------------
+
+-  `ADRV9002 Device Driver Customization <https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9002-customization>`_
+-  `ADRV9002 Integrated Dual RF Transceiver Linux device driver <https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9002>`_
+
+.. |image1_3| image:: ../images/adrv9002_b0_np_w1.png
+.. |image2_2| image:: ../images/adrv9002_b0_np_w2.png
+.. |image3_2| image:: ../images/adrv9002xbcz_c0_np_w1.png
+.. |image4_2| image:: ../images/adrv9002xbcz_c0_np_w2.png
+
+Testing
+=======
+
+.. warning::
+
+   Before executing below steps, VADJ must be set to 1.8V.
+
+   
+   This can be done by changing VADJ jumper (JP18) from default (2V5) to 1V8
+   (see picture below).
+   
+   On an ADRV9002 Card, there is a red LED close to the FMC connector. The role
+   of this LED is to indicate if VADJ voltage exceeded 2.0V level. If that was
+   the case this LED will be ON. If this LED does not turn off after few seconds
+   after boot, then there is an issue and while the board might still operate
+   this is exceeding the recommended level for VADJ, decreasing board lifetime
+   and can lead to permanent damage of the IC in the worst case.
+
+.. image:: ../images/adrv9002_vadj_led.png
+   :align: center
+   :width: 200
+
+-  Connect the :adi:`ADRV9002NP/W1/PCBZ <EVAL-ADRV9002>` or :adi:`ADRV9002NP/W2/PCBZ <EVAL-ADRV9002>` FMC board to the FPGA carrier socket.
+-  On the FMC card set switch to select clock source between:
+
+   -  an on-board 38.4MHz VCTCXO (default)
+   -  external (thru J501) 10MHz to 1000MHz / +13dBm
+
+-  Connect the UART port of ZedBoard (J14) to a PC via MicroUSB.
+
+.. image:: ../images/zed_sw.png
+   :align: right
+   :width: 300
+
+-  Insert the SD card into the slot (J12), located on the underside of ZedBoard.
+-  Configure ZedBoard for SD BOOT: boot (JP7-JP11) and MIO0 (JP6) jumpers set to SD card mode, in accordance with the picture shown on the right. (Click on the picture to enlarge)
+-  Connect 12 V power supply to barrel jack (J20).
+-  Turn on the power switch (SW8) on the FPGA board. Green Power LED (LD13) should illuminate.
+-  Wait ~ 15 seconds. The blue Done LED (LD12) should illuminate.
+-  Observe kernel and serial console messages on your terminal.
+
+**Note!!** USB-OTG* feature: To use USB peripheral devices with ZedBoard, install jumpers JP2 and JP3.
+
+For more detailed information on the ZedBoard jumper settings, check out the *ZedBoard Hardware User Guide*, available on the `ZedBoard doc page <https://www.avnet.com/wps/portal/us/products/avnet-boards/avnet-board-families/zedboard>`_, the *Jumper Settings* chapter.
+
+Messages
+--------
+
+.. collapsible:: Complete kernel boot log (Click to expand)
+
+   .. container:: box bggreen
+
+      This specifies any shell prompt running on the target
+
+      ::
+
+         U-Boot 2014.07-dirty (Nov 20 2014 - 17:05:21)
+
+         Board:  Xilinx Zynq
+         I2C:   ready
+         DRAM:  ECC disabled 512 MiB
+         MMC:   zynq_sdhci: 0
+         SF: Detected S25FL256S_64K with page size 256 Bytes, erase size 64 KiB, total 32 MiB
+         ** Warning - bad CRC, using default environment
+
+         In:    serial
+         Out:   serial
+         Err:   serial
+         Net:   Gem.e000b000
+         Hit any key to stop autoboot:  3  2  1  0
+         Device: zynq_sdhci
+         Manufacturer ID: 3
+         OEM: 5344
+         Name: SB16G
+         Tran Speed: 50000000
+         Rd Block Len: 512
+         SD version 3.0
+         High Capacity: Yes
+         Capacity: 14.8 GiB
+         Bus Width: 4-bit
+         reading uEnv.txt
+         407 bytes read in 26 ms (14.6 KiB/s)
+         Loaded environment from uEnv.txt
+         Importing environment from SD ...
+         Running uenvcmd ...
+         Copying Linux from SD to RAM...
+         reading uImage
+         6484280 bytes read in 583 ms (10.6 MiB/s)
+         reading devicetree.dtb
+         19730 bytes read in 42 ms (458 KiB/s)
+         reading uramdisk.image.gz
+          Unable to read file uramdisk.image.gz 
+         ## Booting kernel from Legacy Image at 03000000 ...
+            Image Name:   Linux-4.19.0-ga6ef26d
+            Image Type:   ARM Linux Kernel Image (uncompressed)
+            Data Size:    6484216 Bytes = 6.2 MiB
+            Load Address: 00008000
+            Entry Point:  00008000
+            Verifying Checksum ... OK
+         ## Flattened Device Tree blob at 02a00000
+            Booting using the fdt blob at 0x2a00000
+            Loading Kernel Image ... OK
+            Loading Device Tree to 1ed1b000, end 1ed22d11 ... OK
+
+         Starting kernel ...
+
+         Booting Linux on physical CPU 0x0
+         Linux version 4.19.0-ga6ef26d (jenkins@romlxbuild1.adlk.analog.com) (gcc version 8.2.0 (GCC)) #1104 SMP PREEMPT Fri Feb 19 15:59:18 GMT 2021
+         CPU: ARMv7 Processor [413fc090] revision 0 (ARMv7), cr=18c5387d
+         CPU: PIPT / VIPT nonaliasing data cache, VIPT aliasing instruction cache
+         OF: fdt: Machine model: Xilinx Zynq ZED
+         OF: fdt: earlycon: stdout-path /amba@0/uart@E0001000 not found
+         Memory policy: Data cache writealloc
+         cma: Reserved 128 MiB at 0x16c00000
+         random: get_random_bytes called from start_kernel+0xa0/0x404 with crng_init=0
+         percpu: Embedded 16 pages/cpu @(ptrval) s33548 r8192 d23796 u65536
+         Built 1 zonelists, mobility grouping on.  Total pages: 130048
+         Kernel command line: console=ttyPS0,115200 root=/dev/mmcblk0p2 rw earlycon rootfstype=ext4 rootwait clk_ignore_unused cpuidle.off=1¹
+         Booting kernel: `1¹' invalid for parameter `cpuidle.off'
+         Dentry cache hash table entries: 65536 (order: 6, 262144 bytes)
+         Inode-cache hash table entries: 32768 (order: 5, 131072 bytes)
+         Memory: 368380K/524288K available (9216K kernel code, 760K rwdata, 7012K rodata, 1024K init, 163K bss, 24836K reserved, 131072K cma-reserved, 0K highmem)
+         Virtual kernel memory layout:
+             vector  : 0xffff0000 - 0xffff1000   (   4 kB)
+             fixmap  : 0xffc00000 - 0xfff00000   (3072 kB)
+             vmalloc : 0xe0800000 - 0xff800000   ( 496 MB)
+             lowmem  : 0xc0000000 - 0xe0000000   ( 512 MB)
+             pkmap   : 0xbfe00000 - 0xc0000000   (   2 MB)
+             modules : 0xbf000000 - 0xbfe00000   (  14 MB)
+               .text : 0x(ptrval) - 0x(ptrval)   (10208 kB)
+               .init : 0x(ptrval) - 0x(ptrval)   (1024 kB)
+               .data : 0x(ptrval) - 0x(ptrval)   ( 761 kB)
+                .bss : 0x(ptrval) - 0x(ptrval)   ( 164 kB)
+         rcu: Preemptible hierarchical RCU implementation.
+         rcu:    RCU restricting CPUs from NR_CPUS=4 to nr_cpu_ids=2.
+             Tasks RCU enabled.
+         rcu: Adjusting geometry for rcu_fanout_leaf=16, nr_cpu_ids=2
+         NR_IRQS: 16, nr_irqs: 16, preallocated irqs: 16
+         efuse mapped to (ptrval)
+         slcr mapped to (ptrval)
+         L2C: platform modifies aux control register: 0x72360000 -> 0x72760000
+         L2C: DT/platform modifies aux control register: 0x72360000 -> 0x72760000
+         L2C-310 erratum 769419 enabled
+         L2C-310 enabling early BRESP for Cortex-A9
+         L2C-310 full line of zeros enabled for Cortex-A9
+         L2C-310 ID prefetch enabled, offset 1 lines
+         L2C-310 dynamic clock gating enabled, standby mode enabled
+         L2C-310 cache controller enabled, 8 ways, 512 kB
+         L2C-310: CACHE_ID 0x410000c8, AUX_CTRL 0x76760001
+         zynq_clock_init: clkc starts at (ptrval)
+         Zynq clock init
+         sched_clock: 64 bits at 333MHz, resolution 3ns, wraps every 4398046511103ns
+         clocksource: arm_global_timer: mask: 0xffffffffffffffff max_cycles: 0x4ce07af025, max_idle_ns: 440795209040 ns
+         Switching to timer-based delay loop, resolution 3ns
+         clocksource: ttc_clocksource: mask: 0xffff max_cycles: 0xffff, max_idle_ns: 537538477 ns
+         timer #0 at (ptrval), irq=17
+         Console: colour dummy device 80x30
+         Calibrating delay loop (skipped), value calculated using timer frequency.. 666.66 BogoMIPS (lpj=3333333)
+         pid_max: default: 32768 minimum: 301
+         Mount-cache hash table entries: 1024 (order: 0, 4096 bytes)
+         Mountpoint-cache hash table entries: 1024 (order: 0, 4096 bytes)
+         CPU: Testing write buffer coherency: ok
+         CPU0: Spectre v2: using BPIALL workaround
+         CPU0: thread -1, cpu 0, socket 0, mpidr 80000000
+         Setting up static identity map for 0x100000 - 0x100060
+         rcu: Hierarchical SRCU implementation.
+         smp: Bringing up secondary CPUs ...
+         CPU1: thread -1, cpu 1, socket 0, mpidr 80000001
+         CPU1: Spectre v2: using BPIALL workaround
+         smp: Brought up 1 node, 2 CPUs
+         SMP: Total of 2 processors activated (1333.33 BogoMIPS).
+         CPU: All CPU(s) started in SVC mode.
+         devtmpfs: initialized
+         VFP support v0.3: implementor 41 architecture 3 part 30 variant 9 rev 4
+         clocksource: jiffies: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 19112604462750000 ns
+         futex hash table entries: 512 (order: 3, 32768 bytes)
+         pinctrl core: initialized pinctrl subsystem
+         NET: Registered protocol family 16
+         DMA: preallocated 256 KiB pool for atomic coherent allocations
+         cpuidle: using governor ladder
+         hw-breakpoint: found 5 (+1 reserved) breakpoint and 1 watchpoint registers.
+         hw-breakpoint: maximum watchpoint size is 4 bytes.
+         zynq-ocm f800c000.ocmc: ZYNQ OCM pool: 256 KiB @ 0x(ptrval)
+         zynq-pinctrl 700.pinctrl: zynq pinctrl initialized
+         e0001000.serial: ttyPS0 at MMIO 0xe0001000 (irq = 25, base_baud = 3125000) is a xuartps
+         console [ttyPS0] enabled
+         SCSI subsystem initialized
+         usbcore: registered new interface driver usbfs
+         usbcore: registered new interface driver hub
+         usbcore: registered new device driver usb
+         media: Linux media interface: v0.10
+         videodev: Linux video capture interface: v2.00
+         jesd204: found 0 devices and 0 topologies
+         FPGA manager framework
+         Advanced Linux Sound Architecture Driver Initialized.
+         clocksource: Switched to clocksource arm_global_timer
+         NET: Registered protocol family 2
+         tcp_listen_portaddr_hash hash table entries: 512 (order: 0, 6144 bytes)
+         TCP established hash table entries: 4096 (order: 2, 16384 bytes)
+         TCP bind hash table entries: 4096 (order: 3, 32768 bytes)
+         TCP: Hash tables configured (established 4096 bind 4096)
+         UDP hash table entries: 256 (order: 1, 8192 bytes)
+         UDP-Lite hash table entries: 256 (order: 1, 8192 bytes)
+         NET: Registered protocol family 1
+         hw perfevents: no interrupt-affinity property for /pmu@f8891000, guessing.
+         hw perfevents: enabled with armv7_cortex_a9 PMU driver, 7 counters available
+         workingset: timestamp_bits=30 max_order=17 bucket_order=0
+         io scheduler noop registered
+         io scheduler deadline registered
+         io scheduler cfq registered (default)
+         io scheduler mq-deadline registered
+         io scheduler kyber registered
+         dma-pl330 f8003000.dmac: Loaded driver for PL330 DMAC-241330
+         dma-pl330 f8003000.dmac:    DBUFF-128x8bytes Num_Chans-8 Num_Peri-4 Num_Events-16
+         brd: module loaded
+         loop: module loaded
+         Registered mathworks_ip class
+         m25p80 spi1.0: found s25fl256s1, expected n25q128a11
+         m25p80 spi1.0: s25fl256s1 (32768 Kbytes)
+         5 fixed-partitions partitions found on MTD device spi1.0
+         Creating 5 MTD partitions on "spi1.0":
+         0x000000000000-0x000000500000 : "boot"
+         0x000000500000-0x000000520000 : "bootenv"
+         0x000000520000-0x000000540000 : "config"
+         0x000000540000-0x000000fc0000 : "image"
+         0x000000fc0000-0x000002000000 : "spare"
+         MACsec IEEE 802.1AE
+         libphy: Fixed MDIO Bus: probed
+         tun: Universal TUN/TAP device driver, 1.6
+         libphy: MACB_mii_bus: probed
+         Marvell 88E1510 e000b000.ethernet-ffffffff:00: attached PHY driver [Marvell 88E1510] (mii_bus:phy_addr=e000b000.ethernet-ffffffff:00, irq=POLL)
+         macb e000b000.ethernet eth0: Cadence GEM rev 0x00020118 at 0xe000b000 irq 28 (00:0a:35:00:01:22)
+         usbcore: registered new interface driver asix
+         usbcore: registered new interface driver ax88179_178a
+         usbcore: registered new interface driver cdc_ether
+         usbcore: registered new interface driver net1080
+         usbcore: registered new interface driver cdc_subset
+         usbcore: registered new interface driver zaurus
+         usbcore: registered new interface driver cdc_ncm
+         ehci_hcd: USB 2.0 'Enhanced' Host Controller (EHCI) Driver
+         usbcore: registered new interface driver uas
+         usbcore: registered new interface driver usb-storage
+         usbcore: registered new interface driver usbserial_generic
+         usbserial: USB Serial support registered for generic
+         usbcore: registered new interface driver ftdi_sio
+         usbserial: USB Serial support registered for FTDI USB Serial Device
+         usbcore: registered new interface driver upd78f0730
+         usbserial: USB Serial support registered for upd78f0730
+         chipidea-usb2 e0002000.usb: e0002000.usb supply vbus not found, using dummy regulator
+         chipidea-usb2 e0002000.usb: Linked as a consumer to regulator.0
+         ULPI transceiver vendor/product ID 0x0451/0x1507
+         Found TI TUSB1210 ULPI transceiver.
+         ULPI integrity check: passed.
+         ci_hdrc ci_hdrc.0: EHCI Host Controller
+         ci_hdrc ci_hdrc.0: new USB bus registered, assigned bus number 1
+         ci_hdrc ci_hdrc.0: USB 2.0 started, EHCI 1.00
+         usb usb1: New USB device found, idVendor=1d6b, idProduct=0002, bcdDevice= 4.19
+         usb usb1: New USB device strings: Mfr=3, Product=2, SerialNumber=1
+         usb usb1: Product: EHCI Host Controller
+         usb usb1: Manufacturer: Linux 4.19.0-ga6ef26d ehci_hcd
+         usb usb1: SerialNumber: ci_hdrc.0
+         hub 1-0:1.0: USB hub found
+         hub 1-0:1.0: 1 port detected
+         i2c /dev entries driver
+         adv7511 0-0039: 0-0039 supply avdd not found, using dummy regulator
+         adv7511 0-0039: Linked as a consumer to regulator.0
+         adv7511 0-0039: 0-0039 supply dvdd not found, using dummy regulator
+         adv7511 0-0039: 0-0039 supply pvdd not found, using dummy regulator
+         adv7511 0-0039: 0-0039 supply bgvdd not found, using dummy regulator
+         adv7511 0-0039: 0-0039 supply dvdd-3v not found, using dummy regulator
+         usbcore: registered new interface driver uvcvideo
+         USB Video Class driver (1.1.1)
+         gspca_main: v2.14.0 registered
+         cdns-wdt f8005000.watchdog: Xilinx Watchdog Timer with timeout 10s
+         Xilinx Zynq CpuIdle Driver started
+         sdhci: Secure Digital Host Controller Interface driver
+         sdhci: Copyright(c) Pierre Ossman
+         sdhci-pltfm: SDHCI platform and OF driver helper
+         mmc0: SDHCI controller on e0100000.mmc [e0100000.mmc] using ADMA
+         ledtrig-cpu: registered to indicate activity on CPUs
+         hidraw: raw HID events driver (C) Jiri Kosina
+         usbcore: registered new interface driver usbhid
+         usbhid: USB HID core driver
+         axi_sysid 45000000.axi-sysid-0: [adrv9001] on [zed] git <061d024d596ef84c6a819854bf2472e6b43a2d5d> clean [2021-02-19 16:09:37] UTC
+         fpga_manager fpga0: Xilinx Zynq FPGA Manager registered
+         usbcore: registered new interface driver snd-usb-audio
+         mmc0: new high speed SDHC card at address aaaa
+         mmcblk0: mmc0:aaaa SB16G 14.8 GiB
+         NET: Registered protocol family 10
+         Segment Routing with IPv6
+         sit: IPv6, IPv4 and MPLS over IPv4 tunneling driver
+         NET: Registered protocol family 17
+          mmcblk0: p1 p2 p3
+         NET: Registered protocol family 36
+         Registering SWP/SWPB emulation handler
+         [drm] Cannot find any crtc or sizes
+         [drm] Initialized axi_hdmi_drm 1.0.0 20120930 for 70e00000.axi_hdmi on minor 0
+         random: fast init done
+         [drm] Cannot find any crtc or sizes
+         random: crng init done
+         adrv9002 spi0.0: adrv9002-phy Rev 12.0, Firmware 0.14.5.6,  Stream 0.5.18.0,  API version: 39.0.7 successfully initialized
+         cf_axi_adc 44a00000.axi-adrv9002-rx-lpc: ADI AIM (10.01.b) at 0x44A00000 mapped to 0x545d73c6, probed ADC ADRV9002 as MASTER
+         cf_axi_tdd 44a0c800.axi-adrv9002-core-tdd1-lpc: Analog Devices CF_AXI_TDD MASTER (1.00.a)
+         cf_axi_tdd 44a0cc00.axi-adrv9002-core-tdd2-lpc: Analog Devices CF_AXI_TDD MASTER (1.00.a)
+         cf_axi_dds 44a0a000.axi-adrv9002-tx-lpc: Analog Devices CF_AXI_DDS_DDS MASTER (9.01.b) at 0x44A0A000 mapped to 0x7132b4c8, probed DDS ADRV9002
+         cf_axi_dds 44a0c000.axi-adrv9002-tx2-lpc: Analog Devices CF_AXI_DDS_DDS MASTER (9.01.b) at 0x44A0C000 mapped to 0x6a16e7aa, probed DDS ADRV9002
+         asoc-simple-card adv7511_hdmi_snd: spdif-hifi <-> 75c00000.axi-spdif-tx mapping ok
+         asoc-simple-card zed_sound: adau-hifi <-> 77600000.axi-i2s mapping ok
+         hctosys: unable to open rtc device (rtc0)
+         clk: Not disabling unused clocks
+         ALSA device list:
+           #0: HDMI monitor
+           #1: ZED ADAU1761
+         EXT4-fs (mmcblk0p2): mounted filesystem with ordered data mode. Opts: (null)
+         VFS: Mounted root (ext4 filesystem) on device 179:2.
+         devtmpfs: mounted
+         Freeing unused kernel memory: 1024K
+         Run /sbin/init as init process
+         systemd[1]: System time before build time, advancing clock.
+         systemd[1]: Failed to lookup module alias 'autofs4': Function not implemented
+         systemd[1]: systemd 241 running in system mode. (+PAM +AUDIT +SELINUX +IMA +APPARMOR +SMACK +SYSVINIT +UTMP +LIBCRYPTSETUP +GCRYPT +GNUTLS +ACL +XZ +LZ4 +SECCOMP +BLKID +ELFUTILS +KMOD -IDN2 +IDN -PCRE2 default-hierarchy=hybrid)
+         systemd[1]: Detected architecture arm.
+
+         Welcome to Kuiper GNU/Linux 10 (buster)!
+
+         systemd[1]: Set hostname to <analog>.
+         systemd[1]: File /lib/systemd/system/systemd-journald.service:12 configures an IP firewall (IPAddressDeny=any), but the local system does not support BPF/cgroup based firewalling.
+         systemd[1]: Proceeding WITHOUT firewalling in effect! (This warning is only shown for the first loaded unit using IP firewalling.)
+         systemd[1]: /etc/systemd/system/tof-server.service:1: Assignment outside of section. Ignoring.
+         systemd[1]: /etc/systemd/system/tof-server.service:2: Assignment outside of section. Ignoring.
+         systemd[1]: Created slice User and Session Slice.
+         [  OK  ] Created slice User and Session Slice.
+         systemd[1]: Listening on udev Kernel Socket.
+         [  OK  ] Listening on udev Kernel Socket.
+         systemd[1]: Listening on udev Control Socket.
+         [  OK  ] Listening on udev Control Socket.
+         [  OK  ] Reached target Slices.
+         [  OK  ] Created slice system-getty.slice.
+         [  OK  ] Reached target Swap.
+         [  OK  ] Listening on Syslog Socket.
+         [  OK  ] Listening on fsck to fsckd communication Socket.
+         [  OK  ] Listening on initctl Compatibility Named Pipe.
+         [  OK  ] Listening on Journal Socket (/dev/log).
+         [  OK  ] Started Forward Password R…uests to Wall Directory Watch.
+         [  OK  ] Created slice system-serial\x2dgetty.slice.
+         [  OK  ] Listening on Journal Socket.
+                  Starting Restore / save the current clock...
+                  Starting Load Kernel Modules...
+                  Mounting RPC Pipe File System...
+                  Starting Set the console keyboard layout...
+                  Starting Journal Service...
+                  Starting udev Coldplug all Devices...
+                  Mounting Kernel Debug File System...
+         [  OK  ] Created slice system-systemd\x2dfsck.slice.
+         [  OK  ] Started Restore / save the current clock.
+         [  OK  ] Started Journal Service.
+         [FAILED] Failed to start Load Kernel Modules.
+         See 'systemctl status systemd-modules-load.service' for details.
+         [FAILED] Failed to mount RPC Pipe File System.
+         See 'systemctl status run-rpc_pipefs.mount' for details.
+         [DEPEND] Dependency failed for RPC …ice for NFS client and server.
+         [DEPEND] Dependency failed for RPC …curity service for NFS server.
+         [  OK  ] Mounted Kernel Debug File System.
+         [  OK  ] Reached target NFS client services.
+         [  OK  ] Reached target Remote File Systems (Pre).
+         [  OK  ] Reached target Remote File Systems.
+                  Starting Apply Kernel Variables...
+                  Mounting Kernel Configuration File System...
+                  Starting Remount Root and Kernel File Systems...
+         [  OK  ] Started Set the console keyboard layout.
+         [  OK  ] Started Apply Kernel Variables.
+         [  OK  ] Mounted Kernel Configuration File System.
+         [  OK  ] Started udev Coldplug all Devices.
+                  Starting Helper to synchronize boot up for ifupdown...
+         [  OK  ] Started Helper to synchronize boot up for ifupdown.
+         [  OK  ] Started Remount Root and Kernel File Systems.
+                  Starting Create System Users...
+                  Starting Load/Save Random Seed...
+                  Starting Flush Journal to Persistent Storage...
+         [  OK  ] Started Load/Save Random Seed.
+         [  OK  ] Started Create System Users.
+                  Starting Create Static Device Nodes in /dev...
+         [  OK  ] Started Flush Journal to Persistent Storage.
+         [  OK  ] Started Create Static Device Nodes in /dev.
+         [  OK  ] Reached target Local File Systems (Pre).
+                  Starting udev Kernel Device Manager...
+         [  OK  ] Started udev Kernel Device Manager.
+                  Starting Show Plymouth Boot Screen...
+         [  OK  ] Started Show Plymouth Boot Screen.
+         [  OK  ] Started Forward Password R…s to Plymouth Directory Watch.
+         [  OK  ] Reached target Local Encrypted Volumes.
+                  Starting Load Kernel Modules...
+         [  OK  ] Found device /dev/ttyPS0.
+         [FAILED] Failed to start Load Kernel Modules.
+         See 'systemctl status systemd-modules-load.service' for details.
+         [  OK  ] Found device /dev/disk/by-partuuid/18f1f9d5-01.
+                  Starting File System Check…isk/by-partuuid/18f1f9d5-01...
+         [  OK  ] Started File System Check Daemon to report status.
+                  Starting Load Kernel Modules...
+         [FAILED] Failed to start Load Kernel Modules.
+         See 'systemctl status systemd-modules-load.service' for details.
+         [  OK  ] Started File System Check …/disk/by-partuuid/18f1f9d5-01.
+                  Mounting /boot...
+         [  OK  ] Mounted /boot.
+         [  OK  ] Reached target Local File Systems.
+                  Starting Set console font and keymap...
+                  Starting Raise network interfaces...
+                  Starting Create Volatile Files and Directories...
+                  Starting Tell Plymouth To Write Out Runtime Data...
+                  Starting Preprocess NFS configuration...
+         [  OK  ] Started Set console font and keymap.
+         [  OK  ] Started Tell Plymouth To Write Out Runtime Data.
+         [  OK  ] Started Preprocess NFS configuration.
+         [  OK  ] Started Create Volatile Files and Directories.
+                  Starting Tell Plymouth To Write Out Runtime Data...
+                  Starting Load Kernel Modules...
+                  Starting Update UTMP about System Boot/Shutdown...
+                  Starting Network Time Synchronization...
+         [  OK  ] Started Tell Plymouth To Write Out Runtime Data.
+         [  OK  ] Started Raise network interfaces.
+         [FAILED] Failed to start Load Kernel Modules.
+         See 'systemctl status systemd-modules-load.service' for details.
+         [  OK  ] Started Update UTMP about System Boot/Shutdown.
+         [  OK  ] Started Network Time Synchronization.
+         [  OK  ] Reached target System Time Synchronized.
+         [  OK  ] Reached target System Initialization.
+         [  OK  ] Listening on GPS (Global P…ioning System) Daemon Sockets.
+         [  OK  ] Listening on Avahi mDNS/DNS-SD Stack Activation Socket.
+         [  OK  ] Started Daily apt download activities.
+         [  OK  ] Started Daily rotation of log files.
+         [  OK  ] Listening on D-Bus System Message Bus Socket.
+         [  OK  ] Listening on triggerhappy.socket.
+         [  OK  ] Started Daily Cleanup of Temporary Directories.
+         [  OK  ] Started CUPS Scheduler.
+         [  OK  ] Reached target Paths.
+         [  OK  ] Listening on CUPS Scheduler.
+         [  OK  ] Reached target Sockets.
+         [  OK  ] Started Daily man-db regeneration.
+         [  OK  ] Reached target Basic System.
+                  Starting Check for Raspberry Pi EEPROM updates...
+                  Starting dphys-swapfile - …unt, and delete a swap file...
+                  Starting triggerhappy global hotkey daemon...
+                  Starting System Logging Service...
+                  Starting rng-tools.service...
+                  Starting Login Service...
+         [  OK  ] Started Regular background program processing daemon.
+         [  OK  ] Started CUPS Scheduler.
+                  Starting Avahi mDNS/DNS-SD Stack...
+                  Starting Disk Manager...
+                  Starting LSB: Switch to on…nless shift key is pressed)...
+         [  OK  ] Started Manage Sound Card State (restore and store).
+                  Starting Save/Restore Sound Card State...
+                  Starting Modem Manager...
+         [  OK  ] Started tof-server.service.
+                  Starting dhcpcd on all interfaces...
+         [  OK  ] Started D-Bus System Message Bus.
+                  Starting WPA supplicant...
+         [  OK  ] Started Daily apt upgrade and clean activities.
+         [  OK  ] Reached target Timers.
+         [  OK  ] Started triggerhappy global hotkey daemon.
+         [  OK  ] Started System Logging Service.
+         [  OK  ] Started Check for Raspberry Pi EEPROM updates.
+         [FAILED] Failed to start rng-tools.service.
+         See 'systemctl status rng-tools.service' for details.
+         [  OK  ] Started Save/Restore Sound Card State.
+         [  OK  ] Reached target Sound Card.
+         [  OK  ] Started Login Service.
+         [  OK  ] Started LSB: Switch to ond…(unless shift key is pressed).
+         [  OK  ] Started dhcpcd on all interfaces.
+         [  OK  ] Started dphys-swapfile - s…mount, and delete a swap file.
+         [  OK  ] Started Avahi mDNS/DNS-SD Stack.
+         [  OK  ] Started WPA supplicant.
+         [  OK  ] Started Make remote CUPS printers available locally.
+         [  OK  ] Reached target Network.
+         [  OK  ] Started IIO Daemon.
+                  Starting HTTP based time synchronization tool...
+                  Starting OpenBSD Secure Shell server...
+                  Starting /etc/rc.local Compatibility...
+                  Starting Permit User Sessions...
+         [  OK  ] Started /etc/rc.local Compatibility.
+                  Starting Authorization Manager...
+         [  OK  ] Started Permit User Sessions.
+                  Starting Light Display Manager...
+                  Starting Hold until boot process finishes up...
+         [  OK  ] Started HTTP based time synchronization tool.
+         [  OK  ] Started OpenBSD Secure Shell server.
+         [  OK  ] Started Authorization Manager.
+
+         Raspbian GNU/Linux 10 analog ttyPS0
+
+         analog login: root (automatic login)
+
+         Last login: Wed Feb 24 01:09:52 GMT 2021 on ttyPS0
+         Linux analog 4.19.0-ga6ef26d #1104 SMP PREEMPT Fri Feb 19 15:59:18 GMT 2021 armv7l
+
+         The programs included with the Debian GNU/Linux system are free software;
+         the exact distribution terms for each program are described in the
+         individual files in /usr/share/doc/*/copyright.
+
+         Debian GNU/Linux comes with ABSOLUTELY NO WARRANTY, to the extent
+         permitted by applicable law.
+         root@analog:~#
+These devices should be present:
+
+.. container:: box bggreen
+
+   This specifies any shell prompt running on the target
+
+   
+   ::
+   
+
+   
+      root@analog:~# iio_info | grep iio:device
+          iio:device0: adrv9002-phy
+          iio:device1: xadc
+          iio:device2: axi-adrv9002-rx-lpc (buffer capable)
+          iio:device3: axi-adrv9002-rx2-lpc (buffer capable)
+          iio:device4: axi-adrv9002-core-tdd1-lpc
+          iio:device5: axi-adrv9002-core-tdd2-lpc
+          iio:device6: axi-adrv9002-tx-lpc (buffer capable)
+          iio:device7: axi-adrv9002-tx2-lpc (buffer capable)
+
+For more on device modes, check `device modes. <https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9002>`_
+
+Pyadi-iio Example
+-----------------
+
+Pyadi-iio is a python abstraction module for ADI hardware with IIO drivers to make them easier to use. For more check `Pyadi-iio <https://github.com/analogdevicesinc/pyadi-iio>`_. An example of using adrv9002 can be checked :git-pyadi-iio:`here <examples/adrv9002_example.py>`
+
+IIO Oscilloscope Remote
+-----------------------
+
+Please see also here:`Oscilloscope <https://wiki.analog.com/resources/tools-software/linux-software/iio_oscilloscope>`_
+
+The IIO Oscilloscope application can be used to connect to another platform that
+has a connected device in order to configure the device and read data from it.
+
+Build and start osc on a network enabled Linux host.
+
+Once the application is launched goto Settings -> Connect and enter the IP
+address of the target in the popup window.
+
+.. important::
+
+   Even thought this is Linux, this is a persistent file systems. Care should be taken not to corrupt the file system -- please shut down things, don't just turn off the power switch. Depending on your monitor, the standard power off could be hiding. You can do this from the terminal as well with ``sudo shutdown -h now``
+
+   |image1_4|
+
+More Information
+----------------
+
+-  :doc:`ADRV9001/2 Quick Start Guides </solutions/reference-designs/adrv9002/quickstart>`
+
+   -  :doc:`ADRV9002 Zynq UltraScale+ MPSoC ZCU102 Quick Start Guide </solutions/reference-designs/adrv9002/quickstart/zynqmp>`
+   -  :doc:`ADRV9002 Zynq SoC ZC706 Quick Start Guide </solutions/reference-designs/adrv9002/quickstart/zynq>`
+   -  :doc:`ADRV9002 Zynq Zed Board Quick Start Guide </solutions/reference-designs/adrv9002/quickstart/zed>`
+   -  :doc:`ADRV9002 Arria10 SoC Quick Start Guide </solutions/reference-designs/adrv9002/quickstart/a10soc>`
+
+-  :doc:`ADRV9001/ADRV9002 HDL Reference Design </solutions/reference-designs/adrv9002/reference_hdl>`
+
+   -  :doc:`AXI_ADRV9001/AXI_ADRV9002 Interface Core </solutions/reference-designs/adrv9002/axi_adrv9002>`
+   -  `Building HDL how-to, ADI Reference Designs HDL User Guide <https://wiki.analog.com/resources/fpga/docs/hdl>`_
+
+-  `ADRV9002 Device Driver Customization <https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9002-customization>`_
+-  `ADRV9002 Integrated Dual RF Transceiver Linux device driver <https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9002>`_
+
+Support
+-------
+
+Analog Devices will provide limited online support for anyone using the reference design with Analog Devices components via the :ez:`EngineerZone <community/fpga>`.
+
+Software resources
+------------------
+
+-  `ADRV9002 Device Driver Customization <https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9002-customization>`_
+-  `ADRV9002 Integrated Dual RF Transceiver Linux device driver <https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9002>`_
+
+More Information
+----------------
+
+-  :doc:`ADRV9001/2 Quick Start Guides </solutions/reference-designs/adrv9002/quickstart>`
+
+   -  :doc:`ADRV9002 Zynq UltraScale+ MPSoC ZCU102 Quick Start Guide </solutions/reference-designs/adrv9002/quickstart/zynqmp>`
+   -  :doc:`ADRV9002 Zynq SoC ZC706 Quick Start Guide </solutions/reference-designs/adrv9002/quickstart/zynq>`
+   -  :doc:`ADRV9002 Zynq Zed Board Quick Start Guide </solutions/reference-designs/adrv9002/quickstart/zed>`
+   -  :doc:`ADRV9002 Arria10 SoC Quick Start Guide </solutions/reference-designs/adrv9002/quickstart/a10soc>`
+
+-  :doc:`ADRV9001/ADRV9002 HDL Reference Design </solutions/reference-designs/adrv9002/reference_hdl>`
+
+   -  :doc:`AXI_ADRV9001/AXI_ADRV9002 Interface Core </solutions/reference-designs/adrv9002/axi_adrv9002>`
+   -  `Building HDL how-to, ADI Reference Designs HDL User Guide <https://wiki.analog.com/resources/fpga/docs/hdl>`_
+
+-  `ADRV9002 Device Driver Customization <https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9002-customization>`_
+-  `ADRV9002 Integrated Dual RF Transceiver Linux device driver <https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9002>`_
+
+Support
+-------
+
+Analog Devices will provide limited online support for anyone using the reference design with Analog Devices components via the :ez:`EngineerZone <community/fpga>`.
+
+Software resources
+------------------
+
+-  `ADRV9002 Device Driver Customization <https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9002-customization>`_
+-  `ADRV9002 Integrated Dual RF Transceiver Linux device driver <https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9002>`_
+
+.. |image1_4| image:: ../images/shutdown.png
+   :width: 300

--- a/docs/solutions/reference-designs/adrv9002/quickstart/zed.rst
+++ b/docs/solutions/reference-designs/adrv9002/quickstart/zed.rst
@@ -689,6 +689,7 @@ Messages
          Raspbian GNU/Linux 10 analog ttyPS0
 
          analog login:
+
 These devices should be present:
 
 .. container:: box bggreen
@@ -1486,6 +1487,7 @@ Messages
          Debian GNU/Linux comes with ABSOLUTELY NO WARRANTY, to the extent
          permitted by applicable law.
          root@analog:~#
+
 These devices should be present:
 
 .. container:: box bggreen

--- a/docs/solutions/reference-designs/adrv9002/quickstart/zynq.rst
+++ b/docs/solutions/reference-designs/adrv9002/quickstart/zynq.rst
@@ -1,0 +1,783 @@
+ADRV9002 Zynq SoC ZC706 Quick Start Guide
+=========================================
+
+.. image:: ../images/adrv9002_zc706_quickstart.png
+   :align: center
+   :width: 600
+
+This guide provides some quick instructions (still takes awhile to download, and set things up) on how to setup the :adi:`ADRV9002NP/W1/PCBZ <EVAL-ADRV9002>` and :adi:`ADRV9002NP/W2/PCBZ <EVAL-ADRV9002>` on:
+
+-  `ZC706 <https://www.xilinx.com/ZC706>`_ The revision that is supported is 1.2 or higher.
+
+Instructions on how to build the Zynq Linux kernel and devicetrees from source
+can be found here:
+
+-  `Building the Zynq Linux kernel and devicetrees from source <https://wiki.analog.com/resources/tools-software/linux-build/generic/zynq>`_
+-  `How to build the Zynq boot image BOOT.BIN <https://wiki.analog.com/resources/tools-software/linux-software/build-the-zynq-boot-image>`_
+
+LVDS support
+------------
+
+According to `7 Series Select IO guide <https://www.xilinx.com/support/documentation/user_guides/ug471_7Series_SelectIO.pdf>`_ section 'LVDS and LVDS_25' and Table 1-43 the LVDS I/O standard (VADJ 1.8V) is not supported on High Range banks.
+
+Since the evaluation board can operate only with **VADJ set to 1.8V** and the FMC connector on the carrier (ZC706, Zedborad) is mapped to HR banks the **LVDS interface is not supported**.
+
+Required Software
+-----------------
+
+-  SD Card 16GB imaged using the instructions here: `SDCARD for Zynq & Altera SoC Quick Start Guide <https://wiki.analog.com/resources/tools-software/linux-software/kuiper-linux>`_. Use 2020_r1 or newer release. (Pre-released files, built using Vivado 2020.1 can be downloaded from `here <https://swdownloads.analog.com/cse/prebuilt/zynq-zc706-adv7511-adrv9002-master-2021_05_13-08_13_21.zip>`_ )
+-  Copy next boot files from ``zynq-zc706-adv7511-adrv9002`` directory directly on sdcard ``BOOT`` partition :
+
+   -  ``BOOT.bin``
+   -  ``uImage``
+   -  ``devicetree.dtb``
+
+-  A UART terminal (Putty/Tera Term/Minicom, etc.), Baud rate 115200 (8N1).
+
+Required Hardware
+-----------------
+
+-  Xilinx `ZC706 <https://www.xilinx.com/ZC706>`_ board - Rev 1.2 or higher
+-  :adi:`ADRV9002NP/W2/PCBZ <EVAL-ADRV9002>` dautherboard
+-  Reference clock source
+-  Mini-USB cable
+-  Ethernet cable
+-  **Specific HW for setting VADJ to 1.8 V**
+-  Optionally USB keyboard, mouse and a HDMI compatible monitor
+
+ADRV9001/2 Quick Start Guides
+-----------------------------
+
+The Quick Start Guides provide a simple step by step instruction on how to do an initial system setup for the :adi:`ADRV9002NP/W1/PCBZ <EVAL-ADRV9002>` and :adi:`ADRV9002NP/W2/PCBZ <EVAL-ADRV9002>` boards on various FPGA development boards. They will discuss how to program the bitstream, run a no-OS program or boot a Linux distribution.
+
+Supported Carriers
+~~~~~~~~~~~~~~~~~~
+
+The :adi:`ADRV9002NP/W1/PCBZ <EVAL-ADRV9002>` and :adi:`ADRV9002NP/W2/PCBZ <EVAL-ADRV9002>` is, by definition a "FPGA mezzanine card" (FMC), that means it needs a carrier to plug into. The carriers we support are:
+
++----------------------------------------------------------------------------------------------------------------------+-------------------------------------+--------------------+
+| Board                                                                                                                | ADRV9002NP                          |                    |
++======================================================================================================================+=====================================+====================+
+|                                                                                                                      | **CMOS inteface**                   | **LVDS interface** |
++----------------------------------------------------------------------------------------------------------------------+-------------------------------------+--------------------+
+| `ZCU102 <https://www.xilinx.com/ZCU102>`_                                                                            | √                                   | √                  |
++----------------------------------------------------------------------------------------------------------------------+-------------------------------------+--------------------+
+| `ZC706 <https://www.xilinx.com/ZC706>`_                                                                              | √ **<fc #ff0000>VADJ 1.8V</fc>**\ ¹ | N/A²               |
++----------------------------------------------------------------------------------------------------------------------+-------------------------------------+--------------------+
+| `Zed Board <http://zedboard.org/product/zedboard>`_                                                                  | √ **<fc #ff0000>VADJ 1.8V</fc>**    | N/A²               |
++----------------------------------------------------------------------------------------------------------------------+-------------------------------------+--------------------+
+| `Arria 10 SoC <https://www.altera.com/products/boards_and_kits/dev-kits/altera/arria-10-soc-development-kit.html>`_  | √                                   | N/A³               |
++----------------------------------------------------------------------------------------------------------------------+-------------------------------------+--------------------+
+
+| ¹ Instruction for reprogramming the VADJ can be found `here <https://www.xilinx.com/Attachment/ZC706_Power_Controllers_Reprogramming_Steps.pdf>`_ and `here <https://forums.xilinx.com/t5/Xilinx-Evaluation-Boards/ZC706-Doesn-t-work-with-VADJ-at-1-8v/td-p/430086>`_
+| ² See :doc:`Cmos only operation </solutions/reference-designs/adrv9002/quickstart>` section
+| ³ Not supported due sub-optimal mapping of the clock pins from the source synchronous interfaces.
+
+CMOS only operation
+~~~~~~~~~~~~~~~~~~~
+
+On the ZC706 / ZedBoard platforms the FMC connectors map to HR IO banks. The HR banks have a limitation that when using LVDS I/O standard you must set the bank VCCO voltage to 2.5V, however the ADRV9001 evaluation board is using IO supplies of 1.8V and does not have level shifters for the single ended lines. Therefore the VCCO of the banks must be set to 1.8 V (VADJ) and limiting the operation to CMOS mode only. More information on the limitation see `7 Series Select IO guide <https://www.xilinx.com/support/documentation/user_guides/ug471_7Series_SelectIO.pdf>`_ section 'LVDS and LVDS_25' and Table 1-43
+
+Supported Environments
+~~~~~~~~~~~~~~~~~~~~~~
+
+The supported OS are:
+
++----------------------------------------------------------------------------------------------------------------------+-----+----------------+----------------+--------------------------+
+| Board                                                                                                                | HDL | Linux Software | No-OS Software | Required Minimum Release |
++======================================================================================================================+=====+================+================+==========================+
+| `ZCU102 <https://www.xilinx.com/ZCU102>`_                                                                            | √   | √              | √              | 2019-R2                  |
++----------------------------------------------------------------------------------------------------------------------+-----+----------------+----------------+--------------------------+
+| `ZC706 <https://www.xilinx.com/ZC706>`_                                                                              | √   | √              | √              | 2020-R1                  |
++----------------------------------------------------------------------------------------------------------------------+-----+----------------+----------------+--------------------------+
+| `Zed Board <http://zedboard.org/product/zedboard>`_                                                                  | √   | √              | √              | 2019-R2                  |
++----------------------------------------------------------------------------------------------------------------------+-----+----------------+----------------+--------------------------+
+| `Arria 10 SoC <https://www.altera.com/products/boards_and_kits/dev-kits/altera/arria-10-soc-development-kit.html>`_  | √   | √              | N/A            | 2020-R1                  |
++----------------------------------------------------------------------------------------------------------------------+-----+----------------+----------------+--------------------------+
+
+Hardware Setup
+~~~~~~~~~~~~~~
+
+In most carriers, the :adi:`ADRV9002NP/W1/PCBZ <EVAL-ADRV9002>` and :adi:`ADRV9002NP/W2/PCBZ <EVAL-ADRV9002>` boards connects to the HPC1 connector (unless otherwise noted). The carrier setup requires power, UART (115200), ethernet (Linux), DisplayPort or HDMI (if available) and/or JTAG (no-OS) connections. A few typical setups are shown below.
+
+Identify your hardware
+^^^^^^^^^^^^^^^^^^^^^^
+
+Evaluation boards were equipped with different silicon revisions. All boards
+built since the middle of December 2020 have C0 silicon, older ones use B0
+silicon these are no longer shipped. You can identify the board you have based
+on its label.
+
+======== ================
+Label    Silicon Revision
+======== ================
+|image1| **B0**
+|image2| **B0**
+|image3| **C0**
+|image4| **C0**
+======== ================
+
+.. tip::
+
+   Each revision of silicon requires its corresponding software support files in
+   the later steps.
+
+ZCU102 + ADRV9002NP
+~~~~~~~~~~~~~~~~~~~
+
+:doc:`ADRV9002 Zynq UltraScale+ MPSoC ZCU102 Quick Start Guide </solutions/reference-designs/adrv9002/quickstart/zynqmp>`
+
+ZC706 + ADRV9002NP
+~~~~~~~~~~~~~~~~~~
+
+:doc:`ADRV9002 Zynq SoC ZC706 Quick Start Guide </solutions/reference-designs/adrv9002/quickstart/zynq>`
+
+Zed Board + ADRV9002NP
+~~~~~~~~~~~~~~~~~~~~~~
+
+:doc:`ADRV9002 Zynq Zed Board Quick Start Guide </solutions/reference-designs/adrv9002/quickstart/zed>`
+
+============
+
+More Information
+----------------
+
+-  :doc:`ADRV9001/2 Quick Start Guides </solutions/reference-designs/adrv9002/quickstart>`
+
+   -  :doc:`ADRV9002 Zynq UltraScale+ MPSoC ZCU102 Quick Start Guide </solutions/reference-designs/adrv9002/quickstart/zynqmp>`
+   -  :doc:`ADRV9002 Zynq SoC ZC706 Quick Start Guide </solutions/reference-designs/adrv9002/quickstart/zynq>`
+   -  :doc:`ADRV9002 Zynq Zed Board Quick Start Guide </solutions/reference-designs/adrv9002/quickstart/zed>`
+   -  :doc:`ADRV9002 Arria10 SoC Quick Start Guide </solutions/reference-designs/adrv9002/quickstart/a10soc>`
+
+-  :doc:`ADRV9001/ADRV9002 HDL Reference Design </solutions/reference-designs/adrv9002/reference_hdl>`
+
+   -  :doc:`AXI_ADRV9001/AXI_ADRV9002 Interface Core </solutions/reference-designs/adrv9002/axi_adrv9002>`
+   -  `Building HDL how-to, ADI Reference Designs HDL User Guide <https://wiki.analog.com/resources/fpga/docs/hdl>`_
+
+-  `ADRV9002 Device Driver Customization <https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9002-customization>`_
+-  `ADRV9002 Integrated Dual RF Transceiver Linux device driver <https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9002>`_
+
+Support
+-------
+
+Analog Devices will provide limited online support for anyone using the reference design with Analog Devices components via the :ez:`EngineerZone <community/fpga>`.
+
+Software resources
+------------------
+
+-  `ADRV9002 Device Driver Customization <https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9002-customization>`_
+-  `ADRV9002 Integrated Dual RF Transceiver Linux device driver <https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9002>`_
+
+More Information
+----------------
+
+-  :doc:`ADRV9001/2 Quick Start Guides </solutions/reference-designs/adrv9002/quickstart>`
+
+   -  :doc:`ADRV9002 Zynq UltraScale+ MPSoC ZCU102 Quick Start Guide </solutions/reference-designs/adrv9002/quickstart/zynqmp>`
+   -  :doc:`ADRV9002 Zynq SoC ZC706 Quick Start Guide </solutions/reference-designs/adrv9002/quickstart/zynq>`
+   -  :doc:`ADRV9002 Zynq Zed Board Quick Start Guide </solutions/reference-designs/adrv9002/quickstart/zed>`
+   -  :doc:`ADRV9002 Arria10 SoC Quick Start Guide </solutions/reference-designs/adrv9002/quickstart/a10soc>`
+
+-  :doc:`ADRV9001/ADRV9002 HDL Reference Design </solutions/reference-designs/adrv9002/reference_hdl>`
+
+   -  :doc:`AXI_ADRV9001/AXI_ADRV9002 Interface Core </solutions/reference-designs/adrv9002/axi_adrv9002>`
+   -  `Building HDL how-to, ADI Reference Designs HDL User Guide <https://wiki.analog.com/resources/fpga/docs/hdl>`_
+
+-  `ADRV9002 Device Driver Customization <https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9002-customization>`_
+-  `ADRV9002 Integrated Dual RF Transceiver Linux device driver <https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9002>`_
+
+Support
+-------
+
+Analog Devices will provide limited online support for anyone using the reference design with Analog Devices components via the :ez:`EngineerZone <community/fpga>`.
+
+Software resources
+------------------
+
+-  `ADRV9002 Device Driver Customization <https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9002-customization>`_
+-  `ADRV9002 Integrated Dual RF Transceiver Linux device driver <https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9002>`_
+
+.. |image1| image:: ../images/adrv9002_b0_np_w1.png
+.. |image2| image:: ../images/adrv9002_b0_np_w2.png
+.. |image3| image:: ../images/adrv9002xbcz_c0_np_w1.png
+.. |image4| image:: ../images/adrv9002xbcz_c0_np_w2.png
+
+Testing
+=======
+
+.. esd-warning::
+
+|http---www.xilinx.com-images-product-images-zc706-base-board.jpg|
+
+.. warning::
+
+   Before executing below steps, VADJ must be set to 1.8V.
+
+   
+   Instruction for reprogramming the VADJ can be found `here <https://e2e.ti.com/support/power-management-group/power-management/f/power-management-forum/960099/configure-zc706-evaluation-board-vadj-for-3-3v>`_ and `here <https://support.xilinx.com/s/article/56811?language=en_US>`_.
+   
+   On an ADRV9002 Card, there is a red LED close to the FMC connector. The role
+   of this LED is to indicate if VADJ voltage exceeded 2.0V level. If that was
+   the case this LED will be ON. If this LED does not turn off after few seconds
+   after boot, then there is an issue and while the board might still operate
+   this is exceeding the recommended level for VADJ, decreasing board lifetime
+   and can lead to permanent damage of the IC in the worst case.
+
+.. image:: ../images/adrv9002_vadj_led.png
+   :align: center
+   :width: 200
+
+-  Connect the :adi:`ADRV9002NP/W1/PCBZ <EVAL-ADRV9002>` or :adi:`ADRV9002NP/W2/PCBZ <EVAL-ADRV9002>` FMC board to the FPGA carrier **LPC FMC** socket.
+-  On the FMC card set switch to select clock source between:
+
+   -  an on-board 38.4MHz VCTCXO (default)
+   -  external (thru J501) 10MHz to 1000MHz / +13dBm
+
+-  Connect USB UART (Mini USB) to your host PC.
+-  Insert SD card into socket.
+-  Configure ZC706 for SD BOOT (Set the jumpers: The main one is: SW11 - Big
+   Blue Switch in the middle, which controls the Boot Mode, it needs to be set:
+   1: Down, 2: Down, 3: Up, 4: Up, 5: Down. Other Jumpers can be checked via
+   looking at the picture. (click the picture to make it bigger)).
+
+.. image:: ../images/zc706plusfmcjesdadc1.png
+   :alt: zc706plusfmcjesdadc1.png
+   :align: right
+   :width: 200
+
+-  Turn on the power switch on the FPGA board.
+-  Observe kernel and serial console messages on your terminal.
+-  \*\* There is supported CMOS interface only.*\*
+
+::
+
+   *
+
+Messages
+--------
+
+.. collapsible:: Complete kernel boot log (Click to expand)
+
+   .. container:: box bggreen
+
+      This specifies any shell prompt running on the target
+
+      ::
+
+         U-Boot 2014.07-dirty (Nov 20 2014 - 17:07:55)
+
+         Board:  Xilinx Zynq
+         I2C:   ready
+         DRAM:  ECC disabled 1 GiB
+         MMC:   zynq_sdhci: 0
+         SF: Detected S25FL128S_64K with page size 512 Bytes, erase size 128 KiB, total 32 MiB
+         ** Warning - bad CRC, using default environment
+
+         In:    serial
+         Out:   serial
+         Err:   serial
+         Net:   Gem.e000b000
+         Hit any key to stop autoboot:  0
+         Device: zynq_sdhci
+         Manufacturer ID: 3
+         OEM: 5344
+         Name: SL16G
+         Tran Speed: 50000000
+         Rd Block Len: 512
+         SD version 3.0
+         High Capacity: Yes
+         Capacity: 14.8 GiB
+         Bus Width: 4-bit
+         reading uEnv.txt
+         389 bytes read in 24 ms (15.6 KiB/s)
+         Loaded environment from uEnv.txt
+         Importing environment from SD ...
+         Running uenvcmd ...
+         Copying Linux from SD to RAM...
+         reading uImage
+         6513112 bytes read in 560 ms (11.1 MiB/s)
+         reading devicetree.dtb
+         18382 bytes read in 28 ms (640.6 KiB/s)
+         reading uramdisk.image.gz
+          Unable to read file uramdisk.image.gz 
+         ## Booting kernel from Legacy Image at 03000000 ...
+            Image Name:   Linux-5.4.0-g2d38bef770bc-dirty
+            Image Type:   ARM Linux Kernel Image (uncompressed)
+            Data Size:    6513048 Bytes = 6.2 MiB
+            Load Address: 00008000
+            Entry Point:  00008000
+            Verifying Checksum ... OK
+         ## Flattened Device Tree blob at 02a00000
+            Booting using the fdt blob at 0x2a00000
+            Loading Kernel Image ... OK
+            Loading Device Tree to 1fff8000, end 1ffff7cd ... OK
+
+         Starting kernel ...
+
+         Booting Linux on physical CPU 0x0
+         Linux version 5.4.0-g2d38bef770bc-dirty (dragos@debian) (gcc version 10.2.1 20201103 (GNU Toolchain for the A-profile Architecture 10.2-2020.11 (arm-10.16))) #22 SMP PREEMPT Thu Mar 11 17:55:04 EET 2021
+         CPU: ARMv7 Processor [413fc090] revision 0 (ARMv7), cr=18c5387d
+         CPU: PIPT / VIPT nonaliasing data cache, VIPT aliasing instruction cache
+         OF: fdt: Machine model: Xilinx Zynq ZED
+         OF: fdt: earlycon: stdout-path /amba@0/uart@E0001000 not found
+         Memory policy: Data cache writealloc
+         cma: Reserved 128 MiB at 0x17c00000
+         percpu: Embedded 15 pages/cpu s29516 r8192 d23732 u61440
+         Built 1 zonelists, mobility grouping on.  Total pages: 130048
+         Kernel command line: console=ttyPS0,115200 root=/dev/mmcblk0p2 rw earlycon rootfstype=ext4 rootwait cpuidle.off=1
+         Dentry cache hash table entries: 65536 (order: 6, 262144 bytes, linear)
+         Inode-cache hash table entries: 32768 (order: 5, 131072 bytes, linear)
+         mem auto-init: stack:off, heap alloc:off, heap free:off
+         Memory: 368404K/524288K available (9216K kernel code, 744K rwdata, 7000K rodata, 1024K init, 162K bss, 24812K reserved, 131072K cma-reserved, 0K highmem)
+         rcu: Preemptible hierarchical RCU implementation.
+         rcu:    RCU restricting CPUs from NR_CPUS=4 to nr_cpu_ids=2.
+                 Tasks RCU enabled.
+         rcu: RCU calculated value of scheduler-enlistment delay is 10 jiffies.
+         rcu: Adjusting geometry for rcu_fanout_leaf=16, nr_cpu_ids=2
+         NR_IRQS: 16, nr_irqs: 16, preallocated irqs: 16
+         efuse mapped to (ptrval)
+         slcr mapped to (ptrval)
+         L2C: platform modifies aux control register: 0x72360000 -> 0x72760000
+         L2C: DT/platform modifies aux control register: 0x72360000 -> 0x72760000
+         L2C-310 erratum 769419 enabled
+         L2C-310 enabling early BRESP for Cortex-A9
+         L2C-310 full line of zeros enabled for Cortex-A9
+         L2C-310 ID prefetch enabled, offset 1 lines
+         L2C-310 dynamic clock gating enabled, standby mode enabled
+         L2C-310 cache controller enabled, 8 ways, 512 kB
+         L2C-310: CACHE_ID 0x410000c8, AUX_CTRL 0x76760001
+         random: get_random_bytes called from start_kernel+0x2c8/0x464 with crng_init=0
+         zynq_clock_init: clkc starts at (ptrval)
+         Zynq clock init
+         sched_clock: 64 bits at 333MHz, resolution 3ns, wraps every 4398046511103ns
+         clocksource: arm_global_timer: mask: 0xffffffffffffffff max_cycles: 0x4ce07af025, max_idle_ns: 440795209040 ns
+         Switching to timer-based delay loop, resolution 3ns
+         clocksource: ttc_clocksource: mask: 0xffff max_cycles: 0xffff, max_idle_ns: 537538477 ns
+         timer #0 at (ptrval), irq=17
+         Console: colour dummy device 80x30
+         Calibrating delay loop (skipped), value calculated using timer frequency.. 666.66 BogoMIPS (lpj=3333333)
+         pid_max: default: 32768 minimum: 301
+         Mount-cache hash table entries: 1024 (order: 0, 4096 bytes, linear)
+         Mountpoint-cache hash table entries: 1024 (order: 0, 4096 bytes, linear)
+         CPU: Testing write buffer coherency: ok
+         CPU0: Spectre v2: using BPIALL workaround
+         CPU0: thread -1, cpu 0, socket 0, mpidr 80000000
+         Setting up static identity map for 0x100000 - 0x100060
+         rcu: Hierarchical SRCU implementation.
+         smp: Bringing up secondary CPUs ...
+         CPU1: thread -1, cpu 1, socket 0, mpidr 80000001
+         CPU1: Spectre v2: using BPIALL workaround
+         smp: Brought up 1 node, 2 CPUs
+         SMP: Total of 2 processors activated (1333.33 BogoMIPS).
+         CPU: All CPU(s) started in SVC mode.
+         devtmpfs: initialized
+         VFP support v0.3: implementor 41 architecture 3 part 30 variant 9 rev 4
+         clocksource: jiffies: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 19112604462750000 ns
+         futex hash table entries: 512 (order: 3, 32768 bytes, linear)
+         pinctrl core: initialized pinctrl subsystem
+         NET: Registered protocol family 16
+         DMA: preallocated 256 KiB pool for atomic coherent allocations
+         hw-breakpoint: found 5 (+1 reserved) breakpoint and 1 watchpoint registers.
+         hw-breakpoint: maximum watchpoint size is 4 bytes.
+         zynq-ocm f800c000.ocmc: ZYNQ OCM pool: 256 KiB @ 0x(ptrval)
+         e0001000.serial: ttyPS0 at MMIO 0xe0001000 (irq = 25, base_baud = 3125000) is a xuartps
+         printk: console [ttyPS0] enabled
+         SCSI subsystem initialized
+         usbcore: registered new interface driver usbfs
+         usbcore: registered new interface driver hub
+         usbcore: registered new device driver usb
+         mc: Linux media interface: v0.10
+         videodev: Linux video capture interface: v2.00
+         jesd204: found 0 devices and 0 topologies
+         FPGA manager framework
+         Advanced Linux Sound Architecture Driver Initialized.
+         clocksource: Switched to clocksource arm_global_timer
+         thermal_sys: Registered thermal governor 'step_wise'
+         NET: Registered protocol family 2
+         tcp_listen_portaddr_hash hash table entries: 512 (order: 0, 6144 bytes, linear)
+         TCP established hash table entries: 4096 (order: 2, 16384 bytes, linear)
+         TCP bind hash table entries: 4096 (order: 3, 32768 bytes, linear)
+         TCP: Hash tables configured (established 4096 bind 4096)
+         UDP hash table entries: 256 (order: 1, 8192 bytes, linear)
+         UDP-Lite hash table entries: 256 (order: 1, 8192 bytes, linear)
+         NET: Registered protocol family 1
+         hw perfevents: no interrupt-affinity property for /pmu@f8891000, guessing.
+         hw perfevents: enabled with armv7_cortex_a9 PMU driver, 7 counters available
+         workingset: timestamp_bits=30 max_order=17 bucket_order=0
+         io scheduler mq-deadline registered
+         io scheduler kyber registered
+         zynq-pinctrl 700.pinctrl: zynq pinctrl initialized
+         dma-pl330 f8003000.dmac: Loaded driver for PL330 DMAC-241330
+         dma-pl330 f8003000.dmac:        DBUFF-128x8bytes Num_Chans-8 Num_Peri-4 Num_Events-16
+         brd: module loaded
+         loop: module loaded
+         Registered mathworks_ip class
+         spi-nor spi1.0: found s25fl128s1, expected n25q128a11
+         random: fast init done
+         spi-nor spi1.0: s25fl128s1 (16384 Kbytes)
+         5 fixed-partitions partitions found on MTD device spi1.0
+         Creating 5 MTD partitions on "spi1.0":
+         0x000000000000-0x000000500000 : "boot"
+         0x000000500000-0x000000520000 : "bootenv"
+         0x000000520000-0x000000540000 : "config"
+         0x000000540000-0x000000fc0000 : "image"
+         0x000000fc0000-0x000001000000 : "spare"
+         MACsec IEEE 802.1AE
+         libphy: Fixed MDIO Bus: probed
+         tun: Universal TUN/TAP device driver, 1.6
+         libphy: MACB_mii_bus: probed
+         mdio_bus e000b000.ethernet-ffffffff: MDIO device at address 0 is missing.
+         usbcore: registered new interface driver asix
+         usbcore: registered new interface driver ax88179_178a
+         usbcore: registered new interface driver cdc_ether
+         usbcore: registered new interface driver net1080
+         usbcore: registered new interface driver cdc_subset
+         usbcore: registered new interface driver zaurus
+         usbcore: registered new interface driver cdc_ncm
+         ehci_hcd: USB 2.0 'Enhanced' Host Controller (EHCI) Driver
+         usbcore: registered new interface driver uas
+         usbcore: registered new interface driver usb-storage
+         usbcore: registered new interface driver usbserial_generic
+         usbserial: USB Serial support registered for generic
+         usbcore: registered new interface driver ftdi_sio
+         usbserial: USB Serial support registered for FTDI USB Serial Device
+         usbcore: registered new interface driver upd78f0730
+         usbserial: USB Serial support registered for upd78f0730
+         chipidea-usb2 e0002000.usb: e0002000.usb supply vbus not found, using dummy regulator
+         ULPI transceiver vendor/product ID 0x0424/0x0007
+         Found SMSC USB3320 ULPI transceiver.
+         ULPI integrity check: passed.
+         ci_hdrc ci_hdrc.0: EHCI Host Controller
+         ci_hdrc ci_hdrc.0: new USB bus registered, assigned bus number 1
+         ci_hdrc ci_hdrc.0: USB 2.0 started, EHCI 1.00
+         usb usb1: New USB device found, idVendor=1d6b, idProduct=0002, bcdDevice= 5.04
+         usb usb1: New USB device strings: Mfr=3, Product=2, SerialNumber=1
+         usb usb1: Product: EHCI Host Controller
+         usb usb1: Manufacturer: Linux 5.4.0-g2d38bef770bc-dirty ehci_hcd
+         usb usb1: SerialNumber: ci_hdrc.0
+         hub 1-0:1.0: USB hub found
+         hub 1-0:1.0: 1 port detected
+         i2c /dev entries driver
+         adv7511 0-0039: 0-0039 supply avdd not found, using dummy regulator
+         adv7511 0-0039: 0-0039 supply dvdd not found, using dummy regulator
+         adv7511 0-0039: 0-0039 supply pvdd not found, using dummy regulator
+         adv7511 0-0039: 0-0039 supply bgvdd not found, using dummy regulator
+         adv7511 0-0039: 0-0039 supply dvdd-3v not found, using dummy regulator
+         adv7511: probe of 0-0039 failed with error -5
+         xiic-i2c 41620000.i2c: IRQ index 0 not found
+         usbcore: registered new interface driver uvcvideo
+         USB Video Class driver (1.1.1)
+         gspca_main: v2.14.0 registered
+         cdns-wdt f8005000.watchdog: Xilinx Watchdog Timer with timeout 10s
+         Xilinx Zynq CpuIdle Driver started
+         failed to register cpuidle driver
+         sdhci: Secure Digital Host Controller Interface driver
+         sdhci: Copyright(c) Pierre Ossman
+         sdhci-pltfm: SDHCI platform and OF driver helper
+         mmc0: SDHCI controller on e0100000.mmc [e0100000.mmc] using ADMA
+         ledtrig-cpu: registered to indicate activity on CPUs
+         hidraw: raw HID events driver (C) Jiri Kosina
+         usbcore: registered new interface driver usbhid
+         usbhid: USB HID core driver
+         axi_sysid 45000000.axi-sysid-0: AXI System ID core version (1.01.a) found
+         axi_sysid 45000000.axi-sysid-0: [adrv9001] [CMOS_LVDS_N=1] on [zc706] git branch <dev_adrv9001_a10soc_zc706> git <9331186e2289103cfb641d9991c4ca809fe57476> clean [2021-02-26 08:58:42] UTC
+         fpga_manager fpga0: Xilinx Zynq FPGA Manager registered
+         usbcore: registered new interface driver snd-usb-audio
+         axi-i2s 77600000.axi-i2s: probed, capture enabled, playback enabled
+         NET: Registered protocol family 10
+         Segment Routing with IPv6
+         mmc0: new high speed SDHC card at address aaaa
+         sit: IPv6, IPv4 and MPLS over IPv4 tunneling driver
+         mmcblk0: mmc0:aaaa SL16G 14.8 GiB
+         NET: Registered protocol family 17
+          mmcblk0: p1 p2 p3
+         NET: Registered protocol family 36
+         Registering SWP/SWPB emulation handler
+         random: crng init done
+         adrv9002 spi0.0: adrv9002-phy Rev 11.0, Firmware 0.13.6.7,  Stream 0.5.18.0,  API version: 39.0.7 successfully initialized
+         cf_axi_adc 44a00000.axi-adrv9002-rx-lpc: ADI AIM (10.01.b) at 0x44A00000 mapped to 0xe9f1d723, probed ADC ADRV9002 as MASTER
+         cf_axi_tdd 44a0c800.axi-adrv9002-core-tdd-lpc: Analog Devices CF_AXI_TDD MASTER (1.00.a)
+         cf_axi_dds 44a0a000.axi-adrv9002-tx-lpc: Analog Devices CF_AXI_DDS_DDS MASTER (9.01.b) at 0x44A0A000 mapped to 0x1b2fbc4a, probed DDS ADRV9002
+         asoc-simple-card zed_sound: adau-hifi <-> 77600000.axi-i2s mapping ok
+         adau1761 0-003b: Unable to sync registers 0x4002-0x4002. -5
+         hctosys: unable to open rtc device (rtc0)
+         ALSA device list:
+           #0: ZED ADAU1761
+         EXT4-fs (mmcblk0p2): mounted filesystem with ordered data mode. Opts: (null)
+         VFS: Mounted root (ext4 filesystem) on device 179:2.
+         devtmpfs: mounted
+         Freeing unused kernel memory: 1024K
+         Run /sbin/init as init process
+         systemd[1]: System time before build time, advancing clock.
+         systemd[1]: Failed to lookup module alias 'autofs4': Function not implemented
+         systemd[1]: systemd 241 running in system mode. (+PAM +AUDIT +SELINUX +IMA +APPARMOR +SMACK +SYSVINIT +UTMP +LIBCRYPTSETUP +GCRYPT +GNUTLS +ACL +XZ +LZ4 +SECCOMP +BLKID +ELFUTILS +KMOD -IDN2 +IDN -PCRE2 default-hierarchy=hybrid)
+         systemd[1]: Detected architecture arm.
+
+         Welcome to Kuiper GNU/Linux 10 (buster)!
+
+         systemd[1]: Set hostname to <analog>.
+         systemd[1]: File /lib/systemd/system/systemd-journald.service:12 configures an IP firewall (IPAddressDeny=any), but the local system does not support BPF/cgroup based firewalling.
+         systemd[1]: Proceeding WITHOUT firewalling in effect! (This warning is only shown for the first loaded unit using IP firewalling.)
+         systemd[1]: Listening on Journal Socket (/dev/log).
+         [  OK  ] Listening on Journal Socket (/dev/log).
+         systemd[1]: Listening on fsck to fsckd communication Socket.
+         [  OK  ] Listening on fsck to fsckd communication Socket.
+         systemd[1]: Created slice system-serial\x2dgetty.slice.
+         [  OK  ] Created slice system-serial\x2dgetty.slice.
+         systemd[1]: Listening on Journal Socket.
+         [  OK  ] Listening on Journal Socket.
+         systemd[1]: Mounting RPC Pipe File System...
+                  Mounting RPC Pipe File System...
+         [  OK  ] Created slice User and Session Slice.
+         [  OK  ] Created slice system-systemd\x2dfsck.slice.
+         [  OK  ] Started Forward Password R…uests to Wall Directory Watch.
+                  Starting Load Kernel Modules...
+         [  OK  ] Listening on udev Kernel Socket.
+         [  OK  ] Listening on Syslog Socket.
+         [  OK  ] Listening on udev Control Socket.
+                  Starting udev Coldplug all Devices...
+                  Mounting Kernel Debug File System...
+                  Starting Journal Service...
+                  Starting Restore / save the current clock...
+         [  OK  ] Reached target Slices.
+         [  OK  ] Created slice system-getty.slice.
+                  Starting Set the console keyboard layout...
+         [  OK  ] Listening on initctl Compatibility Named Pipe.
+         [  OK  ] Reached target Swap.
+         [  OK  ] Started Journal Service.
+         [FAILED] Failed to mount RPC Pipe File System.
+         See 'systemctl status run-rpc_pipefs.mount' for details.
+         [DEPEND] Dependency failed for RPC …ice for NFS client and server.
+         [DEPEND] Dependency failed for RPC …curity service for NFS server.
+         [FAILED] Failed to start Load Kernel Modules.
+         See 'systemctl status systemd-modules-load.service' for details.
+         [  OK  ] Mounted Kernel Debug File System.
+         [  OK  ] Started Restore / save the current clock.
+                  Starting Remount Root and Kernel File Systems...
+                  Mounting Kernel Configuration File System...
+                  Starting Apply Kernel Variables...
+         [  OK  ] Reached target NFS client services.
+         [  OK  ] Reached target Remote File Systems (Pre).
+         [  OK  ] Reached target Remote File Systems.
+         [  OK  ] Started Set the console keyboard layout.
+         [  OK  ] Mounted Kernel Configuration File System.
+         [  OK  ] Started Apply Kernel Variables.
+         [  OK  ] Started udev Coldplug all Devices.
+                  Starting Helper to synchronize boot up for ifupdown...
+         [  OK  ] Started Helper to synchronize boot up for ifupdown.
+         [  OK  ] Started Remount Root and Kernel File Systems.
+                  Starting Load/Save Random Seed...
+                  Starting Flush Journal to Persistent Storage...
+                  Starting Create System Users...
+         [  OK  ] Started Load/Save Random Seed.
+         [  OK  ] Started Create System Users.
+         [  OK  ] Started Flush Journal to Persistent Storage.
+                  Starting Create Static Device Nodes in /dev...
+         [  OK  ] Started Create Static Device Nodes in /dev.
+                  Starting udev Kernel Device Manager...
+         [  OK  ] Reached target Local File Systems (Pre).
+         [  OK  ] Started udev Kernel Device Manager.
+                  Starting Show Plymouth Boot Screen...
+         [  OK  ] Started Show Plymouth Boot Screen.
+         [  OK  ] Reached target Local Encrypted Volumes.
+         [  OK  ] Started Forward Password R…s to Plymouth Directory Watch.
+         [  OK  ] Found device /dev/ttyPS0.
+         [  OK  ] Found device /dev/disk/by-partuuid/0e0f8290-01.
+                  Starting Load Kernel Modules...
+                  Starting File System Check…isk/by-partuuid/0e0f8290-01...
+         [FAILED] Failed to start Load Kernel Modules.
+         See 'systemctl status systemd-modules-load.service' for details.
+         [  OK  ] Started File System Check Daemon to report status.
+         [  OK  ] Started File System Check …/disk/by-partuuid/0e0f8290-01.
+                  Mounting /boot...
+         [  OK  ] Mounted /boot.
+         [  OK  ] Reached target Local File Systems.
+                  Starting Set console font and keymap...
+                  Starting Raise network interfaces...
+                  Starting Create Volatile Files and Directories...
+                  Starting Preprocess NFS configuration...
+                  Starting Tell Plymouth To Write Out Runtime Data...
+         [  OK  ] Started Set console font and keymap.
+         [  OK  ] Started Preprocess NFS configuration.
+         [  OK  ] Started Tell Plymouth To Write Out Runtime Data.
+         [  OK  ] Started Create Volatile Files and Directories.
+                  Starting Network Time Synchronization...
+                  Starting Update UTMP about System Boot/Shutdown...
+         [  OK  ] Started Update UTMP about System Boot/Shutdown.
+         [  OK  ] Started Network Time Synchronization.
+         [  OK  ] Reached target System Time Synchronized.
+         [  OK  ] Reached target System Initialization.
+         [  OK  ] Listening on triggerhappy.socket.
+         [  OK  ] Listening on D-Bus System Message Bus Socket.
+         [  OK  ] Listening on CUPS Scheduler.
+         [  OK  ] Started Daily rotation of log files.
+         [  OK  ] Started CUPS Scheduler.
+         [  OK  ] Reached target Paths.
+         [  OK  ] Started Daily man-db regeneration.
+         [  OK  ] Started Daily Cleanup of Temporary Directories.
+         [  OK  ] Listening on GPS (Global P…ioning System) Daemon Sockets.
+         [  OK  ] Listening on Avahi mDNS/DNS-SD Stack Activation Socket.
+         [  OK  ] Reached target Sockets.
+         [  OK  ] Reached target Basic System.
+                  Starting Modem Manager...
+                  Starting System Logging Service...
+                  Starting triggerhappy global hotkey daemon...
+                  Starting Login Service...
+                  Starting Check for Raspberry Pi EEPROM updates...
+                  Starting rng-tools.service...
+         [  OK  ] Started Regular background program processing daemon.
+         [  OK  ] Started Manage Sound Card State (restore and store).
+                  Starting Save/Restore Sound Card State...
+         [  OK  ] Started D-Bus System Message Bus.
+                  Starting WPA supplicant...
+                  Starting dhcpcd on all interfaces...
+                  Starting Disk Manager...
+                  Starting LSB: Switch to on…nless shift key is pressed)...
+                  Starting Avahi mDNS/DNS-SD Stack...
+         [  OK  ] Started CUPS Scheduler.
+         [  OK  ] Started Daily apt download activities.
+         [  OK  ] Started Daily apt upgrade and clean activities.
+         [  OK  ] Reached target Timers.
+                  Starting dphys-swapfile - …unt, and delete a swap file...
+         [  OK  ] Started triggerhappy global hotkey daemon.
+         [  OK  ] Started System Logging Service.
+         [  OK  ] Started Raise network interfaces.
+         [  OK  ] Started Check for Raspberry Pi EEPROM updates.
+         [FAILED] Failed to start rng-tools.service.
+         See 'systemctl status rng-tools.service' for details.
+         [  OK  ] Started Login Service.
+         [  OK  ] Started Save/Restore Sound Card State.
+         [  OK  ] Started dhcpcd on all interfaces.
+         [  OK  ] Started Avahi mDNS/DNS-SD Stack.
+         [  OK  ] Started WPA supplicant.
+                  Starting Authorization Manager...
+         [  OK  ] Started Make remote CUPS printers available locally.
+         [  OK  ] Reached target Network.
+                  Starting OpenBSD Secure Shell server...
+                  Starting Permit User Sessions...
+                  Starting /etc/rc.local Compatibility...
+         [  OK  ] Started IIO Daemon.
+         [  OK  ] Reached target Sound Card.
+         [  OK  ] Started LSB: Switch to ond…(unless shift key is pressed).
+         [  OK  ] Started dphys-swapfile - s…mount, and delete a swap file.
+         [  OK  ] Started /etc/rc.local Compatibility.
+         [  OK  ] Started Permit User Sessions.
+                  Starting Hold until boot process finishes up...
+                  Starting Light Display Manager...
+         [  OK  ] Started OpenBSD Secure Shell server.
+         [  OK  ] Started Authorization Manager.
+
+         Raspbian GNU/Linux 10 analog ttyPS0
+
+         analog login:
+These devices should be present:
+
+.. container:: box bggreen
+
+   This specifies any shell prompt running on the target
+
+   
+   ::
+   
+   
+
+   
+      analog@analog:~$ iio_info | grep iio:device
+              iio:device0: adrv9002-phy
+              iio:device1: xadc
+              iio:device2: axi-adrv9002-rx-lpc (buffer capable)
+              iio:device3: axi-adrv9002-core-tdd-lpc
+              iio:device4: axi-adrv9002-tx-lpc (buffer capable)
+
+For more on device modes, check `device modes. <https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9002>`_
+
+Pyadi-iio Example
+-----------------
+
+Pyadi-iio is a python abstraction module for ADI hardware with IIO drivers to make them easier to use. For more check `Pyadi-iio <https://github.com/analogdevicesinc/pyadi-iio>`_. An example of using adrv9002 can be checked :git-pyadi-iio:`here <examples/adrv9002_example.py>`
+
+IIO Oscilloscope Remote
+-----------------------
+
+Please see also here:`Oscilloscope <https://wiki.analog.com/resources/tools-software/linux-software/iio_oscilloscope>`_
+
+The IIO Oscilloscope application can be used to connect to another platform that
+has a connected device in order to configure the device and read data from it.
+
+Build and start osc on a network enabled Linux host.
+
+Once the application is launched goto Settings -> Connect and enter the IP
+address of the target in the popup window.
+
+Shut down
+---------
+
+.. important::
+
+   Even thought this is Linux, this is a persistent file systems. Care should be taken not to corrupt the file system -- please shut down things, don't just turn off the power switch. Depending on your monitor, the standard power off could be hiding. You can do this from the terminal as well with ``sudo shutdown -h now``
+
+   |image1_2|
+
+More Information
+----------------
+
+-  :doc:`ADRV9001/2 Quick Start Guides </solutions/reference-designs/adrv9002/quickstart>`
+
+   -  :doc:`ADRV9002 Zynq UltraScale+ MPSoC ZCU102 Quick Start Guide </solutions/reference-designs/adrv9002/quickstart/zynqmp>`
+   -  :doc:`ADRV9002 Zynq SoC ZC706 Quick Start Guide </solutions/reference-designs/adrv9002/quickstart/zynq>`
+   -  :doc:`ADRV9002 Zynq Zed Board Quick Start Guide </solutions/reference-designs/adrv9002/quickstart/zed>`
+   -  :doc:`ADRV9002 Arria10 SoC Quick Start Guide </solutions/reference-designs/adrv9002/quickstart/a10soc>`
+
+-  :doc:`ADRV9001/ADRV9002 HDL Reference Design </solutions/reference-designs/adrv9002/reference_hdl>`
+
+   -  :doc:`AXI_ADRV9001/AXI_ADRV9002 Interface Core </solutions/reference-designs/adrv9002/axi_adrv9002>`
+   -  `Building HDL how-to, ADI Reference Designs HDL User Guide <https://wiki.analog.com/resources/fpga/docs/hdl>`_
+
+-  `ADRV9002 Device Driver Customization <https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9002-customization>`_
+-  `ADRV9002 Integrated Dual RF Transceiver Linux device driver <https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9002>`_
+
+Support
+-------
+
+Analog Devices will provide limited online support for anyone using the reference design with Analog Devices components via the :ez:`EngineerZone <community/fpga>`.
+
+Software resources
+------------------
+
+-  `ADRV9002 Device Driver Customization <https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9002-customization>`_
+-  `ADRV9002 Integrated Dual RF Transceiver Linux device driver <https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9002>`_
+
+More Information
+----------------
+
+-  :doc:`ADRV9001/2 Quick Start Guides </solutions/reference-designs/adrv9002/quickstart>`
+
+   -  :doc:`ADRV9002 Zynq UltraScale+ MPSoC ZCU102 Quick Start Guide </solutions/reference-designs/adrv9002/quickstart/zynqmp>`
+   -  :doc:`ADRV9002 Zynq SoC ZC706 Quick Start Guide </solutions/reference-designs/adrv9002/quickstart/zynq>`
+   -  :doc:`ADRV9002 Zynq Zed Board Quick Start Guide </solutions/reference-designs/adrv9002/quickstart/zed>`
+   -  :doc:`ADRV9002 Arria10 SoC Quick Start Guide </solutions/reference-designs/adrv9002/quickstart/a10soc>`
+
+-  :doc:`ADRV9001/ADRV9002 HDL Reference Design </solutions/reference-designs/adrv9002/reference_hdl>`
+
+   -  :doc:`AXI_ADRV9001/AXI_ADRV9002 Interface Core </solutions/reference-designs/adrv9002/axi_adrv9002>`
+   -  `Building HDL how-to, ADI Reference Designs HDL User Guide <https://wiki.analog.com/resources/fpga/docs/hdl>`_
+
+-  `ADRV9002 Device Driver Customization <https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9002-customization>`_
+-  `ADRV9002 Integrated Dual RF Transceiver Linux device driver <https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9002>`_
+
+Support
+-------
+
+Analog Devices will provide limited online support for anyone using the reference design with Analog Devices components via the :ez:`EngineerZone <community/fpga>`.
+
+Software resources
+------------------
+
+-  `ADRV9002 Device Driver Customization <https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9002-customization>`_
+-  `ADRV9002 Integrated Dual RF Transceiver Linux device driver <https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9002>`_
+
+.. |http---www.xilinx.com-images-product-images-zc706-base-board.jpg_2| image:: http://www.xilinx.com/images/product-images/zc706-base-board.jpg
+.. |image1_2| image:: ../images/shutdown.png
+   :width: 300
+
+.. |http---www.xilinx.com-images-product-images-zc706-base-board.jpg_2| image:: https://wiki.analog.com/_media/http///www.xilinx.com/images/product-images/zc706-base-board.jpg

--- a/docs/solutions/reference-designs/adrv9002/quickstart/zynqmp.rst
+++ b/docs/solutions/reference-designs/adrv9002/quickstart/zynqmp.rst
@@ -1,0 +1,1018 @@
+ADRV9002 Zynq UltraScale+ MPSoC ZCU102 Quick Start Guide
+========================================================
+
+.. image:: ../images/adrv9002_zcu102_quickstart.png.png
+   :align: center
+   :width: 600
+
+This guide provides some quick instructions (still takes awhile to download, and set things up) on how to setup the :adi:`ADRV9002NP/W1/PCBZ <EVAL-ADRV9002>` and :adi:`ADRV9002NP/W2/PCBZ <EVAL-ADRV9002>` on:
+
+-  `ZCU102 <https://www.xilinx.com/ZCU102>`_ The revision that is supported is 1.0 only. Previous versions will not work.
+
+Instructions on how to build the ZynqMP / MPSoC Linux kernel and devicetrees
+from source can be found here:
+
+-  `Building the ZynqMP / MPSoC Linux kernel and devicetrees from source <https://wiki.analog.com/resources/tools-software/linux-build/generic/zynqmp>`_
+-  `How to build the ZynqMP boot image BOOT.BIN <https://wiki.analog.com/resources/tools-software/linux-software/build-the-zynqmp-boot-image>`_
+
+Required Software
+-----------------
+
+-  SD Card 16GB imaged using the instructions here: `Zynq & Altera SoC Quick Start Guide <https://wiki.analog.com/resources/tools-software/linux-software/kuiper-linux>`_. Use the 22 June 2020 release (2019_R1) or later.
+-  A UART terminal (Putty/Tera Term/Minicom, etc.), Baud rate 115200 (8N1).
+
+Required Hardware
+-----------------
+
+-  Xilinx `ZCU102 <https://www.xilinx.com/ZCU102>`_ Rev 1.0 or later board
+-  :adi:`ADRV9002NP/W1/PCBZ <EVAL-ADRV9002>` FMC board.
+-  Reference clock source
+-  Micro-USB cable
+-  Ethernet cable
+-  Optionally USB keyboard mouse and a Display Port compatible monitor
+
+ADRV9001/2 Quick Start Guides
+-----------------------------
+
+The Quick Start Guides provide a simple step by step instruction on how to do an initial system setup for the :adi:`ADRV9002NP/W1/PCBZ <EVAL-ADRV9002>` and :adi:`ADRV9002NP/W2/PCBZ <EVAL-ADRV9002>` boards on various FPGA development boards. They will discuss how to program the bitstream, run a no-OS program or boot a Linux distribution.
+
+Supported Carriers
+~~~~~~~~~~~~~~~~~~
+
+The :adi:`ADRV9002NP/W1/PCBZ <EVAL-ADRV9002>` and :adi:`ADRV9002NP/W2/PCBZ <EVAL-ADRV9002>` is, by definition a "FPGA mezzanine card" (FMC), that means it needs a carrier to plug into. The carriers we support are:
+
++----------------------------------------------------------------------------------------------------------------------+-------------------------------------+--------------------+
+| Board                                                                                                                | ADRV9002NP                          |                    |
++======================================================================================================================+=====================================+====================+
+|                                                                                                                      | **CMOS inteface**                   | **LVDS interface** |
++----------------------------------------------------------------------------------------------------------------------+-------------------------------------+--------------------+
+| `ZCU102 <https://www.xilinx.com/ZCU102>`_                                                                            | √                                   | √                  |
++----------------------------------------------------------------------------------------------------------------------+-------------------------------------+--------------------+
+| `ZC706 <https://www.xilinx.com/ZC706>`_                                                                              | √ **<fc #ff0000>VADJ 1.8V</fc>**\ ¹ | N/A²               |
++----------------------------------------------------------------------------------------------------------------------+-------------------------------------+--------------------+
+| `Zed Board <http://zedboard.org/product/zedboard>`_                                                                  | √ **<fc #ff0000>VADJ 1.8V</fc>**    | N/A²               |
++----------------------------------------------------------------------------------------------------------------------+-------------------------------------+--------------------+
+| `Arria 10 SoC <https://www.altera.com/products/boards_and_kits/dev-kits/altera/arria-10-soc-development-kit.html>`_  | √                                   | N/A³               |
++----------------------------------------------------------------------------------------------------------------------+-------------------------------------+--------------------+
+
+| ¹ Instruction for reprogramming the VADJ can be found `here <https://www.xilinx.com/Attachment/ZC706_Power_Controllers_Reprogramming_Steps.pdf>`_ and `here <https://forums.xilinx.com/t5/Xilinx-Evaluation-Boards/ZC706-Doesn-t-work-with-VADJ-at-1-8v/td-p/430086>`_
+| ² See :doc:`Cmos only operation </solutions/reference-designs/adrv9002/quickstart>` section
+| ³ Not supported due sub-optimal mapping of the clock pins from the source synchronous interfaces.
+
+CMOS only operation
+~~~~~~~~~~~~~~~~~~~
+
+On the ZC706 / ZedBoard platforms the FMC connectors map to HR IO banks. The HR banks have a limitation that when using LVDS I/O standard you must set the bank VCCO voltage to 2.5V, however the ADRV9001 evaluation board is using IO supplies of 1.8V and does not have level shifters for the single ended lines. Therefore the VCCO of the banks must be set to 1.8 V (VADJ) and limiting the operation to CMOS mode only. More information on the limitation see `7 Series Select IO guide <https://www.xilinx.com/support/documentation/user_guides/ug471_7Series_SelectIO.pdf>`_ section 'LVDS and LVDS_25' and Table 1-43
+
+Supported Environments
+~~~~~~~~~~~~~~~~~~~~~~
+
+The supported OS are:
+
++----------------------------------------------------------------------------------------------------------------------+-----+----------------+----------------+--------------------------+
+| Board                                                                                                                | HDL | Linux Software | No-OS Software | Required Minimum Release |
++======================================================================================================================+=====+================+================+==========================+
+| `ZCU102 <https://www.xilinx.com/ZCU102>`_                                                                            | √   | √              | √              | 2019-R2                  |
++----------------------------------------------------------------------------------------------------------------------+-----+----------------+----------------+--------------------------+
+| `ZC706 <https://www.xilinx.com/ZC706>`_                                                                              | √   | √              | √              | 2020-R1                  |
++----------------------------------------------------------------------------------------------------------------------+-----+----------------+----------------+--------------------------+
+| `Zed Board <http://zedboard.org/product/zedboard>`_                                                                  | √   | √              | √              | 2019-R2                  |
++----------------------------------------------------------------------------------------------------------------------+-----+----------------+----------------+--------------------------+
+| `Arria 10 SoC <https://www.altera.com/products/boards_and_kits/dev-kits/altera/arria-10-soc-development-kit.html>`_  | √   | √              | N/A            | 2020-R1                  |
++----------------------------------------------------------------------------------------------------------------------+-----+----------------+----------------+--------------------------+
+
+Hardware Setup
+~~~~~~~~~~~~~~
+
+In most carriers, the :adi:`ADRV9002NP/W1/PCBZ <EVAL-ADRV9002>` and :adi:`ADRV9002NP/W2/PCBZ <EVAL-ADRV9002>` boards connects to the HPC1 connector (unless otherwise noted). The carrier setup requires power, UART (115200), ethernet (Linux), DisplayPort or HDMI (if available) and/or JTAG (no-OS) connections. A few typical setups are shown below.
+
+Identify your hardware
+^^^^^^^^^^^^^^^^^^^^^^
+
+Evaluation boards were equipped with different silicon revisions. All boards
+built since the middle of December 2020 have C0 silicon, older ones use B0
+silicon these are no longer shipped. You can identify the board you have based
+on its label.
+
+======== ================
+Label    Silicon Revision
+======== ================
+|image1| **B0**
+|image2| **B0**
+|image3| **C0**
+|image4| **C0**
+======== ================
+
+.. tip::
+
+   Each revision of silicon requires its corresponding software support files in
+   the later steps.
+
+ZCU102 + ADRV9002NP
+~~~~~~~~~~~~~~~~~~~
+
+:doc:`ADRV9002 Zynq UltraScale+ MPSoC ZCU102 Quick Start Guide </solutions/reference-designs/adrv9002/quickstart/zynqmp>`
+
+ZC706 + ADRV9002NP
+~~~~~~~~~~~~~~~~~~
+
+:doc:`ADRV9002 Zynq SoC ZC706 Quick Start Guide </solutions/reference-designs/adrv9002/quickstart/zynq>`
+
+Zed Board + ADRV9002NP
+~~~~~~~~~~~~~~~~~~~~~~
+
+:doc:`ADRV9002 Zynq Zed Board Quick Start Guide </solutions/reference-designs/adrv9002/quickstart/zed>`
+
+============
+
+More Information
+----------------
+
+-  :doc:`ADRV9001/2 Quick Start Guides </solutions/reference-designs/adrv9002/quickstart>`
+
+   -  :doc:`ADRV9002 Zynq UltraScale+ MPSoC ZCU102 Quick Start Guide </solutions/reference-designs/adrv9002/quickstart/zynqmp>`
+   -  :doc:`ADRV9002 Zynq SoC ZC706 Quick Start Guide </solutions/reference-designs/adrv9002/quickstart/zynq>`
+   -  :doc:`ADRV9002 Zynq Zed Board Quick Start Guide </solutions/reference-designs/adrv9002/quickstart/zed>`
+   -  :doc:`ADRV9002 Arria10 SoC Quick Start Guide </solutions/reference-designs/adrv9002/quickstart/a10soc>`
+
+-  :doc:`ADRV9001/ADRV9002 HDL Reference Design </solutions/reference-designs/adrv9002/reference_hdl>`
+
+   -  :doc:`AXI_ADRV9001/AXI_ADRV9002 Interface Core </solutions/reference-designs/adrv9002/axi_adrv9002>`
+   -  `Building HDL how-to, ADI Reference Designs HDL User Guide <https://wiki.analog.com/resources/fpga/docs/hdl>`_
+
+-  `ADRV9002 Device Driver Customization <https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9002-customization>`_
+-  `ADRV9002 Integrated Dual RF Transceiver Linux device driver <https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9002>`_
+
+Support
+-------
+
+Analog Devices will provide limited online support for anyone using the reference design with Analog Devices components via the :ez:`EngineerZone <community/fpga>`.
+
+Software resources
+------------------
+
+-  `ADRV9002 Device Driver Customization <https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9002-customization>`_
+-  `ADRV9002 Integrated Dual RF Transceiver Linux device driver <https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9002>`_
+
+More Information
+----------------
+
+-  :doc:`ADRV9001/2 Quick Start Guides </solutions/reference-designs/adrv9002/quickstart>`
+
+   -  :doc:`ADRV9002 Zynq UltraScale+ MPSoC ZCU102 Quick Start Guide </solutions/reference-designs/adrv9002/quickstart/zynqmp>`
+   -  :doc:`ADRV9002 Zynq SoC ZC706 Quick Start Guide </solutions/reference-designs/adrv9002/quickstart/zynq>`
+   -  :doc:`ADRV9002 Zynq Zed Board Quick Start Guide </solutions/reference-designs/adrv9002/quickstart/zed>`
+   -  :doc:`ADRV9002 Arria10 SoC Quick Start Guide </solutions/reference-designs/adrv9002/quickstart/a10soc>`
+
+-  :doc:`ADRV9001/ADRV9002 HDL Reference Design </solutions/reference-designs/adrv9002/reference_hdl>`
+
+   -  :doc:`AXI_ADRV9001/AXI_ADRV9002 Interface Core </solutions/reference-designs/adrv9002/axi_adrv9002>`
+   -  `Building HDL how-to, ADI Reference Designs HDL User Guide <https://wiki.analog.com/resources/fpga/docs/hdl>`_
+
+-  `ADRV9002 Device Driver Customization <https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9002-customization>`_
+-  `ADRV9002 Integrated Dual RF Transceiver Linux device driver <https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9002>`_
+
+Support
+-------
+
+Analog Devices will provide limited online support for anyone using the reference design with Analog Devices components via the :ez:`EngineerZone <community/fpga>`.
+
+Software resources
+------------------
+
+-  `ADRV9002 Device Driver Customization <https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9002-customization>`_
+-  `ADRV9002 Integrated Dual RF Transceiver Linux device driver <https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9002>`_
+
+.. |image1| image:: ../images/adrv9002_b0_np_w1.png
+.. |image2| image:: ../images/adrv9002_b0_np_w2.png
+.. |image3| image:: ../images/adrv9002xbcz_c0_np_w1.png
+.. |image4| image:: ../images/adrv9002xbcz_c0_np_w2.png
+
+Testing
+=======
+
+.. image:: ../images/zcu102.jpg
+   :align: center
+   :width: 900
+
+-  Connect the :adi:`ADRV9002NP/W1/PCBZ <EVAL-ADRV9002>` or :adi:`ADRV9002NP/W2/PCBZ <EVAL-ADRV9002>` FMC board to the FPGA carrier **HPC0** FMC0 socket.
+-  On the FMC card set switch to select clock source between:
+
+   -  an on-board 38.4MHz VCTCXO (default)
+   -  external (thru J501) 10MHz to 1000MHz / +13dBm
+
+-  Connect USB UART J83 (Micro USB) to your host PC.
+-  Insert SD card into socket.
+-  Configure ZCU102 for SD BOOT (mode SW6[4:1] switch in the position **OFF,OFF,OFF,ON** as seen in the below picture).
+-  Turn on the power switch on the FPGA board.
+-  Observe kernel and serial console messages on your terminal. (use the first
+   ttyUSB or COM port registered)
+
+.. image:: ../images/zcu102_1p0_bootmode.jpg
+   :align: center
+   :width: 400
+
+.. esd-warning::
+
+SDcard boot files
+-----------------
+
+The files that need to be present on the sdcard ``BOOT`` partition are:
+
+-  ``BOOT.bin``
+-  ``Image``
+-  ``system.dtb``
+
+Copy these from the ``zynqmp-zcu102-rev10-adrv9002`` directory.
+
+Messages
+--------
+
+.. collapsible:: Complete kernel boot log (Click to expand)
+
+   .. container:: box bggreen
+
+      This specifies any shell prompt running on the target
+
+      ::
+
+         Xilinx Zynq MP First Stage Boot Loader
+         Release 2019.1   Feb 19 2021  -  21:11:12
+         NOTICE:  ATF running on XCZU9EG/silicon v4/RTL5.1 at 0xfffea000
+         NOTICE:  BL31: Secure code at 0x0
+         NOTICE:  BL31: Non secure code at 0x8000000
+         NOTICE:  BL31: v2.0(release):xilinx-v2019.2
+         NOTICE:  BL31: Built : 10:19:24, Jan 13 2020
+         PMUFW:  v1.1
+
+         U-Boot 2018.01-21436-gbba91bc203 (Jan 13 2020 - 10:50:58 +0200) Xilinx ZynqMP ZCU102 rev1.0, Build: jenkins-development-build_uboot-1
+
+         I2C:   ready
+         DRAM:  4 GiB
+         EL Level:       EL2
+         Chip ID:        zu9eg
+         MMC:   sdhci@ff170000: 0 (SD)
+         ** Warning - bad CRC, using default environment
+
+         In:    serial@ff000000
+         Out:   serial@ff000000
+         Err:   serial@ff000000
+         Bootmode: LVL_SHFT_SD_MODE1
+         Net:   ZYNQ GEM: ff0e0000, phyaddr c, interface rgmii-id
+
+         Warning: ethernet@ff0e0000 (eth0) using random MAC address - 0a:b9:b6:be:9e:f0
+         eth0: ethernet@ff0e0000
+         Hit any key to stop autoboot:  0
+         switch to partitions #0, OK
+         mmc0 is current device
+         Device: sdhci@ff170000
+         Manufacturer ID: 3
+         OEM: 5344
+         Name: SP32G
+         Tran Speed: 50000000
+         Rd Block Len: 512
+         SD version 3.0
+         High Capacity: Yes
+         Capacity: 29.7 GiB
+         Bus Width: 4-bit
+         Erase Group Size: 512 Bytes
+         reading uEnv.txt
+         407 bytes read in 16 ms (24.4 KiB/s)
+         Loaded environment from uEnv.txt
+         Importing environment from SD ...
+         Running uenvcmd ...
+         Copying Linux from SD to RAM...
+          No boot file defined 
+         reading system.dtb
+         43253 bytes read in 25 ms (1.6 MiB/s)
+         reading Image
+         29737472 bytes read in 1978 ms (14.3 MiB/s)
+         ## Flattened Device Tree blob at 04000000
+            Booting using the fdt blob at 0x4000000
+            Loading Device Tree to 000000000fff2000, end 000000000ffff8f4 ... OK
+
+         Starting kernel ...
+
+         [    0.000000] Booting Linux on physical CPU 0x0000000000 [0x410fd034]
+         [    0.000000] Linux version 4.19.0-ga6ef26d (jenkins@romlxbuild1.adlk.analog.com) (gcc version 8.2.0 (GCC)) #1105 SMP Fri Feb 19 16:51:27 GMT 2021
+         [    0.000000] Machine model: ZynqMP ZCU102 Rev1.0
+         [    0.000000] earlycon: cdns0 at MMIO 0x00000000ff000000 (options '115200n8')
+         [    0.000000] bootconsole [cdns0] enabled
+         [    0.000000] efi: Getting EFI parameters from FDT:
+         [    0.000000] efi: UEFI not found.
+         [    0.000000] cma: Reserved 256 MiB at 0x0000000070000000
+         [    0.000000] psci: probing for conduit method from DT.
+         [    0.000000] psci: PSCIv1.1 detected in firmware.
+         [    0.000000] psci: Using standard PSCI v0.2 function IDs
+         [    0.000000] psci: MIGRATE_INFO_TYPE not supported.
+         [    0.000000] psci: SMC Calling Convention v1.1
+         [    0.000000] random: get_random_bytes called from start_kernel+0x94/0x3f8 with crng_init=0
+         [    0.000000] percpu: Embedded 22 pages/cpu @(____ptrval____) s52504 r8192 d29416 u90112
+         [    0.000000] Detected VIPT I-cache on CPU0
+         [    0.000000] CPU features: enabling workaround for ARM erratum 845719
+         [    0.000000] Speculative Store Bypass Disable mitigation not required
+         [    0.000000] CPU features: detected: Kernel page table isolation (KPTI)
+         [    0.000000] Built 1 zonelists, mobility grouping on.  Total pages: 1034240
+         [    0.000000] Kernel command line: console=ttyPS0,115200 root=/dev/mmcblk0p2 rw earlycon rootfstype=ext4 rootwait clk_ignore_unused cpuidle.off=1 root=/dev/mmcblk0p2 rw rootwait
+         [    0.000000] Dentry cache hash table entries: 524288 (order: 10, 4194304 bytes)
+         [    0.000000] Inode-cache hash table entries: 262144 (order: 9, 2097152 bytes)
+         [    0.000000] software IO TLB: mapped [mem 0x6bfff000-0x6ffff000] (64MB)
+         [    0.000000] Memory: 3772376K/4194304K available (12796K kernel code, 1520K rwdata, 13828K rodata, 832K init, 326K bss, 159784K reserved, 262144K cma-reserved)
+         [    0.000000] rcu: Hierarchical RCU implementation.
+         [    0.000000] rcu:     RCU event tracing is enabled.
+         [    0.000000] rcu:     RCU restricting CPUs from NR_CPUS=8 to nr_cpu_ids=4.
+         [    0.000000] rcu: Adjusting geometry for rcu_fanout_leaf=16, nr_cpu_ids=4
+         [    0.000000] NR_IRQS: 64, nr_irqs: 64, preallocated irqs: 0
+         [    0.000000] GIC: Adjusting CPU interface base to 0x00000000f902f000
+         [    0.000000] GIC: Using split EOI/Deactivate mode
+         [    0.000000] arch_timer: cp15 timer(s) running at 99.99MHz (phys).
+         [    0.000000] clocksource: arch_sys_counter: mask: 0xffffffffffffff max_cycles: 0x170f8de2d3, max_idle_ns: 440795206112 ns
+         [    0.000003] sched_clock: 56 bits at 99MHz, resolution 10ns, wraps every 4398046511101ns
+         [    0.008247] Console: colour dummy device 80x25
+         [    0.012391] Calibrating delay loop (skipped), value calculated using timer frequency.. 199.98 BogoMIPS (lpj=399960)
+         [    0.022757] pid_max: default: 32768 minimum: 301
+         [    0.027449] Mount-cache hash table entries: 8192 (order: 4, 65536 bytes)
+         [    0.034012] Mountpoint-cache hash table entries: 8192 (order: 4, 65536 bytes)
+         [    0.041769] ASID allocator initialised with 32768 entries
+         [    0.046510] rcu: Hierarchical SRCU implementation.
+         [    0.051540] EFI services will not be available.
+         [    0.055826] smp: Bringing up secondary CPUs ...
+         [    0.060482] Detected VIPT I-cache on CPU1
+         [    0.060511] CPU1: Booted secondary processor 0x0000000001 [0x410fd034]
+         [    0.060812] Detected VIPT I-cache on CPU2
+         [    0.060831] CPU2: Booted secondary processor 0x0000000002 [0x410fd034]
+         [    0.061113] Detected VIPT I-cache on CPU3
+         [    0.061132] CPU3: Booted secondary processor 0x0000000003 [0x410fd034]
+         [    0.061176] smp: Brought up 1 node, 4 CPUs
+         [    0.095681] SMP: Total of 4 processors activated.
+         [    0.100355] CPU features: detected: 32-bit EL0 Support
+         [    0.106854] CPU: All CPU(s) started at EL2
+         [    0.109534] alternatives: patching kernel code
+         [    0.114823] devtmpfs: initialized
+         [    0.122439] Registered cp15_barrier emulation handler
+         [    0.122486] Registered setend emulation handler
+         [    0.126850] clocksource: jiffies: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 7645041785100000 ns
+         [    0.136436] futex hash table entries: 1024 (order: 4, 65536 bytes)
+         [    0.148024] xor: measuring software checksum speed
+         [    0.186637]    8regs     :  2375.000 MB/sec
+         [    0.226664]    8regs_prefetch:  2051.000 MB/sec
+         [    0.266695]    32regs    :  2724.000 MB/sec
+         [    0.306724]    32regs_prefetch:  2308.000 MB/sec
+         [    0.306765] xor: using function: 32regs (2724.000 MB/sec)
+         [    0.311069] pinctrl core: initialized pinctrl subsystem
+         [    0.316826] NET: Registered protocol family 16
+         [    0.321061] audit: initializing netlink subsys (disabled)
+         [    0.326088] audit: type=2000 audit(0.272:1): state=initialized audit_enabled=0 res=1
+         [    0.333729] vdso: 2 pages (1 code @ (____ptrval____), 1 data @ (____ptrval____))
+         [    0.333733] hw-breakpoint: found 6 breakpoint and 4 watchpoint registers.
+         [    0.348477] DMA: preallocated 256 KiB pool for atomic allocations
+         [    0.367373] HugeTLB registered 2.00 MiB page size, pre-allocated 0 pages
+         [    0.436466] raid6: int64x1  gen()   445 MB/s
+         [    0.504466] raid6: int64x1  xor()   451 MB/s
+         [    0.572495] raid6: int64x2  gen()   679 MB/s
+         [    0.640509] raid6: int64x2  xor()   599 MB/s
+         [    0.708566] raid6: int64x4  gen()   980 MB/s
+         [    0.776627] raid6: int64x4  xor()   737 MB/s
+         [    0.844663] raid6: int64x8  gen()  1162 MB/s
+         [    0.912718] raid6: int64x8  xor()   759 MB/s
+         [    0.980776] raid6: neonx1   gen()   736 MB/s
+         [    1.048778] raid6: neonx1   xor()   880 MB/s
+         [    1.116836] raid6: neonx2   gen()  1129 MB/s
+         [    1.184875] raid6: neonx2   xor()  1173 MB/s
+         [    1.252923] raid6: neonx4   gen()  1478 MB/s
+         [    1.320965] raid6: neonx4   xor()  1418 MB/s
+         [    1.389010] raid6: neonx8   gen()  1552 MB/s
+         [    1.457057] raid6: neonx8   xor()  1459 MB/s
+         [    1.457095] raid6: using algorithm neonx8 gen() 1552 MB/s
+         [    1.461047] raid6: .... xor() 1459 MB/s, rmw enabled
+         [    1.465979] raid6: using neon recovery algorithm
+         [    1.471270] SCSI subsystem initialized
+         [    1.474446] usbcore: registered new interface driver usbfs
+         [    1.479765] usbcore: registered new interface driver hub
+         [    1.485041] usbcore: registered new device driver usb
+         [    1.490190] media: Linux media interface: v0.10
+         [    1.494548] videodev: Linux video capture interface: v2.00
+         [    1.500023] pps_core: LinuxPPS API ver. 1 registered
+         [    1.504908] pps_core: Software ver. 5.3.6 - Copyright 2005-2007 Rodolfo Giometti <giometti@linux.it>
+         [    1.514002] PTP clock support registered
+         [    1.517899] EDAC MC: Ver: 3.0.0
+         [    1.521390] zynqmp-ipi-mbox mailbox@ff990400: Probed ZynqMP IPI Mailbox driver.
+         [    1.528652] jesd204: found 0 devices and 0 topologies
+         [    1.533319] FPGA manager framework
+         [    1.536823] Advanced Linux Sound Architecture Driver Initialized.
+         [    1.542980] Bluetooth: Core ver 2.22
+         [    1.546271] NET: Registered protocol family 31
+         [    1.550672] Bluetooth: HCI device and connection manager initialized
+         [    1.556988] Bluetooth: HCI socket layer initialized
+         [    1.561832] Bluetooth: L2CAP socket layer initialized
+         [    1.566859] Bluetooth: SCO socket layer initialized
+         [    1.572180] clocksource: Switched to clocksource arch_sys_counter
+         [    1.577835] VFS: Disk quotas dquot_6.6.0
+         [    1.581688] VFS: Dquot-cache hash table entries: 512 (order 0, 4096 bytes)
+         [    1.592648] NET: Registered protocol family 2
+         [    1.593126] tcp_listen_portaddr_hash hash table entries: 2048 (order: 3, 32768 bytes)
+         [    1.600629] TCP established hash table entries: 32768 (order: 6, 262144 bytes)
+         [    1.607968] TCP bind hash table entries: 32768 (order: 7, 524288 bytes)
+         [    1.614718] TCP: Hash tables configured (established 32768 bind 32768)
+         [    1.620891] UDP hash table entries: 2048 (order: 4, 65536 bytes)
+         [    1.626869] UDP-Lite hash table entries: 2048 (order: 4, 65536 bytes)
+         [    1.633352] NET: Registered protocol family 1
+         [    1.637736] RPC: Registered named UNIX socket transport module.
+         [    1.643414] RPC: Registered udp transport module.
+         [    1.648081] RPC: Registered tcp transport module.
+         [    1.652756] RPC: Registered tcp NFSv4.1 backchannel transport module.
+         [    1.659887] hw perfevents: no interrupt-affinity property for /pmu, guessing.
+         [    1.666390] hw perfevents: enabled with armv8_pmuv3 PMU driver, 7 counters available
+         [    1.674773] Initialise system trusted keyrings
+         [    1.678419] workingset: timestamp_bits=62 max_order=20 bucket_order=0
+         [    1.685433] NFS: Registering the id_resolver key type
+         [    1.689790] Key type id_resolver registered
+         [    1.693930] Key type id_legacy registered
+         [    1.697914] nfs4filelayout_init: NFSv4 File Layout Driver Registering...
+         [    1.704583] jffs2: version 2.2. (NAND) (SUMMARY)  © 2001-2006 Red Hat, Inc.
+         [    2.793728] NET: Registered protocol family 38
+         [    2.855264] Key type asymmetric registered
+         [    2.855302] Asymmetric key parser 'x509' registered
+         [    2.858609] Block layer SCSI generic (bsg) driver version 0.4 loaded (major 246)
+         [    2.865926] io scheduler noop registered
+         [    2.869820] io scheduler deadline registered
+         [    2.874074] io scheduler cfq registered (default)
+         [    2.878728] io scheduler mq-deadline registered
+         [    2.883225] io scheduler kyber registered
+         [    2.914847] Serial: 8250/16550 driver, 4 ports, IRQ sharing disabled
+         [    2.918934] cacheinfo: Unable to detect cache hierarchy for CPU 0
+         [    2.925775] brd: module loaded
+         [    2.929542] loop: module loaded
+         [    2.929756] Registered mathworks_ip class
+         [    2.932585] mtdoops: mtd device (mtddev=name/number) must be supplied
+         [    2.939497] libphy: Fixed MDIO Bus: probed
+         [    2.943351] tun: Universal TUN/TAP device driver, 1.6
+         [    2.947341] CAN device driver interface
+         [    2.951948] usbcore: registered new interface driver asix
+         [    2.956437] usbcore: registered new interface driver ax88179_178a
+         [    2.962475] usbcore: registered new interface driver cdc_ether
+         [    2.968268] usbcore: registered new interface driver net1080
+         [    2.973891] usbcore: registered new interface driver cdc_subset
+         [    2.979773] usbcore: registered new interface driver zaurus
+         [    2.985318] usbcore: registered new interface driver cdc_ncm
+         [    2.991589] ehci_hcd: USB 2.0 'Enhanced' Host Controller (EHCI) Driver
+         [    2.997401] ehci-pci: EHCI PCI platform driver
+         [    3.002067] usbcore: registered new interface driver uas
+         [    3.007119] usbcore: registered new interface driver usb-storage
+         [    3.013118] usbcore: registered new interface driver usbserial_generic
+         [    3.019566] usbserial: USB Serial support registered for generic
+         [    3.025535] usbcore: registered new interface driver ftdi_sio
+         [    3.031241] usbserial: USB Serial support registered for FTDI USB Serial Device
+         [    3.038511] usbcore: registered new interface driver upd78f0730
+         [    3.044390] usbserial: USB Serial support registered for upd78f0730
+         [    3.051944] rtc_zynqmp ffa60000.rtc: rtc core: registered ffa60000.rtc as rtc0
+         [    3.057847] i2c /dev entries driver
+         [    3.063205] usbcore: registered new interface driver uvcvideo
+         [    3.066955] USB Video Class driver (1.1.1)
+         [    3.072350] Bluetooth: HCI UART driver ver 2.3
+         [    3.075426] Bluetooth: HCI UART protocol H4 registered
+         [    3.080539] Bluetooth: HCI UART protocol BCSP registered
+         [    3.085831] Bluetooth: HCI UART protocol LL registered
+         [    3.090915] Bluetooth: HCI UART protocol ATH3K registered
+         [    3.096300] Bluetooth: HCI UART protocol Three-wire (H5) registered
+         [    3.102548] Bluetooth: HCI UART protocol Intel registered
+         [    3.107888] Bluetooth: HCI UART protocol QCA registered
+         [    3.113096] usbcore: registered new interface driver bcm203x
+         [    3.118711] usbcore: registered new interface driver bpa10x
+         [    3.124249] usbcore: registered new interface driver bfusb
+         [    3.129697] usbcore: registered new interface driver btusb
+         [    3.135121] Bluetooth: Generic Bluetooth SDIO driver ver 0.1
+         [    3.140785] usbcore: registered new interface driver ath3k
+         [    3.146319] EDAC MC: ECC not enabled
+         [    3.149983] EDAC DEVICE0: Giving out device to module zynqmp-ocm-edac controller zynqmp_ocm: DEV ff960000.memory-controller (INTERRUPT)
+         [    3.162178] CPUidle arm: Failed to register cpuidle driver
+         [    3.167472] sdhci: Secure Digital Host Controller Interface driver
+         [    3.173449] sdhci: Copyright(c) Pierre Ossman
+         [    3.177769] sdhci-pltfm: SDHCI platform and OF driver helper
+         [    3.183770] ledtrig-cpu: registered to indicate activity on CPUs
+         [    3.189405] zynqmp_firmware_probe Platform Management API v1.1
+         [    3.195160] zynqmp_firmware_probe Trustzone version v1.0
+         [    3.203223] zynqmp-pinctrl firmware:zynqmp-firmware:pinctrl: zynqmp pinctrl initialized
+         [    3.230667] zynqmp_clk_mux_get_parent() getparent failed for clock: lpd_wdt, ret = -22
+         [    3.233364] alg: No test for xilinx-zynqmp-aes (zynqmp-aes)
+         [    3.238490] zynqmp_aes zynqmp_aes: AES Successfully Registered
+         [    3.238490]
+         [    3.246004] alg: No test for xilinx-keccak-384 (zynqmp-keccak-384)
+         [    3.252133] alg: No test for xilinx-zynqmp-rsa (zynqmp-rsa)
+         [    3.257710] usbcore: registered new interface driver usbhid
+         [    3.263045] usbhid: USB HID core driver
+         [    3.273657] axi_sysid 85000000.axi-sysid-0: [adrv9001] [CMOS_LVDS_N=1] on [zcu102] git <061d024d596ef84c6a819854bf2472e6b43a2d5d> clean [2021-02-19 20:33:16] UTC
+         [    3.282751] fpga_manager fpga0: Xilinx ZynqMP FPGA Manager registered
+         [    3.289316] usbcore: registered new interface driver snd-usb-audio
+         [    3.296741] pktgen: Packet Generator for packet performance testing. Version: 2.75
+         [    3.302850] Initializing XFRM netlink socket
+         [    3.306795] NET: Registered protocol family 10
+         [    3.311502] Segment Routing with IPv6
+         [    3.314856] sit: IPv6, IPv4 and MPLS over IPv4 tunneling driver
+         [    3.320985] NET: Registered protocol family 17
+         [    3.325070] NET: Registered protocol family 15
+         [    3.329484] bridge: filtering via arp/ip/ip6tables is no longer available by default. Update your scripts to load br_netfilter if you need this.
+         [    3.342754] can: controller area network core (rev 20170425 abi 9)
+         [    3.348559] NET: Registered protocol family 29
+         [    3.352918] can: raw protocol (rev 20170425)
+         [    3.357155] can: broadcast manager protocol (rev 20170425 t)
+         [    3.362780] can: netlink gateway (rev 20170425) max_hops=1
+         [    3.368292] Bluetooth: RFCOMM TTY layer initialized
+         [    3.373080] Bluetooth: RFCOMM socket layer initialized
+         [    3.378192] Bluetooth: RFCOMM ver 1.11
+         [    3.381899] Bluetooth: BNEP (Ethernet Emulation) ver 1.3
+         [    3.387173] Bluetooth: BNEP filters: protocol multicast
+         [    3.392365] Bluetooth: BNEP socket layer initialized
+         [    3.397294] Bluetooth: HIDP (Human Interface Emulation) ver 1.2
+         [    3.403178] Bluetooth: HIDP socket layer initialized
+         [    3.408220] 9pnet: Installing 9P2000 support
+         [    3.412355] NET: Registered protocol family 36
+         [    3.416774] Key type dns_resolver registered
+         [    3.421525] registered taskstats version 1
+         [    3.425069] Loading compiled-in X.509 certificates
+         [    3.430177] Btrfs loaded, crc32c=crc32c-generic
+         [    3.440707] ff000000.serial: ttyPS0 at MMIO 0xff000000 (irq = 40, base_baud = 6249999) is a xuartps
+         [    3.450153] console [ttyPS0] enabled
+         [    3.450153] console [ttyPS0] enabled
+         [    3.453753] bootconsole [cdns0] disabled
+         [    3.453753] bootconsole [cdns0] disabled
+         [    3.461945] ff010000.serial: ttyPS1 at MMIO 0xff010000 (irq = 41, base_baud = 6249999) is a xuartps
+         [    3.475319] of-fpga-region fpga-full: FPGA Region probed
+         [    3.481150] nwl-pcie fd0e0000.pcie: Link is DOWN
+         [    3.485798] nwl-pcie fd0e0000.pcie: host bridge /amba/pcie@fd0e0000 ranges:
+         [    3.492768] nwl-pcie fd0e0000.pcie:   MEM 0xe0000000..0xefffffff -> 0xe0000000
+         [    3.499990] nwl-pcie fd0e0000.pcie:   MEM 0x600000000..0x7ffffffff -> 0x600000000
+         [    3.507574] nwl-pcie fd0e0000.pcie: PCI host bridge to bus 0000:00
+         [    3.513756] pci_bus 0000:00: root bus resource [bus 00-ff]
+         [    3.519239] pci_bus 0000:00: root bus resource [mem 0xe0000000-0xefffffff]
+         [    3.526109] pci_bus 0000:00: root bus resource [mem 0x600000000-0x7ffffffff pref]
+         [    3.537882] pci 0000:00:00.0: PCI bridge to [bus 01-0c]
+         [    3.544313] xilinx-dpdma fd4c0000.dma: Xilinx DPDMA engine is probed
+         [    3.550889] xilinx-zynqmp-dma fd500000.dma: ZynqMP DMA driver Probe success
+         [    3.557988] xilinx-zynqmp-dma fd510000.dma: ZynqMP DMA driver Probe success
+         [    3.565091] xilinx-zynqmp-dma fd520000.dma: ZynqMP DMA driver Probe success
+         [    3.572201] xilinx-zynqmp-dma fd530000.dma: ZynqMP DMA driver Probe success
+         [    3.579300] xilinx-zynqmp-dma fd540000.dma: ZynqMP DMA driver Probe success
+         [    3.586400] xilinx-zynqmp-dma fd550000.dma: ZynqMP DMA driver Probe success
+         [    3.593503] xilinx-zynqmp-dma fd560000.dma: ZynqMP DMA driver Probe success
+         [    3.600605] xilinx-zynqmp-dma fd570000.dma: ZynqMP DMA driver Probe success
+         [    3.607843] xilinx-psgtr fd400000.zynqmp_phy: Lane:1 type:8 protocol:4 pll_locked:yes
+         [    3.619181] zynqmp_clk_divider_set_rate() set divider failed for spi1_ref_div1, ret = -13
+         [    3.627856] xilinx-dp-snd-codec fd4a0000.zynqmp-display:zynqmp_dp_snd_codec0: Xilinx DisplayPort Sound Codec probed
+         [    3.638630] xilinx-dp-snd-pcm zynqmp_dp_snd_pcm0: Xilinx DisplayPort Sound PCM probed
+         [    3.646720] xilinx-dp-snd-pcm zynqmp_dp_snd_pcm1: Xilinx DisplayPort Sound PCM probed
+         [    3.655160] xilinx-dp-snd-card fd4a0000.zynqmp-display:zynqmp_dp_snd_card: xilinx-dp-snd-codec-dai <-> xilinx-dp-snd-codec-dai mapping ok
+         [    3.667600] xilinx-dp-snd-card fd4a0000.zynqmp-display:zynqmp_dp_snd_card: xilinx-dp-snd-codec-dai <-> xilinx-dp-snd-codec-dai mapping ok
+         [    3.680357] xilinx-dp-snd-card fd4a0000.zynqmp-display:zynqmp_dp_snd_card: Xilinx DisplayPort Sound Card probed
+         [    3.690540] OF: graph: no port node found in /amba/zynqmp-display@fd4a0000
+         [    3.697550] [drm] Supports vblank timestamp caching Rev 2 (21.10.2013).
+         [    3.704160] [drm] No driver support for vblank timestamp query.
+         [    3.710141] xlnx-drm xlnx-drm.0: bound fd4a0000.zynqmp-display (ops 0xffffff8008dc2e70)
+         [    3.851542] random: fast init done
+         [    7.834438] [drm] Cannot find any crtc or sizes
+         [    7.839198] [drm] Initialized xlnx 1.0.0 20130509 for fd4a0000.zynqmp-display on minor 0
+         [    7.847310] zynqmp-display fd4a0000.zynqmp-display: ZynqMP DisplayPort Subsystem driver probed
+         [    7.856306] xilinx-psgtr fd400000.zynqmp_phy: Lane:3 type:3 protocol:2 pll_locked:yes
+         [    7.864189] ahci-ceva fd0c0000.ahci: AHCI 0001.0301 32 slots 2 ports 6 Gbps 0x3 impl platform mode
+         [    7.873148] ahci-ceva fd0c0000.ahci: flags: 64bit ncq sntf pm clo only pmp fbs pio slum part ccc sds apst
+         [    7.883629] scsi host0: ahci-ceva
+         [    7.887219] scsi host1: ahci-ceva
+         [    7.890679] ata1: SATA max UDMA/133 mmio [mem 0xfd0c0000-0xfd0c1fff] port 0x100 irq 37
+         [    7.898593] ata2: SATA max UDMA/133 mmio [mem 0xfd0c0000-0xfd0c1fff] port 0x180 irq 37
+         [    7.911116] m25p80 spi0.0: SPI-NOR-UniqueID 1044002c3991000a03001c00668a718bd1
+         [    7.918347] m25p80 spi0.0: found n25q512a, expected m25p80
+         [    7.924030] m25p80 spi0.0: n25q512a (131072 Kbytes)
+         [    7.928929] 4 fixed-partitions partitions found on MTD device spi0.0
+         [    7.935274] Creating 4 MTD partitions on "spi0.0":
+         [    7.940058] 0x000000000000-0x000000100000 : "qspi-fsbl-uboot"
+         [    7.946265] 0x000000100000-0x000000600000 : "qspi-linux"
+         [    7.951966] 0x000000600000-0x000000620000 : "qspi-device-tree"
+         [    7.958204] 0x000000620000-0x000000c00000 : "qspi-rootfs"
+         [    7.966043] macb ff0e0000.ethernet: Not enabling partial store and forward
+         [    7.973403] libphy: MACB_mii_bus: probed
+         [    7.977402] mdio_bus ff0e0000.ethernet-ffffffff: MDIO device at address 21 is missing.
+         [    7.987597] TI DP83867 ff0e0000.ethernet-ffffffff:0c: attached PHY driver [TI DP83867] (mii_bus:phy_addr=ff0e0000.ethernet-ffffffff:0c, irq=POLL)
+         [    8.000642] macb ff0e0000.ethernet eth0: Cadence GEM rev 0x50070106 at 0xff0e0000 irq 22 (0a:b9:b6:be:9e:f0)
+         [    8.010765] xilinx-axipmon ffa00000.perf-monitor: Probed Xilinx APM
+         [    8.017306] xilinx-axipmon fd0b0000.perf-monitor: Probed Xilinx APM
+         [    8.023798] xilinx-axipmon fd490000.perf-monitor: Probed Xilinx APM
+         [    8.030291] xilinx-axipmon ffa10000.perf-monitor: Probed Xilinx APM
+         [    8.038204] dwc3 fe200000.dwc3: Failed to get clk 'ref': -2
+         [    8.044057] xilinx-psgtr fd400000.zynqmp_phy: Lane:2 type:0 protocol:3 pll_locked:yes
+         [    8.052411] xhci-hcd xhci-hcd.0.auto: xHCI Host Controller
+         [    8.057905] xhci-hcd xhci-hcd.0.auto: new USB bus registered, assigned bus number 1
+         [    8.065904] xhci-hcd xhci-hcd.0.auto: hcc params 0x0238f625 hci version 0x100 quirks 0x0000000202010810
+         [    8.075316] xhci-hcd xhci-hcd.0.auto: irq 50, io mem 0xfe200000
+         [    8.081440] usb usb1: New USB device found, idVendor=1d6b, idProduct=0002, bcdDevice= 4.19
+         [    8.089710] usb usb1: New USB device strings: Mfr=3, Product=2, SerialNumber=1
+         [    8.096930] usb usb1: Product: xHCI Host Controller
+         [    8.101798] usb usb1: Manufacturer: Linux 4.19.0-ga6ef26d xhci-hcd
+         [    8.107970] usb usb1: SerialNumber: xhci-hcd.0.auto
+         [    8.113126] hub 1-0:1.0: USB hub found
+         [    8.116906] hub 1-0:1.0: 1 port detected
+         [    8.121025] xhci-hcd xhci-hcd.0.auto: xHCI Host Controller
+         [    8.126519] xhci-hcd xhci-hcd.0.auto: new USB bus registered, assigned bus number 2
+         [    8.134177] xhci-hcd xhci-hcd.0.auto: Host supports USB 3.0  SuperSpeed
+         [    8.140907] usb usb2: New USB device found, idVendor=1d6b, idProduct=0003, bcdDevice= 4.19
+         [    8.149170] usb usb2: New USB device strings: Mfr=3, Product=2, SerialNumber=1
+         [    8.156385] usb usb2: Product: xHCI Host Controller
+         [    8.161254] usb usb2: Manufacturer: Linux 4.19.0-ga6ef26d xhci-hcd
+         [    8.167425] usb usb2: SerialNumber: xhci-hcd.0.auto
+         [    8.172538] hub 2-0:1.0: USB hub found
+         [    8.176314] hub 2-0:1.0: 1 port detected
+         [    8.181473] pca953x 0-0020: 0-0020 supply vcc not found, using dummy regulator
+         [    8.188727] pca953x 0-0020: Linked as a consumer to regulator.0
+         [    8.195533] GPIO line 496 (sel0) hogged as output/low
+         [    8.200920] GPIO line 497 (sel1) hogged as output/high
+         [    8.206393] GPIO line 498 (sel2) hogged as output/high
+         [    8.211866] GPIO line 499 (sel3) hogged as output/high
+         [    8.217220] pca953x 0-0021: 0-0021 supply vcc not found, using dummy regulator
+         [    8.218374] ata2: SATA link down (SStatus 0 SControl 330)
+         [    8.224469] pca953x 0-0021: Linked as a consumer to regulator.0
+         [    8.229855] ata1: SATA link down (SStatus 0 SControl 330)
+         [    8.237269] ina2xx 3-0040: power monitor ina226 (Rshunt = 5000 uOhm)
+         [    8.247949] ina2xx 3-0041: power monitor ina226 (Rshunt = 5000 uOhm)
+         [    8.254762] ina2xx 3-0042: power monitor ina226 (Rshunt = 5000 uOhm)
+         [    8.261576] ina2xx 3-0043: power monitor ina226 (Rshunt = 5000 uOhm)
+         [    8.268391] ina2xx 3-0044: power monitor ina226 (Rshunt = 5000 uOhm)
+         [    8.275205] ina2xx 3-0045: power monitor ina226 (Rshunt = 5000 uOhm)
+         [    8.282017] ina2xx 3-0046: power monitor ina226 (Rshunt = 5000 uOhm)
+         [    8.288840] ina2xx 3-0047: power monitor ina226 (Rshunt = 5000 uOhm)
+         [    8.295657] ina2xx 3-004a: power monitor ina226 (Rshunt = 5000 uOhm)
+         [    8.302472] ina2xx 3-004b: power monitor ina226 (Rshunt = 5000 uOhm)
+         [    8.308889] i2c i2c-0: Added multiplexed i2c bus 3
+         [    8.314358] ina2xx 4-0040: power monitor ina226 (Rshunt = 2000 uOhm)
+         [    8.321174] ina2xx 4-0041: power monitor ina226 (Rshunt = 5000 uOhm)
+         [    8.327987] ina2xx 4-0042: power monitor ina226 (Rshunt = 5000 uOhm)
+         [    8.334799] ina2xx 4-0043: power monitor ina226 (Rshunt = 5000 uOhm)
+         [    8.341617] ina2xx 4-0044: power monitor ina226 (Rshunt = 5000 uOhm)
+         [    8.348429] ina2xx 4-0045: power monitor ina226 (Rshunt = 5000 uOhm)
+         [    8.355247] ina2xx 4-0046: power monitor ina226 (Rshunt = 5000 uOhm)
+         [    8.362055] ina2xx 4-0047: power monitor ina226 (Rshunt = 5000 uOhm)
+         [    8.368462] i2c i2c-0: Added multiplexed i2c bus 4
+         [    8.407815] i2c i2c-0: Added multiplexed i2c bus 5
+         [    8.412789] i2c i2c-0: Added multiplexed i2c bus 6
+         [    8.417585] pca954x 0-0075: registered 4 multiplexed busses for I2C mux pca9544
+         [    8.424933] cdns-i2c ff020000.i2c: 400 kHz mmio ff020000 irq 24
+         [    8.432731] at24 7-0054: 1024 byte 24c08 EEPROM, writable, 1 bytes/write
+         [    8.439481] i2c i2c-1: Added multiplexed i2c bus 7
+         [    8.444612] i2c i2c-1: Added multiplexed i2c bus 8
+         [    8.451554] si570 9-005d: registered, current frequency 300000000 Hz
+         [    8.457963] i2c i2c-1: Added multiplexed i2c bus 9
+         [    8.475140] si570 10-005d: registered, current frequency 148500000 Hz
+         [    8.481634] i2c i2c-1: Added multiplexed i2c bus 10
+         [    8.486746] si5324 11-0069: si5328 probed
+         [    8.548260] si5324 11-0069: si5328 probe successful
+         [    8.553190] i2c i2c-1: Added multiplexed i2c bus 11
+         [    8.558239] i2c i2c-1: Added multiplexed i2c bus 12
+         [    8.563288] i2c i2c-1: Added multiplexed i2c bus 13
+         [    8.568351] i2c i2c-1: Added multiplexed i2c bus 14
+         [    8.573233] pca954x 1-0074: registered 8 multiplexed busses for I2C switch pca9548
+         [    8.581184] i2c i2c-1: Added multiplexed i2c bus 15
+         [    8.612435] i2c i2c-1: Added multiplexed i2c bus 16
+         [    8.617493] i2c i2c-1: Added multiplexed i2c bus 17
+         [    8.622552] i2c i2c-1: Added multiplexed i2c bus 18
+         [    8.627609] i2c i2c-1: Added multiplexed i2c bus 19
+         [    8.632669] i2c i2c-1: Added multiplexed i2c bus 20
+         [    8.637732] i2c i2c-1: Added multiplexed i2c bus 21
+         [    8.642788] i2c i2c-1: Added multiplexed i2c bus 22
+         [    8.647669] pca954x 1-0075: registered 8 multiplexed busses for I2C switch pca9548
+         [    8.655275] cdns-i2c ff030000.i2c: 400 kHz mmio ff030000 irq 25
+         [    8.661651] cdns-wdt fd4d0000.watchdog: Xilinx Watchdog Timer with timeout 60s
+         [    8.696744] mmc0: SDHCI controller on ff170000.mmc [ff170000.mmc] using ADMA 64-bit
+         [    8.826413] mmc0: new ultra high speed SDR104 SDHC card at address aaaa
+         [    8.833526] mmcblk0: mmc0:aaaa SP32G 29.7 GiB
+         [    8.841380]  mmcblk0: p1 p2 p3
+         [    9.100768] random: crng init done
+         [   16.938476] adrv9002 spi1.0: adrv9002-phy Rev 12.0, Firmware 0.14.5.6,  Stream 0.5.18.0,  API version: 39.0.7 successfully initialized
+         [   16.951258] cf_axi_adc 84a00000.axi-adrv9002-rx-lpc: ADI AIM (10.01.b) at 0x84A00000 mapped to 0x0000000017c91dcf, probed ADC ADRV9002 as MASTER
+         [   16.965199] cf_axi_tdd 84a0c800.axi-adrv9002-core-tdd1-lpc: Analog Devices CF_AXI_TDD MASTER (1.00.a)
+         [   16.974840] cf_axi_tdd 84a0cc00.axi-adrv9002-core-tdd2-lpc: Analog Devices CF_AXI_TDD MASTER (1.00.a)
+         [   17.004448] cf_axi_dds 84a0a000.axi-adrv9002-tx-lpc: Analog Devices CF_AXI_DDS_DDS MASTER (9.01.b) at 0x84A0A000 mapped to 0x00000000640a8a22, probed DDS ADRV9002
+         [   17.036426] cf_axi_dds 84a0c000.axi-adrv9002-tx2-lpc: Analog Devices CF_AXI_DDS_DDS MASTER (9.01.b) at 0x84A0C000 mapped to 0x000000006564ee6e, probed DDS ADRV9002
+         [   17.053492] input: gpio-keys as /devices/platform/gpio-keys/input/input0
+         [   17.060492] rtc_zynqmp ffa60000.rtc: setting system clock to 2021-03-09 01:17:41 UTC (1615252661)
+         [   17.069375] of_cfs_init
+         [   17.071824] of_cfs_init: OK
+         [   17.074749] cfg80211: Loading compiled-in X.509 certificates for regulatory database
+         [   17.159479] [drm] Cannot find any crtc or sizes
+         [   17.213690] cfg80211: Loaded X.509 cert 'sforshee: 00b28ddf47aef9cea7'
+         [   17.220214] clk: Not disabling unused clocks
+         [   17.224481] ALSA device list:
+         [   17.227432]   #0: DisplayPort monitor
+         [   17.231432] platform regulatory.0: Direct firmware load for regulatory.db failed with error -2
+         [   17.240042] cfg80211: failed to load regulatory.db
+         [   17.401445] EXT4-fs (mmcblk0p2): recovery complete
+         [   17.406805] EXT4-fs (mmcblk0p2): mounted filesystem with ordered data mode. Opts: (null)
+         [   17.414918] VFS: Mounted root (ext4 filesystem) on device 179:2.
+         [   17.425156] devtmpfs: mounted
+         [   17.428300] Freeing unused kernel memory: 832K
+         [   17.432778] Run /sbin/init as init process
+         [   17.639668] systemd[1]: systemd 241 running in system mode. (+PAM +AUDIT +SELINUX +IMA +APPARMOR +SMACK +SYSVINIT +UTMP +LIBCRYPTSETUP +GCRYPT +GNUTLS +ACL +XZ +LZ4 +SECCOMP +BLKID +ELFUTILS +KMOD -IDN2 +IDN -PCRE2 default-hierarchy=hybrid)
+         [   17.661409] systemd[1]: Detected architecture arm64.
+
+         Welcome to Kuiper GNU/Linux 10 (buster)!
+
+         [   17.682519] systemd[1]: Set hostname to <analog>.
+         [   17.817555] systemd[1]: File /lib/systemd/system/systemd-journald.service:12 configures an IP firewall (IPAddressDeny=any), but the local system does not support BPF/cgroup based firewalling.
+         [   17.834616] systemd[1]: Proceeding WITHOUT firewalling in effect! (This warning is only shown for the first loaded unit using IP firewalling.)
+         [   17.950609] systemd[1]: /etc/systemd/system/tof-server.service:1: Assignment outside of section. Ignoring.
+         [   17.960300] systemd[1]: /etc/systemd/system/tof-server.service:2: Assignment outside of section. Ignoring.
+         [   18.109959] systemd[1]: Created slice system-serial\x2dgetty.slice.
+         [  OK  ] Created slice system-serial\x2dgetty.slice.
+         [   18.136377] systemd[1]: Listening on udev Control Socket.
+         [  OK  ] Listening on udev Control Socket.
+         [   18.156427] systemd[1]: Listening on udev Kernel Socket.
+         [  OK  ] Listening on udev Kernel Socket.
+         [  OK  ] Listening on Journal Socket (/dev/log).
+         [  OK  ] Created slice User and Session Slice.
+         [  OK  ] Listening on initctl Compatibility Named Pipe.
+         [  OK  ] Listening on Journal Audit Socket.
+         [  OK  ] Reached target Slices.
+         [  OK  ] Created slice system-systemd\x2dfsck.slice.
+         [  OK  ] Listening on Syslog Socket.
+         [  OK  ] Listening on Journal Socket.
+                  Mounting Huge Pages File System...
+                  Starting Restore / save the current clock...
+                  Mounting RPC Pipe File System...
+                  Mounting Kernel Debug File System...
+                  Starting Set the console keyboard layout...
+                  Starting Journal Service...
+                  Starting udev Coldplug all Devices...
+                  Mounting POSIX Message Queue File System...
+                  Starting Load Kernel Modules...
+         [  OK  ] Started Forward Password R…uests to Wall Directory Watch.
+         [  OK  ] Reached target Swap.
+         [  OK  ] Created slice system-getty.slice.
+         [  OK  ] Listening on fsck to fsckd communication Socket.
+         [  OK  ] Started Journal Service.
+         [  OK  ] Mounted Huge Pages File System.
+         [  OK  ] Started Restore / save the current clock.
+         [  OK  ] Mounted RPC Pipe File System.
+         [  OK  ] Mounted Kernel Debug File System.
+         [  OK  ] Mounted POSIX Message Queue File System.
+         [FAILED] Failed to start Load Kernel Modules.
+         See 'systemctl status systemd-modules-load.service' for details.
+         [  OK  ] Started Set the console keyboard layout.
+                  Mounting Kernel Configuration File System...
+                  Starting Apply Kernel Variables...
+                  Starting Remount Root and Kernel File Systems...
+         [  OK  ] Mounted Kernel Configuration File System.
+         [  OK  ] Started Apply Kernel Variables.
+         [  OK  ] Started Remount Root and Kernel File Systems.
+                  Starting Load/Save Random Seed...
+                  Starting Create System Users...
+                  Starting Flush Journal to Persistent Storage...
+         [  OK  ] Started Load/Save Random Seed.
+         [  OK  ] Started udev Coldplug all Devices.
+         [  OK  ] Started Create System Users.
+                  Starting Create Static Device Nodes in /dev...
+                  Starting Helper to synchronize boot up for ifupdown...
+         [  OK  ] Started Flush Journal to Persistent Storage.
+         [  OK  ] Started Create Static Device Nodes in /dev.
+         [  OK  ] Started Helper to synchronize boot up for ifupdown.
+                  Starting udev Kernel Device Manager...
+         [  OK  ] Reached target Local File Systems (Pre).
+         [  OK  ] Started udev Kernel Device Manager.
+                  Starting Show Plymouth Boot Screen...
+         [  OK  ] Started Show Plymouth Boot Screen.
+         [  OK  ] Started Forward Password R…s to Plymouth Directory Watch.
+         [  OK  ] Reached target Local Encrypted Volumes.
+                  Starting Load Kernel Modules...
+         [FAILED] Failed to start Load Kernel Modules.
+         See 'systemctl status systemd-modules-load.service' for details.
+         [  OK  ] Found device /dev/ttyPS0.
+         [  OK  ] Found device /dev/disk/by-partuuid/18f1f9d5-01.
+                  Starting File System Check…isk/by-partuuid/18f1f9d5-01...
+         [  OK  ] Started File System Check Daemon to report status.
+         [  OK  ] Found device /dev/ttyS0.
+         [  OK  ] Listening on Load/Save RF …itch Status /dev/rfkill Watch.
+         [  OK  ] Started File System Check …/disk/by-partuuid/18f1f9d5-01.
+                  Mounting /boot...
+         [  OK  ] Mounted /boot.
+         [  OK  ] Reached target Local File Systems.
+                  Starting Tell Plymouth To Write Out Runtime Data...
+                  Starting Raise network interfaces...
+                  Starting Create Volatile Files and Directories...
+                  Starting Set console font and keymap...
+                  Starting Preprocess NFS configuration...
+         [  OK  ] Started Preprocess NFS configuration.
+         [  OK  ] Reached target NFS client services.
+         [  OK  ] Reached target Remote File Systems (Pre).
+         [  OK  ] Reached target Remote File Systems.
+         [  OK  ] Started Set console font and keymap.
+         [  OK  ] Started Create Volatile Files and Directories.
+                  Starting Update UTMP about System Boot/Shutdown...
+                  Starting Network Time Synchronization...
+         [  OK  ] Started Tell Plymouth To Write Out Runtime Data.
+         [  OK  ] Started Network Time Synchronization.
+         [  OK  ] Reached target System Time Synchronized.
+         [  OK  ] Started Update UTMP about System Boot/Shutdown.
+         [  OK  ] Reached target System Initialization.
+         [  OK  ] Listening on CUPS Scheduler.
+         [  OK  ] Listening on triggerhappy.socket.
+         [  OK  ] Started Daily apt download activities.
+         [  OK  ] Listening on D-Bus System Message Bus Socket.
+         [  OK  ] Listening on GPS (Global P…ioning System) Daemon Sockets.
+         [  OK  ] Started Daily Cleanup of Temporary Directories.
+         [  OK  ] Started Daily man-db regeneration.
+         [  OK  ] Started Daily rotation of log files.
+         [  OK  ] Listening on Avahi mDNS/DNS-SD Stack Activation Socket.
+         [  OK  ] Reached target Sockets.
+         [  OK  ] Started Daily apt upgrade and clean activities.
+         [  OK  ] Reached target Timers.
+         [  OK  ] Started CUPS Scheduler.
+         [  OK  ] Reached target Paths.
+         [  OK  ] Reached target Basic System.
+                  Starting dhcpcd on all interfaces...
+                  Starting Modem Manager...
+                  Starting triggerhappy global hotkey daemon...
+                  Starting dphys-swapfile - …unt, and delete a swap file...
+                  Starting LSB: Switch to on…nless shift key is pressed)...
+                  Starting Check for Raspberry Pi EEPROM updates...
+                  Starting rng-tools.service...
+         [  OK  ] Started D-Bus System Message Bus.
+                  Starting WPA supplicant...
+                  Starting Disk Manager...
+         [  OK  ] Started Manage Sound Card State (restore and store).
+         [  OK  ] Started tof-server.service.
+                  Starting Avahi mDNS/DNS-SD Stack...
+         [  OK  ] Started Regular background program processing daemon.
+                  Starting Save/Restore Sound Card State...
+                  Starting Login Service...
+                  Starting System Logging Service...
+         [  OK  ] Started CUPS Scheduler.
+         [FAILED] Failed to start rng-tools.service.
+         See 'systemctl status rng-tools.service' for details.
+                  Starting Rotate log files...
+                  Starting Daily man-db regeneration...
+         [  OK  ] Started triggerhappy global hotkey daemon.
+         [  OK  ] Started Save/Restore Sound Card State.
+         [  OK  ] Started Rotate log files.
+         [FAILED] Failed to start Check for Raspberry Pi EEPROM updates.
+         See 'systemctl status rpi-eeprom-update.service' for details.
+         [  OK  ] Started System Logging Service.
+         [  OK  ] Started dhcpcd on all interfaces.
+         [  OK  ] Started dphys-swapfile - s…mount, and delete a swap file.
+         [  OK  ] Started LSB: Switch to ond…(unless shift key is pressed).
+         [  OK  ] Started Raise network interfaces.
+         [  OK  ] Started Avahi mDNS/DNS-SD Stack.
+         [  OK  ] Started WPA supplicant.
+         [  OK  ] Started Login Service.
+         [  OK  ] Started Make remote CUPS printers available locally.
+                  Starting Authorization Manager...
+         [  OK  ] Reached target Network.
+                  Starting Daily apt download activities...
+                  Starting OpenBSD Secure Shell server...
+                  Starting Permit User Sessions...
+                  Starting HTTP based time synchronization tool...
+                  Starting /etc/rc.local Compatibility...
+         [  OK  ] Started IIO Daemon.
+         [  OK  ] Reached target Sound Card.
+         [  OK  ] Started Permit User Sessions.
+                  Starting Light Display Manager...
+         [  OK  ] Started /etc/rc.local Compatibility.
+                  Starting Hold until boot process finishes up...
+         [  OK  ] Started HTTP based time synchronization tool.
+         [  OK  ] Started OpenBSD Secure Shell server.
+         [  OK  ] Started Authorization Manager.
+
+         Raspbian GNU/Linux 10 analog ttyPS0
+
+         analog login: root (automatic login)
+
+         Last login: Wed Feb 24 01:09:27 GMT 2021 on ttyPS0
+         Linux analog 4.19.0-ga6ef26d #1105 SMP Fri Feb 19 16:51:27 GMT 2021 aarch64
+
+         The programs included with the Debian GNU/Linux system are free software;
+         the exact distribution terms for each program are described in the
+         individual files in /usr/share/doc/*/copyright.
+
+         Debian GNU/Linux comes with ABSOLUTELY NO WARRANTY, to the extent
+         permitted by applicable law.
+         root@analog:~#
+For independent mode, these devices should be present:
+
+.. container:: box bggreen
+
+   This specifies any shell prompt running on the target
+
+   
+   ::
+   
+
+   
+      root@analog:~# iio_info | grep iio:device
+              iio:device0: ams
+              iio:device1: adrv9002-phy
+              iio:device2: axi-adrv9002-rx-lpc (buffer capable)
+              iio:device3: axi-adrv9002-rx2-lpc (buffer capable)
+              iio:device4: axi-adrv9002-core-tdd1-lpc
+              iio:device5: axi-adrv9002-core-tdd2-lpc
+              iio:device6: axi-adrv9002-tx-lpc (buffer capable)
+              iio:device7: axi-adrv9002-tx2-lpc (buffer capable)
+
+For MIMO mode, these devices should be present:
+
+.. container:: box bggreen
+
+   This specifies any shell prompt running on the target
+
+   
+   ::
+   
+
+   
+      root@analog:~# iio_info | grep iio:device
+              iio:device0: ams
+              iio:device1: adrv9002-phy
+              iio:device2: axi-adrv9002-rx-lpc (buffer capable)
+              iio:device3: axi-adrv9002-core-tdd-lpc
+              iio:device4: axi-adrv9002-tx-lpc (buffer capable)
+
+For more on device modes, check `device modes. <https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9002>`_
+
+Pyadi-iio Example
+-----------------
+
+Pyadi-iio is a python abstraction module for ADI hardware with IIO drivers to make them easier to use. For more check `Pyadi-iio <https://github.com/analogdevicesinc/pyadi-iio>`_. An example of using adrv9002 can be checked :git-pyadi-iio:`here <examples/adrv9002_example.py>`
+
+IIO Oscilloscope Remote
+-----------------------
+
+Please see also here:`Oscilloscope <https://wiki.analog.com/resources/tools-software/linux-software/iio_oscilloscope>`_
+
+The IIO Oscilloscope application can be used to connect to another platform that
+has a connected device in order to configure the device and read data from it.
+
+Build and start osc on a network enabled Linux host.
+
+Once the application is launched goto Settings -> Connect and enter the IP
+address of the target in the popup window.
+
+.. important::
+
+   Even thought this is Linux, this is a persistent file systems. Care should be taken not to corrupt the file system -- please shut down things, don't just turn off the power switch. Depending on your monitor, the standard power off could be hiding. You can do this from the terminal as well with ``sudo shutdown -h now``
+
+   |image1_2|
+
+More Information
+----------------
+
+-  :doc:`ADRV9001/2 Quick Start Guides </solutions/reference-designs/adrv9002/quickstart>`
+
+   -  :doc:`ADRV9002 Zynq UltraScale+ MPSoC ZCU102 Quick Start Guide </solutions/reference-designs/adrv9002/quickstart/zynqmp>`
+   -  :doc:`ADRV9002 Zynq SoC ZC706 Quick Start Guide </solutions/reference-designs/adrv9002/quickstart/zynq>`
+   -  :doc:`ADRV9002 Zynq Zed Board Quick Start Guide </solutions/reference-designs/adrv9002/quickstart/zed>`
+   -  :doc:`ADRV9002 Arria10 SoC Quick Start Guide </solutions/reference-designs/adrv9002/quickstart/a10soc>`
+
+-  :doc:`ADRV9001/ADRV9002 HDL Reference Design </solutions/reference-designs/adrv9002/reference_hdl>`
+
+   -  :doc:`AXI_ADRV9001/AXI_ADRV9002 Interface Core </solutions/reference-designs/adrv9002/axi_adrv9002>`
+   -  `Building HDL how-to, ADI Reference Designs HDL User Guide <https://wiki.analog.com/resources/fpga/docs/hdl>`_
+
+-  `ADRV9002 Device Driver Customization <https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9002-customization>`_
+-  `ADRV9002 Integrated Dual RF Transceiver Linux device driver <https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9002>`_
+
+Support
+-------
+
+Analog Devices will provide limited online support for anyone using the reference design with Analog Devices components via the :ez:`EngineerZone <community/fpga>`.
+
+Software resources
+------------------
+
+-  `ADRV9002 Device Driver Customization <https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9002-customization>`_
+-  `ADRV9002 Integrated Dual RF Transceiver Linux device driver <https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9002>`_
+
+More Information
+----------------
+
+-  :doc:`ADRV9001/2 Quick Start Guides </solutions/reference-designs/adrv9002/quickstart>`
+
+   -  :doc:`ADRV9002 Zynq UltraScale+ MPSoC ZCU102 Quick Start Guide </solutions/reference-designs/adrv9002/quickstart/zynqmp>`
+   -  :doc:`ADRV9002 Zynq SoC ZC706 Quick Start Guide </solutions/reference-designs/adrv9002/quickstart/zynq>`
+   -  :doc:`ADRV9002 Zynq Zed Board Quick Start Guide </solutions/reference-designs/adrv9002/quickstart/zed>`
+   -  :doc:`ADRV9002 Arria10 SoC Quick Start Guide </solutions/reference-designs/adrv9002/quickstart/a10soc>`
+
+-  :doc:`ADRV9001/ADRV9002 HDL Reference Design </solutions/reference-designs/adrv9002/reference_hdl>`
+
+   -  :doc:`AXI_ADRV9001/AXI_ADRV9002 Interface Core </solutions/reference-designs/adrv9002/axi_adrv9002>`
+   -  `Building HDL how-to, ADI Reference Designs HDL User Guide <https://wiki.analog.com/resources/fpga/docs/hdl>`_
+
+-  `ADRV9002 Device Driver Customization <https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9002-customization>`_
+-  `ADRV9002 Integrated Dual RF Transceiver Linux device driver <https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9002>`_
+
+Support
+-------
+
+Analog Devices will provide limited online support for anyone using the reference design with Analog Devices components via the :ez:`EngineerZone <community/fpga>`.
+
+Software resources
+------------------
+
+-  `ADRV9002 Device Driver Customization <https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9002-customization>`_
+-  `ADRV9002 Integrated Dual RF Transceiver Linux device driver <https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9002>`_
+
+.. |image1_2| image:: ../images/shutdown.png
+   :width: 300

--- a/docs/solutions/reference-designs/adrv9002/reference_hdl.rst
+++ b/docs/solutions/reference-designs/adrv9002/reference_hdl.rst
@@ -1,0 +1,169 @@
+ADRV9001/ADRV9002 HDL Reference Design
+======================================
+
+.. important::
+
+   We are in the process of migrating our documentation to GitHubIO. This page is outdated and the new one can be found at https://analogdevicesinc.github.io/hdl/projects/adrv9001/index.html\
+
+This design allows controlling, receiving and transmitting sample stream from/to
+an ADRV9001/ADRV9002 device through two independent source synchronous
+interface. Supports both CMOS and LVDS interface, but not in the same time. The
+selection of the I/O standard must be done with a parameter during build.
+
+The design supports SDR or DDR modes in CMOS mode with one of four lanes, as in LVDS mode one or two lane mode. This is runtime selectable. The complete list of supported modes can be consulted in the :doc:`AXI_ADRV9001/AXI_ADRV9002 Interface Core </solutions/reference-designs/adrv9002/axi_adrv9002>` documentation.
+
+Source code
+-----------
+
+.. admonition:: Download
+   :class: download
+
+   The source files can be accessed at:
+
+   
+   -  :git-hdl:`projects/adrv9001`
+   
+
+.. important::
+
+   Build instructions:
+
+   
+   For an LVDS interface the project must be built with the following
+   parameters:
+   
+   ::
+   
+   
+      make CMOS_LVDS_N=0
+
+   For a CMOS interface the project must be built with the following parameters:
+   
+   ::
+   
+
+   
+      make CMOS_LVDS_N=1
+
+Block design
+------------
+
+The design has two receive paths and two transmit paths. One of the receive
+paths (Rx12) has four channels and the other (Rx2) two channels. These can work
+independently having each two active channels, or just the Rx12 path having four
+active channels, while Rx2 is disabled. The same applies to the transmit path
+but in the other direction.
+
+When only the Rx12 path is active with four channels mode the core will take
+ownership of both source synchronous interfaces. The requirement in this case is
+that both interfaces run at the same rate.
+
+|image1|
+
+FMC locations
+-------------
+
+-  ZCU102 - FMC0
+
+DAC Interface
+-------------
+
+-  Has DDS
+-  **Has PRBS** generation
+
+ADC Interface
+-------------
+
+-  Has PN checking
+-  Has data formater
+-  Has programmable input delay
+
+SW programming
+--------------
+
+Register map
+~~~~~~~~~~~~
+
++------------+--------------------------------------------------------------------------------------------+
+| Address    | IP                                                                                         |
++------------+--------------------------------------------------------------------------------------------+
+| 0x44A00000 | :doc:`axi_adrv9001 </solutions/reference-designs/adrv9002/axi_adrv9002>`                   |
++------------+--------------------------------------------------------------------------------------------+
+| 0x44A30000 | `axi_adrv9001_rx1_dma <https://wiki.analog.com/resources/fpga/docs/axi_dmac>`_             |
++------------+--------------------------------------------------------------------------------------------+
+| 0x44A40000 | `axi_adrv9001_rx2_dma <https://wiki.analog.com/resources/fpga/docs/axi_dmac>`_             |
++------------+--------------------------------------------------------------------------------------------+
+| 0x44A50000 | `axi_adrv9001_tx1_dma <https://wiki.analog.com/resources/fpga/docs/axi_dmac>`_             |
++------------+--------------------------------------------------------------------------------------------+
+| 0x44A60000 | `axi_adrv9001_tx2_dma <https://wiki.analog.com/resources/fpga/docs/axi_dmac>`_             |
++------------+--------------------------------------------------------------------------------------------+
+
+ZC706 VADJ protection
+~~~~~~~~~~~~~~~~~~~~~
+
+For ZC706 after bitfile loading all outputs of FPGA are high Z .
+
+-  SW should wait until the VADJ is set to 1.8V
+-  Set **GPIO[52]** to enable the output lines.
+-  Pull out of reset the RX and TX channels (ADC/DAC common REG_RSTN reg RSTN
+   bit)
+
+More Information
+----------------
+
+-  :doc:`ADRV9001/2 Quick Start Guides </solutions/reference-designs/adrv9002/quickstart>`
+
+   -  :doc:`ADRV9002 Zynq UltraScale+ MPSoC ZCU102 Quick Start Guide </solutions/reference-designs/adrv9002/quickstart/zynqmp>`
+   -  :doc:`ADRV9002 Zynq SoC ZC706 Quick Start Guide </solutions/reference-designs/adrv9002/quickstart/zynq>`
+   -  :doc:`ADRV9002 Zynq Zed Board Quick Start Guide </solutions/reference-designs/adrv9002/quickstart/zed>`
+   -  :doc:`ADRV9002 Arria10 SoC Quick Start Guide </solutions/reference-designs/adrv9002/quickstart/a10soc>`
+
+-  :doc:`ADRV9001/ADRV9002 HDL Reference Design </solutions/reference-designs/adrv9002/reference_hdl>`
+
+   -  :doc:`AXI_ADRV9001/AXI_ADRV9002 Interface Core </solutions/reference-designs/adrv9002/axi_adrv9002>`
+   -  `Building HDL how-to, ADI Reference Designs HDL User Guide <https://wiki.analog.com/resources/fpga/docs/hdl>`_
+
+-  `ADRV9002 Device Driver Customization <https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9002-customization>`_
+-  `ADRV9002 Integrated Dual RF Transceiver Linux device driver <https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9002>`_
+
+Support
+-------
+
+Analog Devices will provide limited online support for anyone using the reference design with Analog Devices components via the :ez:`EngineerZone <community/fpga>`.
+
+Software resources
+------------------
+
+-  `ADRV9002 Device Driver Customization <https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9002-customization>`_
+-  `ADRV9002 Integrated Dual RF Transceiver Linux device driver <https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9002>`_
+
+More Information
+----------------
+
+-  :doc:`ADRV9001/2 Quick Start Guides </solutions/reference-designs/adrv9002/quickstart>`
+
+   -  :doc:`ADRV9002 Zynq UltraScale+ MPSoC ZCU102 Quick Start Guide </solutions/reference-designs/adrv9002/quickstart/zynqmp>`
+   -  :doc:`ADRV9002 Zynq SoC ZC706 Quick Start Guide </solutions/reference-designs/adrv9002/quickstart/zynq>`
+   -  :doc:`ADRV9002 Zynq Zed Board Quick Start Guide </solutions/reference-designs/adrv9002/quickstart/zed>`
+   -  :doc:`ADRV9002 Arria10 SoC Quick Start Guide </solutions/reference-designs/adrv9002/quickstart/a10soc>`
+
+-  :doc:`ADRV9001/ADRV9002 HDL Reference Design </solutions/reference-designs/adrv9002/reference_hdl>`
+
+   -  :doc:`AXI_ADRV9001/AXI_ADRV9002 Interface Core </solutions/reference-designs/adrv9002/axi_adrv9002>`
+   -  `Building HDL how-to, ADI Reference Designs HDL User Guide <https://wiki.analog.com/resources/fpga/docs/hdl>`_
+
+-  `ADRV9002 Device Driver Customization <https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9002-customization>`_
+-  `ADRV9002 Integrated Dual RF Transceiver Linux device driver <https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9002>`_
+
+Support
+-------
+
+Analog Devices will provide limited online support for anyone using the reference design with Analog Devices components via the :ez:`EngineerZone <community/fpga>`.
+
+Software resources
+------------------
+
+-  `ADRV9002 Device Driver Customization <https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9002-customization>`_
+-  `ADRV9002 Integrated Dual RF Transceiver Linux device driver <https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9002>`_
+
+.. |image1| image:: images/9002_blockdiagram.png


### PR DESCRIPTION
## Summary
- Move adrv9002 wiki documentation to `solutions/reference-designs/adrv9002/`
- 11 RST files with 21 localized images
- Generated stub `index.rst` with toctree

## Test plan
- [ ] Sphinx build passes without errors
- [ ] All toctree entries resolve correctly
- [ ] Images render properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)