### PR TITLE
reference-designs/cn0507-network-analyzer: Add cn0507-network-analyzer documentation

### DIFF
--- a/docs/solutions/reference-designs/cn0507-network-analyzer/calibration.rst
+++ b/docs/solutions/reference-designs/cn0507-network-analyzer/calibration.rst
@@ -1,0 +1,2 @@
+Guide to Calibrating the 2-port Vector Network Analyzer Shield
+==============================================================

--- a/docs/solutions/reference-designs/cn0507-network-analyzer/cn0507-network-analyzer.rst
+++ b/docs/solutions/reference-designs/cn0507-network-analyzer/cn0507-network-analyzer.rst
@@ -1,0 +1,10 @@
+CN-0507: A Complete 2-Port Network Analyzer on an Arduino Shield
+================================================================
+
+This reference design implements a complete 2-Port radio frequency (RF) Network
+Analyzer using a low-cost zero intermediate frequency (ZIF) architecture in an
+Arduino form factor, which is designed to plug into EVAL-ADICUP3029.
+
+-  :doc:`Setting Up the Hardware </solutions/reference-designs/cn0507-network-analyzer/hw_setup/start>`
+-  :doc:`Setting Up the Software </solutions/reference-designs/cn0507-network-analyzer/sw_setup/start>`
+-  :doc:`The Software GUI </solutions/reference-designs/cn0507-network-analyzer/sw_operation>`

--- a/docs/solutions/reference-designs/cn0507-network-analyzer/hw_setup/start.rst
+++ b/docs/solutions/reference-designs/cn0507-network-analyzer/hw_setup/start.rst
@@ -1,0 +1,6 @@
+Setting Up the Hardware
+=======================
+
+-  Mount the CN-0507 board over the EVAL-ADICUP3029.
+-  Connect the EVAL-ADICUP3029 to the Laptop thru a micro USB cable.
+-  Connect a 6V DC power supply capable of supplying 1.5A to the CN-0507

--- a/docs/solutions/reference-designs/cn0507-network-analyzer/images/connection_screen.png
+++ b/docs/solutions/reference-designs/cn0507-network-analyzer/images/connection_screen.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1d6a6f4bf2d221698f481558af7040f701bc90fc5ced05622440a898914a37e7
+size 46307

--- a/docs/solutions/reference-designs/cn0507-network-analyzer/images/daplink.png
+++ b/docs/solutions/reference-designs/cn0507-network-analyzer/images/daplink.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f2ac3872758881cc6b6cfa38e7614e6a8aefb95fe53569dc93d42402b5a738de
+size 21598

--- a/docs/solutions/reference-designs/cn0507-network-analyzer/images/exe.png
+++ b/docs/solutions/reference-designs/cn0507-network-analyzer/images/exe.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d49ff27c9114512e8aa497ce4037bafb688a921bcb329755c5f59fa5c18b7975
+size 21404

--- a/docs/solutions/reference-designs/cn0507-network-analyzer/images/palantir_gui_overview.png
+++ b/docs/solutions/reference-designs/cn0507-network-analyzer/images/palantir_gui_overview.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:78d6c5843988294d5c01710249df31d1d6ca03139ee5ba684c3fbcfd69cf238e
+size 302883

--- a/docs/solutions/reference-designs/cn0507-network-analyzer/images/sweep_open_default_settings.png
+++ b/docs/solutions/reference-designs/cn0507-network-analyzer/images/sweep_open_default_settings.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:01fc03fc18fca73939d56e3483d88a80d618463163f9c71161cf2874cb2e2289
+size 65997

--- a/docs/solutions/reference-designs/cn0507-network-analyzer/index.rst
+++ b/docs/solutions/reference-designs/cn0507-network-analyzer/index.rst
@@ -1,0 +1,11 @@
+CN-0507: A Complete 2-Port Network Analyzer on an Arduino Shield
+================================================================
+
+.. toctree::
+   :titlesonly:
+
+   cn0507-network-analyzer
+   calibration
+   hw_setup/start
+   sw_operation
+   sw_setup/start

--- a/docs/solutions/reference-designs/cn0507-network-analyzer/index.rst
+++ b/docs/solutions/reference-designs/cn0507-network-analyzer/index.rst
@@ -1,11 +1,49 @@
-CN-0507: A Complete 2-Port Network Analyzer on an Arduino Shield
-================================================================
+.. _cn0507_network_analyzer eval:
+
+CN0507 NETWORK ANALYZER
+===========================================================================================================================================
+
+.. TODO: Add a picture of the chip/board
+
+Overview
+-------------------------------------------------------------------------------
+
+.. TODO: Describe in max 10 rows the main features and applications.
+
+Features:
+
+- feature 1
+- feature 2
+
+Applications:
+
+- application 1
+- application 2
 
 .. toctree::
-   :titlesonly:
+   :hidden:
 
    cn0507-network-analyzer
    calibration
    hw_setup/start
    sw_operation
    sw_setup/start
+
+Recommendations
+-------------------------------------------------------------------------------
+
+People who follow the flow that is outlined, have a much better experience with
+things. However, like many things, documentation is never as complete as it
+should be. If you have any questions, feel free to ask on our
+:ref:`EngineerZone forums <help-and-support>`, but before that, please make
+sure you read our documentation thoroughly.
+
+Warning
+-------------------------------------------------------------------------------
+
+.. esd-warning::
+
+Help and support
+-------------------------------------------------------------------------------
+
+Please go to :ref:`Help and Support <help-and-support>` page.

--- a/docs/solutions/reference-designs/cn0507-network-analyzer/sw_operation.rst
+++ b/docs/solutions/reference-designs/cn0507-network-analyzer/sw_operation.rst
@@ -14,7 +14,7 @@ Connection
 After launching the software GUI. The connection window will be first shown. It
 lists all the available serial ports. To start using the GUI, choose the COM
 port of the EVAL-ADICUP3029 used. Have the baud rate set to the default, 115200,
-then click \*\* Connect \*\*. The connection window will automatically close
+then click **Connect**. The connection window will automatically close
 after a successful connection.
 
 |image2|
@@ -22,7 +22,7 @@ after a successful connection.
 Performing a Sweep
 ~~~~~~~~~~~~~~~~~~
 
-To perform a sweep, just click the \*\* Start Sweep \*\* button. With the
+To perform a sweep, just click the **Start Sweep** button. With the
 default sweep setting values, this is an example of an open sweep.
 
 |image3|

--- a/docs/solutions/reference-designs/cn0507-network-analyzer/sw_operation.rst
+++ b/docs/solutions/reference-designs/cn0507-network-analyzer/sw_operation.rst
@@ -1,0 +1,41 @@
+The Software GUI
+================
+
+The important parts of the CN-0507 software GUI is shown in the next figure.
+
+|image1|
+
+How to use the GUI
+------------------
+
+Connection
+~~~~~~~~~~
+
+After launching the software GUI. The connection window will be first shown. It
+lists all the available serial ports. To start using the GUI, choose the COM
+port of the EVAL-ADICUP3029 used. Have the baud rate set to the default, 115200,
+then click \*\* Connect \*\*. The connection window will automatically close
+after a successful connection.
+
+|image2|
+
+Performing a Sweep
+~~~~~~~~~~~~~~~~~~
+
+To perform a sweep, just click the \*\* Start Sweep \*\* button. With the
+default sweep setting values, this is an example of an open sweep.
+
+|image3|
+
+The default settings have it set at 25 steps, with a start frequency of 1700
+MHz, and a stop frequency of 3400 MHz. The frequency range that the CN-0507 can
+handle is from 1700 to 3400 MHz, hence the default values. The number of steps
+can be chosen between the available value of 25, 50, 100, 500, and 1000 steps.
+The expected time per sweep is indicated at the right of the steps box. The
+S-parameters that will be plotted may also be selected at the sweep settings
+card. It is recommended to have all the S-parameters checked since it is also
+possible to hide a plot by clicking its legend at the top.
+
+.. |image1| image:: images/palantir_gui_overview.png
+.. |image2| image:: images/connection_screen.png
+.. |image3| image:: images/sweep_open_default_settings.png

--- a/docs/solutions/reference-designs/cn0507-network-analyzer/sw_setup/start.rst
+++ b/docs/solutions/reference-designs/cn0507-network-analyzer/sw_setup/start.rst
@@ -1,0 +1,25 @@
+Setting Up the Software
+=======================
+
+Firmware
+--------
+
+-  Download the hex file from the CN-0507 product page.
+-  If running an operating system older than Windows 10, install serial driver as in `1. Install mBed windows serial driver... <https://wiki.analog.com/resources/eval/user-guides/eval-adicup3029/tools/keil_iar_support>`_
+-  You should see DAPLINK in your list of drives.
+
+.. image:: ../images/daplink.png
+
+-  Copy the hex file to the DAPLINK drive to load the firmware to the
+   EVAL-ADICUP3029. Note that the DAPLINK drive will disappear for a moment,
+   then reappear after loading the firmware.
+
+GUI
+---
+
+-  Download the GUI zip archive from the CN-0507 product page.
+-  Extract the zip file to your PC.
+-  Look inside the extracted files and launch the \*\* adi-vna-app.exe \*\*
+   executable.
+
+.. image:: ../images/exe.png

--- a/docs/solutions/reference-designs/cn0507-network-analyzer/sw_setup/start.rst
+++ b/docs/solutions/reference-designs/cn0507-network-analyzer/sw_setup/start.rst
@@ -19,7 +19,7 @@ GUI
 
 -  Download the GUI zip archive from the CN-0507 product page.
 -  Extract the zip file to your PC.
--  Look inside the extracted files and launch the \*\* adi-vna-app.exe \*\*
+-  Look inside the extracted files and launch the **adi-vna-app.exe**
    executable.
 
 .. image:: ../images/exe.png


### PR DESCRIPTION
## Summary
- Move cn0507-network-analyzer wiki documentation to `solutions/reference-designs/cn0507-network-analyzer/`
- 6 RST files with 5 localized images
- Generated stub `index.rst` with toctree

## Test plan
- [ ] Sphinx build passes without errors
- [ ] All toctree entries resolve correctly
- [ ] Images render properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)