### PR TITLE
reference-designs/dac: Add dac documentation

### DIFF
--- a/docs/solutions/reference-designs/dac/ad3552r_eval_zed.rst
+++ b/docs/solutions/reference-designs/dac/ad3552r_eval_zed.rst
@@ -1,0 +1,261 @@
+EVAL-AD3552R Evaluation Board on ZedBoard User Guide
+====================================================
+
+**Evaluation Board for the AD3552R, 16-Bit, 2-Channel, Current Output DAC**
+
+|eval-ad3552rfmcxztop-web.gif|
+
+Features
+--------
+
+-  Full featured evaluation board for the :adi:`AD3552R`
+-  Available in two transimpedance amplifier options
+-  Selectable transimpedance gain
+-  On-board or external power supply
+-  On-board or external voltage reference
+-  Clock and trigger inputs for external synchronization
+-  Is supported on `ZedBoard <https://www.avnet.com/wps/portal/us/products/avnet-boards/avnet-board-families/zedboard/>`_
+
+Evaluation Kit Contents
+-----------------------
+
+-  :adi:`EVAL-AD3552R`
+
+Hardware Required
+-----------------
+
+-  16GB (or larger) Class 10 (or faster) micro-SD card
+-  `ZedBoard <https://www.avnet.com/wps/portal/us/products/avnet-boards/avnet-board-families/zedboard/>`_ Rev D or later board
+-  12Vdc, 3A power supply
+-  Micro-USB cable
+-  Ethernet cable
+-  An oscilloscope( In this demo ADALM 2000 is used)
+-  User interface setup (choose one):
+
+   -  HDMI monitor, keyboard, and mouse plugged directly into the Zedboard
+   -  Host Windows/Linux/Mac computer on the same network as the Zedboard
+
+Software Required
+-----------------
+
+-  You need a Host PC (Windows or Linux)
+-  A UART terminal (Putty/Tera Term/Minicom, etc.), Baud rate 115200 (8N1)
+-  IIO Scope Download
+-  `Kuiper Linux Image <https://wiki.analog.com/resources/tools-software/linux-software/kuiper-linux>`_
+
+General Description
+-------------------
+
+The EVAL-AD3552RFMCxZ is an evaluation board for the AD3552R ultrafast 16-bit
+precision DAC. The board is available in two variants: EVAL-AD3552RFMC1Z is
+optimized for high speed, intended to reproduce dynamic specifications shown in
+the datasheet; EVAL-AD3552RFMC2Z is optimized for DC precision and has a much
+lower bandwidth, intended to reproduce DC electrical specifications shown in the
+datasheet. The difference between these boards is the transimpedance amplifier
+and its corresponding feedback capacitor.
+
+.. tip::
+
+   For more informations about hardware specifications, see the :doc:`EVAL-AD3552R Evaluation Board User Guide </solutions/reference-designs/dac/eval-ad3552r>` page.
+
+Quick Start Guide
+-----------------
+
+Loading Image on SD Card
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+To boot the Zedboard and control the :adi:`EVAL-AD3552R`, you will need to install ADI Kuiper Linux on an SD card. Complete instructions, including where to download the SD card image, how to write it to the SD card, and how to configure the system are provided on the `Kuiper Linux page <https://wiki.analog.com/resources/tools-software/linux-software/kuiper-linux>`_.
+
+Configuring the SD Card
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Follow the configuration procedure under **Configuring the SD Card for FPGA Projects** on the `Kuiper Linux <https://wiki.analog.com/resources/tools-software/linux-software/kuiper-linux>`_ page. Copy the following files onto the boot directory to configure the SD card:
+
+-  **uImage** file for Zynq
+-  **BOOT.BIN** specific to your :adi:`EVAL-AD3552R` + ZedBoard
+-  **devicetree.dtb** for Zynq specific to your :adi:`EVAL-AD3552R` + ZedBoard
+
+.. important::
+
+   At the moment the AD3552R-EVB is not yet supported in the latest Kuiper Image so these `boot files <resources/ad3552r-boot-files-2025-02-27.zip>`_ should be used.
+
+Setting up the Hardware
+~~~~~~~~~~~~~~~~~~~~~~~
+
+You will need to:
+
+-  Get the `ZedBoard <https://www.avnet.com/wps/portal/us/products/avnet-boards/avnet-board-families/zedboard/>`_.
+
+|zedboard.png|
+
+-  Insert the SD-CARD into the SD Card Interface Connector (J12).
+-  Connect the :adi:`EVAL-AD3552R` board into the ZedBoard FMC connector.
+-  Connect USB UART J14 (Micro USB) to your host PC.
+-  Plug your ethernet cable into the RJ45 ethernet connector(J11).
+-  Plug the Power Supply into the 12V Power input connector (J20) (DO NOT turn the device on).
+-  Set the jumpers as seen in the below picture:
+
+.. image:: images/jumpers_boot_sd_zedboard.jpg
+   :alt: jumpers_boot_sd_zedboard.jpg
+   :align: center
+   :width: 400
+
+.. tip::
+
+   Before executing the below steps, make sure that VADJ jumper is set to 1.8V.
+
+-  Connect the oscilloscope probes to the SMB connectors.
+-  Turn it on.
+-  Wait ~30 seconds for the “DONE” LED to turn blue. This is near the DISP1.
+
+::
+
+   .. image:: images/setup_diagram_eval_ad3552r.jpg
+
+.. esd-warning::
+
+Application Software (both locally and remotely on the FPGA)
+------------------------------------------------------------
+
+Hardware Connection
+~~~~~~~~~~~~~~~~~~~
+
+The Libiio is a library used for interfacing with IIO devices and is required to
+be installed on your computer.
+
+.. admonition:: Download
+   :class: download
+
+   Download and Install the latest `Libiio package <https://github.com/analogdevicesinc/libiio/releases>`_ on your machine.
+
+To be able to connect your device, the software must be able to create a context. The context creation in the software depends on the backend used to connect to the device as well as the platform where the :adi:`EVAL-AD3552R` is attached. The Zedboard running ADI Kuiper Linux is currently the only platform supported for the :adi:`EVAL-AD3552R`. The user needs to supply a **URI** which will be used in the context creation.
+
+The `iio_info <https://wiki.analog.com/resources/tools-software/linux-software/libiio/iio_info>`_ command is a part of the libIIO package that reports all IIO attributes.
+
+Upon installation, simply enter the command on the terminal command line to
+access it.
+
+For FPGA(Zedboard) Direct Local Access:
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+::
+
+   iio_info
+
+For Windows machine connected to an FPGA(Zedboard):
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+::
+
+   iio_info -u ip:<ip address of your ip>
+
+Example:
+
+-  If your Zedboard has the IP address 169.254.92.202, you have to use *iio_info -u ip::169.254.92.202* as your URI
+
+.. note::
+
+   Do note that the Windows machine and the FPGA board should be connected to
+   the same network for the machine to detect the device.
+
+IIO Oscilloscope
+~~~~~~~~~~~~~~~~
+
+.. important::
+
+   Make sure to download/update to the latest version of IIO-Oscilloscope found on this link\ https://github.com/analogdevicesinc/iio-oscilloscope/releases
+
+-  Once done with the installation or an update of the latest IIO-Oscilloscope, open the application. The user needs to supply a URI which will be used in the context creation of the IIO Oscilloscope and the instructions can be seen in the previous section.
+-  Press refresh to display available IIO Devices and press connect.
+
+.. image:: images/iio_connect.png
+   :alt: iio_connect.png
+   :align: center
+   :width: 700
+
+-  Once connected it is possible to set voltage raw values as below:
+
+.. image:: images/output_raw_1_.png
+   :alt: output_raw_1\_.png
+   :align: center
+   :width: 700
+
+PyADI-IIO
+~~~~~~~~~
+
+`PyADI-IIO <https://wiki.analog.com/resources/tools-software/linux-software/pyadi-iio>`_ is a Python abstraction module for ADI hardware with IIO drivers to make them easier to use. This module provides device-specific APIs built on top of the current libIIO Python bindings. These interfaces try to match the driver naming as much as possible without the need to understand the complexities of libIIO and IIO.
+
+Follow the step-by-step procedure on how to install, configure, and set up PYADI-IIO and install the necessary packages/modules needed by referring to this `link <https://wiki.analog.com/resources/tools-software/linux-software/pyadi-iio>`_.
+
+Running the example
+^^^^^^^^^^^^^^^^^^^
+
+.. admonition:: Download
+   :class: download
+
+   Github link for the Python sample script: `AD3552R-EVAL Python Example <https://github.com/analogdevicesinc/pyadi-iio/blob/cn0585_v1/examples/ad3552r_example.py>`_
+
+After installing and configuring PYADI-IIO on your machine, you are now ready to run Python script examples. In our case, run the **ad3552r_example.py** found in the examples folder.
+
+.. important::
+
+   Cyclic mode is actually not enabled by defualt, please edit the file
+   examples/ad3552r_example.py and set:
+
+   
+   ::
+   
+       dev.tx_cyclic_buffer = True
+   
+
+::
+
+   D:\pyadi-iio>export PYTHONPATH=D:/pyadi-iio/
+   D:\pyadi-iio>python examples/ad3552r_example.py ip:your_board_ip
+
+Press enter and you will get these readings:
+
+::
+
+   $ python examples/ad3552r_example.py ip:your_board_ip
+   uri: ip:your_board_ip
+   sample rate: 33333333
+   Sample data min: 1
+   Sample data max: 65534
+
+The following window will pop up:
+
+.. image:: images/python_plot_ad3552r.jpg
+   :alt: python_plot_ad3552r.jpg
+   :align: center
+   :width: 700
+
+Schematic, PCB Layout, Bill of Materials
+========================================
+
+.. admonition:: Download
+   :class: download
+
+   
+   -  `EVAL-AD3552RFMC1Z <resources/eval-ad3552rfmc1z.pdf>`_
+   -  `EVAL-AD3552RFMC2Z <resources/eval-ad3552rfmc2z.pdf>`_
+   -  `EVAL-AD3552RFMCxZ Gerber Files <resources/eval_ad3552rfmcxz_gerber_files.zip>`_
+   -  `EVAL-AD3552RFMC1Z Bill of Materials <images/eval-ad3552rfmc1z.xlsx>`_
+   -  `EVAL-AD3552RFMC2Z Bill of Materials <images/eval-ad3552rfmc2z.xlsx>`_
+   
+
+Reference Demos & Software
+--------------------------
+
+-  `PyADI-IIO sources for the EVAL-AD3552R board. <https://github.com/analogdevicesinc/pyadi-iio/blob/cn0585_v1/examples/ad3552r_example.py>`_
+-  `Dual Channel, 16-Bit, 33 MUPS, Multispan, Multi-IO SPI DAC Linux device driver. <https://wiki.analog.com/resources/tools-software/linux-drivers/iio-dac/axi-ad3552r>`_
+-  `AXI-AD3552R HDL IP. <https://wiki.analog.com/resources/fpga/docs/axi_ad3552r>`_
+-  `pyADI-IIO <https://github.com/analogdevicesinc/pyadi-iio>`_
+-  `PyADI-IIO Installation Guide <https://wiki.analog.com/resources/tools-software/linux-software/pyadi-iio>`_
+-  `IIO Oscilloscope Installation Guide <https://wiki.analog.com/resources/tools-software/linux-software/iio_oscilloscope>`_
+-  `Kuiper Linux <https://wiki.analog.com/resources/tools-software/linux-software/kuiper-linux>`_
+
+.. |eval-ad3552rfmcxztop-web.gif| image:: images/eval-ad3552rfmcxztop-web.gif
+   :width: 400
+.. |zedboard.png| image:: https://wiki.analog.com/_media/resources/fpga/xilinx/fmc/ad777x-ardz/zedboard.png
+   :width: 600

--- a/docs/solutions/reference-designs/dac/eval-ad3542r.rst
+++ b/docs/solutions/reference-designs/dac/eval-ad3542r.rst
@@ -1,0 +1,605 @@
+EVAL-AD3542R Evaluation Board User Guide
+========================================
+
+**Evaluation Board for the AD3542R, Dual Channel, 16-Bit, 16 MUPS, Multispan, Multi-IO SPI DAC**
+
+Features
+--------
+
+-  Full featured evaluation board for the :adi:`AD3542R`
+-  Selectable transimpedance gain
+-  Selectable transimpedance amplifier supplies
+-  On-board or external power supply
+-  On-board or external voltage reference
+-  Several impedance matching options
+-  Clock and trigger inputs for external synchronization
+-  Mates with controller board :adi:`SDP-H1`
+
+Evaluation Kit Contents
+-----------------------
+
+-  EVAL-AD3542RFMCZ
+
+Hardware Required
+-----------------
+
+-  :adi:`SDP-H1` board, must be purchased separately
+
+Software Required
+-----------------
+
+-  :adi:`ACE` Software
+-  AD35X2R ACE Plugin (automatically downloaded within ACE)
+
+General Description
+-------------------
+
+The EVAL-AD3542RFMCZ is an evaluation board for the :adi:`AD3542R` ultrafast 16-bit precision DAC.
+
+The board allows testing all the output ranges of the DAC, waveform generation,
+power supply and reference options.
+
+The EVAL-AD3542RFMCZ interfaces to the USB port of a PC via a system demonstration platform (:adi:`SDP-H1` board). It can also be connected to a different controller board using the pin header connector at position P5.
+
+This user guide covers the details of the configuration and operation of the EVAL-AD3542RFMCZ board and the associated ACE plug-in. For additional information on the DAC operation refer to the :adi:`AD3542R` data sheet.
+
+Evaluation Board Photograph
+---------------------------
+
+.. container:: group
+
+   
+   .. container:: half column
+
+   
+      ..
+
+   |eval-ad3542rfmcz_top-web.gif|
+
+   .. container:: half column
+
+      ..
+
+   |eval-ad3542rfmcz_bottom-web2.gif|
+
+Evaluation Board Quick Start Procedure
+--------------------------------------
+
+Installing The Software
+~~~~~~~~~~~~~~~~~~~~~~~
+
+The EVAL-AD3542R uses the :adi:`ACE` software with the AD35X2R Plugin for evaluation.
+
+-  Download and run the latest version of the :adi:`ACE` installer. It installs the application and the necessary drivers for the :adi:`SDP-H1` controller board.
+-  Click on the Plugin Manager item on the left-hand menu as shown in Figure 1.
+-  Go to Available Packages, select Board.AD35X2R and click on the Install Selected button at the bottom of the list. Once the plugin is installed, it moves to the Installed Packages section.
+-  Click on the Home item on the left-hand menu. If the EVAL-AD3542R board is
+   connected it will show up in the Attached Hardware section as shown in Figure
+   2. If you don't have an EVAL-AD3542R board, you can still explore the
+   functionality of the plugin by double clicking on the desired board in the
+   Explore Without Hardware list.
+
+.. image:: images/plug-in_manager_with_red_squares.png
+   :width: 600
+
+**Figure 1. Plug-in Manager**
+
+.. image:: images/start_tab_with_red_squares.png
+   :width: 600
+
+**Figure 2. Start Tab**
+
+Connecting The Board
+~~~~~~~~~~~~~~~~~~~~
+
+To set up the evaluation board, take the following steps:
+
+-  Make sure that all the links are set in the default positions listed in Table 2.
+-  Plug the EVAL-AD3542R evaluation board on the SDP-H1 controller board.
+-  Connect the wall-plug brick power supply to the SDP-H1 DC jack and power from the AC network. Power LEDs on the SDP-H1 board turn on green.
+-  Connect the USB cable between the SDP-H1 board and the PC.
+-  ACE should now be able to detect the board and show it in the Attached
+   Hardware section, as shown in Figure 2. Double click on the board icon to
+   open the board view, as seen in Figure 5. The board view shows the relevant
+   parts included in the evaluation board, where the AD3542R chip is highlighted
+   in a darker blue.
+
+Evaluation Board Hardware
+-------------------------
+
+Power Supplies
+~~~~~~~~~~~~~~
+
+The EVAL-AD3542R includes a complete power conversion solution to allow powering the evaluation board from the SDP-H1. The board includes a DC/DC converter :adi:`LTC7149` to generate -7V from the 12V power provided by SDP-H1. LDOs :adi:`LT3045` and :adi:`LT3094` are used to generate the positive and negative supplies for the transimpedance amplifiers, which are selectable using switch S1. Additional LT3045 LDOs are used to generate the supplies for the logic and the DAC core of the AD3542R. This power solution is configured with the default link settings shown in Table 2.
+
+Alternatively, the board can be powered from a collection of external power
+supplies via connector P3. The assignment of the pins in connector P3 is listed
+in Table 1.
+
+Table 1. Pin Assignment on Power Supply Connector P3
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
++------------+------------+---------------------------------------------------------------------------------------+
+| Pin Number | Signal     | Description                                                                           |
++============+============+=======================================================================================+
+| 1          | EXT_PVDD   | External positive supply for transconductance amplifiers. 4.7V to 10.6V ± 5%.         |
++------------+------------+---------------------------------------------------------------------------------------+
+| 2          | EXT_PVSS   | External negative supply for transconductance amplifiers. 0V down to PVDD-10.6V ± 5%. |
++------------+------------+---------------------------------------------------------------------------------------+
+| 3          | EXT_VDD    | External analog supply for AD3542R. 5V ± 5%.                                          |
++------------+------------+---------------------------------------------------------------------------------------+
+| 4          | EXT_DVDD   | External digital supply for AD3542R. 1.8V ± 5%.                                       |
++------------+------------+---------------------------------------------------------------------------------------+
+| 5          | EXT_VLOGIC | External digital I/O supply for AD3542R. 1.1V to 1.9V.                                |
++------------+------------+---------------------------------------------------------------------------------------+
+| 6          | GND        | Ground.                                                                               |
++------------+------------+---------------------------------------------------------------------------------------+
+
+The EVAL- AD3542R also integrates an on-board 2.5V analog reference :adi:`ADR4525`.
+
+Power Supply Configuration for Transimpedance Amplifier
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The supply for the transimpedance amplifier integrated in AD3542R must be
+adjusted depending on the selected output span using switch S1. Table 2 presents
+the three possible supply configurations. The correspondence with the output
+range is shown in Table 7.
+
+Table 2. Transimpedance Amplifier Supply Options
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+=========== ======= ============ ============
+S1 Position Label   PVDD Voltage PVSS Voltage
+=========== ======= ============ ============
+Left        +/- 5V  5.2V         -5.2V
+Middle      10V     10.2V        -0.2V
+Right       -2.5/7V 7.7V         -2.7V
+=========== ======= ============ ============
+
+.. important::
+
+   Do not change the position of S1 while the board is powered up.
+
+Link Options
+~~~~~~~~~~~~
+
+The EVAL-AD3542R board is delivered with the links placed in the default
+positions listed in Table 3. This configuration is suitable for operating the
+board right out of the box. However, the links J_FB0, J_FB1 and J_REF may need
+to be adjusted depending on the configuration set in the registers of the
+AD3542R. Refer to Figure 3 to locate the position of links and connectors.
+
+.. image:: images/board_layout.png
+   :width: 600
+
+**Figure 3. Board Layout**
+
+Table 3. Link Options
+^^^^^^^^^^^^^^^^^^^^^
+
++--------+------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------+
+| Link   | Silkscreen | Description                                                                                                                                                                                                                                                                                              | Default Position |
++========+============+==========================================================================================================================================================================================================================================================================================================+==================+
+| J_FB0  | FB0        | This link selects the gain of transimpedance amplifier for channel 0. The gains are labeled x1 and x2 which corresponds to the multiplicative factor between them. The gain must be set in accordance to the desired output range listed in Table 6. Inserting the link allows selecting gains x1 or x2. | x1               |
++--------+------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------+
+| J_FB1  | FB1        | This link selects the gain of transimpedance amplifier for channel 0. The gains are labeled x1 and x2 which corresponds to the multiplicative factor between them. The gain must be set in accordance to the desired output range listed in Table 6. Inserting the link allows selecting gains x1 or x2. | x1               |
++--------+------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------+
+| J_OUT0 | J_OUT0     | This link bridges the output voltage of DAC0 to connector VOUT0 through the matching network R4, L5, R28, C15. When inserted, signal can be measured on connector VOUT0. When not inserted, signal can only be measured on test point TP2.                                                               | Inserted         |
++--------+------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------+
+| J_OUT1 | J_OUT1     | This link bridges the output voltage of DAC1 to connector VOUT1 through the matching network R5, L6, R29, C16. When inserted, signal can be measured on connector VOUT1. When not inserted, signal can only be measured on test point TP3.                                                               | Inserted         |
++--------+------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------+
+| J_REF  | J_REF      | This link allows connecting the on-board reference to AD3542R. This link should be removed if an external reference is provided via connector J1 (VREF) or if the internal reference is output to the VREF pin.                                                                                          | Inserted         |
++--------+------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------+
+| J_PVDD | PVDD       | This link selects the positive voltage supply for the transimpedance amplifier. REG selects the supply from the on-board LDO. EXT selects the supply provided externally on connector P3.                                                                                                                | REG              |
++--------+------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------+
+| J_PVSS | PVSS       | This link selects the negative voltage supply for the transimpedance amplifier. REG selects the supply from the on-board LDO. EXT selects the supply provided externally on connector P3. GND sets the supply rail to ground.                                                                            | REG              |
++--------+------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------+
+| J_VDD  | VDD        | This link selects the voltage supply for the analog section of AD3542R. REG selects the 5V supply from the on-board LDO regulator. EXT selects the supply provided externally on connector P3.                                                                                                           | REG              |
++--------+------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------+
+| J_DVDD | DVDD       | This link selects the voltage supply for the digital section of AD3542R. 1V8 REG selects the supply from the on-board LDO regulator. FPGA selects the supply provided from the SDP-H1 board, the same as used in the FPGA IO pins. EXT selects the supply provided externally on connector P3.           | 1V8 REG          |
++--------+------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------+
+| J_VIO  | VLOGIC     | This link selects the voltage supply for AD3542R IO pins. 1V8 REG selects the supply for the on-board LDO regulator. FPGA selects the supply provided from the SDP-H1 board, the same as used in the FPGA IO pins. EXT selects the supply provided externally on connector P3.                           | 1V8 REG          |
++--------+------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------+
+| S1     | S1         | This switch selects one of the following combinations for PVDD and PVSS:                                                                                                                                                                                                                                 | Left             |
+|        |            | • Left: PVDD = 5.2V, PVSS=-5.2V                                                                                                                                                                                                                                                                          | +/- 5V           |
+|        |            | • Middle: PVDD = 10.2V, PVSS = -0.2V                                                                                                                                                                                                                                                                     |                  |
+|        |            | • Right: PVDD = 7.7V, PVSS = -2.7V                                                                                                                                                                                                                                                                       |                  |
++--------+------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------+
+
+| 
+| ==== On-Board Connectors ==== Table 4 shows the list of connectors available on EVAL-AD3542R and their corresponding use. Refer to Figure 3 to find their location in the board.
+
+Table 4. List of Connectors
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
++-----------+------------+-------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| Connector | Silkscreen | Signal Name | Function                                                                                                                                                                                                                                                                   |
++===========+============+=============+============================================================================================================================================================================================================================================================================+
+| J1        | VREF       | VREF        | Reference voltage input / output. This connector can be used to provide an external reference voltage to the AD3542R or to monitor the reference generated by ADR4525 or AD3542R.                                                                                          |
++-----------+------------+-------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| J2        | CLOCK      | CLOCK_FMC   | External clock reference provided to the FPGA to generate the SPI patterns. 1.8V amplitude.                                                                                                                                                                                |
++-----------+------------+-------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| J3        | SYNC       | SYNC_EVENTS | External trigger signal provided to the FPGA to synchronize waveform generation. 1.8V amplitude.                                                                                                                                                                           |
++-----------+------------+-------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| VOUT0     | VOUT0      | VOUT0_C     | Voltage output of DAC channel 0.                                                                                                                                                                                                                                           |
++-----------+------------+-------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| VOUT1     | VOUT1      | VOUT1_C     | Voltage output of DAC channel 1.                                                                                                                                                                                                                                           |
++-----------+------------+-------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| P1        | P1         | -           | FMC connector carrying the digital signals between the evaluation board and the controller board.                                                                                                                                                                          |
++-----------+------------+-------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| P3        | P3         | -           | External supply connector. Pin assignment given in Table 1.                                                                                                                                                                                                                |
++-----------+------------+-------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| P5        | P5         | -           | Digital signal connector. This connector is used to control the AD3542R with a controller different from SDP-H1. The pin assignment is listed in Table 4. The pin header is not assembled by default so that the holes can be used as test points for the digital signals. |
++-----------+------------+-------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+
+Connector P5 is used to connect an external controller when the SDP-H1 is not
+present. This connector grants access to all the digital signals of AD3542R and
+some board supplies and control lines.
+
+Table 5. Pin Assignment on Connector P5
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
++------------+-----------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| Pin number | Connector Label | Function                                                                                                                                                                                           |
++============+=================+====================================================================================================================================================================================================+
+| 1          | +12V_FMC        | External 12V power supply. Use this pin to supply the EVAL-AD3542R board when using a controller different from the SDP-H1.                                                                        |
++------------+-----------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| 2          | POWER_ON_FMC    | Enable signal for the onboard regulators. This pin is used to manually turn on the LDOs and DC/DC converter when the SDP-H1 controller is not present. Set a voltage higher than 1.24V to turn on. |
++------------+-----------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| 3          | GND             | Ground.                                                                                                                                                                                            |
++------------+-----------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| 4          | SPI_QPI         | Connected to FPGA. Not used.                                                                                                                                                                       |
++------------+-----------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| 5          | VLOGIC          | Voltage supply used for AD3542R I/O pins. If this pin is used to supply VLOGIC, remove the link for VLOGIC.                                                                                        |
++------------+-----------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| 6          | GND             | Ground.                                                                                                                                                                                            |
++------------+-----------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| 7          | SPI_CS          | SPI Chip Select signal.                                                                                                                                                                            |
++------------+-----------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| 8          | SPI_SCLK        | SPI clock signal.                                                                                                                                                                                  |
++------------+-----------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| 9          | GND             | Ground.                                                                                                                                                                                            |
++------------+-----------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| 10         | SPI_SDIO0       | SDI / MOSI signal in Classic SPI mode or SDIO0 signal in Dual SPI mode.                                                                                                                            |
++------------+-----------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| 11         | GND             | Ground.                                                                                                                                                                                            |
++------------+-----------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| 12         | SPI_SDIO1       | SDO / MISO signal in Classic SPI mode or SDIO1 signal in Dual SPI mode.                                                                                                                            |
++------------+-----------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| 13         | CLOCK_FMC       | External clock signal (same as connector J2).                                                                                                                                                      |
++------------+-----------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| 14         | GND             | Ground.                                                                                                                                                                                            |
++------------+-----------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| 15         | LDAC            | AD3542R LDAC signal.                                                                                                                                                                               |
++------------+-----------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| 16         | GND             | Ground.                                                                                                                                                                                            |
++------------+-----------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| 17         | RESET           | AD3542R RESET signal.                                                                                                                                                                              |
++------------+-----------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| 18         | GND             | Ground.                                                                                                                                                                                            |
++------------+-----------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| 19         | ALERT           | AD3542R ALERT signal.                                                                                                                                                                              |
++------------+-----------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| 20         | VLOGIC_FMC      | Test Pin for VLOGIC_FMC power supplied from the SDP-H1.                                                                                                                                            |
++------------+-----------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+
+The board includes several test points to access relevant signals. Only TP4 has
+the test ring assembled. The list is given in Table 6.
+
+Table 6. List of Test Points
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
++------------+------------+----------------------------------------------------------------+
+| Test Point | Signal     | Description                                                    |
++============+============+================================================================+
+| TP1        | VREF       | Reference voltage for AD3542R (internal, on-board or external) |
++------------+------------+----------------------------------------------------------------+
+| TP2        | VOUT0      | Voltage output of DAC channel 0                                |
++------------+------------+----------------------------------------------------------------+
+| TP3        | VOUT1      | Voltage output of DAC channel 1                                |
++------------+------------+----------------------------------------------------------------+
+| TP4        | GND        | Ground                                                         |
++------------+------------+----------------------------------------------------------------+
+| TP7        | GPIO_9     | Synchronization signal from FPGA for development purposes      |
++------------+------------+----------------------------------------------------------------+
+| TP8        | SYNC_EVENT | External trigger for waveform generation                       |
++------------+------------+----------------------------------------------------------------+
+
+| 
+| ==== DAC Output Range Selection ==== The selection of the output range requires a combination of register configurations and a given transimpedance gain. The supply of the transimpedance amplifier must be adjusted accordingly. The gains corresponding to each output range and the required board configuration are listed in Table 7. See the AD3542R datasheet for more details on output range configuration.
+
+Table 7. Transimpedance Gain Setting
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
++----------------------------------+---------------+-----------------------------+------------+------------------+------------------+
+| CHx_OUTPUT_RANGE_SEL Field Value | Output Range  | Transimpedance Gain Setting | S1 Setting | V\ :sub:`ZS` (V) | V\ :sub:`FS` (V) |
++==================================+===============+=============================+============+==================+==================+
+| 000                              | 2.5V          | x1                          | Any        | -0.198           | 2.697            |
++----------------------------------+---------------+-----------------------------+------------+------------------+------------------+
+| 001                              | 5V            | x1                          | Any        | -0.077           | 5.076            |
++----------------------------------+---------------+-----------------------------+------------+------------------+------------------+
+| 010                              | 10V           | x2                          | Middle     | -0.163           | 10.163           |
++----------------------------------+---------------+-----------------------------+------------+------------------+------------------+
+| 011                              | ±5V           | x2                          | Left       | -5.163           | 5.166            |
++----------------------------------+---------------+-----------------------------+------------+------------------+------------------+
+| 100                              | -2.5V to 7.5V | x2                          | Right      | -2.666           | 7.662            |
++----------------------------------+---------------+-----------------------------+------------+------------------+------------------+
+
+| 
+| ==== DAC Output Monitoring ==== Monitoring the output of the DAC in dynamic conditions can become difficult because the amplifier is a low-impedance source driving a high-impedance load with a fast rising time. The EVAL-AD3542R allows using different passive networks to adapt the output of the DAC to different loads. The following configurations are foreseen:
+
+-  Using a high-impedance probe on test points TP2 and TP3. Oscilloscope probes, active or passive, have high impedance. However, since the test points are close to the driver the effect of impedance mismatch is not visible. The main drawback is the tolerance of the probe ratio and the noise picked up in the ground lead. This method is suitable for quick checks and slew rate measurement.
+-  Using a coaxial cable with the oscilloscope in high impedance. This solution reduces noise pick-up and eliminates the uncertainty of the probe, allowing accurate measurements with dynamic signals, such as settling time. To attenuate reflections from the oscilloscope, 47Ω resistors are included by default in positions R4 and R5. This configuration can be used to measure the output noise density with the oscilloscope configured in AC mode.
+-  Using a coaxial cable with the oscilloscope in 50Ω impedance. A matching pad must be used so that the impedance seen at the coaxial connector is 50Ω. For example, 976Ω for R4 or R5, 52.3Ω for R28 or R29 and 0Ω for C15 or C16. This solution provides perfect impedance matching on both sides of the coaxial cable while the DAC sees 1kΩ load. The signal is attenuated by a factor 19.55 (25.8 dB). This configuration can be used to measure settling time very accurately. It is not suitable for noise measurements because the attenuation of the matching pad sets the noise below the sensitivity of the spectrum analyzer.
+-  Using a coaxial cable to drive a medium-impedance load, for example 500Ω.
+   This configuration is half-way between perfect impedance matching and
+   high-impedance termination. It provides better matching in high speed, lower
+   noise susceptibility and lower power dissipation with DC voltage. The driver
+   is series-terminated to 47Ω (R4 or R5) to match the nominal impedance of the
+   cable while the receiver is terminated to 500Ω (for example, an oscilloscope
+   in 1MΩ impedance with 500Ω on a Tee connector). To minimize DC loss, 1μH
+   inductors are used at L5 and L6. A snubber network can be added on R28, R29,
+   C15 and C16 to reduce the overshoot caused by these inductors.
+
+.. note::
+
+   Square waves may not look perfectly square on many oscilloscopes. This is due
+   to the large variation in DC levels affecting the oscilloscope front end or
+   ADC. This results in the flat top and bottom of the waveform showing a slow
+   drift. The effect increases when zooming in the signal due to overdrive
+   recovery in the oscilloscope front end. It is recommended to use the 50Ω
+   matching pad to reduce the span of the signal.
+
+ACE Plug-In Description And Features
+------------------------------------
+
+ACE Plug-In Hierarchy
+~~~~~~~~~~~~~~~~~~~~~
+
+ACE has several views to control different aspects of the DAC. When a view is first opened it creates a new tab at the top of the main window. The AD3542R plugin has a Board View, a Chip View, a Memory Map view, a Waveform Generator view, and a Vector Generator view. Figure 4 shows the hierarchical relation between these views. For additional information refer to the The user manual that is accessible from the help panel displayed when clicking on the Help button on the lower left angle of the application. There is also an `ACE Wiki <https://wiki.analog.com/resources/tools-software/ace>`_ with additional information.
+
+.. image:: images/ace_hierarchy.png
+   :width: 400
+
+**Figure 4. ACE Plugin Hierarchy**
+
+|image1|
+
+Board View
+~~~~~~~~~~
+
+The board view displays a simplified diagram of the evaluation board including
+some relevant connectors and the interconnection between chips, as seen in
+Figure 5. Analog Devices chips are shown with their part number and the AD3542R
+is highlighted in darker blue.
+
+.. image:: images/board_view.png
+   :width: 600
+
+**Figure 5. AD3542R Board View**
+
+The actions that can be performed at this level are displayed as buttons at the
+top of the main window, as seen in Figure 6.
+
+-  **Poll Device:** this action is performed automatically every second to verify that the evaluation board is connected to the system. The button allows turning on or off this feature.
+-  **Reset Board:** this action performs a power cycle on the evaluation board, bringing everything back to default.
+
+.. image:: images/board_view_buttons.png
+   :width: 300
+
+**Figure 6. AD3542R Board View Buttons**
+
+To open the chip view, double-click on the AD3542R block.
+
+Chip View
+~~~~~~~~~
+
+The Chip View displays a simplified internal diagram of the chip showing the
+interface logic, the DAC cores, the precision feedback resistors and the
+relevant pins for those blocks. This view contains three interactive areas, as
+depicted in Figure 7:
+
+-  **Button list.** These buttons perform the following actions on the chip:
+
+   -  **Apply Changes:** changes in the values of the registers are recorded in a cached copy kept on the PC memory. When the button Apply Changes is pressed, only the registers that were changed are updated in the AD3542R.
+   -  **Read All:** this button reads all the registers from the AD3542R and updates the cached copy in the PC memory, displaying the values in the corresponding fields.
+   -  **Reset Chip:** this button resets the AD3542R but not the board. All registers are cleared to default values and ACE reads them back to keep the cached copy synchronized.
+   -  **Diff:** this button reads the registers of AD3542R and compares their value to the cached copy, highlighting in bold those that are different.
+   -  **Software Defaults:** this button loads the software default values in the cached copy without copying the values to the AD3542R.
+   -  **Memory Map Side-By-Side:** this button opens a new window besides the chip view containing the list of AD3542R registers.
+
+-  **DAC Registers.** Each DAC symbol contains an editable field where the hexadecimal code can be written to the DAC Output register. This allows performing an static update of the DAC. After writing the value, the button Apply Changes must be pressed to update the DAC output.
+-  **Shortcuts to other views.** There are two buttons on the lower right corner to access the Register Map view and the Waveform Generator view. The use of these panels is explained in the sections Memory Map View and Generating a Waveform.
+
+.. image:: images/chip_view_with_labels.png
+   :width: 600
+
+**Figure 7. Chip View**
+
+Memory Map View
+~~~~~~~~~~~~~~~
+
+The Memory Map view displays the entire configuration space of the AD3542R. The
+configuration space can be displayed as a list of registers or as a list of bit
+fields. The application allows sorting by any of the column categories or
+searching by register name or field name. Registers can be displayed collapsed
+or expanded into its bit fields, as shown in Figure 8.
+
+This view has the following interactive elements:
+
+-  **Button list.** These buttons perform the following actions:
+
+   -  **Apply Changes:** this button writes all the registers that have been changed since the last update.
+   -  **Apply Selected:** this button writes only the register or bit field that is selected in the list.
+   -  **Read All:** this button forces the reading of all the AD3542R registers and the update of the cached copy.
+   -  **Read Selected:** this button reads only the register or bit field that is selected and updates its value in the cached copy.
+   -  **Reset Chip:** this button resets the AD3542R and forces the reading of all registers to update the cached copy.
+   -  **Diff:** this button reads the registers of AD3542R and compares them with the cached copy, highlighting in bold those that have any difference.
+   -  **Software Defaults:** this button loads the software default values in the cached copy without copying the values to the AD3542R.
+   -  **Export:** This button exports the list of registers and their values to a CSV file. This feature is useful to generate the configuration file for a given application avoiding human error.
+   -  **Import:** This button allows reading a CSV file containing the register values.
+   -  **Chip View Side-by-Side:** this button displays the chip view by the side of the register map.
+   -  **Show Bitfields / Show Registers:** this button toggles presentation mode as register list or bit field list.
+
+-  **Register value.** This field allows editing the entire register value in hexadecimal (left side) or toggling the bits one by one (right side). Modified registers are highlighted in bold.
+-  **Bit field values.** Registers can be expanded into their bit fields and each bit can be edited individually by clicking on it to toggle its value. Modified registers are highlighted in bold.
+
+.. image:: images/register_map_with_labels.png
+   :width: 600
+
+**Figure 8. AD3542R Memory Map View**
+
+Waveform Generator View
+~~~~~~~~~~~~~~~~~~~~~~~
+
+The waveform generator view allows assigning vectors to the channels and
+starting or stopping waveform generation. A screenshot of this view is given in
+Figure 9.
+
+.. image:: images/waveform_generator_view.png
+   :width: 600
+
+**Figure 9. Waveform Generator View**
+
+The operation mode of AD3542R and the assignment of the waveforms is controlled
+from the Transmit pane that contains the following controls:
+
+-  **Generate Vectors:** this button opens the Vector Generator view there waveforms can be defined, scaled, loaded or exported. The use of this generator is covered in section Vector Generator View.
+-  **DAC Mode:** radio buttons allow selecting Fast Mode that uses 16-bit data or Precision Mode that uses 24-bit data. The same mode is used for both DAC channels when operated simultaneously.
+-  **Auto Register Update:** this feature automatically configures the interface registers to operate in streaming mode with the highest possible update rate. If this box is not checked, configuration must be made manually on the Memory Map. The settings are described at the end of this section.
+-  **Enable Simultaneous Mode:** this checkbox allows playing the same samples on both channels. Data is written to the DAC Page register, therefore maintaining the same update rate as for a single channel. When this box is checked, the waveform is selected in the Simultaneous Update menu as seen in Figure 10.
+-  **Enable Channel 1/2:** these checkboxes allow enabling channels individually. When both channels are enabled, each one can play a different waveform, as seen in Figure 11. The update rate depends on the DAC Mode and the update mode; all the combinations are shown in Table 8.
+-  **Play Button:** this button starts and stops the waveform playback. The status of the playback is displayed on the EVALAD3542R LED: blue when running and green when stopped.
+
+Table 8. Update Rate Combinations
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
++------------------------------------+--------------------+-------------------------+
+|                                    | Fast Mode (16 bit) | Precision Mode (24 bit) |
++====================================+====================+=========================+
+| Dual Channel Mode                  | 6.25 MUPS          | 4.16 MUPS               |
++------------------------------------+--------------------+-------------------------+
+| Single Channel / Simultaneous Mode | 12.5 MUPS          | 8.33 MUPS               |
++------------------------------------+--------------------+-------------------------+
+
+| 
+| |image2|
+
+**Figure 10. Waveform Generation in Dual Mode**
+
+.. image:: images/transmit_pane_simultaneous_mode.png
+   :width: 200
+
+**Figure 11. Waveform Generation in Simultanoeus Mode**
+
+Manual Register Configuration for Streaming Mode
+""""""""""""""""""""""""""""""""""""""""""""""""
+
+If the Auto Register Update checkbox is not checked, the streaming mode
+parameters have to be configured manually in the memory map before pressing the
+Play button. The following registers must be set:
+
+-  STREAM_MODE register (0x0E). Length value should be set according to Table 9.
+-  TRANSFER_REGISTER (0x0F). Set STREAM_LENGTH_KEEP_VALUE bit to 1.
+-  INTERFACE_CONFIG_D register (0x14). Set SPI_CONFIG_DDR bit to 1.
+
+Table 9. Stream Mode Length Values
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
++------------------------------------+--------------------+-------------------------+
+|                                    | Fast Mode (16 bit) | Precision Mode (24 bit) |
++====================================+====================+=========================+
+| Single Channel / Simultaneous Mode | 2                  | 3                       |
++------------------------------------+--------------------+-------------------------+
+| Dual Channel Mode                  | 4                  | 6                       |
++------------------------------------+--------------------+-------------------------+
+
+Vector Generator View
+~~~~~~~~~~~~~~~~~~~~~
+
+The Vector Generator view allows defining or loading waveforms that can later be
+assigned to the DAC channels. Waveforms are identified by name. The generator
+automatically adapts the sample rate based on the operating mode and the number
+of DAC channels enabled. A snapshot of this view if presented in Figure 12.
+
+The Vector Generator tool is composed of the following sections:
+
+-  **Predefined Waveforms.** The generator has several predefined waveforms: DC, single tone, square, triangle, sawtooth, chirp, noise and multi-tone. Clicking the **+** button adds this waveform to the Generate panel where it can be customized.
+-  **Waveforms from File.** The generator can load waveforms from file in three different formats: text file, hexadecimal file or ACE Vector file. Refer to the ACE User Manual for further details on the file formats. When loading a waveform all the samples are played irrespective of the update rate. Therefor the waveform files must be generated for a specific update rate.
+-  **First Waveform Parameters.** Every waveform has a set of parameters that can be customized:
+
+   -  **Vector Name:** specify a name in this field to identify the waveforms in the Waveform Generator view.
+   -  **Desired Frequency:** specify the repetition frequency of the waveform. The value is assumed to be in Hz if no unit is specified. If the unit is specified, it must adhere to the standard capitalization (e.g. kHz, not khz).
+   -  **Attenuation:** all waveforms are generated at full scale by default. Attenuation can be used to reduce the signal amplitude keeping the offset constant at mid scale. Amplitude is scaled by 10\ :sup:`−Att / 20`.
+   -  **Relative Phase:** specify the phase offset relative to the start of the waveform record.
+   -  **Preview button:** pressing this button displays the waveform in the time-domain and its FFT in the frequency-domain window, if present.
+   -  **Copy:** pressing this button duplicates the waveform entry in the Generate pane.
+   -  **Export:** pressing this button allows exporting the waveform as a text file containing decimal numbers.
+
+-  **Second Waveform Parameters.** If a second waveform is added, it will show up stacked in the Generate pane under the first waveform. The same parameters are applicable.
+-  **Time-domain waveform preview.** A preview of the selected waveform is displayed in this window. Only one waveform is displayed at a time. The plot window allows zooming, panning and measuring on the waveform.
+-  **Waveform FFT.** The frequency-domain analysis of the selected waveform is displayed in this window. The plot window allows zooming, panning and measuring on the spectrum.
+
+.. image:: images/vector_generator_with_labels.png
+   :width: 800
+
+**Figure 12. Vector Generator View**
+
+Creating a Waveform
+~~~~~~~~~~~~~~~~~~~
+
+Follow these steps to produce a dual waveform playback on the EVAL-AD3542R
+evaluation board:
+
+-  From the start page, double click on the board icon to open the *Board view*.
+-  Double click on the AD3542R block to open the *Chip View*.
+-  Click the button Proceed to Memory Map to open the *Memory Map View*.
+-  Go to CH0_CH1_OUTPUT_RANGE register and set the desired output range (0x33 in this example). Refer to Table 6 for the possible values of this register. Then click Apply All to force the register update.
+-  Click on the Vector Generator item on the left-hand panel to open the// Vector Generator View//.
+-  Follow the instructions given in *Vector Generator View* to create a 1 kHz sinewave and a 1 kHz sawtooth.
+-  Follow the shortcuts in the gray bar at the top of the window to go back to the *Chip View*. Then click on the button Proceed to Waveform Generator to open the *Waveform Generator View*.
+-  Select Fast Mode and enable channels 1 and 2. Then unfold the Channel 1 and Channel 2 sections to select each of the waveforms you created. Finally click the Play button.
+-  The LED on EVAL-AD3542R changes from green to blue and the playback starts.
+   The waveforms should look like the ones shown in Figure 13 in the
+   oscilloscope.
+
+.. image:: images/waveforms_on_oscilloscope.png
+   :width: 600
+
+**Figure 13. Dual Waveform Output**
+
+Unsupported Features in the Plugin
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The current version of EVAL-AD3542R ACE Plugin (1.2021.38200) does not support
+all the board features at the moment. ACE notifies when an update of the plugin
+is available, so these features will be progressively incorporated. These are
+the features not currently supported:
+
+-  DAC output range selection and customization.
+-  CRC checking.
+-  Amplitude and offset control in waveform generation. Waveform scaling is only possible using the Attenuation field in dB. Offset is fixed to mid-scale.
+-  Using the LDAC line to update the DAC output.
+-  ALERT pin monitoring, error status readback and on-screen reporting.
+-  External clock for FPGA.
+-  External triggering of waveform playback.
+
+Schematic, PCB Layout, Bill of Materials
+========================================
+
+.. admonition:: Download
+   :class: download
+
+   
+   -  `EVAL-AD3542RFMCZ Schematics <resources/02_050892d_top.pdf>`_
+   -  `EVAL-AD3542RFMCZ Gerber Files <https://wiki.analog.com/_media/resources/eval/user-guides/dac/eval-ad3542r/09-050892-01C.zip>`_
+   -  `EVAL-AD3542RFMCZ Bill of Materials <images/05-050892-01-d.xlsx>`_
+   
+
+.. |eval-ad3542rfmcz_top-web.gif| image:: images/eval-ad3542rfmcz_top-web.gif
+   :width: 400
+.. |eval-ad3542rfmcz_bottom-web2.gif| image:: images/eval-ad3542rfmcz_bottom-web2.gif
+   :width: 400
+.. |image1| image:: https://wiki.analog.com/_media/resources/eval/user-guides/dac/eval-ad3542r/chip_view_with_labels.svg
+.. |image2| image:: images/transmit_pane_dual_mode.png
+   :width: 200

--- a/docs/solutions/reference-designs/dac/eval-ad3552r.rst
+++ b/docs/solutions/reference-designs/dac/eval-ad3552r.rst
@@ -1,0 +1,572 @@
+EVAL-AD3552R Evaluation Board User Guide
+========================================
+
+**Evaluation Board for the AD3552R, 16-Bit, 2-Channel, Current Output DAC**
+
+Features
+--------
+
+-  Full featured evaluation board for the :adi:`AD3552R`
+-  Available in two transimpedance amplifier options
+-  Selectable transimpedance gain
+-  On-board or external power supply
+-  On-board or external voltage reference
+-  Clock and trigger inputs for external synchronization
+-  Mates with controller board :adi:`SDP-H1`
+
+Evaluation Kit Contents
+-----------------------
+
+-  EVAL-AD3552RFMCxZ
+
+Hardware Required
+-----------------
+
+-  :adi:`SDP-H1` board, must be purchased separately
+
+Software Required
+-----------------
+
+-  :adi:`ACE` Software
+-  EVAL-AD35X2RFMCxZ ACE Plugin (automatically downloaded within ACE)
+
+General Description
+-------------------
+
+The EVAL-AD3552RFMCxZ is an evaluation board for the AD3552R ultrafast 16-bit
+precision DAC. The board is available in two variants: EVAL-AD3552RFMC1Z is
+optimized for high speed, intended to reproduce dynamic specifications shown in
+the datasheet; EVAL-AD3552RFMC2Z is optimized for DC precision and has a much
+lower bandwidth, intended to reproduce DC electrical specifications shown in the
+datasheet. The difference between these boards is the transimpedance amplifier
+and its corresponding feedback capacitor.
+
+The board allows testing all the output ranges of the DAC, waveform generation,
+power supply and reference options.
+
+The EVAL-AD3552RFMCxZ interfaces to the USB port of a PC via a system demonstration platform (:adi:`SDP-H1` board). It can also be connected to a different controller board using the pin header connector at position P5.
+
+This user guide covers the details of the configuration and operation of the EVAL-AD3552RFMCxZ board and the associated ACE plug-in. For additional information on the DAC operation refer to the :adi:`AD3552R` data sheet.
+
+Evaluation Board Photograph
+---------------------------
+
+|image1|\ |image2|
+
+Evaluation Board Quick Start Procedure
+--------------------------------------
+
+Installing The Software
+~~~~~~~~~~~~~~~~~~~~~~~
+
+The EVAL-AD3552R uses the :adi:`ACE` software with the AD3552R Plugin for evaluation.
+
+-  Download and run the latest version of the :adi:`ACE` installer. It installs the application and the necessary drivers for the :adi:`SDP-H1` controller board.
+-  Click on the Plugin Manager item on the left-hand menu as shown in Figure 1.
+-  Go to Available Packages, select Board.AD35X2R and click on the Install Selected button at the bottom of the list. Once the plugin is installed, it moves to the Installed Packages section.
+-  Click on the Home item on the left-hand menu. If the EVALAD3552R board is
+   connected it will show up in the Attached Hardware section as shown in Figure
+   2. If you don't have an EVAL-AD3552R board, you can still explore the
+   functionality of the plugin by double clicking on the desired board in the
+   Explore Without Hardware list.
+
+.. image:: images/ad3552r-plug-in_manager_with_red_squares.png
+   :width: 400
+
+**Figure 1. Plug-in Manager**
+
+.. image:: images/ad3552r-start_tab_with_red_squares.png
+   :width: 400
+
+**Figure 2. Start Tab**
+
+Connecting The Board
+~~~~~~~~~~~~~~~~~~~~
+
+To set up the evaluation board, take the following steps:
+
+-  Make sure that all the links are set in the default positions listed in Table 2.
+-  Plug the EVAL-AD3552R evaluation board on the SDP-H1 controller board.
+-  Connect the wall-plug brick power supply to the SDP-H1 DC jack and power from the AC network. Power LEDs turn on green.
+-  With ACE running, connect the evaluation board to the SDP-H1board, and then connect the USB cable between the SDP-H1 board and the PC.
+-  ACE should now be able to detect the board and show it in the Attached
+   Hardware section, as shown in Figure 2. Double click on the board icon to
+   open the board view, as seen in Figure 5. The board view shows the relevant
+   parts included in the evaluation board, where the AD3552R chip is highlighted
+   in a darker blue.
+
+Evaluation Board Hardware
+-------------------------
+
+Power Supplies
+~~~~~~~~~~~~~~
+
+The EVAL-AD3552R includes a complete power conversion solution to allow powering
+the evaluation board from the SDP-H1. The board includes two DC/DC converters
+LT8336 and LTC7149 to generate ±16V from the 12V power provided by SDP-H1. LDOs
+LT3045 and LT3094 are used to generate ±12V for the transimpedance amplifiers.
+LDOs ADM7170 and LT3045 are used to generate the supplies for the AD3552R. This
+power solution is configured with the default link settings shown in Table 2.
+
+Alternatively, the board can be powered from a collection of external power
+supplies via connector P3. The assignment of the pins in connector P3 is listed
+in Table 1.
+
+Table 1. Pin Assignment on Power Supply Connector P3
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
++------------+------------+---------------------------------------------------------------------+
+| Pin Number | Signal     | Description                                                         |
++============+============+=====================================================================+
+| 1          | EXT_PVDD   | External positive supply for transconductance amplifier. 12V ± 5%.  |
++------------+------------+---------------------------------------------------------------------+
+| 2          | EXT_PVSS   | External negative supply for transconductance amplifier. -12V ± 5%. |
++------------+------------+---------------------------------------------------------------------+
+| 3          | EXT_VDD    | External analog supply for AD3552R. 5V ± 5%.                        |
++------------+------------+---------------------------------------------------------------------+
+| 4          | EXT_DVDD   | External digital supply for AD3552R. 1.8V ± 5%.                     |
++------------+------------+---------------------------------------------------------------------+
+| 5          | EXT_VLOGIC | External digital I/O supply for AD3552R. 1.1 V to 1.9 V.            |
++------------+------------+---------------------------------------------------------------------+
+| 6          | GND        | Ground.                                                             |
++------------+------------+---------------------------------------------------------------------+
+
+The EVAL- AD3552R also integrates an on-board 2.5V analog reference ADR4525.
+
+Link Options
+~~~~~~~~~~~~
+
+The EVAL-AD3552R board is delivered with the links placed in the default
+positions listed in Table 2. This configuration is suitable for operating the
+board right out of the box. However, the links J_FB0, J_FB1 and J_REF may need
+to be adjusted depending on the configuration set in the registers of the
+AD3552R.
+
+Table 2. Link Options
+^^^^^^^^^^^^^^^^^^^^^
+
++--------+------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------+
+| Link   | Silkscreen | Description                                                                                                                                                                                                                                                                                                                                     | Default Position |
++========+============+=================================================================================================================================================================================================================================================================================================================================================+==================+
+| J_FB0  | FB0        | This link selects the gain of transimpedance amplifier for channel 0. The gains are labeled x1, x2 and x4 which corresponds to the multiplicative factor between them. The gain must be set in accordance to the desired output range listed in Table 6. Inserting the link allows selecting gains x1 or x2. Removing the link selects gain x4. | x1               |
++--------+------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------+
+| J_FB1  | FB1        | This link selects the gain of transimpedance amplifier for channel 0. The gains are labeled x1, x2 and x4 which corresponds to the multiplicative factor between them. The gain must be set in accordance to the desired output range listed in Table 6. Inserting the link allows selecting gains x1 or x2. Removing the link selects gain x4. | x1               |
++--------+------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------+
+| J_REF  | J_REF      | This link allows connecting the on-board reference to AD3552R. This link should be removed if an external reference is provided via connector J3 or if the internal reference is output to the VREF pin.                                                                                                                                        | inserted         |
++--------+------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------+
+| J_PVDD | PVDD       | This link selects the positive voltage supply for the transimpedance amplifier. 12V selects the supply from the on-board LDO. EXT selects the supply provided externally on connector P3.                                                                                                                                                       | 12V              |
++--------+------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------+
+| J_PVSS | PVSS       | This link selects the negative voltage supply for the transimpedance amplifier. -12V selects the supply from the on-board LDO. EXT selects the supply provided externally on connector P3. GND sets the supply rail to ground.                                                                                                                  | -12V             |
++--------+------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------+
+| J_VDD  | VDD        | This link selects the voltage supply for the analog section of AD3552R. 5V selects the supply from the on-board LDO regulator. EXT selects the supply provided externally on connector P3.                                                                                                                                                      | 5V               |
++--------+------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------+
+| J_DVDD | DVDD       | This link selects the voltage supply for the digital section of AD3552R. 1V8 selects the supply from the on-board LDO regulator. FPGA selects the supply provided from the SDP-H1 board, the same as used in the FPGA IO pins. EXT selects the supply provided externally on connector P3.                                                      | 1V8              |
++--------+------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------+
+| J_VIO  | VLOGIC     | This link selects the voltage supply for AD3552R IO pins. 1V8 selects the supply for the on-board LDO regulator. FPGA selects the supply provided from the SDP-H1 board, the same as used in the FPGA IO pins. EXT selects the supply provided externally on connector P3.                                                                      | 1V8              |
++--------+------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------+
+
+On-Board Connectors
+~~~~~~~~~~~~~~~~~~~
+
+Table 3 shows the list of connectors available on EVAL-AD3552R and their
+corresponding use.
+
+Table 3. List of Connectors
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
++-----------+-------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| Connector | Signal Name | Function                                                                                                                                                                                                                                                                   |
++===========+=============+============================================================================================================================================================================================================================================================================+
+| J1        | CLOCK_FMC   | External clock reference provided to the FPGA to generate the SPI patterns. 1.8V amplitude.                                                                                                                                                                                |
++-----------+-------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| J2        | SYNC_EVENTS | External trigger signal provided to the FPGA to synchronize waveform generation. 1.8V amplitude.                                                                                                                                                                           |
++-----------+-------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| J3        | VREF        | Reference voltage input / output. This connector can be used to provide an external reference voltage to the AD3552R or to monitor the reference generated by ADR4525 or AD3552R.                                                                                          |
++-----------+-------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| J4        | -           | Voltage output of transimpedance amplifier A1, corresponding to DAC channel 0.                                                                                                                                                                                             |
++-----------+-------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| J5        | -           | Voltage output of transimpedance amplifier A2, corresponding to DAC channel 1.                                                                                                                                                                                             |
++-----------+-------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| P1        | -           | FMC connector carrying the digital signals between the evaluation board and the controller board.                                                                                                                                                                          |
++-----------+-------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| P3        | -           | External supply connector. Pin assignment given in Table 1.                                                                                                                                                                                                                |
++-----------+-------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| P5        | -           | Digital signal connector. This connector is used to control the AD3552R with a controller different from SDP-H1. The pin assignment is listed in Table 4. The pin header is not assembled by default so that the holes can be used as test points for the digital signals. |
++-----------+-------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+
+.. tip::
+
+   Connector P5 is used to connect an external controlled when the SDP-H1 is not
+   present. This connector grants access to all the digital signals of AD3552R
+   and some board supplies and control lines.
+
+Table 4. Pin Assignment on Connector P5
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
++------------+-----------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| Pin number | Connector Label | Function                                                                                                                                                                                            |
++============+=================+=====================================================================================================================================================================================================+
+| 1          | +12V_FMC        | External 12V power supply. Use this pin to supply the EVAL-AD3552R board when using a controller different from the SDP-H1.                                                                         |
++------------+-----------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| 2          | POWER_ON_FMC    | Enable signal for the onboard regulators. This pin is used to manually turn on the LDOs and DC/DC converters when the SDP-H1 controller is not present. Set a voltage higher than 1.24V to turn on. |
++------------+-----------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| 3          | GND             | Ground.                                                                                                                                                                                             |
++------------+-----------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| 4          | SPI_QPI         | Signal SPI_QPI. A high level sets the bus in Quad-SPI mode. A low level sets the bus in classic SPI mode.                                                                                           |
++------------+-----------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| 5          | VLOGIC          | Voltage supply used for AD3552R I/O pins. If this pin is used to supply VLOGIC, remove the link on J_VIO.                                                                                           |
++------------+-----------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| 6          | GND             | Ground.                                                                                                                                                                                             |
++------------+-----------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| 7          | SPI_CS SPI      | Chip Select signal.                                                                                                                                                                                 |
++------------+-----------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| 8          | SPI_SCLK        | SPI clock signal.                                                                                                                                                                                   |
++------------+-----------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| 9          | GND             | Ground.                                                                                                                                                                                             |
++------------+-----------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| 10         | SPI_SDIO0       | SDI / MOSI signal in Classic SPI mode or SDIO0 signal in Dual / Quad SPI modes.                                                                                                                     |
++------------+-----------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| 11         | GND             | Ground.                                                                                                                                                                                             |
++------------+-----------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| 12         | SPI_SDIO1       | SDO / MISO signal in Classic SPI mode or SDIO1 signal in Dual / Quad SPI modes.                                                                                                                     |
++------------+-----------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| 13         | CLOCK_FMC       | External clock signal (same as connector J1).                                                                                                                                                       |
++------------+-----------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| 14         | SPI_SDIO2       | SPI SDIO2 signal in Quad SPI mode.                                                                                                                                                                  |
++------------+-----------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| 15         | LDAC            | AD3552R LDAC signal.                                                                                                                                                                                |
++------------+-----------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| 16         | SPI_SDIO3       | SPI SDIO2 signal in Quad SPI mode.                                                                                                                                                                  |
++------------+-----------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| 17         | RESET           | AD3552R RESET signal.                                                                                                                                                                               |
++------------+-----------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| 18         | GND             | Ground.                                                                                                                                                                                             |
++------------+-----------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| 19         | ALERT           | AD3552R ALERT signal.                                                                                                                                                                               |
++------------+-----------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| 20         | VLOGIC_FMC      | Test Pin for VLOGIC_FMC power supplied from the SDP-H1.                                                                                                                                             |
++------------+-----------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+
+.. tip::
+
+   The board includes several test points to access relevant signals. Only TP1
+   has the test ring assembled. The list is given in Table 5.
+
+Table 5. List of Test Points
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
++------------+------------+-------------------------------------------------------------------------------+
+| Test Point | Signal     | Description                                                                   |
++============+============+===============================================================================+
+| TP1        | GND        | Ground                                                                        |
++------------+------------+-------------------------------------------------------------------------------+
+| TP2        | VOUT0      | Voltage output of transimpedance amplifier A1, corresponding to DAC channel 0 |
++------------+------------+-------------------------------------------------------------------------------+
+| TP3        | VOUT1      | Voltage output of transimpedance amplifier A2, corresponding to DAC channel 1 |
++------------+------------+-------------------------------------------------------------------------------+
+| TP4        | VREF       | Reference voltage for AD3552R (internal, on-board or external)                |
++------------+------------+-------------------------------------------------------------------------------+
+| TP5        | SYNC_EVENT | External trigger for waveform generation                                      |
++------------+------------+-------------------------------------------------------------------------------+
+| TP6        | GPIO_9     | Synchronization signal from FPGA for development purposes                     |
++------------+------------+-------------------------------------------------------------------------------+
+
+DAC Output Range Selection
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The selection of the output range requires a combination of register
+configurations and a given transimpedance gain. The gains corresponding to each
+output range are listed in Table 6. See the AD3552R datasheet for more details
+on output range configuration.
+
+Table 6. Transimpedance Gain Setting
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
++----------------------------------+--------------+-----------------------------+
+| CHx_OUTPUT_RANGE_SEL Field Value | Output Range | Transimpedance Gain Setting |
++==================================+==============+=============================+
+| 000                              | 2.5V         | x1                          |
++----------------------------------+--------------+-----------------------------+
+| 001                              | 5V           | x1                          |
++----------------------------------+--------------+-----------------------------+
+| 010                              | 10V          | x2                          |
++----------------------------------+--------------+-----------------------------+
+| 011                              | ±5V          | x2                          |
++----------------------------------+--------------+-----------------------------+
+| 100                              | ±10V         | x4                          |
++----------------------------------+--------------+-----------------------------+
+
+DAC Output Monitoring
+~~~~~~~~~~~~~~~~~~~~~
+
+Monitoring the output of the DAC in dynamic conditions can become difficult
+because the amplifier is a low-impedance source driving a high-impedance load
+with a fast rising time. There are several options:
+
+-  Using a high-impedance probe on test points TP2 and TP3. Oscilloscope probes, active or passive, have high impedance. However, since the test points are close to the driver the effect of impedance mismatch is not visible. The main drawback is the tolerance of the probe ratio and the noise picked up in the ground lead. This method is suitable for quick measurements and slew rate characterization.
+-  Using a coaxial cable with the oscilloscope in high impedance. This solution reduces noise pick-up and eliminates the uncertainty of the probe ratio but it is not convenient for dynamic measurements. The capacitance of the coaxial cable plus the reflections at the high-impedance end distort the step response and increase the settling time. The response can be improved by adding some series resistance on R11 and R12 and some termination resistance on the oscilloscope side but the influence of the cable is not removed. This method is suitable for static measurements and noise density.
+-  Using a coaxial cable with the oscilloscope in 50Ω impedance. This solution
+   provides the cleanest step response when source and load are close to the
+   characteristic impedance of the cable. However it is not feasible for DC
+   coupled measurements due to the high power delivered to the instrument and
+   the current limitation of the driver. This method is suitable for small
+   signal measurements with AC coupling. Note that the low impedance on the
+   instrument can alter the noise profile of the amplifier.
+
+ACE Plug-In Description And Features
+------------------------------------
+
+ACE Plug-In Hierarchy
+~~~~~~~~~~~~~~~~~~~~~
+
+ACE has several views to control different aspects of the DAC. When a view is
+first opened it creates a new tab at the top of the main window. The AD3552R
+plugin has a Board View, a Chip View, a Memory Map view, a Waveform Generator
+view, and a Vector Generator view. Figure 3 shows the hierarchical relation
+between these views. Refer to the ACE User Manual for more details. The user
+manual is accessible from the help panel displayed when click on the Help button
+on the lower left angle of the application.
+
+.. image:: images/ad3552r-ace_hierarchy.png
+   :width: 400
+
+**Figure 3. ACE Plugin Hierarchy**
+
+Board View
+~~~~~~~~~~
+
+The board view displays a simplified diagram of the evaluation board including
+some relevant connectors and the interconnection between chips, as seen in
+Figure 4. Analog Devices chips are shown with their part number and the AD3552R
+is highlighted in darker blue.
+
+|image3|
+
+**Figure 4. AD3552R Board View**
+
+The actions that can be performed at this level are displayed as buttons at the
+top of the main window, as seen in Figure 5.
+
+-  **Poll Device:** this action is performed automatically every second to verify that the evaluation board is connected to the system. The button allows turning on or off this feature.
+-  **Reset Board:** this action performs a power cycle on the evaluation board, bringing everything back to default.
+
+.. image:: images/ad3552r-board_view_buttons.png
+   :width: 400
+
+**Figure 5. AD3552R Board View Buttons**
+
+To open the chip view, double-click on the AD3552R block.
+
+Chip View
+~~~~~~~~~
+
+The Chip View displays a simplified internal diagram of the chip showing the
+interface logic, the DAC cores, the precision feedback resistors and the
+relevant pins for those blocks. This view contains three interactive areas, as
+depicted in Figure 6:
+
+-  **Button list.** These buttons perform the following actions on the chip:
+
+   -  **Apply Changes:** changes in the values of the registers are recorded in a cached copy kept on the PC memory. When the button Apply Changes is pressed, only the registers that were changed are updated in the AD3552R.
+   -  **Read All:** this button reads all the registers from the AD3552R and updates the cached copy in the PC memory, displaying the values in the corresponding fields.
+   -  **Reset Chip:** this button resets the AD3552R but not the board. All registers are cleared to default values and ACE reads them back to keep the cached copy synchronized.
+   -  **Diff:** this button reads the registers of AD3552R and compares their value to the cached copy, highlighting in bold those that are different.
+   -  **Software Defaults:** this button loads the software default values in the cached copy without copying the values to the AD3552R.
+   -  **Memory Map Side-By-Side:** this button opens a new window besides the chip view containing the list of AD3552R registers.
+
+-  **DAC Registers.** Each DAC symbol contains an editable field where the hexadecimal code can be written to the DAC Output register. This allows performing an static update of the DAC. After writing the value, the button Apply Changes must be pressed to update the DAC output.
+-  **Shortcuts to other views.** There are two buttons on the lower right corner to access the Register Map view and the Waveform Generator view. The use of these panels is explained in the sections Memory Map View and Generating a Waveform.
+
+.. image:: images/chip_view_with_labels.png
+   :width: 400
+
+**Figure 6. Chip View**
+
+Memory Map View
+~~~~~~~~~~~~~~~
+
+The Memory Map view displays the entire configuration space of the AD3552R. The
+configuration space can be displayed as a list of registers or as a list of bit
+fields. The application allows sorting by any of the column categories or
+searching by register name or field name. Registers can be displayed collapsed
+or expanded into its bit fields, as shown in Figure 7.
+
+This view has the following interactive elements:
+
+-  **Button list.** These buttons perform the following actions:
+
+   -  **Apply Changes:** this button writes all the registers that have been changed since the last update.
+   -  **Apply Selected:** this button writes only the register or bit field that is selected in the list.
+   -  **Read All:** this button forces the reading of all the AD3552R registers and the update of the cached copy.
+   -  **Read Selected:** this button reads only the register or bit field that is selected and updates its value in the cached copy.
+   -  **Reset Chip:** this button resets the AD3552R and forces the reading of all registers to update the cached copy.
+   -  **Diff:** this button reads the registers of AD3552R and compares them with the cached copy, highlighting in bold those that have any difference.
+   -  **Software Defaults:** this button loads the software default values in the cached copy without copying the values to the AD3552R.
+   -  **Export:** This button exports the list of registers and their values to a CSV file. This feature is useful to generate the configuration file for a given application avoiding human error.
+   -  **Import:** This button allows reading a CSV file containing the register values.
+   -  **Chip View Side-by-Syde:** this button displays the chip view by the side of the register map.
+   -  **Show Bitfields / Show Registers:** this button toggles presentation mode as register list or bit field list.
+
+-  **Register value.** This field allows editing the entire register value in hexadecimal (left side) or toggling the bits one by one (right side). Modified registers are highlighted in bold.
+-  **Bit field values.** Registers can be expanded into their bit fields and each bit can be edited individually by clicking on it to toggle its value. Modified registers are highlighted in bold.
+
+.. image:: images/ad3552r-register_map_with_labels.png
+   :width: 400
+
+**Figure 7. AD3552R Memory Map View**
+
+Waveform Generator View
+~~~~~~~~~~~~~~~~~~~~~~~
+
+The waveform generator view allows assigning vectors to the channels and
+starting or stopping waveform generation. A screenshot of this view is given in
+Figure 8.
+
+.. image:: images/ad3552r-waveform_generator_view.png
+   :width: 400
+
+**Figure 8. Waveform Generator View**
+
+The operation mode of AD3552R and the assignment of the waveforms is controlled
+from the Transmit pane that contains the following controls:
+
+-  **Generate Vectors:** this button opens the Vector Generator view there waveforms can be defined, scaled, loaded or exported. The use of this generator is covered in section Vector Generator View.
+-  **DAC Mode:** radio buttons allow selecting Fast Mode that uses 16-bit data or Precision Mode that uses 24-bit data. The same mode is used for both DAC channels when operated simultaneously.
+-  **Auto Register Update:** this feature automatically configures the interface registers to operate in streaming mode with the highest possible update rate. If this box is not checked, configuration must be made manually on the Memory Map. The settings are described at the end of this section.
+-  **Enable Simultaneous Mode:** this checkbox allows playing the same samples on both channels. Data is written to the DAC Page register, therefore maintaining the same update rate as for a single channel. When this box is checked, the waveform is selected in the Simultaneous Update menu as seen in Figure 10.
+-  **Enable Channel 1/2:** these checkboxes allow enabling channels individually. When both channels are enabled, each one can play a different waveform, as seen in Figure 9. The update rate depends on the DAC Mode and the update mode; all the combinations are shown in Table 7.
+-  **Play Button:** this button starts and stops the waveform playback. The status of the playback is displayed on the EVALAD3552R LED: blue when running and green when stopped.
+
+Table 7. Update Rate Combinations
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
++------------------------------------+--------------------+-------------------------+
+|                                    | Fast Mode (16 bit) | Precision Mode (24 bit) |
++====================================+====================+=========================+
+| Dual Channel Mode                  | 12.5               | 8.33                    |
++------------------------------------+--------------------+-------------------------+
+| Single Channel / Simultaneous Mode | 25                 | 16.66                   |
++------------------------------------+--------------------+-------------------------+
+
+.. image:: images/ad3552r-transmit_pane_dual_mode.png
+   :width: 200
+
+**Figure 9. Waveform Generation in Dual Mode**
+
+.. image:: images/ad3552r-transmit_pane_simultaneous_mode.png
+   :width: 200
+
+**Figure 10. Waveform Generation in Simultanoeus Mode**
+
+Manual Register Configuration for Streaming Mode
+""""""""""""""""""""""""""""""""""""""""""""""""
+
+If the Auto Register Update checkbox is not checked, the streaming mode
+parameters have to be configured manually in the memory map before pressing the
+Play button. The following registers must be set:
+
+-  STREAM_MODE register (0x0E). Length value should be set according to Table 8.
+-  TRANSFER_REGISTER (0x0F). Set STREAM_LENGTH_KEEP_VALUE bit to 1.
+-  INTERFACE_CONFIG_D register (0x14). Set SPI_CONFIG_DDR bit to 1.
+
+Table 8. Stream Mode Length Values
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
++------------------------------------+--------------------+-------------------------+
+|                                    | Fast Mode (16 bit) | Precision Mode (24 bit) |
++====================================+====================+=========================+
+| Single Channel / Simultaneous Mode | 2                  | 3                       |
++------------------------------------+--------------------+-------------------------+
+| Dual Channel Mode                  | 4                  | 6                       |
++------------------------------------+--------------------+-------------------------+
+
+Vector Generator View
+~~~~~~~~~~~~~~~~~~~~~
+
+The Vector Generator view allows defining or loading waveforms that can later be
+assigned to the DAC channels. Waveforms are identified by name. The generator
+automatically adapts the sample rate based on the operating mode and the number
+of DAC channels enabled. A snapshot of this view if presented in Figure 11.
+
+The Vector Generator tool is composed of the following sections:
+
+-  **Predefined Waveforms.** The generator has several predefined waveforms: DC, single tone, square, triangle, sawtooth, chirp, noise and multi-tone. Clicking the **+** button adds this waveform to the Generate panel where it can be customized.
+-  **Waveforms from File.** The generator can load waveforms from file in three different formats: text file, hexadecimal file or ACE Vector file. Refer to the ACE User Manual for further details on the file formats. When loading a waveform all the samples are played irrespective of the update rate. Therefor the waveform files must be generated for a specific update rate.
+-  **First Waveform Parameters.** Every waveform has a set of parameters that can be customized:
+
+   -  **Vector Name:** specify a name in this field to identify the waveforms in the Waveform Generator view.
+   -  **Desired Frequency:** specify the repetition frequency of the waveform. The value is assumed to be in Hz if no unit is specified. If the unit is specified, it must adhere to the standard capitalization (e.g. kHz, not khz).
+   -  **Attenuation:** all waveforms are generated at full scale by default. Attenuation can be used to reduce the signal amplitude keeping the offset constant at mid scale. Amplitude is scaled by 10−Att 20.
+   -  **Relative Phase:** specify the phase offset relative to the start of the waveform record.
+   -  **Preview button:** pressing this button displays the waveform in the time-domain and its FFT in the frequency-domain window, if present.
+   -  **Copy:** pressing this button duplicates the waveform entry in the Generate pane.
+   -  **Export:** pressing this button allows exporting the waveform as a text file containing decimal numbers.
+
+-  **Second Waveform Parameters.** If a second waveform is added, it will show up stacked in the Generate pane under the first waveform. The same parameters are applicable.
+-  **Time-domain waveform preview.** A preview of the selected waveform is displayed in this window. Only one waveform is displayed at a time. The plot window allows zooming, panning and measuring on the waveform.
+-  **Waveform FFT.** The frequency-domain analysis of the selected waveform is displayed in this window. The plot window allows zooming, panning and measuring on the spectrum.
+
+.. image:: images/ad3552r-vector_generator_with_labels.png
+   :width: 400
+
+**Figure 11. Vector Generator View**
+
+Creating a Waveform
+~~~~~~~~~~~~~~~~~~~
+
+Follow these steps to produce a dual waveform playback on the EVAL-AD3552R
+evaluation board:
+
+-  From the start page, double click on the board icon to open the *Board view*.
+-  Double click on the AD3552R block to open the *Chip View*.
+-  Click the button Proceed to Memory Map to open the *Memory Map View*.
+-  Go to CH0_CH1_OUTPUT_RANGE register and set the desired output range (0x33 in this example). Refer to Table 6 for the possible values of this register. Then click Apply All to force the register update.
+-  Click on the Vector Generator item on the left-hand panel to open the// Vector Generator View//.
+-  Follow the instructions given in *Vector Generator View* to create a 1 kHz sinewave and a 1 kHz sawtooth.
+-  Follow the shortcuts in the gray bar at the top of the window to go back to the *Chip View*. Then click on the button Proceed to Waveform Generator to open the *Waveform Generator View*.
+-  Select Fast Mode and enable channels 1 and 2. Then unfold the Channel 1 and Channel 2 sections to select each of the waveforms you created. Finally click the Play button.
+-  The LED on EVAL-AD3552R changes from green to blue and the playback starts.
+   The waveforms should look like the ones shown in Figure 12 in the
+   oscilloscope.
+
+.. image:: images/ad3552r-waveforms-on-oscilloscope.png
+   :width: 400
+
+**Figure 12. Simultaneous Waveform Output**
+
+Unsupported Features in the Plugin
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The current version of EVAL-AD3552R ACE Plugin (1.2021.38200) does not support
+all the board features at the moment. ACE notifies when an update of the plugin
+is available, so these features will be progressively incorporated. These are
+the features not currently supported:
+
+-  DAC output range selection and customization.
+-  CRC checking.
+-  Amplitude and offset control in waveform generation. Waveform scaling is only possible using the Attenuation field in dB. Offset is fixed to mid-scale.
+-  Using the LDAC line to update the DAC output.
+-  ALERT pin monitoring, error status readback and on-screen reporting.
+-  External clock for FPGA.
+-  External triggering of waveform playback.
+
+Schematic, PCB Layout, Bill of Materials
+========================================
+
+.. admonition:: Download
+   :class: download
+
+   
+   -  `EVAL-AD3552RFMC1Z <resources/eval-ad3552rfmc1z.pdf>`_
+   -  `EVAL-AD3552RFMC2Z <resources/eval-ad3552rfmc2z.pdf>`_
+   -  `EVAL-AD3552RFMCxZ Gerber Files <resources/eval_ad3552rfmcxz_gerber_files.zip>`_
+   -  `EVAL-AD3552RFMC1Z Bill of Materials <images/eval-ad3552rfmc1z.xlsx>`_
+   -  `EVAL-AD3552RFMC2Z Bill of Materials <images/eval-ad3552rfmc2z.xlsx>`_
+   
+
+.. |image1| image:: images/eval-ad3552rfmcxztop-web.gif
+   :width: 400
+.. |image2| image:: images/eval-ad3552rfmcxzbottom-web.gif
+   :width: 400
+.. |image3| image:: images/ad3552r-board_view.png
+   :width: 400

--- a/docs/solutions/reference-designs/dac/eval-ad5676r-ardz.rst
+++ b/docs/solutions/reference-designs/dac/eval-ad5676r-ardz.rst
@@ -1,0 +1,276 @@
+EVAL-AD5676RARDZ Evaluation Board User Guide
+============================================
+
+**Evaluation Board for the AD5676R WLCSP**
+
+Features
+--------
+
+-  Full featured evaluation board for the :adi:`AD5676R` WLCSP
+-  On-board or external power supply
+-  On-board or external voltage reference
+-  Arduino® Uno form-factor, mates with :adi:`SDP-K1`
+-  PC control via :adi:`Analysis \| Control \| Evaluation (ACE) Software <ACE>`
+
+Evaluation Kit Contents
+-----------------------
+
+-  EVAL-AD5676RARDZ
+
+Hardware Required
+-----------------
+
+-  :adi:`SDP-K1` board - must be purchased separately
+-  PC running on Windows 7 or later with USB 2.0 port
+
+Software Required
+-----------------
+
+-  Latest :adi:`ACE` Software
+-  NanoDAC ACE plugin - downloadable within ACE
+-   :adi:`Link to Nanodac v1.2021.432000 Plugin <plugins/ace/board.nanodac.1.2021.43200.acezip>` - Check for the latest plugin
+
+General Description
+-------------------
+
+This user guide details the operation of the EVAL-AD5676RARDZ for the AD5676R
+WLCSP 16-bit, octal, voltage output, digital-to-analog converter (DAC).
+
+The EVAL-AD5676RARDZ allows users to quickly prototype AD5676R circuits and
+reduce design time. The AD5676R operates from a single 2.7 V to 5.5 V supply.
+The AD5676R incorporates an internal 2.5 V reference to give a full-scale output
+voltage of 2.5 V or 5 V. An ADR4525 is also provided on-board as a 2.5V
+reference source. A different external reference voltage can be applied via the
+EXT_REF SMB connector or test pin if needed.
+
+The EVAL-AD5676RARDZ interfaces to the USB port of a PC via a system
+demonstration platform board (SDP-K1 ). The Analysis \| Control \| Evaluation
+(ACE) software is available for download from the EVAL-AD5676RARDZ product page
+to use with the evaluation board to allow the user to program the AD5676R. A
+peripheral module interface (PMOD) connection is also available to allow the
+connection of microcontrollers to the evaluation board without the SDP-K1 board.
+When a microcontroller is used through the PMOD connection, the SDP-K1 board
+must be disconnected, and the user is unable to operate the ACE software.
+
+The EVAL-AD5676RARDZ is compatible with the EVAL-SDP-CK1Z (SDP-K1), which should
+be purchased separately. A typical connection between the EVAL-AD5676RARDZ and
+the SDP-B controller board is shown below. For full details, see the AD5676R
+data sheet, which must be used in conjunction with this user guide when using
+the EVAL-AD5676RARDZ.
+
+Evaluation Board Photograph
+---------------------------
+
+|Evaluation Board Photograph| |Evaluation Board Photograph with SDP-K1|
+
+Evaluation Board Software Quick Start Procedure
+-----------------------------------------------
+
+Installing the Software
+~~~~~~~~~~~~~~~~~~~~~~~
+
+The EVAL-AD5676RARDZ uses the ACE evaluation software, which allows the
+evaluation and control of multiple evaluation systems.
+
+The ACE installer installs the necessary SDP-K1 drivers and the Microsoft® .NET Framework 4 by default. The ACE software must be installed before connecting the SDP-K1 board to the USB port of the PC to ensure that the SDP-K1 board is recognized properly. For full instructions on how to install and use this software, see the :adi:`ACE` software page on the Analog Devices website.
+
+After the installation is finished, the EVAL-AD5676RARDZ plug-in appears when
+the ACE software is opened.
+
+Initial Setup
+~~~~~~~~~~~~~
+
+To set up the evaluation board, take the following steps:
+
+-  Connect the evaluation board to the SDP-K1 board, and then connect the USB cable between the SDP-K1 board and the PC.
+-  Run the ACE application. The EVAL-AD5676RARDZ plug-ins appear in the attached hardware section of the Start tab.
+-  Double-click the board plug-in to open the board view.
+-  Double-click the AD5676R chip to access the chip block diagram. This view
+   provides a basic representation of the functionality of the board.
+
+**EVAL-AD5676RARDZ and SDP-K1 Board Connection**
+
+.. image:: images/eval-ad5676rardz_and_sdp-k1_connection.png
+   :alt: EVAL-AD5676RARDZ and SDP-K1 Board Connection
+   :width: 400
+
+**EVAL-AD5676RARDZ Plugin - Board View**
+
+.. image:: images/plugin_board_view.png
+   :alt: ACE Plugin - Board View
+   :width: 400
+
+**EVAL-AD5676RARDZ Plugin - Chip View**
+
+.. image:: images/plugin_chip_view.png
+   :alt: ACE Plugin - Chip View
+   :width: 400
+
+Functional Block Diagram and Description
+----------------------------------------
+
+The EVAL-AD5676RARDZ software is organized to appear similar to the functional
+block diagram shown in the AD5676R datasheet, which simplifies correlating the
+functions on the EVAL-AD5676RARDZ with the description in the AD5676R datasheet.
+
+For a full description of each block, register, and its settings, see the
+AD5676R datasheet.
+
+Some of the blocks and their functions are described in this section as they
+pertain to the evaluation board. The full-screen block diagram UI is shown
+below.
+
+.. image:: images/plugin_bd_with_labels.png
+   :alt: Plugin - Block Diagram with Labels
+   :width: 600
+
+**Block Diagram Functions**
+
++-------+------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| Label | Button/Function              | Function/Description                                                                                                                                                                                                                                                                               |
++=======+==============================+====================================================================================================================================================================================================================================================================================================+
+| **A** | General Commands             | These consist of general command buttons with functions as follows.                                                                                                                                                                                                                                |
+|       |                              | **Apply Changes** - Applies user inputs in the text fields, such as Label D, to the device.                                                                                                                                                                                                        |
+|       |                              | **Read All** - Reads the AD5676R's registers. Applicable only to select registers.                                                                                                                                                                                                                 |
+|       |                              | **Reset Chip** - Initiates the software reset sequence for AD5676R.                                                                                                                                                                                                                                |
+|       |                              | **Diff** - Shows the registers that are different on the device.                                                                                                                                                                                                                                   |
+|       |                              | **Software Defaults** - Returns all fields to the default settings.                                                                                                                                                                                                                                |
+|       |                              | **Memory Map side-by-side** - Launches the Memory Map window side-by-side in the same window with the block diagram UI.                                                                                                                                                                            |
++-------+------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| **B** | Configuration WIndow         | Used to set the configuration for the board. Select the gain setting from the **Output Gain** drop-down menu. A gain of 1 is the default. After setting up the initial configuration, click **Apply** to apply the values. These settings can be modified at any stage while evaluating the board. |
++-------+------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| **C** | Select a Command             | Contains command drop-down menus as described below.                                                                                                                                                                                                                                               |
+|       |                              | **Command option** drop-down menu selects how the user input data in **Label D** is transferred to the device. The user input data can be **(Option 1)** written to the input registers only or **(Option 2)** written to the input register and the DAC register **(Label E)**.                   |
+|       |                              | **Channel group** drop-down menu selects which channels are displayed in the **Input Register** block **(Label D)**. **(Option1)** displays DAC Channel 0 to 3 while **(Option 2)** displays DAC Channel 4 to 7.                                                                                   |
++-------+------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| **D** | Input Register               | 16-bit data word to be transferred to the device. Data word should be in hexadecimal format. Select the channel group **(Label C)** to write to from the drop-down menu. Click **Apply Changes (Label A)** to transfer this 16-bit data word to the device.                                        |
++-------+------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| **E** | DAC Register                 | Displays the value that is currently present in the DAC register on the device. Update the DAC registers by selecting the appropriate command option or by toggling **Load DAC (Label G)** for specific channels or **Software LDAC (Label J)** for all channels.                                  |
++-------+------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| **F** | Software RESET               | Returns the evaluation board and software to default values.                                                                                                                                                                                                                                       |
++-------+------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| **G** | Load DAC                     | Users can individually control which channel loads the values from the input registers field **(Label D)** to the DAC register. Click this button to initiate the software LDAC function and transfer the contents of the channel input register to the channel DAC register.                      |
++-------+------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| **H** | DAC Config                   | DAC configuration options provide access to individual channel configuration, mainly, the power-down option, which can be set to either of the 3 states: **Normal**, **1kΩ to GND**, or **Tri-state**. See datasheet for more info.                                                                |
++-------+------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| **I** | Internal Reference           | Configuration to **Enable**/**Disable** the on-chip reference. Note that the on-chip reference is enabled by default. Make sure to disable the on-chip reference when using an external reference source.                                                                                          |
++-------+------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| **J** | Software LDAC (All Channels) | Loads the data word entered in the Input Registers field **(Label D)** to the device's DAC Register. Unlike the **Load DAC (Label G)**, this command applies to all 8 channels of the AD5676R.                                                                                                     |
++-------+------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| **K** | Memory Map                   | Launches the Memory Map window in a separate tab as the Block Diagram window. See Memory Map for more details.                                                                                                                                                                                     |
++-------+------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+
+Memory Map
+~~~~~~~~~~
+
+All registers are fully accessible from the **AD5676R Memory Map** tab as shown below. This tab allows registers to be edited at the bit level. The bits shaded in dark gray are read-only bits and cannot be accessed from the ACE software. All other bits can be toggled.
+
+.. image:: images/plugin_memory_map.png
+   :alt: Plugin - Memory Map
+   :width: 800
+
+All changes made in the memory map tab correspond to the block diagram. For example, if the internal register bit is enabled, it displays as enabled on the block diagram. Any bits or registers that are shown in bold in the memory map tab are modified values that have not been transferred to the evaluation board. Click **Apply Changes** to transfer the data to the evaluation board.
+
+.. image:: images/plugin_memory_map_unsaved.png
+   :alt: Plugin - Memory Map with Unsaved Changes
+   :width: 800
+
+Evaluation Board Hardware
+-------------------------
+
+Power Supplies
+~~~~~~~~~~~~~~
+
+The EVAL-AD5676RARDZ provides an onboard 3.3 V regulator powered through the USB
+supply for the AD5676R main supply. If a different supply is required or if the
+evaluation board is controlled through the PMOD connector, an external supply
+must be provided by the external supply voltage (P8) connector. See the below
+table for more details.
+
+An onboard 2.5V reference (ADR4525) is also provided. Every supply is decoupled
+to the ground with 10 µF tantalum and 0.1 µF ceramic capacitors.
+
+**PowerSupply Connectors**
+
+=============== =================================================
+Connector Label External Voltage Supplies Description
+=============== =================================================
+P8, Pin 1       External analog power supply from 2.7 V to 5.5 V.
+P8, Pin 2       Analog ground.
+EXT_REF         External voltage reference.
+=============== =================================================
+
+Link Options
+~~~~~~~~~~~~
+
+Several link options are incorporated on the EVAL-AD5676RARDZ and must be set
+for the required operating conditions before using the board. The functions of
+these link options are described in the table below.
+
+**Link Functions**
+
++--------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| Link Name    | Description                                                                                                                                                   |
++==============+===============================================================================================================================================================+
+| VDD_SEL, P10 | This link selects the analog voltage source for the AD5676R. There are three options, as follows:                                                             |
+|              | **5V0** - 5V supply from the SDP-K1 or the PMOD connectors.                                                                                                   |
+|              | **3V3** - 3.3V supply from onboard LDO powered by the 5V0 supply.                                                                                             |
+|              | **EXT** - 2.7V to 5.5V supply from an external source connected to P8.                                                                                        |
++--------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| REF_LDO_SEL  | This link selects the analog voltage source for the onboard 2.5V reference :adi:`ADM7160`. There are three options, as follows:                               |
+|              | **5V0** - 5V supply from the SDP-K1 or the PMOD connectors.                                                                                                   |
+|              | **3V3** - 3.3V supply from onboard LDO powered by the 5V0 supply.                                                                                             |
+|              | **EXT** - 2.7V to 5.5V supply from an external source connected to P8.                                                                                        |
++--------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| REF, JP2     | This link selects the external voltage source for the AD5676R. There are two options, as follows:                                                             |
+|              | **2V5** - 2.5V supply from the onboard reference :adi:`ADM7160`.                                                                                              |
+|              | **EXT** - External supply coming from EXT_REF connector.                                                                                                      |
++--------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| P1           | This link connects the corresponding DAC output channel to the SMB connector.                                                                                 |
++--------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------+
+
+On-Board Connectors
+~~~~~~~~~~~~~~~~~~~
+
++-----+-----------------+---------------------------------------------------------------+
+| Ref | Connector Label | Function                                                      |
++=====+=================+===============================================================+
+| A   | P8              | External analog power supply from 2.7 V to 5.5 V.             |
++-----+-----------------+---------------------------------------------------------------+
+| B   | TP1 (GND)       | Analog ground Testpoint.                                      |
++-----+-----------------+---------------------------------------------------------------+
+| C   | EXT_REF, J1     | External voltage reference input port.                        |
++-----+-----------------+---------------------------------------------------------------+
+| D   | P2, P3, P5, P6  | Connector for SDP-K1 using standard Arduino form factor.      |
++-----+-----------------+---------------------------------------------------------------+
+| E   | SPI_PMOD        | External SPI input using the PMOD standard pin configuration. |
++-----+-----------------+---------------------------------------------------------------+
+| F   | I2C_PMOD        | External I2C input using the PMOD standard pin configuration. |
++-----+-----------------+---------------------------------------------------------------+
+| G   | P11             | DAC outputs from V\ :sub:`OUT`\ 0 to V\ :sub:`OUT`\ 7.        |
++-----+-----------------+---------------------------------------------------------------+
+
+| |image1|
+| ===== Schematic, Layout, Bill of Materials & Board Photos =====
+
+.. admonition:: Download
+   :class: download
+
+   
+   -  `eval-ad5676rardz_schematic.pdf <resources/eval-ad5676rardz_schematic.pdf>`_
+   -  `eval-ad5676rardz_layout.pdf <resources/eval-ad5676rardz_layout.pdf>`_
+   -  `eval-ad5676rardz_bom.xlsx <images/eval-ad5676rardz_bom.xlsx>`_
+   -  ` </resources/eval/user-guides/dac/eval-ad5676r-ardz/eval-ad5676rardz_board_photograph.png>`__
+   -  ` </resources/eval/user-guides/dac/eval-ad5676r-ardz/eval-ad5676rardz_board_photograph_bottom.png>`__
+   -  ` </resources/eval/user-guides/dac/eval-ad5676r-ardz/eval-ad5676rardz_kit_board_photograph.png>`__
+   -  ` </resources/eval/user-guides/dac/eval-ad5676r-ardz/eval-ad5676rardz_kit_board_photograph_top.png>`__
+   
+
+*End of Document*
+
+.. |Evaluation Board Photograph| image:: images/eval-ad5676rardz_board_photograph.png
+   :width: 400
+.. |Evaluation Board Photograph with SDP-K1| image:: images/eval-ad5676rardz_kit_board_photograph.png
+   :width: 600
+.. |image1| image:: images/eval-ad5676rardz_connectors.png
+   :width: 600

--- a/docs/solutions/reference-designs/dac/images/05-050892-01-d.xlsx
+++ b/docs/solutions/reference-designs/dac/images/05-050892-01-d.xlsx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4608d8884754e5768424832af2331fa0490ab90e05a990a1292bf8f7bab0f7df
+size 24856

--- a/docs/solutions/reference-designs/dac/images/ace_hierarchy.png
+++ b/docs/solutions/reference-designs/dac/images/ace_hierarchy.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:28541ef16ea43ad84fe1341a2f3926ffcd11b91051a0d75690c5283c8996784a
+size 13402

--- a/docs/solutions/reference-designs/dac/images/ad3552r-ace_hierarchy.png
+++ b/docs/solutions/reference-designs/dac/images/ad3552r-ace_hierarchy.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:28541ef16ea43ad84fe1341a2f3926ffcd11b91051a0d75690c5283c8996784a
+size 13402

--- a/docs/solutions/reference-designs/dac/images/ad3552r-board_view.png
+++ b/docs/solutions/reference-designs/dac/images/ad3552r-board_view.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:08c4047a69ade83b244e573d7360327c30b01fddced504c32a3cb371480f31f8
+size 93538

--- a/docs/solutions/reference-designs/dac/images/ad3552r-board_view_buttons.png
+++ b/docs/solutions/reference-designs/dac/images/ad3552r-board_view_buttons.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:be1957c46eaa5b72342b1b6ca92b70b64572497ab5d0a3f7468b20b91763f3ae
+size 10322

--- a/docs/solutions/reference-designs/dac/images/ad3552r-plug-in_manager_with_red_squares.png
+++ b/docs/solutions/reference-designs/dac/images/ad3552r-plug-in_manager_with_red_squares.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:67b94c3e56596f389e8cd9ef18846cb11c57c0e470c0b1130377f164dc515c88
+size 73094

--- a/docs/solutions/reference-designs/dac/images/ad3552r-register_map_with_labels.png
+++ b/docs/solutions/reference-designs/dac/images/ad3552r-register_map_with_labels.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:15dc60fe6601d1ba48a8431fbce224731af608ddc2d6597dfeb620a8a0e56678
+size 50615

--- a/docs/solutions/reference-designs/dac/images/ad3552r-start_tab_with_red_squares.png
+++ b/docs/solutions/reference-designs/dac/images/ad3552r-start_tab_with_red_squares.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5e45ce66526205a6793b6eee9cf056e874141835a5f5026c4e1d941333502b68
+size 64660

--- a/docs/solutions/reference-designs/dac/images/ad3552r-transmit_pane_dual_mode.png
+++ b/docs/solutions/reference-designs/dac/images/ad3552r-transmit_pane_dual_mode.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:44974908d393372a61d2bc7e2d9e921bff77690e92b4f61205682bde90e17538
+size 16224

--- a/docs/solutions/reference-designs/dac/images/ad3552r-transmit_pane_simultaneous_mode.png
+++ b/docs/solutions/reference-designs/dac/images/ad3552r-transmit_pane_simultaneous_mode.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8c856c164939c22a5e2c511fb9887e84ee981e7acac1bb1cbc05b78cd0c1af72
+size 14184

--- a/docs/solutions/reference-designs/dac/images/ad3552r-vector_generator_with_labels.png
+++ b/docs/solutions/reference-designs/dac/images/ad3552r-vector_generator_with_labels.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f45f41668444f38842d62cbad628629cb88b0d3c7f59720905d2971a21fc78eb
+size 57668

--- a/docs/solutions/reference-designs/dac/images/ad3552r-waveform_generator_view.png
+++ b/docs/solutions/reference-designs/dac/images/ad3552r-waveform_generator_view.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b5da207b37c694a62a9af992ec51c25f8d5a519ff8d6157df99fb1fbbbcca16e
+size 130061

--- a/docs/solutions/reference-designs/dac/images/ad3552r-waveforms-on-oscilloscope.png
+++ b/docs/solutions/reference-designs/dac/images/ad3552r-waveforms-on-oscilloscope.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6c0f891a803f888944ea5861162ef46709a93f8a54128541934f830816e054f5
+size 535959

--- a/docs/solutions/reference-designs/dac/images/board_layout.png
+++ b/docs/solutions/reference-designs/dac/images/board_layout.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:14db32ff1f20e7a37eb7f3d05cf19a160b0f524fe0ff8cc252ce6bea88b40f22
+size 189757

--- a/docs/solutions/reference-designs/dac/images/board_view.png
+++ b/docs/solutions/reference-designs/dac/images/board_view.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:90671f0d16f270c0f242c8f012d13c69d00aea420b015321e8aa09f336503fbf
+size 126650

--- a/docs/solutions/reference-designs/dac/images/board_view_buttons.png
+++ b/docs/solutions/reference-designs/dac/images/board_view_buttons.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1495348885b8ac140fee58e1b84e534adc2807b3348feb2346e3b3fc1af07041
+size 7379

--- a/docs/solutions/reference-designs/dac/images/chip_view_with_labels.png
+++ b/docs/solutions/reference-designs/dac/images/chip_view_with_labels.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cb4d221e8e4d83522b9549d79dece8753e0b2a2f82068c4d0c2126ebcb910941
+size 118147

--- a/docs/solutions/reference-designs/dac/images/eval-ad3542rfmcz_bottom-web2.gif
+++ b/docs/solutions/reference-designs/dac/images/eval-ad3542rfmcz_bottom-web2.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cedbcf09b9dcc3e865a0080a20a659757f7c21db6a5c3f90428ccb79edb6ac4b
+size 286091

--- a/docs/solutions/reference-designs/dac/images/eval-ad3542rfmcz_top-web.gif
+++ b/docs/solutions/reference-designs/dac/images/eval-ad3542rfmcz_top-web.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:97d8f543d7d5e16d4c3edf998fc9f100399af6bea7e90a47dcb46c0330972d3d
+size 373197

--- a/docs/solutions/reference-designs/dac/images/eval-ad3552rfmc1z.xlsx
+++ b/docs/solutions/reference-designs/dac/images/eval-ad3552rfmc1z.xlsx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:690cc1465742e7d662d678a138b059e98e1d5f29be78c071954103baece4d718
+size 18593

--- a/docs/solutions/reference-designs/dac/images/eval-ad3552rfmc2z.xlsx
+++ b/docs/solutions/reference-designs/dac/images/eval-ad3552rfmc2z.xlsx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:889ccdf23a4da8a05f6d641b244f1134480cee1944b23407e5fda8aad98f8679
+size 18563

--- a/docs/solutions/reference-designs/dac/images/eval-ad3552rfmcxzbottom-web.gif
+++ b/docs/solutions/reference-designs/dac/images/eval-ad3552rfmcxzbottom-web.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6bff8b7d2953dc328ec562cb01d954593029461fbaafbeb9c6f64f176cf23380
+size 325542

--- a/docs/solutions/reference-designs/dac/images/eval-ad3552rfmcxztop-web.gif
+++ b/docs/solutions/reference-designs/dac/images/eval-ad3552rfmcxztop-web.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1dfd2e93e89b89dd445657ebab4ea38f90cbd25a92afd60d2ed1a6ebf8d87abb
+size 382760

--- a/docs/solutions/reference-designs/dac/images/eval-ad5676rardz_and_sdp-k1_connection.png
+++ b/docs/solutions/reference-designs/dac/images/eval-ad5676rardz_and_sdp-k1_connection.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:258f96500fbfc1b57829d3734d232203ca4ea3383a44d7d839c7a5005e150e56
+size 907632

--- a/docs/solutions/reference-designs/dac/images/eval-ad5676rardz_board_photograph.png
+++ b/docs/solutions/reference-designs/dac/images/eval-ad5676rardz_board_photograph.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e81019f31998bac628e6d90ebbd7df213901cbe5ae35f7c25205902e5c678cdd
+size 3620405

--- a/docs/solutions/reference-designs/dac/images/eval-ad5676rardz_bom.xlsx
+++ b/docs/solutions/reference-designs/dac/images/eval-ad5676rardz_bom.xlsx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:49355398f190591a07b4f13a148787f054ed2b3265e11be84f0f69587953c0d9
+size 13989

--- a/docs/solutions/reference-designs/dac/images/eval-ad5676rardz_connectors.png
+++ b/docs/solutions/reference-designs/dac/images/eval-ad5676rardz_connectors.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7a79ad3cebcd4a02faed1387415759312fae5be7ad19a6d7fa927ff5c55ff2df
+size 2028703

--- a/docs/solutions/reference-designs/dac/images/eval-ad5676rardz_kit_board_photograph.png
+++ b/docs/solutions/reference-designs/dac/images/eval-ad5676rardz_kit_board_photograph.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:49a38cde7bc34fe24a2ae13091b2567f130cf428a108655bbb1aa790d1c094c4
+size 2444919

--- a/docs/solutions/reference-designs/dac/images/iio_connect.png
+++ b/docs/solutions/reference-designs/dac/images/iio_connect.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b549c54ff3b559269f949e94dfdb8850dc741f54380be895054aa792f1d0f202
+size 74460

--- a/docs/solutions/reference-designs/dac/images/jumpers_boot_sd_zedboard.jpg
+++ b/docs/solutions/reference-designs/dac/images/jumpers_boot_sd_zedboard.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0d3079bb2a0e632a9de77e1d2aa7c842d18683edeb77a2fbfd6940b2535f156e
+size 146199

--- a/docs/solutions/reference-designs/dac/images/output_raw_1_.png
+++ b/docs/solutions/reference-designs/dac/images/output_raw_1_.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:adb2165d0a29dbfb7ddf4f5ffba8d5a3607869977079d722c52b63638ee855a7
+size 41778

--- a/docs/solutions/reference-designs/dac/images/plug-in_manager_with_red_squares.png
+++ b/docs/solutions/reference-designs/dac/images/plug-in_manager_with_red_squares.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:67b94c3e56596f389e8cd9ef18846cb11c57c0e470c0b1130377f164dc515c88
+size 73094

--- a/docs/solutions/reference-designs/dac/images/plugin_bd_with_labels.png
+++ b/docs/solutions/reference-designs/dac/images/plugin_bd_with_labels.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:30b5126e078c4b5e2d08c3dc1ae3bc301e27f5cd59132b03edbb1df554aa13f3
+size 742044

--- a/docs/solutions/reference-designs/dac/images/plugin_board_view.png
+++ b/docs/solutions/reference-designs/dac/images/plugin_board_view.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:742632d48ac5259052f9177f6711ef1d46924fc003a9be8914d4575f72540c25
+size 120743

--- a/docs/solutions/reference-designs/dac/images/plugin_chip_view.png
+++ b/docs/solutions/reference-designs/dac/images/plugin_chip_view.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cf7ee959766120ebf4f398e76e063316bc1cd531f1b50f33218bdab1b39e3e6a
+size 162368

--- a/docs/solutions/reference-designs/dac/images/plugin_memory_map.png
+++ b/docs/solutions/reference-designs/dac/images/plugin_memory_map.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c25c857465a27c0d7ade13b000f480f38fb027bc05b38f67e175980ca9afee2a
+size 350759

--- a/docs/solutions/reference-designs/dac/images/plugin_memory_map_unsaved.png
+++ b/docs/solutions/reference-designs/dac/images/plugin_memory_map_unsaved.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9799b7a532c3f04f3be900c2a998465b248b98e0a080fb2ad5e58223e125e22c
+size 136457

--- a/docs/solutions/reference-designs/dac/images/python_plot_ad3552r.jpg
+++ b/docs/solutions/reference-designs/dac/images/python_plot_ad3552r.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:22877a2cb751ba27889754fee85b6f8be088d2ac4a853d409f1852fd0ba9a6d3
+size 37760

--- a/docs/solutions/reference-designs/dac/images/register_map_with_labels.png
+++ b/docs/solutions/reference-designs/dac/images/register_map_with_labels.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f4f05c3dcc5687cf517f7b454fda162286725bcf7547c4d9db938e433eb968ad
+size 187417

--- a/docs/solutions/reference-designs/dac/images/setup_diagram_eval_ad3552r.jpg
+++ b/docs/solutions/reference-designs/dac/images/setup_diagram_eval_ad3552r.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b4d039e4ab9257661a721fe10f7bdcdcd31626efd526df3b89c96f27d67ea061
+size 274532

--- a/docs/solutions/reference-designs/dac/images/start_tab_with_red_squares.png
+++ b/docs/solutions/reference-designs/dac/images/start_tab_with_red_squares.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:26bd16f8a54f6217cab1e39b6198fe272b20fc65f1bf8603207881250ada8f9b
+size 79276

--- a/docs/solutions/reference-designs/dac/images/transmit_pane_dual_mode.png
+++ b/docs/solutions/reference-designs/dac/images/transmit_pane_dual_mode.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:44974908d393372a61d2bc7e2d9e921bff77690e92b4f61205682bde90e17538
+size 16224

--- a/docs/solutions/reference-designs/dac/images/transmit_pane_simultaneous_mode.png
+++ b/docs/solutions/reference-designs/dac/images/transmit_pane_simultaneous_mode.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8c856c164939c22a5e2c511fb9887e84ee981e7acac1bb1cbc05b78cd0c1af72
+size 14184

--- a/docs/solutions/reference-designs/dac/images/vector_generator_with_labels.png
+++ b/docs/solutions/reference-designs/dac/images/vector_generator_with_labels.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6e037b245a98024cdc286c6fc876a03b4a97699e2518b35993823e08666c95b6
+size 207689

--- a/docs/solutions/reference-designs/dac/images/waveform_generator_view.png
+++ b/docs/solutions/reference-designs/dac/images/waveform_generator_view.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9bda1c1f9359d0b0a240da20ebe59149a23cfb7aeec8fe7fb613ebeb8589b2a3
+size 134717

--- a/docs/solutions/reference-designs/dac/images/waveforms_on_oscilloscope.png
+++ b/docs/solutions/reference-designs/dac/images/waveforms_on_oscilloscope.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:98e5bcd571f1948c42753ced6836af7010db312b605d25e6578ee5d777c6aea1
+size 613112

--- a/docs/solutions/reference-designs/dac/index.rst
+++ b/docs/solutions/reference-designs/dac/index.rst
@@ -1,0 +1,10 @@
+DAC
+===
+
+.. toctree::
+   :titlesonly:
+
+   ad3552r_eval_zed
+   eval-ad3542r
+   eval-ad3552r
+   eval-ad5676r-ardz

--- a/docs/solutions/reference-designs/dac/index.rst
+++ b/docs/solutions/reference-designs/dac/index.rst
@@ -1,10 +1,48 @@
+.. _dac eval:
+
 DAC
-===
+===================
+
+.. TODO: Add a picture of the chip/board
+
+Overview
+-------------------------------------------------------------------------------
+
+.. TODO: Describe in max 10 rows the main features and applications.
+
+Features:
+
+- feature 1
+- feature 2
+
+Applications:
+
+- application 1
+- application 2
 
 .. toctree::
-   :titlesonly:
+   :hidden:
 
    ad3552r_eval_zed
    eval-ad3542r
    eval-ad3552r
    eval-ad5676r-ardz
+
+Recommendations
+-------------------------------------------------------------------------------
+
+People who follow the flow that is outlined, have a much better experience with
+things. However, like many things, documentation is never as complete as it
+should be. If you have any questions, feel free to ask on our
+:ref:`EngineerZone forums <help-and-support>`, but before that, please make
+sure you read our documentation thoroughly.
+
+Warning
+-------------------------------------------------------------------------------
+
+.. esd-warning::
+
+Help and support
+-------------------------------------------------------------------------------
+
+Please go to :ref:`Help and Support <help-and-support>` page.

--- a/docs/solutions/reference-designs/dac/resources/02_050892d_top.pdf
+++ b/docs/solutions/reference-designs/dac/resources/02_050892d_top.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e7955c8278e3d2f75fff5e6d6c77c59d9bb20260acb9972fdc6e94c48ee3c78e
+size 297871

--- a/docs/solutions/reference-designs/dac/resources/ad3552r-boot-files-2025-02-27.zip
+++ b/docs/solutions/reference-designs/dac/resources/ad3552r-boot-files-2025-02-27.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c8d07b9d2e0cb5cf08e952388dccdd80d3be32408ae80d218fab95838eecc78e
+size 5557474

--- a/docs/solutions/reference-designs/dac/resources/eval-ad3552rfmc1z.pdf
+++ b/docs/solutions/reference-designs/dac/resources/eval-ad3552rfmc1z.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ddae6e1a9c215e095a5fd5f75209097eb4f9d9340e32dec117f81b1ea6764201
+size 362094

--- a/docs/solutions/reference-designs/dac/resources/eval-ad3552rfmc2z.pdf
+++ b/docs/solutions/reference-designs/dac/resources/eval-ad3552rfmc2z.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7318e81f02e3f42e9ebf9533e7d3b8012b6e5dda04569494594374917fa7f825
+size 364651

--- a/docs/solutions/reference-designs/dac/resources/eval-ad5676rardz_layout.pdf
+++ b/docs/solutions/reference-designs/dac/resources/eval-ad5676rardz_layout.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1f2f264bc8f2ef0add08b6fc3b323807eeaeca212f4ad8842c99f7e2d67e1ed2
+size 681249

--- a/docs/solutions/reference-designs/dac/resources/eval-ad5676rardz_schematic.pdf
+++ b/docs/solutions/reference-designs/dac/resources/eval-ad5676rardz_schematic.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f66debe202712c58d3f51c617518296cc32ce144b5de8a49ba4308b6b8322526
+size 178080

--- a/docs/solutions/reference-designs/dac/resources/eval_ad3552rfmcxz_gerber_files.zip
+++ b/docs/solutions/reference-designs/dac/resources/eval_ad3552rfmcxz_gerber_files.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0bc297bfa9ac4ffb4199c5073095352f9604a03b523e1e4218e91b9a387d0259
+size 577190


### PR DESCRIPTION
## Summary
- Move dac wiki documentation to `solutions/reference-designs/dac/`
- 5 RST files with 46 localized images
- Generated stub `index.rst` with toctree

## Test plan
- [ ] Sphinx build passes without errors
- [ ] All toctree entries resolve correctly
- [ ] Images render properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)