### PR TITLE
reference-designs/depthcompute: Add depthcompute documentation

### DIFF
--- a/docs/solutions/reference-designs/depthcompute/index.rst
+++ b/docs/solutions/reference-designs/depthcompute/index.rst
@@ -1,0 +1,7 @@
+DEPTHCOMPUTE
+============
+
+.. toctree::
+   :titlesonly:
+
+   params

--- a/docs/solutions/reference-designs/depthcompute/index.rst
+++ b/docs/solutions/reference-designs/depthcompute/index.rst
@@ -1,7 +1,45 @@
+.. _depthcompute eval:
+
 DEPTHCOMPUTE
-============
+=========================================================================
+
+.. TODO: Add a picture of the chip/board
+
+Overview
+-------------------------------------------------------------------------------
+
+.. TODO: Describe in max 10 rows the main features and applications.
+
+Features:
+
+- feature 1
+- feature 2
+
+Applications:
+
+- application 1
+- application 2
 
 .. toctree::
-   :titlesonly:
+   :hidden:
 
    params
+
+Recommendations
+-------------------------------------------------------------------------------
+
+People who follow the flow that is outlined, have a much better experience with
+things. However, like many things, documentation is never as complete as it
+should be. If you have any questions, feel free to ask on our
+:ref:`EngineerZone forums <help-and-support>`, but before that, please make
+sure you read our documentation thoroughly.
+
+Warning
+-------------------------------------------------------------------------------
+
+.. esd-warning::
+
+Help and support
+-------------------------------------------------------------------------------
+
+Please go to :ref:`Help and Support <help-and-support>` page.

--- a/docs/solutions/reference-designs/depthcompute/params.rst
+++ b/docs/solutions/reference-designs/depthcompute/params.rst
@@ -1,0 +1,18 @@
+Depth Compute Parameters
+========================
+
+=================== ======= ============
+Name                Unit    Range
+=================== ======= ============
+abThreshMin         -       0 - 65,535
+abSumThresh         -       0 - 65,535
+confThresh          degrees 0 - 360
+radialThreshMin     mm      0 - 65,535
+radialThreshMax     mm      0 - 65,535
+jblfApplyFlag       -       [0, 1]
+jblfWindowSize      pixel   [1, 3, 5, 7]
+jblfGaussianSigma   pixel   
+jblfExponentialTerm -       
+jblfMaxEdge         -       
+jblfABThreshold     -       
+=================== ======= ============


### PR DESCRIPTION
## Summary
- Move depthcompute wiki documentation to `solutions/reference-designs/depthcompute/`
- 2 RST files with 0 localized images
- Generated stub `index.rst` with toctree

## Test plan
- [ ] Sphinx build passes without errors
- [ ] All toctree entries resolve correctly
- [ ] Images render properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)