### PR TITLE
reference-designs/eval-ad4116asdz: Add eval-ad4116asdz documentation

### DIFF
--- a/docs/solutions/reference-designs/eval-ad4116asdz/eval-ad4116asdz.rst
+++ b/docs/solutions/reference-designs/eval-ad4116asdz/eval-ad4116asdz.rst
@@ -1,0 +1,94 @@
+EVAL-AD4116ASDZ User Guide
+==========================
+
+The :adi:`EVAL-AD4116ASDZ <en/design-center/evaluation-hardware-and-software/evaluation-boards-kits/EVAL-AD4116.html>` is a full-featured evaluation board that can be used to evaluate all the features of the :adi:`AD4116 <en/products/ad4116.html>`. The AD4116 is a 24-bit, sigma-delta analog-to-digital converter (ADC) with 6 differential/11 single-ended, high impedance (≥10 MΩ) bipolar, ±10 V voltage inputs, and 2 differential/4 single-ended/pseudo differential direct ADC inputs. All channels have onboard overvoltage and overcurrent protection.
+
+The EVAL-AD4116ASDZ board includes voltage references and power and data insulation and can be connected to the Analog Devices, Inc., :adi:`EVAL-SDP-CB1Z system demonstration platform <en/design-center/evaluation-hardware-and-software/evaluation-boards-kits/sdp-b.html>`. The SDP board provides the connection to a PC via a universal serial bus (USB) port and can provide power for the EVAL-AD4116ASDZ board from the PC USB port. The AD411X Eval+ evaluation software configures the AD4116 device functionality and provides dc time domain analysis in the form of waveform graphs, histograms, and associated noise analysis for ADC performance evaluation. Full specifications for the AD4116 are available in the product datasheet, which must be consulted in conjunction with this user guide when working with this evaluation board.
+
+.. image:: images/ad4116_block_diagram_with_fig.png
+   :align: center
+
+Features
+--------
+
+-  Full featured evaluation board for the AD4116
+-  PC control in conjunction with the system demonstration platform (EVAL-SDP-CB1Z)
+-  PC software for control and data analysis (time domain)
+-  Standalone capability
+
+Documents Needed
+----------------
+
+-  :adi:`AD4116 Data Sheet <media/en/technical-documentation/data-sheets/ad4116.pdf>`
+
+Required Software
+-----------------
+
+-  :adi:`AD411x Evaluation Software <media/en/evaluation-boards-kits/evaluation-software/ad411x-eval-installer.zip>` (:doc:`Install guide </solutions/reference-designs/eval-ad4116asdz/software>`)(:doc:`Eval+ Description </solutions/reference-designs/eval-ad4116asdz/software>`)
+
+Equipment Needed
+----------------
+
+-  :adi:`EVAL-AD4116ASDZ <en/design-center/evaluation-hardware-and-software/evaluation-boards-kits/EVAL-AD4116.html>`
+-  :adi:`EVAL-SDP-CB1Z system demonstration platform <en/design-center/evaluation-hardware-and-software/evaluation-boards-kits/sdp-b.html>`
+-  DC signal source
+-  USB cable
+-  PC running Windows with USB 2.0 port
+
+Quick Start Guide
+=================
+
+Recommended Quick Start Guide
+-----------------------------
+
+Use the following procedure to set up the evaluation board:
+
+-   Disconnect the SDP (SDP-B) board from the USB port of the PC. Install the **AD411X Eval+** software. Restart the PC after installation.
+-   Connect the SDP board to the EVAL-AD4116ASDZ board, as shown in Figure 3.
+-   Fasten the two boards together with the enclosed plastic screw washer set.
+-   Connect the SDP board to the PC via the USB cable. For Windows® XP, it may be necessary to search for the SDP drivers. Choose to automatically search for the drivers for the SDP board if prompted by the operating system.
+-   Launch the **AD411X Eval+** software from the **Analog Devices** subfolder in the **Programs** menu.
+
+Quick Start Measurement
+-----------------------
+
+Use the following procedure to capture data quickly:
+
+-  Connect the dc signal source to the selected voltage input (for example, VIN0 and VIN1 for differential input).
+-  Launch the **AD411X Eval+** software and select **QuickStart**.
+-  In the **Configuration** tab, under **Demo Mode**, click **All Single-Ended**, and then click **Sample** (see Figure 16).
+-  In the **Voltage Waveform tab**, the user can evaluate the measured data.
+
+The **Samples** box in the top right corner of the main window sets the number of samples collected in each batch.
+
+|image1| **Figure 2. Evaluation Board Hardware Configuration**
+
+Hardware Guide
+==============
+
+:doc:`Visit the hardware guide chapter here </solutions/reference-designs/eval-ad4116asdz/hardware_guide>` **Contents of the Hardware guide:**
+
+-  :doc:`Description </solutions/reference-designs/eval-ad4116asdz/hardware_guide>`
+-  :doc:`Set Up Procedures </solutions/reference-designs/eval-ad4116asdz/hardware_guide>`
+-  :doc:`Block Diagram </solutions/reference-designs/eval-ad4116asdz/hardware_guide>`
+-  :doc:`Hardware Link Options </solutions/reference-designs/eval-ad4116asdz/hardware_guide>`
+-  :doc:`On Board Connectors </solutions/reference-designs/eval-ad4116asdz/hardware_guide>`
+-  :doc:`Power Supplies </solutions/reference-designs/eval-ad4116asdz/hardware_guide>`
+-  :doc:`Serial Interface </solutions/reference-designs/eval-ad4116asdz/hardware_guide>`
+-  :doc:`Analog Inputs </solutions/reference-designs/eval-ad4116asdz/hardware_guide>`
+-  :doc:`Reference Options </solutions/reference-designs/eval-ad4116asdz/hardware_guide>`
+-  :doc:`Schematic, PCB Layout, BOM </solutions/reference-designs/eval-ad4116asdz/hardware_guide>`
+
+Software Guide
+==============
+
+:doc:`Visit the software guide chapter here </solutions/reference-designs/eval-ad4116asdz/software>` **Contents of the Software guide:**
+
+-  :doc:`Evaluation+ Software </solutions/reference-designs/eval-ad4116asdz/software>`
+
+   -  :doc:`Install Guide </solutions/reference-designs/eval-ad4116asdz/software>`
+
+      -  :doc:`Evaluation+ Windows </solutions/reference-designs/eval-ad4116asdz/software>`
+
+.. |image1| image:: images/26267-003.png
+   :width: 400

--- a/docs/solutions/reference-designs/eval-ad4116asdz/eval-ad4116asdz.rst
+++ b/docs/solutions/reference-designs/eval-ad4116asdz/eval-ad4116asdz.rst
@@ -1,9 +1,25 @@
 EVAL-AD4116ASDZ User Guide
 ==========================
 
-The :adi:`EVAL-AD4116ASDZ <en/design-center/evaluation-hardware-and-software/evaluation-boards-kits/EVAL-AD4116.html>` is a full-featured evaluation board that can be used to evaluate all the features of the :adi:`AD4116 <en/products/ad4116.html>`. The AD4116 is a 24-bit, sigma-delta analog-to-digital converter (ADC) with 6 differential/11 single-ended, high impedance (≥10 MΩ) bipolar, ±10 V voltage inputs, and 2 differential/4 single-ended/pseudo differential direct ADC inputs. All channels have onboard overvoltage and overcurrent protection.
+The :adi:`EVAL-AD4116ASDZ <en/design-center/evaluation-hardware-and-software/evaluation-boards-kits/EVAL-AD4116.html>`
+is a full-featured evaluation board that can be used to evaluate all the
+features of the :adi:`AD4116 <en/products/ad4116.html>`. The AD4116 is a
+24-bit, sigma-delta analog-to-digital converter (ADC) with 6 differential/11
+single-ended, high impedance (≥10 MΩ) bipolar, ±10 V voltage inputs, and 2
+differential/4 single-ended/pseudo differential direct ADC inputs. All
+channels have onboard overvoltage and overcurrent protection.
 
-The EVAL-AD4116ASDZ board includes voltage references and power and data insulation and can be connected to the Analog Devices, Inc., :adi:`EVAL-SDP-CB1Z system demonstration platform <en/design-center/evaluation-hardware-and-software/evaluation-boards-kits/sdp-b.html>`. The SDP board provides the connection to a PC via a universal serial bus (USB) port and can provide power for the EVAL-AD4116ASDZ board from the PC USB port. The AD411X Eval+ evaluation software configures the AD4116 device functionality and provides dc time domain analysis in the form of waveform graphs, histograms, and associated noise analysis for ADC performance evaluation. Full specifications for the AD4116 are available in the product datasheet, which must be consulted in conjunction with this user guide when working with this evaluation board.
+The EVAL-AD4116ASDZ board includes voltage references and power and data
+insulation and can be connected to the Analog Devices, Inc.,
+:adi:`EVAL-SDP-CB1Z system demonstration platform <en/design-center/evaluation-hardware-and-software/evaluation-boards-kits/sdp-b.html>`.
+The SDP board provides the connection to a PC via a universal serial bus (USB)
+port and can provide power for the EVAL-AD4116ASDZ board from the PC USB port.
+The AD411X Eval+ evaluation software configures the AD4116 device
+functionality and provides dc time domain analysis in the form of waveform
+graphs, histograms, and associated noise analysis for ADC performance
+evaluation. Full specifications for the AD4116 are available in the product
+datasheet, which must be consulted in conjunction with this user guide when
+working with this evaluation board.
 
 .. image:: images/ad4116_block_diagram_with_fig.png
    :align: center
@@ -12,7 +28,8 @@ Features
 --------
 
 -  Full featured evaluation board for the AD4116
--  PC control in conjunction with the system demonstration platform (EVAL-SDP-CB1Z)
+-  PC control in conjunction with the system demonstration platform
+   (EVAL-SDP-CB1Z)
 -  PC software for control and data analysis (time domain)
 -  Standalone capability
 
@@ -36,37 +53,46 @@ Equipment Needed
 -  PC running Windows with USB 2.0 port
 
 Quick Start Guide
-=================
+-----------------
 
 Recommended Quick Start Guide
------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Use the following procedure to set up the evaluation board:
 
--   Disconnect the SDP (SDP-B) board from the USB port of the PC. Install the **AD411X Eval+** software. Restart the PC after installation.
+-   Disconnect the SDP (SDP-B) board from the USB port of the PC. Install the
+    **AD411X Eval+** software. Restart the PC after installation.
 -   Connect the SDP board to the EVAL-AD4116ASDZ board, as shown in Figure 3.
 -   Fasten the two boards together with the enclosed plastic screw washer set.
--   Connect the SDP board to the PC via the USB cable. For Windows® XP, it may be necessary to search for the SDP drivers. Choose to automatically search for the drivers for the SDP board if prompted by the operating system.
--   Launch the **AD411X Eval+** software from the **Analog Devices** subfolder in the **Programs** menu.
+-   Connect the SDP board to the PC via the USB cable. For Windows® XP, it
+    may be necessary to search for the SDP drivers. Choose to automatically
+    search for the drivers for the SDP board if prompted by the operating
+    system.
+-   Launch the **AD411X Eval+** software from the **Analog Devices** subfolder
+    in the **Programs** menu.
 
 Quick Start Measurement
------------------------
+~~~~~~~~~~~~~~~~~~~~~~~
 
 Use the following procedure to capture data quickly:
 
--  Connect the dc signal source to the selected voltage input (for example, VIN0 and VIN1 for differential input).
+-  Connect the dc signal source to the selected voltage input (for example,
+   VIN0 and VIN1 for differential input).
 -  Launch the **AD411X Eval+** software and select **QuickStart**.
--  In the **Configuration** tab, under **Demo Mode**, click **All Single-Ended**, and then click **Sample** (see Figure 16).
+-  In the **Configuration** tab, under **Demo Mode**, click
+   **All Single-Ended**, and then click **Sample** (see Figure 16).
 -  In the **Voltage Waveform tab**, the user can evaluate the measured data.
 
-The **Samples** box in the top right corner of the main window sets the number of samples collected in each batch.
+The **Samples** box in the top right corner of the main window sets the number
+of samples collected in each batch.
 
 |image1| **Figure 2. Evaluation Board Hardware Configuration**
 
 Hardware Guide
-==============
+--------------
 
-:doc:`Visit the hardware guide chapter here </solutions/reference-designs/eval-ad4116asdz/hardware_guide>` **Contents of the Hardware guide:**
+:doc:`Visit the hardware guide chapter here </solutions/reference-designs/eval-ad4116asdz/hardware_guide>`
+**Contents of the Hardware guide:**
 
 -  :doc:`Description </solutions/reference-designs/eval-ad4116asdz/hardware_guide>`
 -  :doc:`Set Up Procedures </solutions/reference-designs/eval-ad4116asdz/hardware_guide>`
@@ -80,9 +106,10 @@ Hardware Guide
 -  :doc:`Schematic, PCB Layout, BOM </solutions/reference-designs/eval-ad4116asdz/hardware_guide>`
 
 Software Guide
-==============
+--------------
 
-:doc:`Visit the software guide chapter here </solutions/reference-designs/eval-ad4116asdz/software>` **Contents of the Software guide:**
+:doc:`Visit the software guide chapter here </solutions/reference-designs/eval-ad4116asdz/software>`
+**Contents of the Software guide:**
 
 -  :doc:`Evaluation+ Software </solutions/reference-designs/eval-ad4116asdz/software>`
 

--- a/docs/solutions/reference-designs/eval-ad4116asdz/hardware_guide.rst
+++ b/docs/solutions/reference-designs/eval-ad4116asdz/hardware_guide.rst
@@ -4,7 +4,16 @@ Hardware Guide
 Device Description
 ------------------
 
-The :adi:`AD4116 <en/products/ad4116.html>` is a highly accurate, high resolution, multiplexed, Σ Δ ADC with eleven single-ended or six differential voltage inputs, a voltage range of ±10 V and additional 2 differential or 4 single-ended/pseudo differential direct ADC inputs provides excellent performance at lower input ranges. The maximum channel-to-channel scan rate is 12.4 kSPS (80 µs) for fully settled data. The output data rates range from 1.25 SPS to 62.5 kSPS. The device includes integrated analog reference buffers, an integrated precision 2.5 V reference, and an integrated oscillator. See the AD4116 datasheet for complete specifications. Consult the datasheet in conjunction with this user guide when using the evaluation board.
+The :adi:`AD4116 <en/products/ad4116.html>` is a highly accurate, high
+resolution, multiplexed, Σ Δ ADC with eleven single-ended or six differential
+voltage inputs, a voltage range of ±10 V and additional 2 differential or 4
+single-ended/pseudo differential direct ADC inputs provides excellent
+performance at lower input ranges. The maximum channel-to-channel scan rate is
+12.4 kSPS (80 µs) for fully settled data. The output data rates range from
+1.25 SPS to 62.5 kSPS. The device includes integrated analog reference
+buffers, an integrated precision 2.5 V reference, and an integrated
+oscillator. See the AD4116 datasheet for complete specifications. Consult the
+datasheet in conjunction with this user guide when using the evaluation board.
 
 Set-up Procedures
 -----------------
@@ -19,10 +28,14 @@ Configuring the Evaluation and SDP Boards section.
    EVAL-AD4116ASDZ evaluation board and EVAL-SDP-CB1Z board to the USB port of
    the PC to ensure the PC correctly recognizes the evaluation system.
 
-**Configuring the Evaluation and SDP Boards** Use the following procedure to configure the boards
+**Configuring the Evaluation and SDP Boards** Use the following procedure to
+configure the boards
 
--  Connect the SDP board to Connector A or Connector B on the EVAL-AD4116ASDZ board. Screw the two boards together firmly using the plastic screw and washer set included in the evaluation board kit.
--  If using the SDP-K1 board the Arduino headers can also be used to connect to the board
+-  Connect the SDP board to Connector A or Connector B on the EVAL-AD4116ASDZ
+   board. Screw the two boards together firmly using the plastic screw and
+   washer set included in the evaluation board kit.
+-  If using the SDP-K1 board the Arduino headers can also be used to connect
+   to the board
 -  Ensure that LK3 is in Position B (USB).
 -  Connect the SDP board to the PC using the USB cable.
 
@@ -88,14 +101,22 @@ On Board Connections
 +------------+---------------------------------------------------+-------------------------------------------------------+
 
 Power Supplies
-==============
+--------------
 
-By default, the board is powered from the USB. The board can be also powered from the J4 connector by setting LK3 to Position A or from Arduino standard headers The :adi:`ADuM6411 <en/products/Adum6411.html>` isoPower® digital isolator is used to isolate power and data lines up to 2.5 kV rms.
+By default, the board is powered from the USB. The board can be also powered
+from the J4 connector by setting LK3 to Position A or from Arduino standard
+headers The :adi:`ADuM6411 <en/products/Adum6411.html>` isoPower® digital
+isolator is used to isolate power and data lines up to 2.5 kV rms.
 
 Serial Interface
-================
+----------------
 
-The evaluation board connects via the serial peripheral interface (SPI) to the Blackfin® :adi:`ADSP-BF527 <en/products/adsp-bf527.html>` on the SDP-B board. There are four primary signals: CS, SCLK, DIN, and DOUT/RDY (all are inputs, except for DOUT/RDY, which is an output). The EVAL-AD4116ASDZ evaluation board connects to any microcontroller board that uses the Arduino standard headers. This can be developed user code in for a variety of platforms.
+The evaluation board connects via the serial peripheral interface (SPI) to the
+Blackfin® :adi:`ADSP-BF527 <en/products/adsp-bf527.html>` on the SDP-B board.
+There are four primary signals: CS, SCLK, DIN, and DOUT/RDY (all are inputs,
+except for DOUT/RDY, which is an output). The EVAL-AD4116ASDZ evaluation board
+connects to any microcontroller board that uses the Arduino standard headers.
+This can be developed user code in for a variety of platforms.
 
 To operate the evaluation board in standalone mode, disconnect any board
 connected, J9 can be used to access all SPI signals and set the input/output
@@ -107,7 +128,7 @@ For an introduction to the Serial Peripheral Interface (SPI), click :adi:`here <
    :align: center
 
 Analog Inputs
-=============
+-------------
 
 Eleven voltage inputs are available on P1 to P3. If a different common voltage
 must be set for single-ended measurement, remove LK2 and connect the desired
@@ -115,7 +136,7 @@ voltage to VINCOM on P2. Five additional low-level inputs are available on P4.
 The differential voltage for these inputs is ±VREF only.
 
 Reference Options
-=================
+-----------------
 
 The EVAL-AD4116ASDZ includes an external 2.5 V reference, the ADR4525ARZ. By
 default, LK1 is inserted, connecting the external reference to REF+ of the
@@ -126,19 +147,16 @@ button is located below the external reference controls in the block diagram
 (Label 7 in Figure 16).
 
 Schematic, PCB Layout, Bill of Materials
-========================================
+----------------------------------------
 
 .. admonition:: Download
    :class: download
 
    EVAL-AD4116ASDZ Rev B Design and Integration Files
 
-   
    -  `schematic.pdf <resources/schematic.pdf>`_
-   
    -  `layout.pdf <resources/layout.pdf>`_
-   
    -  `bom.xlsx <images/bom.xlsx>`_
-   
+
 
 :doc:`Continue to Software Guide </solutions/reference-designs/eval-ad4116asdz/software>` :doc:`Return to Homepage </solutions/reference-designs/eval-ad4116asdz/eval-ad4116asdz>`

--- a/docs/solutions/reference-designs/eval-ad4116asdz/hardware_guide.rst
+++ b/docs/solutions/reference-designs/eval-ad4116asdz/hardware_guide.rst
@@ -1,0 +1,144 @@
+Hardware Guide
+==============
+
+Device Description
+------------------
+
+The :adi:`AD4116 <en/products/ad4116.html>` is a highly accurate, high resolution, multiplexed, Σ Δ ADC with eleven single-ended or six differential voltage inputs, a voltage range of ±10 V and additional 2 differential or 4 single-ended/pseudo differential direct ADC inputs provides excellent performance at lower input ranges. The maximum channel-to-channel scan rate is 12.4 kSPS (80 µs) for fully settled data. The output data rates range from 1.25 SPS to 62.5 kSPS. The device includes integrated analog reference buffers, an integrated precision 2.5 V reference, and an integrated oscillator. See the AD4116 datasheet for complete specifications. Consult the datasheet in conjunction with this user guide when using the evaluation board.
+
+Set-up Procedures
+-----------------
+
+After following the instructions in the Software Installation Procedures
+section, set up the evaluation board and SDP board as detailed in the
+Configuring the Evaluation and SDP Boards section.
+
+.. important::
+
+   The evaluation software and drivers must be installed before connecting the
+   EVAL-AD4116ASDZ evaluation board and EVAL-SDP-CB1Z board to the USB port of
+   the PC to ensure the PC correctly recognizes the evaluation system.
+
+**Configuring the Evaluation and SDP Boards** Use the following procedure to configure the boards
+
+-  Connect the SDP board to Connector A or Connector B on the EVAL-AD4116ASDZ board. Screw the two boards together firmly using the plastic screw and washer set included in the evaluation board kit.
+-  If using the SDP-K1 board the Arduino headers can also be used to connect to the board
+-  Ensure that LK3 is in Position B (USB).
+-  Connect the SDP board to the PC using the USB cable.
+
+Evaluation Board
+----------------
+
+.. image:: images/board_photo.png
+   :align: center
+   :width: 600
+
+Hardware Link Options
+---------------------
+
++-------------+------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| Link Number | Default Position | Description                                                                                                                                                                                             |
++=============+==================+=========================================================================================================================================================================================================+
+| LK1         | Inserted         | Connects the on-board external reference :adi:`ADR4525 <en/products/adr4525.html>` (U2) to AD4116(U1). Remove LK1 if using a different single-ended external reference.                                 |
++-------------+------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| LK2         | Inserted         | Connects VINCOM to GND_ISO. This configuration is typical for single-ended measurement. Remove LK2 to set the custom common analog input for single-ended channels. VINCOM is available on Pin 5 of J3. |
++-------------+------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| LK3         | B (USB)          | Selects the power supply voltage. **Position A:** board is powered from the external dc power supply connector, J4. **Position B:** board is powered from USB through the SDP or Arduino connector.     |
++-------------+------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| LK4 to LK6  | STD              | Selects which Arduino SPI Lines to connect. **STD :** Standard Arduino Headers. **ALT :** Alternate IFCSP Header                                                                                        |
++-------------+------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| LK9, LK10   | Inserted         | Connects VIN4 and VIN5 to the Zener diode D16 and D17 respectfully. These can be removed to evaluate the voltage inputs of the AD4116 directly by removing external components.                         |
++-------------+------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| LK11, LK12  | Removed          | Bypasses R10 and R11 on VIN4 and VIN5 respectfully. By inserting this link the resistor is removed from the input path and AD4116 can be evaluated directly.                                            |
++-------------+------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| LK13, LK14  | Inserted         | Connects ADCIN11 and ADCIN12 to the Zener diode D8 and D9 respectfully. These can be removed to evaluate the voltage inputs of the AD4116 directly by removing external components.                     |
++-------------+------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| LK15, LK16  | Removed          | Bypasses R21 and R22 on ADCIN11 and ADCIN12 respectfully. By inserting this link the resistor is removed from the input path and AD4116 can be evaluated directly.                                      |
++-------------+------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| J14         | CS0              | Selects which GPIO to use on the Arduino header as CS to enable stacking boards.                                                                                                                        |
++-------------+------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+
+On Board Connections
+--------------------
+
++------------+---------------------------------------------------+-------------------------------------------------------+
+| Connector  | Function                                          | Connector Type                                        |
++============+===================================================+=======================================================+
+| J1         | Connects to GPIO’s of AD4116                      | 4-pin header, 2.54mm pitch                            |
++------------+---------------------------------------------------+-------------------------------------------------------+
+| P1, P2, P3 | Voltage inputs to AD4116                          | Connector, header, 90°, 5 position, 3.81 mm           |
++------------+---------------------------------------------------+-------------------------------------------------------+
+| P4         | Low-level inputs to AD4116                        | Connector, header, 90°, 5 position, 3.81 mm           |
++------------+---------------------------------------------------+-------------------------------------------------------+
+| J4         | External supply voltage (optional)                | Power socket block, 3-way, 3.81 mm pitch              |
++------------+---------------------------------------------------+-------------------------------------------------------+
+| J7         | Arduino Headers (Power)                           | 8 Position Receptacle Connector, 2.54mm pitch         |
++------------+---------------------------------------------------+-------------------------------------------------------+
+| J8         | Arduino Header (Analog)                           | 6 Position Receptacle Connector, 2.54mm pitch         |
++------------+---------------------------------------------------+-------------------------------------------------------+
+| J9         | Arduino Header (Digital 1                         | 10 Position Receptacle Connector, 2.54mm pitch        |
++------------+---------------------------------------------------+-------------------------------------------------------+
+| J10        | Arduino Header (Digital 0)                        | 8 Position Receptacle Connector, 2.54mm pitch         |
++------------+---------------------------------------------------+-------------------------------------------------------+
+| J11        | Arduino Header (IFCSP)                            | 6 Position, 2 row, Receptable Connector, 2.54mm pitch |
++------------+---------------------------------------------------+-------------------------------------------------------+
+| J12        | SDP Connector                                     | 120-way connector, 0.6 mm pitch                       |
++------------+---------------------------------------------------+-------------------------------------------------------+
+| J13        | Earth for electromagnetic discharge (ESD testing) | Not applicable                                        |
++------------+---------------------------------------------------+-------------------------------------------------------+
+
+Power Supplies
+==============
+
+By default, the board is powered from the USB. The board can be also powered from the J4 connector by setting LK3 to Position A or from Arduino standard headers The :adi:`ADuM6411 <en/products/Adum6411.html>` isoPower® digital isolator is used to isolate power and data lines up to 2.5 kV rms.
+
+Serial Interface
+================
+
+The evaluation board connects via the serial peripheral interface (SPI) to the Blackfin® :adi:`ADSP-BF527 <en/products/adsp-bf527.html>` on the SDP-B board. There are four primary signals: CS, SCLK, DIN, and DOUT/RDY (all are inputs, except for DOUT/RDY, which is an output). The EVAL-AD4116ASDZ evaluation board connects to any microcontroller board that uses the Arduino standard headers. This can be developed user code in for a variety of platforms.
+
+To operate the evaluation board in standalone mode, disconnect any board
+connected, J9 can be used to access all SPI signals and set the input/output
+voltage levels.
+
+For an introduction to the Serial Peripheral Interface (SPI), click :adi:`here <en/analog-dialogue/articles/introduction-to-spi-interface.html>`
+
+.. image:: images/spi_int_for_wikipage.png
+   :align: center
+
+Analog Inputs
+=============
+
+Eleven voltage inputs are available on P1 to P3. If a different common voltage
+must be set for single-ended measurement, remove LK2 and connect the desired
+voltage to VINCOM on P2. Five additional low-level inputs are available on P4.
+The differential voltage for these inputs is ±VREF only.
+
+Reference Options
+=================
+
+The EVAL-AD4116ASDZ includes an external 2.5 V reference, the ADR4525ARZ. By
+default, LK1 is inserted, connecting the external reference to REF+ of the
+AD4116. Remove LK1 if using a different single-ended external reference. In the
+evaluation software, click the blue pop-up button associated with Setup 0 to
+Setup 7 to select the reference used for conversions by the AD4116. The pop-up
+button is located below the external reference controls in the block diagram
+(Label 7 in Figure 16).
+
+Schematic, PCB Layout, Bill of Materials
+========================================
+
+.. admonition:: Download
+   :class: download
+
+   EVAL-AD4116ASDZ Rev B Design and Integration Files
+
+   
+   -  `schematic.pdf <resources/schematic.pdf>`_
+   
+   -  `layout.pdf <resources/layout.pdf>`_
+   
+   -  `bom.xlsx <images/bom.xlsx>`_
+   
+
+:doc:`Continue to Software Guide </solutions/reference-designs/eval-ad4116asdz/software>` :doc:`Return to Homepage </solutions/reference-designs/eval-ad4116asdz/eval-ad4116asdz>`

--- a/docs/solutions/reference-designs/eval-ad4116asdz/images/26267-003.png
+++ b/docs/solutions/reference-designs/eval-ad4116asdz/images/26267-003.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b7d72ac617065d8fc30a369505ec9b4ee7ae65985b8c437b789c342860b149e3
+size 3826546

--- a/docs/solutions/reference-designs/eval-ad4116asdz/images/26267-004.png
+++ b/docs/solutions/reference-designs/eval-ad4116asdz/images/26267-004.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:17fc86829cdaff72cec95553153f40fd6eae0e7fa6489e2823c7504852e6444f
+size 169414

--- a/docs/solutions/reference-designs/eval-ad4116asdz/images/26267-005.png
+++ b/docs/solutions/reference-designs/eval-ad4116asdz/images/26267-005.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c08f7e3650d00de48ae74de0f6b3b6b6ea7841d86db288c72f9ce43b055e38c1
+size 32591

--- a/docs/solutions/reference-designs/eval-ad4116asdz/images/26267-006.png
+++ b/docs/solutions/reference-designs/eval-ad4116asdz/images/26267-006.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:64e4c1d5ad4c03c1a5bebe8ff10d61c383cc6a86521ed64396271ba705c15788
+size 62573

--- a/docs/solutions/reference-designs/eval-ad4116asdz/images/26267-007.png
+++ b/docs/solutions/reference-designs/eval-ad4116asdz/images/26267-007.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:78f7d3d1e69319040820ff298d4d942f5aadf9d3415c238fbc7c3f26ed3c0286
+size 23742

--- a/docs/solutions/reference-designs/eval-ad4116asdz/images/26267-008.png
+++ b/docs/solutions/reference-designs/eval-ad4116asdz/images/26267-008.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8553e022eeb10cdd4f9d6a564caf2bdeb5de27f35b2915abe9238d6c71228eae
+size 23101

--- a/docs/solutions/reference-designs/eval-ad4116asdz/images/26267-009.png
+++ b/docs/solutions/reference-designs/eval-ad4116asdz/images/26267-009.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:14643999872489af73ab315ccb9134e648049824ce0a74408a635c7ce0a2bc5f
+size 146293

--- a/docs/solutions/reference-designs/eval-ad4116asdz/images/26267-010.png
+++ b/docs/solutions/reference-designs/eval-ad4116asdz/images/26267-010.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6754dcb6eb9b3970a8440a6128bad6c59a454ebd3433e01c539c47c707311be4
+size 55300

--- a/docs/solutions/reference-designs/eval-ad4116asdz/images/26267-011.png
+++ b/docs/solutions/reference-designs/eval-ad4116asdz/images/26267-011.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e12822c39eceb221be66063d534f97ab89ebcd93d219b3236a51faee730fa06b
+size 89306

--- a/docs/solutions/reference-designs/eval-ad4116asdz/images/26267-012.png
+++ b/docs/solutions/reference-designs/eval-ad4116asdz/images/26267-012.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f22cc2425fe30f123794dd84dd68f21305142031f8de9f7cfb1c1de24ebb0a5e
+size 166628

--- a/docs/solutions/reference-designs/eval-ad4116asdz/images/26267-013.png
+++ b/docs/solutions/reference-designs/eval-ad4116asdz/images/26267-013.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1a72d5e7f592a850dbf19a1994cd0998ff775806d3c2187314f9aa96b4a1f41e
+size 49468

--- a/docs/solutions/reference-designs/eval-ad4116asdz/images/26267-014.png
+++ b/docs/solutions/reference-designs/eval-ad4116asdz/images/26267-014.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ea02041002d7bd14cbc40c2901eb290c9a2fba4daf6b3695afd422f9416d274e
+size 19459

--- a/docs/solutions/reference-designs/eval-ad4116asdz/images/26267-015.png
+++ b/docs/solutions/reference-designs/eval-ad4116asdz/images/26267-015.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e1b8dfe2777cc9f79a637ae798c51c529e9e7cc9c7fb6932e2ea748dbf815780
+size 128966

--- a/docs/solutions/reference-designs/eval-ad4116asdz/images/26267-016.png
+++ b/docs/solutions/reference-designs/eval-ad4116asdz/images/26267-016.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c359e0146031943e3ae050693d410ac4d348397a97353bbe59b09fc62904ae5d
+size 387357

--- a/docs/solutions/reference-designs/eval-ad4116asdz/images/26267-017.png
+++ b/docs/solutions/reference-designs/eval-ad4116asdz/images/26267-017.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c86ea07e5f3149394c3ca2425e5412b6fc9b6c55a66c06ad4520ce79f9a1e050
+size 300928

--- a/docs/solutions/reference-designs/eval-ad4116asdz/images/26267-018.png
+++ b/docs/solutions/reference-designs/eval-ad4116asdz/images/26267-018.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4808386473517433e0348c128233824cfbf1bb146dbb09e806a22250a69e518d
+size 267467

--- a/docs/solutions/reference-designs/eval-ad4116asdz/images/26267-019.png
+++ b/docs/solutions/reference-designs/eval-ad4116asdz/images/26267-019.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bdb5a078b24b0e65cdafd43db4b82d236c6a1363cbf060a44527054d2064f410
+size 189387

--- a/docs/solutions/reference-designs/eval-ad4116asdz/images/26267-020.png
+++ b/docs/solutions/reference-designs/eval-ad4116asdz/images/26267-020.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5d5aef8084a29d11365b43552a3bb6d56d65ba60724d409d484445547d65751c
+size 463175

--- a/docs/solutions/reference-designs/eval-ad4116asdz/images/ad4116_block_diagram_with_fig.png
+++ b/docs/solutions/reference-designs/eval-ad4116asdz/images/ad4116_block_diagram_with_fig.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1fdba510ef907ab97866fda69f0092b1d37b9c065ea810bf57a34f687c928a33
+size 188423

--- a/docs/solutions/reference-designs/eval-ad4116asdz/images/board_photo.png
+++ b/docs/solutions/reference-designs/eval-ad4116asdz/images/board_photo.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c466aa3bbade64f7999ccc844f2d614657939631dcba98d8c63a1e6ba90a66e9
+size 3201472

--- a/docs/solutions/reference-designs/eval-ad4116asdz/images/bom.xlsx
+++ b/docs/solutions/reference-designs/eval-ad4116asdz/images/bom.xlsx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dbce1ab07ca9e82fcbb6f39ca81199b274d559341d09efb94e8c71201b74e397
+size 18730

--- a/docs/solutions/reference-designs/eval-ad4116asdz/images/spi_int_for_wikipage.png
+++ b/docs/solutions/reference-designs/eval-ad4116asdz/images/spi_int_for_wikipage.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:43f4bf2dcb24434a5e601c57ef179cf6ef5ef10d4c6494a31c8852cd05e9e151
+size 67960

--- a/docs/solutions/reference-designs/eval-ad4116asdz/index.rst
+++ b/docs/solutions/reference-designs/eval-ad4116asdz/index.rst
@@ -1,9 +1,47 @@
-EVAL-AD4116ASDZ User Guide
-==========================
+.. _eval_ad4116asdz eval:
+
+EVAL AD4116ASDZ
+===========================================================================================
+
+.. TODO: Add a picture of the chip/board
+
+Overview
+-------------------------------------------------------------------------------
+
+.. TODO: Describe in max 10 rows the main features and applications.
+
+Features:
+
+- feature 1
+- feature 2
+
+Applications:
+
+- application 1
+- application 2
 
 .. toctree::
-   :titlesonly:
+   :hidden:
 
    eval-ad4116asdz
    hardware_guide
    software
+
+Recommendations
+-------------------------------------------------------------------------------
+
+People who follow the flow that is outlined, have a much better experience with
+things. However, like many things, documentation is never as complete as it
+should be. If you have any questions, feel free to ask on our
+:ref:`EngineerZone forums <help-and-support>`, but before that, please make
+sure you read our documentation thoroughly.
+
+Warning
+-------------------------------------------------------------------------------
+
+.. esd-warning::
+
+Help and support
+-------------------------------------------------------------------------------
+
+Please go to :ref:`Help and Support <help-and-support>` page.

--- a/docs/solutions/reference-designs/eval-ad4116asdz/index.rst
+++ b/docs/solutions/reference-designs/eval-ad4116asdz/index.rst
@@ -1,0 +1,9 @@
+EVAL-AD4116ASDZ User Guide
+==========================
+
+.. toctree::
+   :titlesonly:
+
+   eval-ad4116asdz
+   hardware_guide
+   software

--- a/docs/solutions/reference-designs/eval-ad4116asdz/resources/layout.pdf
+++ b/docs/solutions/reference-designs/eval-ad4116asdz/resources/layout.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d1f084746f0a296eead57a567a0dd36951e8251d62a02aea6d1e32115c0ff5a7
+size 1381917

--- a/docs/solutions/reference-designs/eval-ad4116asdz/resources/schematic.pdf
+++ b/docs/solutions/reference-designs/eval-ad4116asdz/resources/schematic.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0795bd23b3dcf6a5b58e121a606ea8def150f3d62e4e9fcb567184ccdc2b6947
+size 356930

--- a/docs/solutions/reference-designs/eval-ad4116asdz/software.rst
+++ b/docs/solutions/reference-designs/eval-ad4116asdz/software.rst
@@ -2,11 +2,14 @@ Software Guide
 ==============
 
 Eval+ Software
-==============
+--------------
 
-The AD411x Evaluation+ software is available :adi:`Here. <media/en/evaluation-boards-kits/evaluation-software/ad411x-eval-installer.zip>`
+The AD411x Evaluation+ software is available
+:adi:`Here. <media/en/evaluation-boards-kits/evaluation-software/ad411x-eval-installer.zip>`
 
-The quick start guide is available on the landing page here :doc:`(Quick Start Guide) </solutions/reference-designs/eval-ad4116asdz/eval-ad4116asdz>` or for the step by step install guide see the below
+The quick start guide is available on the landing page here
+:doc:`(Quick Start Guide) </solutions/reference-designs/eval-ad4116asdz/eval-ad4116asdz>`
+or for the step by step install guide see the below
 
 Install Guide
 -------------
@@ -20,27 +23,35 @@ parts to the installation:
 
 .. important::
 
-   \ Warning: The evaluation software and drivers must be installed before
-   connecting both the evaluation board and the SDP-B board to the PC. This
-   ensures that the evaluations system is correctly recognized when it is
-   connected to the PC.
+   The evaluation software and drivers must be installed before connecting
+   both the evaluation board and the SDP-B board to the PC. This ensures that
+   the evaluations system is correctly recognized when it is connected to the
+   PC.
 
 Installing the AD411x Eval+ Software
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 To install the **AD411X Eval+** software,
 
--  With the SDP board disconnected from the USB port of the PC, download and unzip the **AD411X Eval+** software installer file from the EVAL-AD4116ASDZ product page.
--  Double-click the **setup.exe** file to begin the evaluation board software installation. The software then installs to the following default location: **C:\\Program Files\\Analog Devices\\AD411X EVAL+**.
--  A dialog box appears asking for permission to allow the program to make changes to the PC. Click **Yes**.
+-  With the SDP board disconnected from the USB port of the PC, download and
+   unzip the **AD411X Eval+** software installer file from the
+   EVAL-AD4116ASDZ product page.
+-  Double-click the **setup.exe** file to begin the evaluation board software
+   installation. The software then installs to the following default location:
+   **C:\\Program Files\\Analog Devices\\AD411X EVAL+**.
+-  A dialog box appears asking for permission to allow the program to make
+   changes to the PC. Click **Yes**.
 
 |image1| **Figure 4. Granting Permission for the Program to Make Changes to PC**
 
--  Select a location to install the software and then click Next. Figure 5 shows the default locations, which are displayed when the dialogue box opens, but another location can be selected by clicking **Browse**.
+-  Select a location to install the software and then click Next. Figure 5
+   shows the default locations, which are displayed when the dialogue box
+   opens, but another location can be selected by clicking **Browse**.
 
 |image2| **Figure 5. Selecting the Location for Software Installation**
 
--  A license agreement appears. Read the agreement, select **I accept the License Agreement**, and click **Next**.
+-  A license agreement appears. Read the agreement, select
+   **I accept the License Agreement**, and click **Next**.
 
 |image3| **Figure 6. Accepting the License Agreement**
 
@@ -48,20 +59,24 @@ To install the **AD411X Eval+** software,
 
 |image4| **Figure 7. Reviewing a Summary of the Installation**
 
--  The message in Figure 8 appears when the installation is complete. Click **Next**.
+-  The message in Figure 8 appears when the installation is complete.
+   Click **Next**.
 
 |image5| **Figure 8. Indicating when the Installation is Complete**
 
 Installing the Eval+ Dependencies Drivers
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-After the installation of the evaluation software is complete, a welcome window appears for the installation of the **Eval+ Dependencies**.
+After the installation of the evaluation software is complete, a welcome window
+appears for the installation of the **Eval+ Dependencies**.
 
--  With the SDP board still disconnected from the USB port of the PC, ensure that all other applications are closed, and then click **Install**.
+-  With the SDP board still disconnected from the USB port of the PC, ensure
+   that all other applications are closed, and then click **Install**.
 
 |image6| **Figure 9. Beginning the Drivers Installation**
 
--  To complete the driver installation, click **Close**, which closes the installation setup wizard.
+-  To complete the driver installation, click **Close**, which closes the
+   installation setup wizard.
 
 |image7| **Figure 10. Completing the Drivers Setup Wizard**
 
@@ -76,38 +91,69 @@ After completing the steps in the Software Installation Procedures section and
 the Evaluation Board Hardware section, set up the system for data capture as
 follows:
 
--  Allow the **Found New Hardware** wizard to run after connecting the SDP board to the PC. If using Windows XP, it may be necessary to search for the SDP drivers. Choose to automatically search for the drivers for the SDP board if prompted by the operating system.
--  Check that the board is connecting to the PC correctly using the **Device Manager** of the PC. Access the **Device Manager** as follows:
+-  Allow the **Found New Hardware** wizard to run after connecting the SDP
+   board to the PC. If using Windows XP, it may be necessary to search for
+   the SDP drivers. Choose to automatically search for the drivers for the SDP
+   board if prompted by the operating system.
+-  Check that the board is connecting to the PC correctly using the
+   **Device Manager** of the PC. Access the **Device Manager** as follows:
 
    -  Right-click **My Computer** and then click **Manage**.
-   -  A dialog box appears asking for permission to allow the program to make changes to the PC. Click **Yes**.
-   -  The **Computer Management** window appears. Click **Device Manager** from the **System Tools** list (see Figure 12).
-   -  If the SDP board appears under **ADI Development Tools** in the **TEST PC** nested list, the driver software has installed and the board is connecting to the PC correctly.
+   -  A dialog box appears asking for permission to allow the program to make
+      changes to the PC. Click **Yes**.
+   -  The **Computer Management** window appears. Click **Device Manager**
+      from the **System Tools** list (see Figure 12).
+   -  If the SDP board appears under **ADI Development Tools** in the
+      **TEST PC** nested list, the driver software has installed and the board
+      is connecting to the PC correctly.
 
 |image9| **Figure 12. Checking if the Board is Connected to the PC Correctly**
 
 Launching the Software
 ~~~~~~~~~~~~~~~~~~~~~~
 
-After completing the steps in the Setting Up the System for Data Capture section, launch the **AD411X Eval+** software as follows:
+After completing the steps in the Setting Up the System for Data Capture
+section, launch the **AD411X Eval+** software as follows:
 
--  From the **Start** menu, click **Programs** > **Analog Devices** > **AD411X Eval+** > **AD411X Eval+**. The dialog box shown in Figure 13 appears. Select **AD4116 Evaluation Board** and the main window of the software shown in Figure 16 appears.
+-  From the **Start** menu, click **Programs** > **Analog Devices** >
+   **AD411X Eval+** > **AD411X Eval+**. The dialog box shown in Figure 13
+   appears. Select **AD4116 Evaluation Board** and the main window of the
+   software shown in Figure 16 appears.
 
 |image10| **Figure 13. AD4116 Evaluation Board Selection**
 
--  If the EVAL-AD4116ASDZ evaluation system is not connected to the USB port via the SDP when the software is launched, the software displays the dialog box shown in Figure 14. Connect the evaluation board to the USB port of the PC, wait a few seconds, then click **Refresh**, and the dialog box shown in Figure 13 appears.
+-  If the EVAL-AD4116ASDZ evaluation system is not connected to the USB port
+   via the SDP when the software is launched, the software displays the dialog
+   box shown in Figure 14. Connect the evaluation board to the USB port of the
+   PC, wait a few seconds, then click **Refresh**, and the dialog box shown in
+   Figure 13 appears.
 
 |image11| **Figure 14. Evaluation Board Selection, No Board Connected**
 
--  The dialog box shown in in Figure 15 appears. Quickstart mode provides a simplified version of the software that can be used as a starting point for evaluating the AD4116. This mode provides a graphical user interface (GUI) for setting up inputs, as shown in Figure 16, and allows the user to configure the device further by using the blue configuration buttons (Label 7 Figure 16).
--  Advanced mode can be used when more configurability of the inputs is required. In this mode, the input GUI is not available. However, the user has access to the **Registers** tab, which provides full control of the AD4116 register map. When operating in advanced mode, the user must consult the AD4116 data sheet.
+-  The dialog box shown in in Figure 15 appears. Quickstart mode provides a
+   simplified version of the software that can be used as a starting point for
+   evaluating the AD4116. This mode provides a graphical user interface (GUI)
+   for setting up inputs, as shown in Figure 16, and allows the user to
+   configure the device further by using the blue configuration buttons
+   (Label 7 Figure 16).
+-  Advanced mode can be used when more configurability of the inputs is
+   required. In this mode, the input GUI is not available. However, the user
+   has access to the **Registers** tab, which provides full control of the
+   AD4116 register map. When operating in advanced mode, the user must consult
+   the AD4116 data sheet.
 
 |image12| **Figure 15. AD411X Eval+ Startup Mode Selection**
 
 Eval+ Software Windows
 ----------------------
 
-After selecting **AD4116 Evaluation Board**, the main window of the evaluation software displays, as shown in Figure 16. This tab shows the control buttons and analysis indicators of the AD411X Eval+ software. The main window of the **AD411X Eval+** software in **Quickstart** mode contains five tabs: **Configuration**, **Voltage Waveform**, **Noise Table**, and **Histogram**. In advanced mode, two additional tabs are available: **Ch Waveform** and **Registers**.
+After selecting **AD4116 Evaluation Board**, the main window of the evaluation
+software displays, as shown in Figure 16. This tab shows the control buttons
+and analysis indicators of the AD411X Eval+ software. The main window of the
+**AD411X Eval+** software in **Quickstart** mode contains five tabs:
+**Configuration**, **Voltage Waveform**, **Noise Table**, and **Histogram**.
+In advanced mode, two additional tabs are available: **Ch Waveform** and
+**Registers**.
 
 |image13| **Figure 16. Configuration Tab in Quickstart Mode** |image14| **Figure 17. Configuration Tab in Advanced Mode**
 
@@ -123,33 +169,58 @@ Configuration Tab
 Inputs Quickstart Mode Only (1)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
--  The AD4116 has twelve voltage inputs and five low-level inputs, which can be configured as single-ended or fully differential pairs (Label 1 in Figure 16).
--  The voltage range can also be set per input to ±10 V, ±5 V, 0 V to 10 V, 0 V to 5 V or N/A for low-level inputs. Changing the appropriate voltage range provides more realistic values for **P - P Resolution** and **RMS Resolution** shown in the **Noise Analysis** area (Label 22 in Figure 18).
+-  The AD4116 has twelve voltage inputs and five low-level inputs, which can
+   be configured as single-ended or fully differential pairs (Label 1 in
+   Figure 16).
+-  The voltage range can also be set per input to ±10 V, ±5 V, 0 V to 10 V,
+   0 V to 5 V or N/A for low-level inputs. Changing the appropriate voltage
+   range provides more realistic values for **P - P Resolution** and
+   **RMS Resolution** shown in the **Noise Analysis** area (Label 22 in
+   Figure 18).
 
 Output Data Rate (ODR)/Measurement Time (2)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
--  The ODR can be set for all inputs in the Configuration tab (Label 2 in Figure 16). Set the ODR by entering a value in hertz into the **ODR(Hz)** box or a measurement time in milliseconds into the **Time(ms)** box. If an ODR is entered, the software calculates the measurement time. If a time is entered, the software calculates the fastest ODR that can achieve the required measurement time.
--  The device only supports a certain number of ODRs. Therefore, the software rounds up to the closest available value. ODR values depend on if a single or multiple channels are enabled. The fastest ODRs are available if only one channel is enabled. The values shown are valid for the sinc5 + sinc1 filter, which is enabled by default. If the sinc3 filter is enabled instead, refer to the AD4116 data sheet for the corresponding values.
--  The value in the **Time(ms)** box represents time taken for one sample for one enabled channel.
--  The value in the **Total Time** box represents the total time to take one sample for all enabled **Inputs**.
+-  The ODR can be set for all inputs in the Configuration tab (Label 2 in
+   Figure 16). Set the ODR by entering a value in hertz into the **ODR(Hz)**
+   box or a measurement time in milliseconds into the **Time(ms)** box. If an
+   ODR is entered, the software calculates the measurement time. If a time is
+   entered, the software calculates the fastest ODR that can achieve the
+   required measurement time.
+-  The device only supports a certain number of ODRs. Therefore, the software
+   rounds up to the closest available value. ODR values depend on if a single
+   or multiple channels are enabled. The fastest ODRs are available if only
+   one channel is enabled. The values shown are valid for the sinc5 + sinc1
+   filter, which is enabled by default. If the sinc3 filter is enabled
+   instead, refer to the AD4116 data sheet for the corresponding values.
+-  The value in the **Time(ms)** box represents time taken for one sample for
+   one enabled channel.
+-  The value in the **Total Time** box represents the total time to take one
+   sample for all enabled **Inputs**.
 
 Demo Modes (3)
 ^^^^^^^^^^^^^^
 
--  The **AD411X Eval+** software contains a number of demonstration modes in the **Demo Modes** area (Label 3 in Figure 16). These demonstration modes configure the AD4116 for each of the input types (represented by the **All ADCIN or All VIN Single-Ended and All Differential**).
+-  The **AD411X Eval+** software contains a number of demonstration modes in
+   the **Demo Modes** area (Label 3 in Figure 16). These demonstration modes
+   configure the AD4116 for each of the input types (represented by the
+   **All ADCIN or All VIN Single-Ended and All Differential**).
 
 ADC Reset (4)
 ^^^^^^^^^^^^^
 
--  Click **Reset** to perform a software reset of the AD4116 (Label 4 in Figure 16). There is no hardware reset pin on the AD4116.
+-  Click **Reset** to perform a software reset of the AD4116 (Label 4 in
+   Figure 16). There is no hardware reset pin on the AD4116.
 -  To perform a hard reset, remove power from the board. The software reset has
    the same effect as a hard reset.
 
 Tutorial Button (5)
 ^^^^^^^^^^^^^^^^^^^
 
--  Click the tutorial button (Label 5 in Figure 16) to open a tutorial on using the software and additional information on using the **AD411X Eval+** software. Click the blue information buttons for further information on different elements of the **Configuration** tab.
+-  Click the tutorial button (Label 5 in Figure 16) to open a tutorial on
+   using the software and additional information on using the **AD411X Eval+**
+   software. Click the blue information buttons for further information on
+   different elements of the **Configuration** tab.
 
 Functional Block Diagram (6)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -167,24 +238,41 @@ Configuration Popup Button (7)
 External Parameters (8,9,10)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
--  There are three external parameters that are set by the EVAL-AD4116ASDZ board but must be entered into the software: the external reference (Label 8 in Figure 16), AVDD (Label 9 in Figure 16), and AVSS (Label 10 in Figure 16). The external reference on the EVAL-AD4116ASDZ board is set to 2.5 V by using an ADR4525. If bypassing the ADR4525 on board, change the external reference voltage value in the software to ensure correct calculation of results in the **Waveform** and **Histogram** tabs.
+-  There are three external parameters that are set by the EVAL-AD4116ASDZ
+   board but must be entered into the software: the external reference (Label
+   8 in Figure 16), AVDD (Label 9 in Figure 16), and AVSS (Label 10 in Figure
+   16). The external reference on the EVAL-AD4116ASDZ board is set to 2.5 V
+   by using an ADR4525. If bypassing the ADR4525 on board, change the external
+   reference voltage value in the software to ensure correct calculation of
+   results in the **Waveform** and **Histogram** tabs.
 
 Configuration Summary (11)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
--  Clicking **Summary** (Label 11 in Figure 16) shows the input configuration, channel configuration, and information on each of the individual setups as well as information on any error present. These tabs can be used to quickly check how the ADC inputs and channels are configured, as well as any errors that are present.
+-  Clicking **Summary** (Label 11 in Figure 16) shows the input
+   configuration, channel configuration, and information on each of the
+   individual setups as well as information on any error present. These tabs
+   can be used to quickly check how the ADC inputs and channels are
+   configured, as well as any errors that are present.
 
 Status Bar (12)
 ^^^^^^^^^^^^^^^
 
--  The status bar (Label 12 in Figure 16) displays status updates such as **Analysis Completed**, **Reset Completed**, and **Writing to Registers** during software use, as well as the **Busy** indicator.
+-  The status bar (Label 12 in Figure 16) displays status updates such as
+   **Analysis Completed**, **Reset Completed**, and **Writing to Registers**
+   during software use, as well as the **Busy** indicator.
 
 Waveform Tab
 ~~~~~~~~~~~~
 
 |image15| **Figure 18. Voltage Waveform Tab**
 
-The AD411X Eval+ software has two different waveform tabs: **Voltage Waveform** and **Ch Waveform** (in advanced mode only). The waveform tabs graph the conversions gathered and processes the data, calculating the peak-to-peak noise, rms noise, and resolution (see Figure 18). The **Voltage Waveform** tab graphs the data at the voltage input in QuickStart mode. The **Ch Waveform** tab shows the data converted per channel in Advanced mode.
+The AD411X Eval+ software has two different waveform tabs: **Voltage
+Waveform** and **Ch Waveform** (in advanced mode only). The waveform tabs
+graph the conversions gathered and processes the data, calculating the
+peak-to-peak noise, rms noise, and resolution (see Figure 18). The **Voltage
+Waveform** tab graphs the data at the voltage input in QuickStart mode. The
+**Ch Waveform** tab shows the data converted per channel in Advanced mode.
 
 Waveform Graph and Controls (13,14)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -197,7 +285,13 @@ Waveform Graph and Controls (13,14)
 Samples (15,16)
 ^^^^^^^^^^^^^^^
 
--  The **Samples** box (Label 15 in Figure 18) and **Sampling Mode** (Label 16 in Figure 18) set the number of samples gathered per batch. If **Sampling Mode** is set to **Single Capture**, the ADC returns the number of samples specified in the **Samples** box. If **Sampling Mode** is set to **Continuous**, the ADC continuously returns samples until stopped by the user. **Samples** specifies the amount of samples to be shown on the data graph. **Samples** is unrelated to the ADC mode.
+-  The **Samples** box (Label 15 in Figure 18) and **Sampling Mode** (Label
+   16 in Figure 18) set the number of samples gathered per batch. If
+   **Sampling Mode** is set to **Single Capture**, the ADC returns the number
+   of samples specified in the **Samples** box. If **Sampling Mode** is set to
+   **Continuous**, the ADC continuously returns samples until stopped by the
+   user. **Samples** specifies the amount of samples to be shown on the data
+   graph. **Samples** is unrelated to the ADC mode.
 
 Sample (17)
 ^^^^^^^^^^^
@@ -208,41 +302,62 @@ Sample (17)
 Plot Selection (18)
 ^^^^^^^^^^^^^^^^^^^
 
--  The plot selection control area (Label 18 in Figure 18) allows the user to select which inputs display on the data waveform and shows the name of the input.
+-  The plot selection control area (Label 18 in Figure 18) allows the user to
+   select which inputs display on the data waveform and shows the name of the
+   input.
 -  These controls only affect the waveform graphs and have no effect on the
    channel settings in the ADC register map.
 
 Display Units and Axis Controls (19)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
--  Click the **Units** box in the **Graph Configuration** area (Label 19 in Figure 18) to select whether the data graph displays in units of voltage in amps or codes. This control is independent for each graph. The **Y-scale** and **X scale** boxes can be set to autoscale or fixed scaling. When **Autoscale** is selected, the axis automatically adjusts to show the entire range of the ADC results after each batch of samples. When **Fixed** is selected, the axis range can be set by the user. These ranges do not automatically adjust after each batch of samples.
+-  Click the **Units** box in the **Graph Configuration** area (Label 19 in
+   Figure 18) to select whether the data graph displays in units of voltage in
+   amps or codes. This control is independent for each graph. The **Y-scale**
+   and **X scale** boxes can be set to autoscale or fixed scaling. When
+   **Autoscale** is selected, the axis automatically adjusts to show the
+   entire range of the ADC results after each batch of samples. When
+   **Fixed** is selected, the axis range can be set by the user. These ranges
+   do not automatically adjust after each batch of samples.
 
 Device Error (20)
 ^^^^^^^^^^^^^^^^^
 
--  The **Device Error** indicator (Label 20 in Figure 18) illuminates in the **Waveform** tab when a cyclic redundancy check (CRC) error or an error in the ADC is detected. More specific information on the error can be by clicking Summary in the Configuration tab (Label 11 in Figure 16).
+-  The **Device Error** indicator (Label 20 in Figure 18) illuminates in the
+   **Waveform** tab when a cyclic redundancy check (CRC) error or an error in
+   the ADC is detected. More specific information on the error can be by
+   clicking Summary in the Configuration tab (Label 11 in Figure 16).
 
 Analysis Input (21)
 ^^^^^^^^^^^^^^^^^^^
 
--  The **Noise Analysis** box shows the analysis of the input selected via the analysis control (Label 21 in Figure 18).
+-  The **Noise Analysis** box shows the analysis of the input selected via
+   the analysis control (Label 21 in Figure 18).
 
 Noise Analysis (22)
 ^^^^^^^^^^^^^^^^^^^
 
--  The **Noise Analysis** area (Label 22 in Figure 18) displays the results of the noise analysis for the selected analysis input, including both noise and resolution measurements.
+-  The **Noise Analysis** area (Label 22 in Figure 18) displays the results
+   of the noise analysis for the selected analysis input, including both noise
+   and resolution measurements.
 
 Input Range (23)
 ^^^^^^^^^^^^^^^^
 
--  The **Range** box (Label 23 in Figure 18) is an indicator in QuickStart mode. The value is selected in the inputs area on the **Configuration** tab (Label 1 in Figure 16). In advanced mode, **Range** is a control that allows the user to select an input range for the input chosen for noise analysis.
+-  The **Range** box (Label 23 in Figure 18) is an indicator in QuickStart
+   mode. The value is selected in the inputs area on the **Configuration** tab
+   (Label 1 in Figure 16). In advanced mode, **Range** is a control that
+   allows the user to select an input range for the input chosen for noise
+   analysis.
 
 Histogram Tab
 ~~~~~~~~~~~~~
 
-The **Histogram** tab generates a histogram using the gathered samples and processes the data, calculating the peak-to-peak noise, rms noise, and resolution (see Figure 19).
+The **Histogram** tab generates a histogram using the gathered samples and
+processes the data, calculating the peak-to-peak noise, rms noise, and
+resolution (see Figure 19).
 
-|image16| \*\* Figure 19. Histogram Tab of the AD411X Eval+ Software \*\*
+|image16| *Figure 19. Histogram Tab of the AD411X Eval+ Software*
 
 Histogram Graph and Controls (24,25)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -255,29 +370,45 @@ Histogram Graph and Controls (24,25)
 Noise Analysis (26)
 ^^^^^^^^^^^^^^^^^^^
 
--  The **Noise Analysis** area (Label 26 in Figure 19) displays the results of the noise analysis for the selected analysis input, including both noise and resolution measurements.
+-  The **Noise Analysis** area (Label 26 in Figure 19) displays the results
+   of the noise analysis for the selected analysis input, including both noise
+   and resolution measurements.
 
 Analysis Input (27)
 ^^^^^^^^^^^^^^^^^^^
 
--  The data used to generate the histogram and values in the **Noise Analysis** area (Label 26 in Figure 19) is set by the **Noise Analysis** box (Label 27 in Figure 19). All enabled inputs appear here in the Noise Analysis box.
+-  The data used to generate the histogram and values in the **Noise
+   Analysis** area (Label 26 in Figure 19) is set by the **Noise Analysis**
+   box (Label 27 in Figure 19). All enabled inputs appear here in the Noise
+   Analysis box.
 
 Display Units and Axis Controls (28)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
--  Click the **Units** box in the **Graph Configuration** area (Label 28 in Figure 19) to select whether the data graph displays in units of voltages/amps or codes. This control is independent for each graph.
+-  Click the **Units** box in the **Graph Configuration** area (Label 28 in
+   Figure 19) to select whether the data graph displays in units of
+   voltages/amps or codes. This control is independent for each graph.
 
-The **Y-scale** and **X scale** boxes can be set to autoscale or fixed scaling. When **Autoscale** is selected, the axis automatically adjusts to show the entire range of the ADC results after each batch of samples. When **Fixed** is selected, the user can set the axis range. These ranges do not automatically adjust after each batch of samples.
+The **Y-scale** and **X scale** boxes can be set to autoscale or fixed
+scaling. When **Autoscale** is selected, the axis automatically adjusts to
+show the entire range of the ADC results after each batch of samples. When
+**Fixed** is selected, the user can set the axis range. These ranges do not
+automatically adjust after each batch of samples.
 
 Device Error (29)
 ^^^^^^^^^^^^^^^^^
 
--  The **Device Error** indicator (Label 29 in Figure 19) illuminates in the **Histogram** tab when a CRC error or an error in the ADC is detected. More specific information on the error can be by clicking **Summary** in the **Configuration** tab (Label 11 in Figure 16).
+-  The **Device Error** indicator (Label 29 in Figure 19) illuminates in the
+   **Histogram** tab when a CRC error or an error in the ADC is detected. More
+   specific information on the error can be by clicking **Summary** in the
+   **Configuration** tab (Label 11 in Figure 16).
 
 Register Map Tab
 ~~~~~~~~~~~~~~~~
 
-Use the Register Map tab to access the registers of the AD7124-8. This tab changes register settings and shows additional information about each bit in each individual register. |image17| **Figure 20. Register Tab**
+Use the Register Map tab to access the registers of the AD7124-8. This tab
+changes register settings and shows additional information about each bit in
+each individual register. |image17| **Figure 20. Register Tab**
 
 Register Map (30)
 ^^^^^^^^^^^^^^^^^
@@ -307,12 +438,19 @@ Register and Bit Field Control (32-35)
 Documentation (36,37)
 ^^^^^^^^^^^^^^^^^^^^^
 
--  The **Documentation** area (Label 37 in Figure 20) contains the documentation for the register or the bit field selected. This field can be updated by selecting a register or bit field in the register list or hovering over the register or bit field in the register list or register control. The documentation area can also be displayed in a separate window by clicking **Expand** (Label 36 in Figure 20).
+-  The **Documentation** area (Label 37 in Figure 20) contains the
+   documentation for the register or the bit field selected. This field can be
+   updated by selecting a register or bit field in the register list or
+   hovering over the register or bit field in the register list or register
+   control. The documentation area can also be displayed in a separate window
+   by clicking **Expand** (Label 36 in Figure 20).
 
 Save and Load (38)
 ^^^^^^^^^^^^^^^^^^
 
--  **Save** and **Load** (Label 38 in Figure 20) allow the user to save the current register map setting to a file and to load the setting from the same file, respectively.
+-  **Save** and **Load** (Label 38 in Figure 20) allow the user to save the
+   current register map setting to a file and to load the setting from the
+   same file, respectively.
 
 :doc:`Return to Hardware Guide </solutions/reference-designs/eval-ad4116asdz/hardware_guide>` :doc:`Return to Homepage </solutions/reference-designs/eval-ad4116asdz/eval-ad4116asdz>`
 

--- a/docs/solutions/reference-designs/eval-ad4116asdz/software.rst
+++ b/docs/solutions/reference-designs/eval-ad4116asdz/software.rst
@@ -1,0 +1,352 @@
+Software Guide
+==============
+
+Eval+ Software
+==============
+
+The AD411x Evaluation+ software is available :adi:`Here. <media/en/evaluation-boards-kits/evaluation-software/ad411x-eval-installer.zip>`
+
+The quick start guide is available on the landing page here :doc:`(Quick Start Guide) </solutions/reference-designs/eval-ad4116asdz/eval-ad4116asdz>` or for the step by step install guide see the below
+
+Install Guide
+-------------
+
+The EVAL-AD4116ASDZ evaluation kit includes a link to the software that needs to
+be installed before using the EVAL-AD4116ASDZ evaluation board. There are two
+parts to the installation:
+
+-  **AD411X Eval+** software installation
+-  **EVAL+ Dependencies** installation, including SDP board drivers
+
+.. important::
+
+   \ Warning: The evaluation software and drivers must be installed before
+   connecting both the evaluation board and the SDP-B board to the PC. This
+   ensures that the evaluations system is correctly recognized when it is
+   connected to the PC.
+
+Installing the AD411x Eval+ Software
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To install the **AD411X Eval+** software,
+
+-  With the SDP board disconnected from the USB port of the PC, download and unzip the **AD411X Eval+** software installer file from the EVAL-AD4116ASDZ product page.
+-  Double-click the **setup.exe** file to begin the evaluation board software installation. The software then installs to the following default location: **C:\\Program Files\\Analog Devices\\AD411X EVAL+**.
+-  A dialog box appears asking for permission to allow the program to make changes to the PC. Click **Yes**.
+
+|image1| **Figure 4. Granting Permission for the Program to Make Changes to PC**
+
+-  Select a location to install the software and then click Next. Figure 5 shows the default locations, which are displayed when the dialogue box opens, but another location can be selected by clicking **Browse**.
+
+|image2| **Figure 5. Selecting the Location for Software Installation**
+
+-  A license agreement appears. Read the agreement, select **I accept the License Agreement**, and click **Next**.
+
+|image3| **Figure 6. Accepting the License Agreement**
+
+-  A summary of the installation displays. Click Next to continue.
+
+|image4| **Figure 7. Reviewing a Summary of the Installation**
+
+-  The message in Figure 8 appears when the installation is complete. Click **Next**.
+
+|image5| **Figure 8. Indicating when the Installation is Complete**
+
+Installing the Eval+ Dependencies Drivers
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+After the installation of the evaluation software is complete, a welcome window appears for the installation of the **Eval+ Dependencies**.
+
+-  With the SDP board still disconnected from the USB port of the PC, ensure that all other applications are closed, and then click **Install**.
+
+|image6| **Figure 9. Beginning the Drivers Installation**
+
+-  To complete the driver installation, click **Close**, which closes the installation setup wizard.
+
+|image7| **Figure 10. Completing the Drivers Setup Wizard**
+
+-  Before using the evaluation board, restart the PC.
+
+|image8| **Figure 11. Restarting the PC**
+
+Setting Up the System for Data Capture
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+After completing the steps in the Software Installation Procedures section and
+the Evaluation Board Hardware section, set up the system for data capture as
+follows:
+
+-  Allow the **Found New Hardware** wizard to run after connecting the SDP board to the PC. If using Windows XP, it may be necessary to search for the SDP drivers. Choose to automatically search for the drivers for the SDP board if prompted by the operating system.
+-  Check that the board is connecting to the PC correctly using the **Device Manager** of the PC. Access the **Device Manager** as follows:
+
+   -  Right-click **My Computer** and then click **Manage**.
+   -  A dialog box appears asking for permission to allow the program to make changes to the PC. Click **Yes**.
+   -  The **Computer Management** window appears. Click **Device Manager** from the **System Tools** list (see Figure 12).
+   -  If the SDP board appears under **ADI Development Tools** in the **TEST PC** nested list, the driver software has installed and the board is connecting to the PC correctly.
+
+|image9| **Figure 12. Checking if the Board is Connected to the PC Correctly**
+
+Launching the Software
+~~~~~~~~~~~~~~~~~~~~~~
+
+After completing the steps in the Setting Up the System for Data Capture section, launch the **AD411X Eval+** software as follows:
+
+-  From the **Start** menu, click **Programs** > **Analog Devices** > **AD411X Eval+** > **AD411X Eval+**. The dialog box shown in Figure 13 appears. Select **AD4116 Evaluation Board** and the main window of the software shown in Figure 16 appears.
+
+|image10| **Figure 13. AD4116 Evaluation Board Selection**
+
+-  If the EVAL-AD4116ASDZ evaluation system is not connected to the USB port via the SDP when the software is launched, the software displays the dialog box shown in Figure 14. Connect the evaluation board to the USB port of the PC, wait a few seconds, then click **Refresh**, and the dialog box shown in Figure 13 appears.
+
+|image11| **Figure 14. Evaluation Board Selection, No Board Connected**
+
+-  The dialog box shown in in Figure 15 appears. Quickstart mode provides a simplified version of the software that can be used as a starting point for evaluating the AD4116. This mode provides a graphical user interface (GUI) for setting up inputs, as shown in Figure 16, and allows the user to configure the device further by using the blue configuration buttons (Label 7 Figure 16).
+-  Advanced mode can be used when more configurability of the inputs is required. In this mode, the input GUI is not available. However, the user has access to the **Registers** tab, which provides full control of the AD4116 register map. When operating in advanced mode, the user must consult the AD4116 data sheet.
+
+|image12| **Figure 15. AD411X Eval+ Startup Mode Selection**
+
+Eval+ Software Windows
+----------------------
+
+After selecting **AD4116 Evaluation Board**, the main window of the evaluation software displays, as shown in Figure 16. This tab shows the control buttons and analysis indicators of the AD411X Eval+ software. The main window of the **AD411X Eval+** software in **Quickstart** mode contains five tabs: **Configuration**, **Voltage Waveform**, **Noise Table**, and **Histogram**. In advanced mode, two additional tabs are available: **Ch Waveform** and **Registers**.
+
+|image13| **Figure 16. Configuration Tab in Quickstart Mode** |image14| **Figure 17. Configuration Tab in Advanced Mode**
+
+Configuration Tab
+~~~~~~~~~~~~~~~~~
+
+-  The Configuration tab shows a block diagram of the AD4116. This tab allows
+   the user to select inputs, set up the ADC, reset the ADC, view errors
+   present, and configure the device for different demonstration modes. Figure
+   16 shows the Configuration tab in detail, and the following sections discuss
+   the different elements on the Configuration tab of the software window.
+
+Inputs Quickstart Mode Only (1)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+-  The AD4116 has twelve voltage inputs and five low-level inputs, which can be configured as single-ended or fully differential pairs (Label 1 in Figure 16).
+-  The voltage range can also be set per input to ±10 V, ±5 V, 0 V to 10 V, 0 V to 5 V or N/A for low-level inputs. Changing the appropriate voltage range provides more realistic values for **P - P Resolution** and **RMS Resolution** shown in the **Noise Analysis** area (Label 22 in Figure 18).
+
+Output Data Rate (ODR)/Measurement Time (2)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+-  The ODR can be set for all inputs in the Configuration tab (Label 2 in Figure 16). Set the ODR by entering a value in hertz into the **ODR(Hz)** box or a measurement time in milliseconds into the **Time(ms)** box. If an ODR is entered, the software calculates the measurement time. If a time is entered, the software calculates the fastest ODR that can achieve the required measurement time.
+-  The device only supports a certain number of ODRs. Therefore, the software rounds up to the closest available value. ODR values depend on if a single or multiple channels are enabled. The fastest ODRs are available if only one channel is enabled. The values shown are valid for the sinc5 + sinc1 filter, which is enabled by default. If the sinc3 filter is enabled instead, refer to the AD4116 data sheet for the corresponding values.
+-  The value in the **Time(ms)** box represents time taken for one sample for one enabled channel.
+-  The value in the **Total Time** box represents the total time to take one sample for all enabled **Inputs**.
+
+Demo Modes (3)
+^^^^^^^^^^^^^^
+
+-  The **AD411X Eval+** software contains a number of demonstration modes in the **Demo Modes** area (Label 3 in Figure 16). These demonstration modes configure the AD4116 for each of the input types (represented by the **All ADCIN or All VIN Single-Ended and All Differential**).
+
+ADC Reset (4)
+^^^^^^^^^^^^^
+
+-  Click **Reset** to perform a software reset of the AD4116 (Label 4 in Figure 16). There is no hardware reset pin on the AD4116.
+-  To perform a hard reset, remove power from the board. The software reset has
+   the same effect as a hard reset.
+
+Tutorial Button (5)
+^^^^^^^^^^^^^^^^^^^
+
+-  Click the tutorial button (Label 5 in Figure 16) to open a tutorial on using the software and additional information on using the **AD411X Eval+** software. Click the blue information buttons for further information on different elements of the **Configuration** tab.
+
+Functional Block Diagram (6)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+-  The functional block diagram of the AD4116 (Label 6 in Figure 16) shows each
+   of the functional blocks within the AD4116. Clicking a configuration button
+   on the block diagram opens the configuration window for that block.
+
+Configuration Popup Button (7)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+-  Each configuration button (Label 7 in Figure 16) opens a different window to
+   configure the relevant functional block.
+
+External Parameters (8,9,10)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+-  There are three external parameters that are set by the EVAL-AD4116ASDZ board but must be entered into the software: the external reference (Label 8 in Figure 16), AVDD (Label 9 in Figure 16), and AVSS (Label 10 in Figure 16). The external reference on the EVAL-AD4116ASDZ board is set to 2.5 V by using an ADR4525. If bypassing the ADR4525 on board, change the external reference voltage value in the software to ensure correct calculation of results in the **Waveform** and **Histogram** tabs.
+
+Configuration Summary (11)
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+-  Clicking **Summary** (Label 11 in Figure 16) shows the input configuration, channel configuration, and information on each of the individual setups as well as information on any error present. These tabs can be used to quickly check how the ADC inputs and channels are configured, as well as any errors that are present.
+
+Status Bar (12)
+^^^^^^^^^^^^^^^
+
+-  The status bar (Label 12 in Figure 16) displays status updates such as **Analysis Completed**, **Reset Completed**, and **Writing to Registers** during software use, as well as the **Busy** indicator.
+
+Waveform Tab
+~~~~~~~~~~~~
+
+|image15| **Figure 18. Voltage Waveform Tab**
+
+The AD411X Eval+ software has two different waveform tabs: **Voltage Waveform** and **Ch Waveform** (in advanced mode only). The waveform tabs graph the conversions gathered and processes the data, calculating the peak-to-peak noise, rms noise, and resolution (see Figure 18). The **Voltage Waveform** tab graphs the data at the voltage input in QuickStart mode. The **Ch Waveform** tab shows the data converted per channel in Advanced mode.
+
+Waveform Graph and Controls (13,14)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+-  The data waveform graph (Label 13 in Figure 18) shows each successive sample
+   of the ADC output. Zoom in on the data in the graph using the control buttons
+   (Label 14 in Figure 18). Change the scales on the graph by typing values into
+   the x-axis and y-axis.
+
+Samples (15,16)
+^^^^^^^^^^^^^^^
+
+-  The **Samples** box (Label 15 in Figure 18) and **Sampling Mode** (Label 16 in Figure 18) set the number of samples gathered per batch. If **Sampling Mode** is set to **Single Capture**, the ADC returns the number of samples specified in the **Samples** box. If **Sampling Mode** is set to **Continuous**, the ADC continuously returns samples until stopped by the user. **Samples** specifies the amount of samples to be shown on the data graph. **Samples** is unrelated to the ADC mode.
+
+Sample (17)
+^^^^^^^^^^^
+
+-  Click Sample (Label 17 in Figure 18) to start gathering ADC results. Results
+   appear in the waveform graph.
+
+Plot Selection (18)
+^^^^^^^^^^^^^^^^^^^
+
+-  The plot selection control area (Label 18 in Figure 18) allows the user to select which inputs display on the data waveform and shows the name of the input.
+-  These controls only affect the waveform graphs and have no effect on the
+   channel settings in the ADC register map.
+
+Display Units and Axis Controls (19)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+-  Click the **Units** box in the **Graph Configuration** area (Label 19 in Figure 18) to select whether the data graph displays in units of voltage in amps or codes. This control is independent for each graph. The **Y-scale** and **X scale** boxes can be set to autoscale or fixed scaling. When **Autoscale** is selected, the axis automatically adjusts to show the entire range of the ADC results after each batch of samples. When **Fixed** is selected, the axis range can be set by the user. These ranges do not automatically adjust after each batch of samples.
+
+Device Error (20)
+^^^^^^^^^^^^^^^^^
+
+-  The **Device Error** indicator (Label 20 in Figure 18) illuminates in the **Waveform** tab when a cyclic redundancy check (CRC) error or an error in the ADC is detected. More specific information on the error can be by clicking Summary in the Configuration tab (Label 11 in Figure 16).
+
+Analysis Input (21)
+^^^^^^^^^^^^^^^^^^^
+
+-  The **Noise Analysis** box shows the analysis of the input selected via the analysis control (Label 21 in Figure 18).
+
+Noise Analysis (22)
+^^^^^^^^^^^^^^^^^^^
+
+-  The **Noise Analysis** area (Label 22 in Figure 18) displays the results of the noise analysis for the selected analysis input, including both noise and resolution measurements.
+
+Input Range (23)
+^^^^^^^^^^^^^^^^
+
+-  The **Range** box (Label 23 in Figure 18) is an indicator in QuickStart mode. The value is selected in the inputs area on the **Configuration** tab (Label 1 in Figure 16). In advanced mode, **Range** is a control that allows the user to select an input range for the input chosen for noise analysis.
+
+Histogram Tab
+~~~~~~~~~~~~~
+
+The **Histogram** tab generates a histogram using the gathered samples and processes the data, calculating the peak-to-peak noise, rms noise, and resolution (see Figure 19).
+
+|image16| \*\* Figure 19. Histogram Tab of the AD411X Eval+ Software \*\*
+
+Histogram Graph and Controls (24,25)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+-  The data histogram graph (Label 24 in Figure 19) shows the number of times
+   each sample of the ADC output occurs. Zoom in on the data using the control
+   buttons (Label 25 in Figure 19) in the graph. Change the scales on the graph
+   by typing values into the x-axis and y-axis.
+
+Noise Analysis (26)
+^^^^^^^^^^^^^^^^^^^
+
+-  The **Noise Analysis** area (Label 26 in Figure 19) displays the results of the noise analysis for the selected analysis input, including both noise and resolution measurements.
+
+Analysis Input (27)
+^^^^^^^^^^^^^^^^^^^
+
+-  The data used to generate the histogram and values in the **Noise Analysis** area (Label 26 in Figure 19) is set by the **Noise Analysis** box (Label 27 in Figure 19). All enabled inputs appear here in the Noise Analysis box.
+
+Display Units and Axis Controls (28)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+-  Click the **Units** box in the **Graph Configuration** area (Label 28 in Figure 19) to select whether the data graph displays in units of voltages/amps or codes. This control is independent for each graph.
+
+The **Y-scale** and **X scale** boxes can be set to autoscale or fixed scaling. When **Autoscale** is selected, the axis automatically adjusts to show the entire range of the ADC results after each batch of samples. When **Fixed** is selected, the user can set the axis range. These ranges do not automatically adjust after each batch of samples.
+
+Device Error (29)
+^^^^^^^^^^^^^^^^^
+
+-  The **Device Error** indicator (Label 29 in Figure 19) illuminates in the **Histogram** tab when a CRC error or an error in the ADC is detected. More specific information on the error can be by clicking **Summary** in the **Configuration** tab (Label 11 in Figure 16).
+
+Register Map Tab
+~~~~~~~~~~~~~~~~
+
+Use the Register Map tab to access the registers of the AD7124-8. This tab changes register settings and shows additional information about each bit in each individual register. |image17| **Figure 20. Register Tab**
+
+Register Map (30)
+^^^^^^^^^^^^^^^^^
+
+-  Clicking the register maps nested list (Label 30 in Figure 20) shows each
+   register. Clicking the expand button next to each register shows all the bit
+   fields contained within that register.
+
+Search (31)
+^^^^^^^^^^^
+
+-  The search box (Label 31 in Figure 20) allows the user to search the register
+   maps list for any register or bit field. Entering a value into this control
+   filters the register list.
+
+Register and Bit Field Control (32-35)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+-  The register control area (Label 32 in Figure 20) allows the user to change
+   the individual bit of the register selected in the register by clicking the
+   bits or by programming the register value directly into the value control box
+   (Label 33 in Figure 20). The register and bit controls also show all bit
+   fields for the selected register. Change the values by using the dropdown
+   boxes (Label 34 in Figure 20) or by selecting or clearing a check box (Label
+   35 in Figure 20).
+
+Documentation (36,37)
+^^^^^^^^^^^^^^^^^^^^^
+
+-  The **Documentation** area (Label 37 in Figure 20) contains the documentation for the register or the bit field selected. This field can be updated by selecting a register or bit field in the register list or hovering over the register or bit field in the register list or register control. The documentation area can also be displayed in a separate window by clicking **Expand** (Label 36 in Figure 20).
+
+Save and Load (38)
+^^^^^^^^^^^^^^^^^^
+
+-  **Save** and **Load** (Label 38 in Figure 20) allow the user to save the current register map setting to a file and to load the setting from the same file, respectively.
+
+:doc:`Return to Hardware Guide </solutions/reference-designs/eval-ad4116asdz/hardware_guide>` :doc:`Return to Homepage </solutions/reference-designs/eval-ad4116asdz/eval-ad4116asdz>`
+
+.. |image1| image:: images/26267-004.png
+   :width: 400
+.. |image2| image:: images/26267-005.png
+   :width: 400
+.. |image3| image:: images/26267-006.png
+   :width: 400
+.. |image4| image:: images/26267-007.png
+   :width: 400
+.. |image5| image:: images/26267-008.png
+   :width: 400
+.. |image6| image:: images/26267-009.png
+   :width: 400
+.. |image7| image:: images/26267-010.png
+   :width: 400
+.. |image8| image:: images/26267-011.png
+   :width: 400
+.. |image9| image:: images/26267-012.png
+   :width: 400
+.. |image10| image:: images/26267-013.png
+   :width: 400
+.. |image11| image:: images/26267-014.png
+   :width: 400
+.. |image12| image:: images/26267-015.png
+   :width: 400
+.. |image13| image:: images/26267-016.png
+   :width: 600
+.. |image14| image:: images/26267-017.png
+   :width: 600
+.. |image15| image:: images/26267-018.png
+   :width: 600
+.. |image16| image:: images/26267-019.png
+   :width: 600
+.. |image17| image:: images/26267-020.png
+   :width: 600


### PR DESCRIPTION
## Summary
- Move eval-ad4116asdz wiki documentation to `solutions/reference-designs/eval-ad4116asdz/`
- 4 RST files with 22 localized images
- Generated stub `index.rst` with toctree

## Test plan
- [ ] Sphinx build passes without errors
- [ ] All toctree entries resolve correctly
- [ ] Images render properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)