### PR TITLE
reference-designs/eval-ad5940: Add eval-ad5940 documentation

### DIFF
--- a/docs/solutions/reference-designs/eval-ad5940/calibration_routines.rst
+++ b/docs/solutions/reference-designs/eval-ad5940/calibration_routines.rst
@@ -1,0 +1,17 @@
+AD5940 Calibration Routines
+===========================
+
+The AD5940 is highly complex providing a large range of configuration options
+for the ADC circuits, the DAC circuits and current measuring channels. This
+section describes the calibration routines implemented on the AD5940 to
+calibrate gain errors, offset errors and internal load and gain resistors on the
+current channels.
+
+The following examples detail how the relevant calibration routine is
+implemented
+
+-  :doc:`Low Frequency Oscillator Calibration </solutions/reference-designs/eval-ad5940/calibration_routines/lfosc_cal>`
+-  :doc:`ADC Calibration </solutions/reference-designs/eval-ad5940/calibration_routines/adc_cal>`
+-  :doc:`High Speed DAC Calibration </solutions/reference-designs/eval-ad5940/calibration_routines/hsdac_cal>`
+-  :doc:`High Speed TIA Calibration </solutions/reference-designs/eval-ad5940/calibration_routines/hstia_cal>`
+-  :doc:`Low Power TIA Calibration </solutions/reference-designs/eval-ad5940/calibration_routines/lptia_cal>`

--- a/docs/solutions/reference-designs/eval-ad5940/calibration_routines/adc_cal.rst
+++ b/docs/solutions/reference-designs/eval-ad5940/calibration_routines/adc_cal.rst
@@ -1,0 +1,85 @@
+ADC PGA Calibration
+===================
+
+Overview
+--------
+
+The AD5940 has a large number of possible current and gain stages to its SAR
+ADC. The ADC voltage input has 5x PGA gain settings. There are separate Offset
+and Gain calibration registers for each gain setting. The ADC can work in low
+power mode from 16MHz clock or in high power mode from 32MHz clock.
+Self-calibration code was developed so the ADC can self calibrate itself for all
+configuration without the need for an external precision voltage source. It uses
+the internal 1.82V reference. The accuracy of the reference is ±5 mV with only
+20 ppm/ºC drift. This means it is suitable for self-calibration. The figure
+below displays the various current and voltage input options for the ADC.
+
+.. image:: ../images/adc_circuits.png
+   :width: 600
+
+Calibration Steps
+-----------------
+
+The following are the steps involved for calibrating the ADC PGA offset and gain
+errors:
+
+::
+
+   *Calibrate ADC offset for each PGA gain setting by connecting the 1.11V ADC reference to the P mux and N mux of the ADC. The expected coded is 0x8000. The offset error is expected code - measured code. The ADCOFFSET registers have a resolution of 0.25 bits.
+   *For PGA gain of 1, 1.5 and 2 the gain calibration is done using the internal 1.82V reference. The precision reference is connected to the P mux and the 1.11V ADC reference is connected to the N mux.
+   *For PGA gain of 4 and 9 the HSDAC is used to generate a voltage across the external RCAL resistor. The P-Node and N-Node are connected to the ADC mux.
+
+Using the ADC Calibration Function in the SDK
+---------------------------------------------
+
+The ADC PGA calibration code is implemented in the AD5940 SDK. The function
+AD5940_ADCPGACal() is used. It accepts one input argument of type
+ADCPGACal_Type. The members of this datatype and their function are as follows:
+
+-  SysClkFreq - defines the frequency of the system clock. Should be 16MHz
+-  AdcClkFreq - defines the frequency of the ADC clock. Should be 16MHz or 32MHz.
+-  Vref1p82 - The voltage of the 1.82 reference. Measured on Vfref1P82 pin
+-  Vref1p11 - The actual voltage of 1.11V ADC reference. Measured on VBIAS_CAP pin
+-  ADCSinc3Osr - Sinc3 Oversampling rate. Ideally 4.
+-  ADCSinc2Osr - Sinc2 Oversampling rate. Should be a big value to remove noise from measurement
+-  ADCPga - Selected PGA setting
+-  PGACalType - type of calibration. Offset, gain or both.
+-  TimeOut10us - Timeout for ADC measurement.
+
+If the PGA needs to be calibrated for a gain of 9 the PGA gain of 1 must be
+calibrated first. The following is example code to calibrate the PGA offset and
+gain for all settings:
+
+::
+
+   static AD5940Err AppADCPgaCal(void)
+   {
+      ADCPGACal_Type pga_cal;
+
+::
+
+      /* Calibrate ADC PGA(offset and gain) */
+      pga_cal.AdcClkFreq = AppAMPCfg.AdcClkFreq;
+      pga_cal.SysClkFreq = AppAMPCfg.SysClkFreq;
+      pga_cal.ADCPga = ADCPGA_1;
+      pga_cal.ADCSinc2Osr = ADCSINC2OSR_1333;    /* 800kSPS/4/1333 = 150Hz,  T = 6.67ms*/
+      pga_cal.ADCSinc3Osr = ADCSINC3OSR_4;
+      pga_cal.TimeOut10us = 10\*100;          /* 10ms max */
+      pga_cal.VRef1p82 = AppAMPCfg.ADCRefVolt;
+      pga_cal.VRef1p11  = 1.0979f;
+      pga_cal.PGACalType = PGACALTYPE_OFFSETGAIN; /* Calibrate Offset and Gain errors */
+      AD5940_ADCPGACal(&pga_cal);
+      /* Calibrate Offset and Gain for PGA = 1.5 */
+      pga_cal.ADCPga = ADCPGA_1P5;
+      AD5940_ADCPGACal(&pga_cal);
+      /* Calibrate Offset and Gain for PGA = 2 */
+      pga_cal.ADCPga = ADCPGA_2;
+      AD5940_ADCPGACal(&pga_cal);
+      /* Calibrate Offset and Gain for PGA = 4 */
+      pga_cal.ADCPga = ADCPGA_4;
+      AD5940_ADCPGACal(&pga_cal);
+      /* Calibrate Offset and Gain for PGA = 9 */
+      pga_cal.ADCPga = ADCPGA_9;
+      AD5940_ADCPGACal(&pga_cal);
+      return AD5940ERR_OK;
+   }

--- a/docs/solutions/reference-designs/eval-ad5940/calibration_routines/adc_cal.rst
+++ b/docs/solutions/reference-designs/eval-ad5940/calibration_routines/adc_cal.rst
@@ -37,11 +37,14 @@ AD5940_ADCPGACal() is used. It accepts one input argument of type
 ADCPGACal_Type. The members of this datatype and their function are as follows:
 
 -  SysClkFreq - defines the frequency of the system clock. Should be 16MHz
--  AdcClkFreq - defines the frequency of the ADC clock. Should be 16MHz or 32MHz.
+-  AdcClkFreq - defines the frequency of the ADC clock. Should be 16MHz or
+   32MHz.
 -  Vref1p82 - The voltage of the 1.82 reference. Measured on Vfref1P82 pin
--  Vref1p11 - The actual voltage of 1.11V ADC reference. Measured on VBIAS_CAP pin
+-  Vref1p11 - The actual voltage of 1.11V ADC reference. Measured on
+   VBIAS_CAP pin
 -  ADCSinc3Osr - Sinc3 Oversampling rate. Ideally 4.
--  ADCSinc2Osr - Sinc2 Oversampling rate. Should be a big value to remove noise from measurement
+-  ADCSinc2Osr - Sinc2 Oversampling rate. Should be a big value to remove
+   noise from measurement
 -  ADCPga - Selected PGA setting
 -  PGACalType - type of calibration. Offset, gain or both.
 -  TimeOut10us - Timeout for ADC measurement.

--- a/docs/solutions/reference-designs/eval-ad5940/calibration_routines/hsdac_cal.rst
+++ b/docs/solutions/reference-designs/eval-ad5940/calibration_routines/hsdac_cal.rst
@@ -1,0 +1,90 @@
+HSDAC Calibration
+=================
+
+Overview
+--------
+
+The high speed DAC is not calibrated during production testing. This section
+describes the steps to calibrate the offset errors on the high speed DAC for all
+gain settings and in both high power and low power modes. The high speed DAC
+should be calibrated if it is intended to generate a precision excitation signal
+to a sensor. If an offset error exists on the excitation signal, and a current
+or voltage output is to be measured, the excitation signal may exceed the
+headroom of the selected TIA or ADC input buffer/PGA setting.
+
+.. image:: ../images/ad5940_hsdaccal.jpg
+   :width: 600
+
+HSDAC Output Configurations
+---------------------------
+
+The HSDAC signal chain has Programmable Gain Amplifier and and Excitation Buffer
+with a programmable gain. The HSDAC also has 2 power modes and various
+calibration registers that correspond to selected gain and power mode setting.
+These settings are summarized in below table.
+
++--------------+-------------+--------------+----------------+------------------+---------+
+| HSDACCON[12] | HSDACCON[0] | Output Range | Low Power Mode | High Power Mode  | Gain    |
++==============+=============+==============+================+==================+=========+
+| 0            | 0           | ±607mV       | DACOFFSET      | DACOFFSETHP      | DACGAIN |
++--------------+-------------+--------------+----------------+------------------+---------+
+| 1            | 0           | ±75mV        | DACOFFSET      | DACOFFSETHP      | DACGAIN |
++--------------+-------------+--------------+----------------+------------------+---------+
+| 1            | 1           | ±15.14mV     | DACOFFSETATTEN | DACOFFSETATTENHP | DACGAIN |
++--------------+-------------+--------------+----------------+------------------+---------+
+| 0            | 1           | ±121.2mV     | DACOFFSETATTEN | DACOFFSETATTENHP | DACGAIN |
++--------------+-------------+--------------+----------------+------------------+---------+
+
+For each of the settings shown in the above table a seperate calibration
+sequence is required. For example if the DAC offset is calibrated in low power
+mode, if the DAC's power mode is changed to high power mode, the calibration
+will need to be redone writing to the relevant High Power Mode calibration
+register Note, the gain errors associated with the HSDAC are negligible and have
+not been calibrated in the HSDACCAL function provided in the SDK
+
+Calibration Steps
+-----------------
+
+The HSDAC is a differential output DAC that swings on the voltage applied to the
+N terminal of the Excitation Amplifier which is connected to RCAL1 pin shown in
+the figure above. To calibrate the offset, the HSDAC is configured to midscale
+(0x800) which means there should be 0V voltage drop across RCAL. The P node and
+N node are connected to the ADC mux and the actual voltage across RCAL is
+measured. This measured voltage is the offset error. The relevant DACOFFSET
+register is written to to remove this error. It is important to ensure the
+offset error is calibrated out for the chosen HSDAC output range and power mode.
+The following are the steps involved for calibrating the HSDAC offset errors for
+all settings:
+
+-  Calibrate the offset and gain errors on the ADC PGA for a gain of 1.
+-  Calibrate the offset error on the ±607mV range firstly with the ADC PGA gain of 1.
+-  Calibrate the ADC with a selected gain of 4. For the smaller DAC ranges the
+   PGA is required on the ADC to amplify the
+
+::
+
+     signal
+   * Calibrate remaining DAC ranges, ±121.2mV, ±75mV and 15.14mV.
+
+Using the HSDAC Calibration Function in the AD5940 SDK
+------------------------------------------------------
+
+The AD5940 SDK contains an example project that demonstrates how to the use the
+HSDACCal function. The relevant project is AD5940_HSDACCal. The below function
+is an example on how to calibrate the HSDAC for ±607mV range.
+
+::
+
+   static AD5940Err AppHSDACCal(void)
+   {
+       HSDACCal_Type hsdac_cal;
+
+::
+
+       hsdac_cal.ExcitBufGain = EXCITBUFGAIN_2;  /**< Select from  EXCITBUFGAIN_2, EXCITBUFGAIN_0P25 */
+       hsdac_cal.HsDacGain = HSDACGAIN_1;                /**< Select from  HSDACGAIN_1, HSDACGAIN_0P2 */
+       hsdac_cal.AfePwrMode = AFEPWR_LP;
+       hsdac_cal.ADCSinc2Osr = ADCSINC2OSR_1333;
+       hsdac_cal.ADCSinc3Osr = ADCSINC3OSR_4;
+       AD5940_HSDACCal(&hsdac_cal);
+   }

--- a/docs/solutions/reference-designs/eval-ad5940/calibration_routines/hstia_cal.rst
+++ b/docs/solutions/reference-designs/eval-ad5940/calibration_routines/hstia_cal.rst
@@ -4,7 +4,15 @@ High Speed TIA Calibration
 Overview
 --------
 
-The high speed TIA gain resistor is configurable from 50, 100, 200, 1k, 5k, 10k, 20k, 40k, 80k and 160kΩ. To calibrate the Rtia a precision RCAL resistor needs to be connected to RCAL0 and RCAL1 pins. Ideally the RCAL should be close in value to the Rtia to be calibrated and should have a tolerance <= 0.1%. The calibration process implements an impedance measurement where the magnitude of the impedance is the value of Rtia. A sine wave is applied through RCAL and the Rtia. The voltage drop across each is measured with a DFT calculated on each. Using ratiometric analysis the actual impedance of the Rtia is calculated by the following equation: \|Rtia \| = \|Vrcal|/\|Vrtia\|.
+The high speed TIA gain resistor is configurable from 50, 100, 200, 1k, 5k,
+10k, 20k, 40k, 80k and 160kΩ. To calibrate the Rtia a precision RCAL resistor
+needs to be connected to RCAL0 and RCAL1 pins. Ideally the RCAL should be
+close in value to the Rtia to be calibrated and should have a tolerance <=
+0.1%. The calibration process implements an impedance measurement where the
+magnitude of the impedance is the value of Rtia. A sine wave is applied
+through RCAL and the Rtia. The voltage drop across each is measured with a DFT
+calculated on each. Using ratiometric analysis the actual impedance of the
+Rtia is calculated by the following equation: |Rtia| = |Vrcal|/|Vrtia|.
 
 It is important to calibrate at the correct frequency. For example, if the
 measurement of the sensor requires an excitation signal of 50 kHz, the
@@ -24,10 +32,14 @@ The following are the steps involved for calibrating the HSTIA Gain resistor:
    :align: center
    :width: 600
 
--  Generate a sine wave with required frequency using the waveform generator, HSDAC and Excitation amplifier.
+-  Generate a sine wave with required frequency using the waveform generator,
+   HSDAC and Excitation amplifier.
 -  The signal path is highlighted in above image.
--  The P_Node and N_Node are connectted to the ADC mux and the DFT of the voltage is measured.
--  Then, maintaining the same excitation voltage, the HSTIA_P and HSTIA_N nodes are connected to the ADC mux. A DFT of the voltage is calculated again.
+-  The P_Node and N_Node are connected to the ADC mux and the DFT of the
+   voltage is measured.
+-  Then, maintaining the same excitation voltage, the HSTIA_P and HSTIA_N
+   nodes are connected to the ADC mux. A DFT of the voltage is calculated
+   again.
 -  The real and imaginary parts of the DFT results are used to calculate the
    value of the Rtia with the following equations:
 

--- a/docs/solutions/reference-designs/eval-ad5940/calibration_routines/hstia_cal.rst
+++ b/docs/solutions/reference-designs/eval-ad5940/calibration_routines/hstia_cal.rst
@@ -12,7 +12,7 @@ close in value to the Rtia to be calibrated and should have a tolerance <=
 magnitude of the impedance is the value of Rtia. A sine wave is applied
 through RCAL and the Rtia. The voltage drop across each is measured with a DFT
 calculated on each. Using ratiometric analysis the actual impedance of the
-Rtia is calculated by the following equation: |Rtia| = |Vrcal|/|Vrtia|.
+Rtia is calculated by the following equation: Rtia = Vrcal/Vrtia.
 
 It is important to calibrate at the correct frequency. For example, if the
 measurement of the sensor requires an excitation signal of 50 kHz, the

--- a/docs/solutions/reference-designs/eval-ad5940/calibration_routines/hstia_cal.rst
+++ b/docs/solutions/reference-designs/eval-ad5940/calibration_routines/hstia_cal.rst
@@ -1,0 +1,90 @@
+High Speed TIA Calibration
+==========================
+
+Overview
+--------
+
+The high speed TIA gain resistor is configurable from 50, 100, 200, 1k, 5k, 10k, 20k, 40k, 80k and 160kΩ. To calibrate the Rtia a precision RCAL resistor needs to be connected to RCAL0 and RCAL1 pins. Ideally the RCAL should be close in value to the Rtia to be calibrated and should have a tolerance <= 0.1%. The calibration process implements an impedance measurement where the magnitude of the impedance is the value of Rtia. A sine wave is applied through RCAL and the Rtia. The voltage drop across each is measured with a DFT calculated on each. Using ratiometric analysis the actual impedance of the Rtia is calculated by the following equation: \|Rtia \| = \|Vrcal|/\|Vrtia\|.
+
+It is important to calibrate at the correct frequency. For example, if the
+measurement of the sensor requires an excitation signal of 50 kHz, the
+calibration routine should be carried out at this frequency. This insures CTIA
+is factored into the calculation. If carrying out a frequency sweep, it is
+recommend to do a calibration for each frequency point in the sweep.
+
+Calibration Steps
+-----------------
+
+The following are the steps involved for calibrating the HSTIA Gain resistor:
+
+-  Configure switch matrix to connect RCAL between the Excitation buffer and the
+   HSTIA as per below figure:
+
+.. image:: ../images/hstia_rtiacal.jpg
+   :align: center
+   :width: 600
+
+-  Generate a sine wave with required frequency using the waveform generator, HSDAC and Excitation amplifier.
+-  The signal path is highlighted in above image.
+-  The P_Node and N_Node are connectted to the ADC mux and the DFT of the voltage is measured.
+-  Then, maintaining the same excitation voltage, the HSTIA_P and HSTIA_N nodes are connected to the ADC mux. A DFT of the voltage is calculated again.
+-  The real and imaginary parts of the DFT results are used to calculate the
+   value of the Rtia with the following equations:
+
+.. image:: ../images/rtia_equation.png
+   :align: center
+   :width: 200
+
+-  This value of Rtia is then saved by the host controller and used for
+   calculating impedance's.
+
+Using the HSTIA Rtia Calibration Function in the SDK
+----------------------------------------------------
+
+The following function is an example on how to calibrate the HSTIA gain
+resistor:
+
+::
+
+   static AD5940Err AppRtiaCal(void)
+   {
+      HSRTIACal_Type hsrtia_cal;
+      hsrtia_cal.AdcClkFreq = AppBIACfg.AdcClkFreq;
+      hsrtia_cal.ADCSinc2Osr = AppBIACfg.ADCSinc2Osr;
+      hsrtia_cal.ADCSinc3Osr = AppBIACfg.ADCSinc3Osr;
+      hsrtia_cal.bPolarResult = bTRUE; /* We need magnitude and phase here */
+      hsrtia_cal.DftCfg.DftNum = AppBIACfg.DftNum;
+      hsrtia_cal.DftCfg.DftSrc = AppBIACfg.DftSrc;
+      hsrtia_cal.DftCfg.HanWinEn = AppBIACfg.HanWinEn;
+      hsrtia_cal.fRcal= AppBIACfg.RcalVal;
+      hsrtia_cal.HsTiaCfg.DiodeClose = bFALSE;
+      hsrtia_cal.HsTiaCfg.HstiaBias = HSTIABIAS_1P1;
+      hsrtia_cal.HsTiaCfg.HstiaCtia = AppBIACfg.CtiaSel;
+      hsrtia_cal.HsTiaCfg.HstiaDeRload = HSTIADERLOAD_OPEN;
+      hsrtia_cal.HsTiaCfg.HstiaDeRtia = HSTIADERTIA_TODE;
+      hsrtia_cal.HsTiaCfg.HstiaRtiaSel = AppBIACfg.HstiaRtiaSel;
+      hsrtia_cal.SysClkFreq = AppBIACfg.SysClkFreq;
+      if(AppBIACfg.SweepCfg.SweepEn == bTRUE)
+      {
+         uint32_t i;
+         AppBIACfg.SweepCfg.SweepIndex = 0;  /* Reset index */
+         for(i=0;i<AppBIACfg.SweepCfg.SweepPoints;i++)
+         {
+            AD5940_SweepNext(&AppBIACfg.SweepCfg, &hsrtia_cal.fFreq);
+            AD5940_HSRtiaCal(&hsrtia_cal, AppBIACfg.RtiaCalTable[i]);
+            printf("Freq:%.2f,Mag:%.2f,Phase:%fDegree\n", hsrtia_cal.fFreq, AppBIACfg.RtiaCalTable[i][0],
+            AppBIACfg.RtiaCalTable[i][1]*180/MATH_PI);
+          }
+          AppBIACfg.RtiaCurrValue[AppBIACfg.SweepCfg.SweepIndex] = AppBIACfg.RtiaCalTable[i][0];
+          AppBIACfg.RtiaCurrValue[AppBIACfg.SweepCfg.SweepIndex] = AppBIACfg.RtiaCalTable[i][0];
+          AppBIACfg.SweepCfg.SweepIndex = 0;  /* Reset index */
+      }
+      else
+      {
+         hsrtia_cal.fFreq = AppBIACfg.SinFreq;
+         AD5940_HSRtiaCal(&hsrtia_cal, AppBIACfg.RtiaCurrValue);
+         printf("RtiaMag:%.2f,Phase:%fDegree\n", AppBIACfg.RtiaCurrValue[0],
+         AppBIACfg.RtiaCurrValue[1]*180/MATH_PI);
+      }
+      return AD5940ERR_OK;
+   }

--- a/docs/solutions/reference-designs/eval-ad5940/calibration_routines/lfosc_cal.rst
+++ b/docs/solutions/reference-designs/eval-ad5940/calibration_routines/lfosc_cal.rst
@@ -1,0 +1,66 @@
+Low Frequency Oscillator Calibration
+====================================
+
+Overview
+--------
+
+The low frequency oscillator is used to control the sleep/wakeup timer. The
+sleep/wakeup timer controls the measurement frequency i.e. how often the AD5940
+wakes up to run a measurement sequence. Refer to the Sleep/Wakeup Timer chapter
+in the AD5940 datasheet for further details. For applications requiring a highly
+accurate measurement sample rate, the sleep/wakeup timer needs to be calibrated.
+The calibration function uses two measurement sequences. The first sequence
+starts the timeout counter and second sequence stops the timeout counter and
+generates an interrupt to the MCU to read back the timeout value. The second
+sequence is then modified to reset the timer so the length of time required for
+the MCU to read back the timeout value can be measured. It is important that SPI
+speed is fast, ideally 16MHz. Slower SPI speeds will reduce calibration
+accuracy. Also using an external 16MHz crystal will increase calibration
+accuracy.
+
+Calibration Steps
+-----------------
+
+The following are the steps required to calibrate the LFOSC:
+
+-  Configure Sequence A. Sequence A should have one sequencer command that sets the time-out timer - SEQ_TOUT(0x3fffffff)
+-  Configure Sequence B. Sequence B should have one sequence command which generates the END_SEQ interrupt- SEQ_STOP(). This interrupt informs the MCU to read current time count from SEQTIMEOUT register.
+-  Write the two sequences to SRAM. Sequence A should be written to Sequence ID 0 and Sequence B should be written to Sequence ID 1.
+-  Configure the sleep/wakeup timer. The wakeup timer order should be configured to end on sequence B.
+-  Enable the wakeup timer. Sequence A runs and starts the timeout timer, After CalDuration time has elapsed sequence B is executed which generates an ENDSEQ interrupt. The host reads timer count register and TimerCount is stored. TimerCount value includes the WuptPeriod plus the time taken to read timer count register.
+-  Sequence B is reconfigured to reset the time out counter and then generates END_SEQ interrupt. The host reads back the timeout value to calculate the length of time it takes to read the register, TimerCount2. The WuptPeriod is TimerCount – TimerCount2.
+-  The frequency of the low frequency oscillator is calculated using the
+   following equation:
+
+::
+
+        Frequency =  (SystemClkFreq ×WuptPeriod) / (TimerCount2-TimerCount)
+        where,
+        Frequency = Low Frequency Oscillator Frequency
+        SystemClkFreq  = Frequency of AD5940 system clock (Ideally 16MHz using external crystal)
+        WuptPeriod = Period of the wakeup timer
+
+Using the LFOSC Function in the SDK
+-----------------------------------
+
+The code to carry out the low frequency oscillator calibration is included in
+the AD5940 SDK. The function AD5940_LFOSCMeasure() is used. The function takes
+two input parameters. THe fist parameter is a pointer to the data structure
+LFOSCMeasure_Type that contains the measurement parameters. The second argument
+is a pointer to a variable that stores the result of the calibration. This
+structure contains the following paramteres:
+
+-  CalSeqAddr - this sets the start address in SRAM for the first sequence used.
+-  CalDuration - this parameter sets the length of the calibration routine. 1000ms is advisable
+-  SystemClkFreq - this parameter sets the system clock frequency. It should be
+   16MHz.
+
+The result of the calibration is then used in the calculation for the period of
+the sleep/wakeup timer. The sleep/wakeup timer configures the sampling frequency
+of measurements so after this calibration a high level of accuracy is achieved.
+For highest accuracy it is best to use a precision 16MHz crystal connected to
+the AD5940.
+
+.. image:: ../images/bia_terminal.png
+   :align: center
+   :width: 400

--- a/docs/solutions/reference-designs/eval-ad5940/calibration_routines/lptia_cal.rst
+++ b/docs/solutions/reference-designs/eval-ad5940/calibration_routines/lptia_cal.rst
@@ -1,0 +1,68 @@
+Low Power TIA Gain Resistor Calibration
+=======================================
+
+Overview
+--------
+
+The LPTIA channel has a programmable gain resistor to scale the input current
+from the SE0 pin to a voltage that the ADC can measure. The programmable Rtia
+has an initial accuracy range as specified in the AD5940 data sheet. The Rtia
+also varies with temperature as specified in the AD5940 data sheet. If
+uncalibrated, an error is present if trying to measure an absolute input
+current.
+
+Calibration Steps
+-----------------
+
+The following are the steps involved for calibrating the LPTIA Gain resistor:
+
+-  Configure the switch matrix as per the diagram below. Vzero is connected to
+   the non-inverting input of the HSTIA. A precision calibration resistor is
+   connected between RCAL0 and RCAL1. RCAL0 is connected to the HSTIA inverting
+   input through DR0. RCAL1 is connected to the LPTIA inverting input via DR0
+   and D7. A differential voltage is created across RCAL by adjusting VBIAS and
+   VZERO.
+
+.. image:: ../images/lprtia_cal.jpg
+   :align: center
+   :width: 600
+
+-  The differential voltage generates a precision calibration current that is fed into the LPTIA gain resistor highlighted in red in above diagram.
+-  The P_Node and N_Node are connected to the ADC mux to determine the voltage across RCAL and therefore, the calibration current.
+-  Then the LPTIA_P and LPTIA_N inputs are connected to the ADC mux and the current is measured.
+-  This current reading is compared to the precision calibration current to determine the actual value of the Rtia.
+-  This value of Rtia is then saved by the host controller and used for
+   calculating impedance's.
+
+Using the LPTIA Rtia Calibration Function in the SDK
+----------------------------------------------------
+
+The AD5940 SDK provides a function to calibrate the LPTIA gain resistor. The
+function is located in the AD5940.c file. The following is an example code on
+how to use the function.
+
+::
+
+   static AD5940Err AppLPRtiaCal(void)
+   {
+      fImpPol_Type RtiaCalValue;  /* Calibration result */
+      LPRTIACal_Type lprtia_cal;
+      AD5940_StructInit(&lprtia_cal, sizeof(lprtia_cal));
+      lprtia_cal.bPolarResult = bTRUE;                /* Magnitude + Phase */
+      lprtia_cal.AdcClkFreq = AppAMPCfg.AdcClkFreq;
+      lprtia_cal.SysClkFreq = AppAMPCfg.SysClkFreq;
+      lprtia_cal.ADCSinc3Osr = ADCSINC3OSR_4;
+      lprtia_cal.ADCSinc2Osr = ADCSINC2OSR_22;        /* Use SINC2 data as DFT data source */
+      lprtia_cal.DftCfg.DftNum = DFTNUM_2048;
+      lprtia_cal.DftCfg.DftSrc = DFTSRC_SINC2NOTCH;
+      lprtia_cal.DftCfg.HanWinEn = bTRUE;
+      lprtia_cal.fFreq = AppAMPCfg.AdcClkFreq/4/22/2048\*3;  /* Sample 3 period of signal, 13.317Hz here.
+      lprtia_cal.fRcal = AppAMPCfg.RcalVal;
+      lprtia_cal.LpTiaRtia = AppAMPCfg.LptiaRtiaSel;
+      lprtia_cal.LpAmpPwrMod = LPAMPPWR_NORM;
+      lprtia_cal.bWithCtia = bFALSE;
+      AD5940_LPRtiaCal(&lprtia_cal, &RtiaCalValue);
+      AppAMPCfg.RtiaCalValue = RtiaCalValue;
+      printf("Rtia,%f,%f\n", RtiaCalValue.Magnitude, RtiaCalValue.Phase);
+      return AD5940ERR_OK;
+   }

--- a/docs/solutions/reference-designs/eval-ad5940/calibration_routines/lptia_offset_cal.rst
+++ b/docs/solutions/reference-designs/eval-ad5940/calibration_routines/lptia_offset_cal.rst
@@ -1,0 +1,68 @@
+Low Power TIA Offset Calibration
+================================
+
+Overview
+--------
+
+The LPTIA channel has dedicated Offset and Gain calibration registers to remove
+any errors. The following sections describe the calibration method and gives an
+example on how to calibrate the errors using the AD5940 SDK.
+
+Calibration Steps
+-----------------
+
+The following are the steps involved for calibrating the LPTIA offset error:
+
+-  Disconnect any sensor attached so that there is no current flowing into SE0.
+-  Connect LPTIA_P and LPTIA_N inputs to the ADC mux.
+-  Configure the power mode of the LPTIA amplifier. The offset error will vary depending on power mode selected.
+-  Take a measurement using the ADC. Since there is no current flowing into the TIA the measured ADC value should be zero or ADC code of 0x8000.
+-  Adjust the ADCOFFSETLPTIA0 register based on result.
+
+.. image:: ../images/lptia_offset.jpg
+   :align: center
+   :width: 600
+
+Using the LPTIA Rtia Calibration Function in the SDK
+----------------------------------------------------
+
+The AD5940 SDK provides a function to calibrate the LPTIA offset error. The
+function is located in the AD5940.c file. The following is an example code on
+how to use the function.
+
+::
+
+   static AD5940Err AppLPTIAOffsetCal(void)
+   {
+      AD5940Err error = AD5940ERR_OK;
+      LPTIAOffsetCal_Type lptiaoffset_cal;
+      uint32_t lpdac6bit, lpdac12bit;
+      /* LP Loop  */
+      lpdac6bit = (uint32_t)((AppAMPCfg.Vzero-200)/DAC6BITVOLT_1LSB)+1;
+      if(lpdac6bit > 0x3f)lpdac12bit = 0x3f;
+      lpdac12bit = (uint32_t)(lpdac6bit * 64 + AppAMPCfg.SensorBias/DAC12BITVOLT_1LSB);
+      if(lpdac12bit > 0xfff)lpdac12bit = 0xfff;
+      if(lpdac12bit < (lpdac6bit * 64))
+         lpdac12bit --;
+      /* calibration LPTIA offset */
+      lptiaoffset_cal.AdcClkFreq = 16e6;
+      lptiaoffset_cal.SysClkFreq = 16e6;
+      lptiaoffset_cal.ADCSinc2Osr = ADCSINC2OSR_1333;
+      lptiaoffset_cal.ADCSinc3Osr = ADCSINC3OSR_4;
+      lptiaoffset_cal.ADCPga = AppAMPCfg.ADCPgaGain;
+      lptiaoffset_cal.DacData6Bit = lpdac6bit;
+      lptiaoffset_cal.DacData12Bit = lpdac12bit;
+      lptiaoffset_cal.LpDacVzeroMux = LPDACVZERO_6BIT;
+      lptiaoffset_cal.LpAmpPwrMod = AppAMPCfg.LpAmpPwrMod;
+      lptiaoffset_cal.LpTiaRtia = AppAMPCfg.LpTiaRtia;
+      lptiaoffset_cal.LpTiaSW = LPTIASW(13)|LPTIASW(12)|LPTIASW(8)|LPTIASW(5);
+      lptiaoffset_cal.SettleTime10us = 5000\*100;        /* 1000ms, the time needed for RTIA//CTIA settlling. */
+      lptiaoffset_cal.TimeOut10us = 10\*100;     /* 10ms. */
+      error = AD5940_LPTIAOffsetCal(&lptiaoffset_cal);
+      if(error != AD5940ERR_OK)
+     {
+         printf("ERR: LPTIA Offset calibration error! %d\n", error);
+         return error;
+     }
+      return AD5940ERR_OK;
+   }

--- a/docs/solutions/reference-designs/eval-ad5940/hardware.rst
+++ b/docs/solutions/reference-designs/eval-ad5940/hardware.rst
@@ -1,0 +1,16 @@
+Hardware
+========
+
+This chapter contains hardware-related information about the available AD5940
+evaluation boards and also the EVAL-ADICUP3029 base board provided in the AD5940
+evaluation kit. Each sub-section contains a general description of the board,
+detailed descriptions of the connectors, jumpers, and buttons. It also provides
+links to the Schematics, Bill of materials, design projects, and Technical
+documentation. It also gives internal links to the provided example software
+projects.
+
+The following boards are currently available:
+
+-  `EVAL-ADICUP3029 Base Board <https://wiki.analog.com/resources/eval/user-guides/eval-adicup3029/hardware/adicup3029>`_
+-  :doc:`EVAL-AD5940BIOZ Bio-Electric Shield </solutions/reference-designs/eval-ad5940/hardware/eval-ad5940bioz>`
+-  :doc:`EVAL-AD5940ELCZ Electrochemical Shield </solutions/reference-designs/eval-ad5940/hardware/eval-ad5940elcz>`

--- a/docs/solutions/reference-designs/eval-ad5940/hardware.rst
+++ b/docs/solutions/reference-designs/eval-ad5940/hardware.rst
@@ -2,12 +2,12 @@ Hardware
 ========
 
 This chapter contains hardware-related information about the available AD5940
-evaluation boards and also the EVAL-ADICUP3029 base board provided in the AD5940
-evaluation kit. Each sub-section contains a general description of the board,
-detailed descriptions of the connectors, jumpers, and buttons. It also provides
-links to the Schematics, Bill of materials, design projects, and Technical
-documentation. It also gives internal links to the provided example software
-projects.
+evaluation boards and also the EVAL-ADICUP3029 base board provided in the
+AD5940 evaluation kit. Each sub-section contains a general description of the
+board, detailed descriptions of the connectors, jumpers, and buttons. It also
+provides links to the Schematics, Bill of materials, design projects, and
+Technical documentation. It also gives internal links to the provided example
+software projects.
 
 The following boards are currently available:
 

--- a/docs/solutions/reference-designs/eval-ad5940/hardware/eval-ad5940bioz.rst
+++ b/docs/solutions/reference-designs/eval-ad5940/hardware/eval-ad5940bioz.rst
@@ -12,7 +12,10 @@ bio-electric measurements. These include:
 -  Electrocardiogram (ECG)
 -  Body Impedance Analysis (2-wire) (BIOZ-2Wire)
 
-The platform is an Arduino UNO form factorbase board. This section describes the key features of the board and how to set it up to take measurements. |image1|
+The platform is an Arduino UNO form factor base board. This section describes
+the key features of the board and how to set it up to take measurements.
+
+|image1|
 
 |image2|
 
@@ -81,7 +84,10 @@ USB Connector
 
 The Micro USB connector, P6, on the EVAL-AD5940BIOZ board serves 2 functions.
 
--  The provided ECG cables can be connected to a human body simulator which can be used to verify ECG, body composition etc. Note: The EVAL-AD5940BIOZ must never be connected to the human body while the board is connected to a PC or Laptop
+-  The provided ECG cables can be connected to a human body simulator which
+   can be used to verify ECG, body composition etc. Note: The EVAL-AD5940BIOZ
+   must never be connected to the human body while the board is connected to a
+   PC or Laptop
 -  The provided AD5940 Z Test board can also be connected to the Micro USB
    connecter. This board contains a number of banks of resistors and capacitors
    which can be used to model Body Impedance, Skin Impedance, Electrode
@@ -111,14 +117,14 @@ Schematics, PCB Layout, Bill of Materials
 .. admonition:: Download
    :class: download
 
-   
+
    EVAL-AD5940BIOZ Rev B Design Files
-   
+
    -  `Schematics <../resources/02_049988b_top.pdf>`_ (PDF)
    -  `PCB Layout (PDF) <../resources/08-049988-01-b.pdf>`_
    -  `Bill of Materials (Excel) <../images/eval-ad5940bioz_bom.xlsx>`_
    -  `Fabrication Files (zip) <../resources/eval-ad5940bioz_fabrication.zip>`_
-   
+
 
 .. |image1| image:: ../images/eval-ad5940bioz.jpg
    :width: 600

--- a/docs/solutions/reference-designs/eval-ad5940/hardware/eval-ad5940bioz.rst
+++ b/docs/solutions/reference-designs/eval-ad5940/hardware/eval-ad5940bioz.rst
@@ -1,0 +1,126 @@
+AD5940 Bio-Electric Shield User Guide
+=====================================
+
+Introduction
+------------
+
+The EVAL-AD5940BIOZ shield was designed specifically for carrying out
+bio-electric measurements. These include:
+
+-  Electrodermal Activity (EDA)
+-  Body Impedance Analysis (4-wire) (BIA) with Z-board
+-  Electrocardiogram (ECG)
+-  Body Impedance Analysis (2-wire) (BIOZ-2Wire)
+
+The platform is an Arduino UNO form factorbase board. This section describes the key features of the board and how to set it up to take measurements. |image1|
+
+|image2|
+
+Connectors and Jumpers
+----------------------
+
+All the connectors and their default configurations are described in the table
+below.
+
++----------------------+----------------+------------------------------------------------------------+
+| Connector            | Jmpr Position. | Description                                                |
++======================+================+============================================================+
+| JP1 (DVDD)           | A              | DVDD powered from 3.3V on Arduino Header (Default)         |
++----------------------+----------------+------------------------------------------------------------+
+|                      | B              | DVDD powered from LDO                                      |
++----------------------+----------------+------------------------------------------------------------+
+|                      | C              | DVDD powered from external source connected to P11         |
++----------------------+----------------+------------------------------------------------------------+
+| JP2 (AVDD)           | A              | AVDD powered from 3.3V on Arduino Header (Default)         |
++----------------------+----------------+------------------------------------------------------------+
+|                      | B              | AVDD powered from LDO                                      |
++----------------------+----------------+------------------------------------------------------------+
+|                      | C              | AVDD powered from external source connected to P8          |
++----------------------+----------------+------------------------------------------------------------+
+| JP3 (Reset)          | A              | Reset pin connected to ARST Button (Default)               |
++----------------------+----------------+------------------------------------------------------------+
+|                      | B              | Reset pin connected to Arduino Header Reset pin            |
++----------------------+----------------+------------------------------------------------------------+
+|                      | C              | Reset pin connected to Arduino header P1.3 (Default)       |
++----------------------+----------------+------------------------------------------------------------+
+| P9 (LDO Enable)      | 1-2            | LDO Enabled                                                |
++----------------------+----------------+------------------------------------------------------------+
+|                      | 2-3            | LDO Disabled (Default)                                     |
++----------------------+----------------+------------------------------------------------------------+
+| P15 (LDO Aux Enable) | 1-2            | LDO Enabled                                                |
++----------------------+----------------+------------------------------------------------------------+
+|                      | 2-3            | LDO Disabled (Default)                                     |
++----------------------+----------------+------------------------------------------------------------+
+| JP5 (Default DNI)    | A              | Pull up resistor (R25) connected to electrode bias         |
++----------------------+----------------+------------------------------------------------------------+
+|                      | B              | Pull down resistor (R25)connected electrode bias           |
++----------------------+----------------+------------------------------------------------------------+
+| JP6 (Default DNI)    | A              | Pull up resistor (R42) connected to electrode bias         |
++----------------------+----------------+------------------------------------------------------------+
+|                      | B              | Pull down resistor (R42)connected electrode bias           |
++----------------------+----------------+------------------------------------------------------------+
+| JP7 (Bias Select)    | 3-1            | Electrode bias connected to REFOUTS                        |
++----------------------+----------------+------------------------------------------------------------+
+|                      | 3-4            | Electrode bias connected RLD                               |
++----------------------+----------------+------------------------------------------------------------+
+|                      | 3-5            | Electrode bias connected to VDD                            |
++----------------------+----------------+------------------------------------------------------------+
+| JP8                  | A              | Connected. EEPROM write protect                            |
++----------------------+----------------+------------------------------------------------------------+
+| P16                  | 1-2            | Pull up resistor R46 for ECG_P to electrode bias (Default) |
++----------------------+----------------+------------------------------------------------------------+
+|                      | 2-3            | Pull down resistor R46 for ECG_P to GND                    |
++----------------------+----------------+------------------------------------------------------------+
+| P17                  | 1-2            | Pull up resistor R23 for ECG_P to electrode bias (Defaut)  |
++----------------------+----------------+------------------------------------------------------------+
+|                      | 2-3            | Pull down resistor R23 for ECG_P to GND                    |
++----------------------+----------------+------------------------------------------------------------+
+
+USB Connector
+-------------
+
+The Micro USB connector, P6, on the EVAL-AD5940BIOZ board serves 2 functions.
+
+-  The provided ECG cables can be connected to a human body simulator which can be used to verify ECG, body composition etc. Note: The EVAL-AD5940BIOZ must never be connected to the human body while the board is connected to a PC or Laptop
+-  The provided AD5940 Z Test board can also be connected to the Micro USB
+   connecter. This board contains a number of banks of resistors and capacitors
+   which can be used to model Body Impedance, Skin Impedance, Electrode
+   impedances and Contact impedance. These resistor values are configured with
+   the various switches.
+
+Note, P6 USB connector must only be used with the supplied AD5940 Z Test board
+or the provided ECG Cables. No other cable should ever be connected.
+
+Micro USB pinout for connecting ECG Cables:
+
+3-wire ECG cable:
+
+======= ============ ===========
+USB pin Function     Cable color
+======= ============ ===========
+1       F+           RED
+2       S+ (ECG IN+) N/C
+3       S- (ECG IN-) BLUE/GREEN
+4       N/C          N/C
+5       F- (ECG RLD) BLACK
+======= ============ ===========
+
+Schematics, PCB Layout, Bill of Materials
+-----------------------------------------
+
+.. admonition:: Download
+   :class: download
+
+   
+   EVAL-AD5940BIOZ Rev B Design Files
+   
+   -  `Schematics <../resources/02_049988b_top.pdf>`_ (PDF)
+   -  `PCB Layout (PDF) <../resources/08-049988-01-b.pdf>`_
+   -  `Bill of Materials (Excel) <../images/eval-ad5940bioz_bom.xlsx>`_
+   -  `Fabrication Files (zip) <../resources/eval-ad5940bioz_fabrication.zip>`_
+   
+
+.. |image1| image:: ../images/eval-ad5940bioz.jpg
+   :width: 600
+.. |image2| image:: ../images/bioz_block_diagram.jpg
+   :width: 600

--- a/docs/solutions/reference-designs/eval-ad5940/hardware/eval-ad5940elcz.rst
+++ b/docs/solutions/reference-designs/eval-ad5940/hardware/eval-ad5940elcz.rst
@@ -148,14 +148,14 @@ Schematics, PCB Layout, Bill of Materials
 .. admonition:: Download
    :class: download
 
-   
+
    EVAL-AD5940ELCZ Rev A Design and Integration Files
-   
+
    -  `Schematics (PDF) <../resources/02_050193b.pdf>`_
    -  `PCB Layout (PDF) <../resources/08-050193a.pdf>`_
    -  `Bill of Materials (xlsx) <../images/eval-ad5940elcz_bom.xlsx>`_
    -  `Fabrication Files (zip) <../resources/eval-ad5940elcz_fabriaction.zip>`_
-   
+
 
 .. |image1| image:: ../images/eval-ad5940elcz.jpg
    :width: 600

--- a/docs/solutions/reference-designs/eval-ad5940/hardware/eval-ad5940elcz.rst
+++ b/docs/solutions/reference-designs/eval-ad5940/hardware/eval-ad5940elcz.rst
@@ -1,0 +1,163 @@
+AD5940 Electrochemical Shield User Guide
+========================================
+
+Introduction
+------------
+
+The EVAL-AD5940ELCZ shield was designed specifically for carrying out
+electrochemical measurements. These include:
+
+-  Measurements on a dummy RC sensor
+-  Electrochemical Gas Sensing
+-  Water Quality
+
+   -  Conductivity
+   -  pH
+   -  Oxidation Reduction
+
+-  General electrochemical measurements through cables provided
+
+The platform is an Arduino form factor that can be used with any Arduino
+form-factor base board. This section describes the features of the evaluation
+board and how to use it.
+
+|image1|
+
+.. image:: ../images/elcz_block_diagram.jpg
+   :align: center
+   :width: 600
+
+Connectors and Jumpers
+----------------------
+
+All the connectors and their default configurations are described in the table
+below.
+
++------------------------+------------------------------------------+------------------------------------------------------+
+| Connector              | Jmpr Position.                           | Description                                          |
++========================+==========================================+======================================================+
+| JP1 (DVDD)             | A                                        | DVDD powered from 3.3V on Arduino Header (Default)   |
++------------------------+------------------------------------------+------------------------------------------------------+
+|                        | B                                        | DVDD powered from LDO                                |
++------------------------+------------------------------------------+------------------------------------------------------+
+|                        | C                                        | DVDD powered from external source connected to P11   |
++------------------------+------------------------------------------+------------------------------------------------------+
+| JP2 (AVDD)             | A                                        | AVDD powered from 3.3V on Arduino Header (Default)   |
++------------------------+------------------------------------------+------------------------------------------------------+
+|                        | B                                        | AVDD powered from LDO                                |
++------------------------+------------------------------------------+------------------------------------------------------+
+|                        | C                                        | AVDD powered from external source connected to P8    |
++------------------------+------------------------------------------+------------------------------------------------------+
+| JP3 (Reset)            | A                                        | Reset pin connected to ARST Button (Default)         |
++------------------------+------------------------------------------+------------------------------------------------------+
+|                        | B                                        | Reset pin connected to Arduino Header Reset pin      |
++------------------------+------------------------------------------+------------------------------------------------------+
+|                        | C                                        | Reset pin connected to Arduino header P1.3 (Default) |
++------------------------+------------------------------------------+------------------------------------------------------+
+| P9 (LDO Enable)        | 1-2                                      | LDO Enabled                                          |
++------------------------+------------------------------------------+------------------------------------------------------+
+|                        | 2-3                                      | LDO Disabled (Default)                               |
++------------------------+------------------------------------------+------------------------------------------------------+
+| P10 (LDO Aux Enable)   | 1-2                                      | LDO Enabled                                          |
++------------------------+------------------------------------------+------------------------------------------------------+
+|                        | 2-3                                      | LDO Disabled (Default)                               |
++------------------------+------------------------------------------+------------------------------------------------------+
+| JP6 (Dummy RC)         | A                                        | Connect network A to CE, RE and SE (Default)         |
++------------------------+------------------------------------------+------------------------------------------------------+
+|                        | B                                        | Connect network B to CE, RE and SE                   |
++------------------------+------------------------------------------+------------------------------------------------------+
+| JP9,JP10,JP11          | Note, A is 1-2, B is 3-4, C is 5-6 (USB) |                                                      |
++------------------------+------------------------------------------+------------------------------------------------------+
+| JP9 (DE0 Mux)          | A                                        | DE0 connected to gas sensor connector                |
++------------------------+------------------------------------------+------------------------------------------------------+
+|                        | B                                        | DE0 connected to dummy network                       |
++------------------------+------------------------------------------+------------------------------------------------------+
+|                        | C                                        | DE0 connected to USB port                            |
++------------------------+------------------------------------------+------------------------------------------------------+
+| JP10 (RE0 Mux)         | A                                        | RE0 connected to gas sensor                          |
++------------------------+------------------------------------------+------------------------------------------------------+
+|                        | B                                        | RE0 connected to dummy network                       |
++------------------------+------------------------------------------+------------------------------------------------------+
+|                        | C                                        | RE0 connected to USB port                            |
++------------------------+------------------------------------------+------------------------------------------------------+
+| JP11 (SE0 Mux)         | A                                        | SE0 connected to gas sensor                          |
++------------------------+------------------------------------------+------------------------------------------------------+
+|                        | B                                        | SE0 connected to dummy network                       |
++------------------------+------------------------------------------+------------------------------------------------------+
+|                        | C                                        | SE0 connected to USB port                            |
++------------------------+------------------------------------------+------------------------------------------------------+
+| JP4 (Cable Shield Mux) | A                                        | Shield connected to CE0                              |
++------------------------+------------------------------------------+------------------------------------------------------+
+|                        | B                                        | Shield connected to Bead                             |
++------------------------+------------------------------------------+------------------------------------------------------+
+| JP5 (BNC Mux)          | A                                        | Water conductivity                                   |
++------------------------+------------------------------------------+------------------------------------------------------+
+|                        | B                                        | pH Measurement                                       |
++------------------------+------------------------------------------+------------------------------------------------------+
+|                        | C                                        | Connected to AFE1                                    |
++------------------------+------------------------------------------+------------------------------------------------------+
+
+USB Connector and Cable
+-----------------------
+
+The USB connector provides an interface to connected the provided USB to
+Crocodile cable to the AD5940. This USB connector is only intended to be used in
+conjunction with the provided USB to crocodile cable. No other USB cable should
+be ever be connected.
+
+The following table shows which color lead corresponds to which input:
+
+=========== ====================== ===================
+Cable Color Description            Schematic Reference
+=========== ====================== ===================
+Red         Counter Electrode      USB_1
+Blue/white  Reference Electrode    USB_2
+Green       Working Electrode      USB_3
+Black       Connected to DE0 input USB_4
+=========== ====================== ===================
+
+The image below shows the crocodile connected to the EVAL-AD5940ELCZ. A dummy
+sensor consisting of a Resistor in parallel with a capacitor is connected. The
+counter and reference connectors are connected to one end and the working
+electrode is connected to the other end.
+
+|image2|
+
+Note, the USB to crocodile cable is intended for rapid prototyping. There is a
+parasitic resistance and capacitance associated with it which may effect
+measurement accuracy. This is especially through for high frequency impedance
+measurements.
+
+EC Gas Connector
+----------------
+
+M1 is an Electrochemical gas sensor socket. Standard EC gas sensors can be
+connected to perform gas sensor measurements. When measuring a Gas sensor ensure
+JP9, JP10 and JP11 are switched to position A.
+
+BNC Connector
+-------------
+
+The BNC connector is connected to the AD5940 via LTC6078 amplifier. This
+amplifier can be used with high impedance sensor's such as pH sensors and for
+water conductivity measurements.
+
+Schematics, PCB Layout, Bill of Materials
+-----------------------------------------
+
+.. admonition:: Download
+   :class: download
+
+   
+   EVAL-AD5940ELCZ Rev A Design and Integration Files
+   
+   -  `Schematics (PDF) <../resources/02_050193b.pdf>`_
+   -  `PCB Layout (PDF) <../resources/08-050193a.pdf>`_
+   -  `Bill of Materials (xlsx) <../images/eval-ad5940elcz_bom.xlsx>`_
+   -  `Fabrication Files (zip) <../resources/eval-ad5940elcz_fabriaction.zip>`_
+   
+
+.. |image1| image:: ../images/eval-ad5940elcz.jpg
+   :width: 600
+.. |image2| image:: ../images/ad5940_crocodile.jpg
+   :width: 600

--- a/docs/solutions/reference-designs/eval-ad5940/hardware/eval-ad5941elcz.rst
+++ b/docs/solutions/reference-designs/eval-ad5940/hardware/eval-ad5941elcz.rst
@@ -1,0 +1,163 @@
+AD5941 Electrochemical Shield User Guide
+========================================
+
+Introduction
+------------
+
+The EVAL-AD5941ELCZ shield was designed specifically for carrying out
+electrochemical measurements. These include:
+
+-  Measurements on a dummy RC sensor
+-  Electrochemical Gas Sensing
+-  Water Quality
+
+   -  Conductivity
+   -  pH
+   -  Oxidation Reduction
+
+-  General electrochemical measurements through cables provided
+
+The platform is an Arduino form factor that can be used with any Arduino
+form-factor base board. This section describes the features of the evaluation
+board and how to use it.
+
+|image1|
+
+.. image:: ../images/ad5941_elcz.jpg
+   :align: center
+   :width: 600
+
+Connectors and Jumpers
+----------------------
+
+All the connectors and their default configurations are described in the table
+below.
+
++------------------------+------------------------------------------+------------------------------------------------------+
+| Connector              | Jmpr Position.                           | Description                                          |
++========================+==========================================+======================================================+
+| JP1 (DVDD)             | A                                        | DVDD powered from 3.3V on Arduino Header (Default)   |
++------------------------+------------------------------------------+------------------------------------------------------+
+|                        | B                                        | DVDD powered from LDO                                |
++------------------------+------------------------------------------+------------------------------------------------------+
+|                        | C                                        | DVDD powered from external source connected to P11   |
++------------------------+------------------------------------------+------------------------------------------------------+
+| JP2 (AVDD)             | A                                        | AVDD powered from 3.3V on Arduino Header (Default)   |
++------------------------+------------------------------------------+------------------------------------------------------+
+|                        | B                                        | AVDD powered from LDO                                |
++------------------------+------------------------------------------+------------------------------------------------------+
+|                        | C                                        | AVDD powered from external source connected to P8    |
++------------------------+------------------------------------------+------------------------------------------------------+
+| JP3 (Reset)            | A                                        | Reset pin connected to ARST Button (Default)         |
++------------------------+------------------------------------------+------------------------------------------------------+
+|                        | B                                        | Reset pin connected to Arduino Header Reset pin      |
++------------------------+------------------------------------------+------------------------------------------------------+
+|                        | C                                        | Reset pin connected to Arduino header P1.3 (Default) |
++------------------------+------------------------------------------+------------------------------------------------------+
+| P9 (LDO Enable)        | 1-2                                      | LDO Enabled                                          |
++------------------------+------------------------------------------+------------------------------------------------------+
+|                        | 2-3                                      | LDO Disabled (Default)                               |
++------------------------+------------------------------------------+------------------------------------------------------+
+| P10 (LDO Aux Enable)   | 1-2                                      | LDO Enabled                                          |
++------------------------+------------------------------------------+------------------------------------------------------+
+|                        | 2-3                                      | LDO Disabled (Default)                               |
++------------------------+------------------------------------------+------------------------------------------------------+
+| JP6 (Dummy RC)         | A                                        | Connect network A to CE, RE and SE (Default)         |
++------------------------+------------------------------------------+------------------------------------------------------+
+|                        | B                                        | Connect network B to CE, RE and SE                   |
++------------------------+------------------------------------------+------------------------------------------------------+
+| JP9,JP10,JP11          | Note, A is 1-2, B is 3-4, C is 5-6 (USB) |                                                      |
++------------------------+------------------------------------------+------------------------------------------------------+
+| JP9 (DE0 Mux)          | A                                        | DE0 connected to Gas sensor connector                |
++------------------------+------------------------------------------+------------------------------------------------------+
+|                        | B                                        | DE0 connected to dummy network                       |
++------------------------+------------------------------------------+------------------------------------------------------+
+|                        | C                                        | DE0 connected to USB port                            |
++------------------------+------------------------------------------+------------------------------------------------------+
+| JP10 (RE0 Mux)         | A                                        | RE0 connected to gas sensor                          |
++------------------------+------------------------------------------+------------------------------------------------------+
+|                        | B                                        | RE0 connected to dummy network                       |
++------------------------+------------------------------------------+------------------------------------------------------+
+|                        | C                                        | RE0 connected to USB port                            |
++------------------------+------------------------------------------+------------------------------------------------------+
+| JP11 (SE0 Mux)         | A                                        | SE0 connected to gas sensor                          |
++------------------------+------------------------------------------+------------------------------------------------------+
+|                        | B                                        | SE0 connected to dummy network                       |
++------------------------+------------------------------------------+------------------------------------------------------+
+|                        | C                                        | SE0 connected to USB port                            |
++------------------------+------------------------------------------+------------------------------------------------------+
+| JP4 (Cable Shield Mux) | A                                        | Shield connected to CE0                              |
++------------------------+------------------------------------------+------------------------------------------------------+
+|                        | B                                        | Shield connected to Bead                             |
++------------------------+------------------------------------------+------------------------------------------------------+
+| JP5 (BNC Mux)          | A                                        | Water conductivity                                   |
++------------------------+------------------------------------------+------------------------------------------------------+
+|                        | B                                        | pH Measurement                                       |
++------------------------+------------------------------------------+------------------------------------------------------+
+|                        | C                                        | Connected to AFE1                                    |
++------------------------+------------------------------------------+------------------------------------------------------+
+
+USB Connector and Cable
+-----------------------
+
+The USB connector provides an interface to connected the provided USB to
+Crocodile cable to the AD5941. This USB connector is only intended to be used in
+conjunction with the provided USB to crocodile cable. No other USB cable should
+be ever be connected.
+
+The following table shows which color lead corresponds to which input:
+
+=============== ====================== ===================
+Connector Color Description            Schematic Reference
+=============== ====================== ===================
+Red             Counter Electrode      USB_1
+Blue            Reference Electrode    USB_2
+Green           Working Electrode      USB_3
+Black           Connected to DE0 input USB_4
+=============== ====================== ===================
+
+The image below shows the crocodile connected to the EVAL-AD5941ELCZ. A dummy
+sensor consisting of a Resistor in parallel with a capacitor is connected. The
+counter and reference connectors are connected to one end and the working
+electrode is connected to the other end.
+
+|image2|
+
+Note, the USB to crocodile cable is intended for rapid prototyping. There is a
+parasitic resistance and capacitance associated with it which may effect
+measurement accuracy. This is especially through for high frequency impedance
+measurements.
+
+EC Gas Connector
+----------------
+
+M1 is an Electrochemical gas sensor socket. Standard EC gas sensors can be
+connected to perform gas sensor measurements. When measuring a Gas sensor ensure
+JP9, JP10 and JP11 are switched to position C.
+
+BNC Connector
+-------------
+
+The BNC connector is connected to the AD5941 via LTC6078 amplifier. This
+amplifier can be used with high impedance sensor's such as pH sensors and for
+water conductivity measurements.
+
+Schematics, PCB Layout, Bill of Materials
+-----------------------------------------
+
+.. admonition:: Download
+   :class: download
+
+   
+   EVAL-AD5941ELCZ Rev A Design and Integration Files
+   
+   -  `Schematics (PDF) <../resources/02-057011-01-a-1.pdf>`_
+   -  `PCB Layout (PDF) <../resources/08-057011-01-a-1.pdf>`_
+   -  `Bill of Materials (Excel) <../images/05-057011-01-a.xlsx>`_
+   -  `Fabrication Files (zip) <../resources/09-057011-01a.zip>`_
+   
+
+.. |image1| image:: ../images/eval_ad5941_elcz.jpg
+   :width: 600
+.. |image2| image:: ../images/elcz_cable.jpg
+   :width: 600

--- a/docs/solutions/reference-designs/eval-ad5940/hardware/eval-ad5941elcz.rst
+++ b/docs/solutions/reference-designs/eval-ad5940/hardware/eval-ad5941elcz.rst
@@ -148,14 +148,14 @@ Schematics, PCB Layout, Bill of Materials
 .. admonition:: Download
    :class: download
 
-   
+
    EVAL-AD5941ELCZ Rev A Design and Integration Files
-   
+
    -  `Schematics (PDF) <../resources/02-057011-01-a-1.pdf>`_
    -  `PCB Layout (PDF) <../resources/08-057011-01-a-1.pdf>`_
    -  `Bill of Materials (Excel) <../images/05-057011-01-a.xlsx>`_
    -  `Fabrication Files (zip) <../resources/09-057011-01a.zip>`_
-   
+
 
 .. |image1| image:: ../images/eval_ad5941_elcz.jpg
    :width: 600

--- a/docs/solutions/reference-designs/eval-ad5940/hardware/power_connections.rst
+++ b/docs/solutions/reference-designs/eval-ad5940/hardware/power_connections.rst
@@ -1,0 +1,15 @@
+Power Connections
+=================
+
+There are two options for supplying power to the board. The default power supply comes from the connector P2 5V pin provided by the host microcontroller. This supply drives the ADP5320 to generate low noise 5V, 1.8V and 1.2 V and 3.3V supplies for the ADAS1021. Ensure that P9 and P10 are in position 2,3 with AVDDS5V,1V8, IOVDD and DVDD jumpers in place. Alternatively, the board can be powered from connector P1 and P7. • Remove AVDD5V, 1V8, IOVDD and DVDD jumpers • Supply power through P1 and P7.
+
+============================= ========= =============== =============
+Supply Requirement            Parameter Connector & Pin Supply Range
+============================= ========= =============== =============
+Alternative Supplies(P1 & P7) AVDD      P1 Pin 3        +5V ± 5%
+\                             IOVDD     P7 Pin 1        1.71V to 3.6V
+\                             ADVDD1V8  P1 Pin 1        1.8V ± 5%
+\                             DVDD      P7 Pin 3        1.2V ± 5%
+\                             AGND      P1 Pin 2        Ground
+\                             DGND      P7 Pin 2        Ground
+============================= ========= =============== =============

--- a/docs/solutions/reference-designs/eval-ad5940/help_and_support.rst
+++ b/docs/solutions/reference-designs/eval-ad5940/help_and_support.rst
@@ -1,0 +1,95 @@
+Help and Support
+================
+
+Do you need help or have general support questions? This page will help you
+resolve these.
+
+This page has a quickstart troubleshooting approach that goes over some very
+general questions and common pitfalls, but if you have a specific issue which
+requires more information or detail please contact us through EngineerZone or
+Email. (links can be found further down on the page where to direct specific
+questions)
+
+What to do When Things Go Wrong
+-------------------------------
+
+There are many things that can go wrong with an ecosystem this complex, but if
+you are having issues getting the board or software working, here are a few
+simple things you can try before contacting Analog Devices.
+
+-  Check the Power on ADICUP3029
+
+   -  Do you have the USB cable plugged in? What about the DC power jack? Is switch (S5) in the "Wall/USB" position?
+   -  If you are using batteries, is the switch (S5) in the "BATT" position
+
+      -  Try replacing your batteries, and see if the board powers up
+
+-  Check the Power on EVAL-AD5940xxxx
+
+   -  Ensure the EVAL-AD5940xxx is connected to Arduino UNO connectors on ADICUP3029
+   -  Ensure JP1 and JP2 supply jumpers are in position A to power the board
+      from the ADICUP3029.
+
+-  Program the ADuCM3029
+
+   -  Sometimes a flashed program doesn't run properly or can make it difficult to run the debugger.
+   -  The first thing to try in this case, is to `drag and drop <https://wiki.analog.com/resources/eval/user-guides/eval-adicup3029/tools/adicup3029_hw_drivers>`_ a known good .HEX or .BIN program into flash.(something with quick visible indicators works best)
+   -  If drag and drop is not working, it may be necessary to erase the flash.
+      To do so:
+
+      -  Download and install the CrossCore Serial Flash Programmer from here: :adi:`en/design-center/processors-and-dsp/evaluation-and-development-software/crosscore-serial-flash-programmer.html#dsp-overview`.
+      -  Make sure that the USB is selected on the three way UART switch (S2).
+      -  Power cycle the ADICUP3029 board while holding down the boot switch (S3)
+      -  Select the mbed serial COM port in the CrossCore Serial Flash Programmer, and erase the flash.
+      -  Then try `dragging and dropping <https://wiki.analog.com/resources/eval/user-guides/eval-adicup3029/tools/adicup3029_hw_drivers>`_ a .HEX or .BIN file into flash
+
+   -  If the mass erase didn't work, and you are trying to drag and drop a large
+      .BIN file on EVAL-ADICUP3029 Rev B hardware, it's possible that the mbed
+      interface file needs to be updated to support your application.
+
+      -  Please visit the `Maintenance Drive details <https://wiki.analog.com/resources/eval/user-guides/eval-adicup3029/tools/adicup3029_hw_drivers>`_ page in order to put the board in update mode.
+      -  Once you are in "maintenance mode" you should drag and drop the latest interface file onto your maintenance drive. That file can be downloaded at the bottom of `Maintenance Drive Page <https://wiki.analog.com/resources/eval/user-guides/eval-adicup3029/tools/adicup3029_hw_drivers>`_.
+
+-  Not receiving/transmitting data to the UART
+
+   -  Make sure that the UART switch (S2) is positioned in the correct
+      destination to transmit/receive UART data.
+
+-  I'm trying to program/debug, but I'm getting errors.
+
+   -  Check the drives attached to your computer, do you see a mass storage device called **DAPLINK** or **Maintenance**? If you see the Maintenance drive and your USB is plugged in, then likely the ADuCM3029 isn't being powered, which means the power switch (S5) is likely in the "BATT" position. Flip it "WALL/USB" and unplug/reconnect your USB cable to your computer, and try to programming again.
+
+This is just a brief self-help guide to troubleshooting common issues. If you
+have other questions that need answering please direct those requests to the
+locations outlined below.
+
+Hardware, Software, and Documentation Questions
+-----------------------------------------------
+
+If you have any questions regarding the ADICUP3029 base board or are experiencing any problems using the **AD5940 SDK** or issues following any of the **documentation** feel free to ask us a question.
+
+-  :ez:`ADuCM3029 support community <community/analog-microcontrollers/aducm302x>` for questions about:
+
+   -  ADICUP3029 hardware
+   -  ADuCM3029 silicon
+   -  ADICUP3029 documentation
+
+-  :ez:`AD5940 Support Community <data_converters/precision_adcs/w/documents/14012/ad5940-faqs>` for questions about:
+
+   -  AD5940 silicon
+   -  AD5940 documentation
+   -  AD5940 evaluation boards
+
+When asking a question please take the time to give a detailed description of
+your problem. If you are experiencing a problem please state the steps you have
+executed, the result you expected you would get and the result you actually got.
+By doing so you enable us to provide you precise and detailed answers in a
+timely manner.
+
+.. tip::
+
+   Before asking questions please take the time to check if somebody else
+   already asked the same question. You might just find your question already
+   answered.
+
+*End of Document*

--- a/docs/solutions/reference-designs/eval-ad5940/help_and_support.rst
+++ b/docs/solutions/reference-designs/eval-ad5940/help_and_support.rst
@@ -19,28 +19,33 @@ simple things you can try before contacting Analog Devices.
 
 -  Check the Power on ADICUP3029
 
-   -  Do you have the USB cable plugged in? What about the DC power jack? Is switch (S5) in the "Wall/USB" position?
+   -  Do you have the USB cable plugged in? What about the DC power jack? Is
+      switch (S5) in the "Wall/USB" position?
    -  If you are using batteries, is the switch (S5) in the "BATT" position
 
       -  Try replacing your batteries, and see if the board powers up
 
 -  Check the Power on EVAL-AD5940xxxx
 
-   -  Ensure the EVAL-AD5940xxx is connected to Arduino UNO connectors on ADICUP3029
+   -  Ensure the EVAL-AD5940xxx is connected to Arduino UNO
+      connectors on ADICUP3029
    -  Ensure JP1 and JP2 supply jumpers are in position A to power the board
       from the ADICUP3029.
 
 -  Program the ADuCM3029
 
-   -  Sometimes a flashed program doesn't run properly or can make it difficult to run the debugger.
+   -  Sometimes a flashed program doesn't run properly or can make it
+      difficult to run the debugger.
    -  The first thing to try in this case, is to `drag and drop <https://wiki.analog.com/resources/eval/user-guides/eval-adicup3029/tools/adicup3029_hw_drivers>`_ a known good .HEX or .BIN program into flash.(something with quick visible indicators works best)
    -  If drag and drop is not working, it may be necessary to erase the flash.
       To do so:
 
       -  Download and install the CrossCore Serial Flash Programmer from here: :adi:`en/design-center/processors-and-dsp/evaluation-and-development-software/crosscore-serial-flash-programmer.html#dsp-overview`.
       -  Make sure that the USB is selected on the three way UART switch (S2).
-      -  Power cycle the ADICUP3029 board while holding down the boot switch (S3)
-      -  Select the mbed serial COM port in the CrossCore Serial Flash Programmer, and erase the flash.
+      -  Power cycle the ADICUP3029 board while holding down the
+         boot switch (S3)
+      -  Select the mbed serial COM port in the CrossCore Serial Flash
+         Programmer, and erase the flash.
       -  Then try `dragging and dropping <https://wiki.analog.com/resources/eval/user-guides/eval-adicup3029/tools/adicup3029_hw_drivers>`_ a .HEX or .BIN file into flash
 
    -  If the mass erase didn't work, and you are trying to drag and drop a large
@@ -48,7 +53,9 @@ simple things you can try before contacting Analog Devices.
       interface file needs to be updated to support your application.
 
       -  Please visit the `Maintenance Drive details <https://wiki.analog.com/resources/eval/user-guides/eval-adicup3029/tools/adicup3029_hw_drivers>`_ page in order to put the board in update mode.
-      -  Once you are in "maintenance mode" you should drag and drop the latest interface file onto your maintenance drive. That file can be downloaded at the bottom of `Maintenance Drive Page <https://wiki.analog.com/resources/eval/user-guides/eval-adicup3029/tools/adicup3029_hw_drivers>`_.
+      -  Once you are in "maintenance mode" you should drag and drop the
+         latest interface file onto your maintenance drive. That file can be
+         downloaded at the bottom of `Maintenance Drive Page <https://wiki.analog.com/resources/eval/user-guides/eval-adicup3029/tools/adicup3029_hw_drivers>`_.
 
 -  Not receiving/transmitting data to the UART
 
@@ -57,7 +64,12 @@ simple things you can try before contacting Analog Devices.
 
 -  I'm trying to program/debug, but I'm getting errors.
 
-   -  Check the drives attached to your computer, do you see a mass storage device called **DAPLINK** or **Maintenance**? If you see the Maintenance drive and your USB is plugged in, then likely the ADuCM3029 isn't being powered, which means the power switch (S5) is likely in the "BATT" position. Flip it "WALL/USB" and unplug/reconnect your USB cable to your computer, and try to programming again.
+   -  Check the drives attached to your computer, do you see a mass storage
+      device called **DAPLINK** or **Maintenance**? If you see the Maintenance
+      drive and your USB is plugged in, then likely the ADuCM3029 isn't being
+      powered, which means the power switch (S5) is likely in the "BATT"
+      position. Flip it "WALL/USB" and unplug/reconnect your USB cable to your
+      computer, and try to programming again.
 
 This is just a brief self-help guide to troubleshooting common issues. If you
 have other questions that need answering please direct those requests to the
@@ -66,7 +78,9 @@ locations outlined below.
 Hardware, Software, and Documentation Questions
 -----------------------------------------------
 
-If you have any questions regarding the ADICUP3029 base board or are experiencing any problems using the **AD5940 SDK** or issues following any of the **documentation** feel free to ask us a question.
+If you have any questions regarding the ADICUP3029 base board or are
+experiencing any problems using the **AD5940 SDK** or issues following any of
+the **documentation** feel free to ask us a question.
 
 -  :ez:`ADuCM3029 support community <community/analog-microcontrollers/aducm302x>` for questions about:
 

--- a/docs/solutions/reference-designs/eval-ad5940/images/05-057011-01-a.xlsx
+++ b/docs/solutions/reference-designs/eval-ad5940/images/05-057011-01-a.xlsx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2a3128dcb717f72cf15bd40f03ddcb28780839626386f1623b5a747674af5692
+size 19857

--- a/docs/solutions/reference-designs/eval-ad5940/images/ad5940_crocodile.jpg
+++ b/docs/solutions/reference-designs/eval-ad5940/images/ad5940_crocodile.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:42825f23ea18a364b00fd5c7b93aec1b37a97c2eeec3fdb7215f5173e163d06e
+size 3436458

--- a/docs/solutions/reference-designs/eval-ad5940/images/ad5940_hsdaccal.jpg
+++ b/docs/solutions/reference-designs/eval-ad5940/images/ad5940_hsdaccal.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5153cacc052106635c62ea6cb47f3f7d5dc33928095a1e8be11c98e16e38fb93
+size 1463861

--- a/docs/solutions/reference-designs/eval-ad5940/images/ad5940elcz.jpg
+++ b/docs/solutions/reference-designs/eval-ad5940/images/ad5940elcz.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d8b82291d036561c296bc382ca9f46b66cabcde10378e02595f33236fc3fc2d6
+size 2544604

--- a/docs/solutions/reference-designs/eval-ad5940/images/ad5941_elcz.jpg
+++ b/docs/solutions/reference-designs/eval-ad5940/images/ad5941_elcz.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7a8ba6101b09c3e2062e357def9e7e1cdda176f163cd4e260afb1233f0a4ecd0
+size 656032

--- a/docs/solutions/reference-designs/eval-ad5940/images/adc_circuits.png
+++ b/docs/solutions/reference-designs/eval-ad5940/images/adc_circuits.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:997e51f7aa2056f762c34a619837a0cea6d63b434b82717182ecbde047249f5a
+size 530215

--- a/docs/solutions/reference-designs/eval-ad5940/images/bia_terminal.png
+++ b/docs/solutions/reference-designs/eval-ad5940/images/bia_terminal.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1838ea9fd86a271aacb7e026ab854c40141fe76fcd4eefcf75c239a2c1d4d2ac
+size 39639

--- a/docs/solutions/reference-designs/eval-ad5940/images/bioz_block_diagram.jpg
+++ b/docs/solutions/reference-designs/eval-ad5940/images/bioz_block_diagram.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b95de3dd18690abab1ff2077e7b03c19dcd1363cf97883b9f18d4c157b6fb313
+size 643010

--- a/docs/solutions/reference-designs/eval-ad5940/images/comm_port.png
+++ b/docs/solutions/reference-designs/eval-ad5940/images/comm_port.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e89986a71d97702497a9fd588184dac02b7c7ba1c2208a912bf1c7ea1c3cb369
+size 367517

--- a/docs/solutions/reference-designs/eval-ad5940/images/elcz_block_diagram.jpg
+++ b/docs/solutions/reference-designs/eval-ad5940/images/elcz_block_diagram.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c0a0275c934152c09e4ab991f3b1693d9ff5104805452b2dd0285a311dca8958
+size 657491

--- a/docs/solutions/reference-designs/eval-ad5940/images/elcz_cable.jpg
+++ b/docs/solutions/reference-designs/eval-ad5940/images/elcz_cable.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:14d85dc45932f3bf529ac270ea8ccf1dafd5c8568b2bff3992095db6bf1d67cd
+size 3666839

--- a/docs/solutions/reference-designs/eval-ad5940/images/eval-ad5940bioz.jpg
+++ b/docs/solutions/reference-designs/eval-ad5940/images/eval-ad5940bioz.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:313dc05b6f51ba05b4404705bf82a6016c45a15ae11255653013402dd7f722a7
+size 208564

--- a/docs/solutions/reference-designs/eval-ad5940/images/eval-ad5940bioz_bom.xlsx
+++ b/docs/solutions/reference-designs/eval-ad5940/images/eval-ad5940bioz_bom.xlsx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:885f0938921b6bdc4c45f154a46e86cd1513accfe9747cd2ef446d23d9a4f8fc
+size 21666

--- a/docs/solutions/reference-designs/eval-ad5940/images/eval-ad5940bioz_ecg.jpg
+++ b/docs/solutions/reference-designs/eval-ad5940/images/eval-ad5940bioz_ecg.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d8dcebcd03bb644761cddd80b74f94331c1ede30a889f6c079fc9d46a80daea8
+size 3995122

--- a/docs/solutions/reference-designs/eval-ad5940/images/eval-ad5940elcz.jpg
+++ b/docs/solutions/reference-designs/eval-ad5940/images/eval-ad5940elcz.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:137781e0daa26405f9c433225ce3d23d165550bfaa061f13361c63ec039e2a45
+size 2631891

--- a/docs/solutions/reference-designs/eval-ad5940/images/eval-ad5940elcz_bom.xlsx
+++ b/docs/solutions/reference-designs/eval-ad5940/images/eval-ad5940elcz_bom.xlsx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:859fdcdd52eb73d50e2d130b45cfe883e36453960ff4e36c2f4eda23a33897d7
+size 19385

--- a/docs/solutions/reference-designs/eval-ad5940/images/eval_ad5941_elcz.jpg
+++ b/docs/solutions/reference-designs/eval-ad5940/images/eval_ad5941_elcz.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c959d679d5dda0c3e055a1fa41edaad4aa98e75e88ca7a8003df4c0a5e6c25f2
+size 3588002

--- a/docs/solutions/reference-designs/eval-ad5940/images/firmware_load.png
+++ b/docs/solutions/reference-designs/eval-ad5940/images/firmware_load.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e6b0c34b7845d93550f02b5a2290ba643f11b213b92713a0b147fbc544273893
+size 367499

--- a/docs/solutions/reference-designs/eval-ad5940/images/firmware_load_2.png
+++ b/docs/solutions/reference-designs/eval-ad5940/images/firmware_load_2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dcf86501f85bb0a743401e37ea0e83eae271724bcda7e49221b192a45a87341d
+size 23878

--- a/docs/solutions/reference-designs/eval-ad5940/images/folder_structure.png
+++ b/docs/solutions/reference-designs/eval-ad5940/images/folder_structure.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2e7e5120a04bb13bf34ed0f989e30d167e5a382c88f39706adb7814cf650619c
+size 10654

--- a/docs/solutions/reference-designs/eval-ad5940/images/hstia_rtiacal.jpg
+++ b/docs/solutions/reference-designs/eval-ad5940/images/hstia_rtiacal.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9c7135f5474688670af6ae9cad1ffa311d420d02edad73dd18e06169fbd7f5c7
+size 197693

--- a/docs/solutions/reference-designs/eval-ad5940/images/iar.png
+++ b/docs/solutions/reference-designs/eval-ad5940/images/iar.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d62a94401d572c5b6060636d1c8648d34ef15f452b3681cb931dc6abe5e06c74
+size 62056

--- a/docs/solutions/reference-designs/eval-ad5940/images/iar_debug.png
+++ b/docs/solutions/reference-designs/eval-ad5940/images/iar_debug.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bcee2d896ca250d323438f7845bf6bb8f26b9dbce27e883dc77d5a12bcdfb4da
+size 19867

--- a/docs/solutions/reference-designs/eval-ad5940/images/iar_debugger.png
+++ b/docs/solutions/reference-designs/eval-ad5940/images/iar_debugger.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a1baecdb797b367c7b6fc88287ccac873bd441b50f2e24eb856fdebf804ae3d0
+size 34096

--- a/docs/solutions/reference-designs/eval-ad5940/images/img_20170612_144023_hdr.jpg
+++ b/docs/solutions/reference-designs/eval-ad5940/images/img_20170612_144023_hdr.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e6ee11e6f6883967a05648adf784c27b44231c8a68397e6a3ed175e427b16f25
+size 2577547

--- a/docs/solutions/reference-designs/eval-ad5940/images/impedance_equation.png
+++ b/docs/solutions/reference-designs/eval-ad5940/images/impedance_equation.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9423ada8ae4def37a0f77afe1574a53e02b918557ad1d276da49f1b18246425c
+size 2068

--- a/docs/solutions/reference-designs/eval-ad5940/images/keil_adc.png
+++ b/docs/solutions/reference-designs/eval-ad5940/images/keil_adc.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b8695088b1d2459bc7ba552672cef2b61eeb65005e4bba883f08d567a32e7e5d
+size 58783

--- a/docs/solutions/reference-designs/eval-ad5940/images/keil_amperometric.png
+++ b/docs/solutions/reference-designs/eval-ad5940/images/keil_amperometric.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5033a86bb2bcc499e17501100c821d0dba7653c3695676c286a141c0fc530922
+size 100269

--- a/docs/solutions/reference-designs/eval-ad5940/images/keil_debug.png
+++ b/docs/solutions/reference-designs/eval-ad5940/images/keil_debug.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4dacdf0c3e8e3ae536b540b068f929294f45e4722c64de8646de05750b5eec4f
+size 57911

--- a/docs/solutions/reference-designs/eval-ad5940/images/keil_debugger.png
+++ b/docs/solutions/reference-designs/eval-ad5940/images/keil_debugger.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d2d89fd9fb3cac328b4cdaf23cce6f2e2bb2da742688d3bb4db0734024b72836
+size 72913

--- a/docs/solutions/reference-designs/eval-ad5940/images/keil_impedance.png
+++ b/docs/solutions/reference-designs/eval-ad5940/images/keil_impedance.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:80d11072647f4e242013b1287134086456c8ab9f259ea1f636d284b1fdadfe0a
+size 92553

--- a/docs/solutions/reference-designs/eval-ad5940/images/keil_ramp.png
+++ b/docs/solutions/reference-designs/eval-ad5940/images/keil_ramp.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ec0f2cf39ca09064b5561a63ea4cb86b4ad3d82d9f802acd7b639b03b018bac5
+size 100419

--- a/docs/solutions/reference-designs/eval-ad5940/images/lprtia_cal.jpg
+++ b/docs/solutions/reference-designs/eval-ad5940/images/lprtia_cal.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b5331ee9394523acb58ec4fbff2bb4bb82fcd2b86ccf7303e014b399b0729762
+size 162334

--- a/docs/solutions/reference-designs/eval-ad5940/images/lptia_offset.jpg
+++ b/docs/solutions/reference-designs/eval-ad5940/images/lptia_offset.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2b93a3be0f8ff8712ee6254a98930d475d4efb307c935c6ed773f56ebecedd84
+size 1823528

--- a/docs/solutions/reference-designs/eval-ad5940/images/pack_installation.png
+++ b/docs/solutions/reference-designs/eval-ad5940/images/pack_installation.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ef0dc26afca313e29ae6da33ccf42a9e1aad59e2488094d8b589d829cc3b839e
+size 53733

--- a/docs/solutions/reference-designs/eval-ad5940/images/pack_manager.png
+++ b/docs/solutions/reference-designs/eval-ad5940/images/pack_manager.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:be34160daae8b1e8d1565dda5123186aa30818dcf3813e454b0e38d5fc6b410a
+size 80182

--- a/docs/solutions/reference-designs/eval-ad5940/images/project_display.png
+++ b/docs/solutions/reference-designs/eval-ad5940/images/project_display.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3e91857359ed8668230af2009e608e3a7f5df66c7a971c0d352ed33fc8486f13
+size 38468

--- a/docs/solutions/reference-designs/eval-ad5940/images/realterm_amperometric.png
+++ b/docs/solutions/reference-designs/eval-ad5940/images/realterm_amperometric.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c6e4b2a02e5a1f6dc7062be5651613a8fb45423cdfd784bf63e32e6184877e88
+size 27633

--- a/docs/solutions/reference-designs/eval-ad5940/images/realterm_impedance.png
+++ b/docs/solutions/reference-designs/eval-ad5940/images/realterm_impedance.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d50ae7f3ca0e3fe3b6c74c81d794f7ad02097d661a1caccdbb836ab0637d64f4
+size 34862

--- a/docs/solutions/reference-designs/eval-ad5940/images/realterm_ramp.png
+++ b/docs/solutions/reference-designs/eval-ad5940/images/realterm_ramp.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:64390b9965e7e01102beea8eaa3b3ea521ae5dfe5b6f2ec972bca642bd29a3aa
+size 27800

--- a/docs/solutions/reference-designs/eval-ad5940/images/rtia_equation.png
+++ b/docs/solutions/reference-designs/eval-ad5940/images/rtia_equation.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1f1f7e2dcd608686570c26124872d4a8d7db39dbb783a39742919f90cd715dfc
+size 5413

--- a/docs/solutions/reference-designs/eval-ad5940/images/select_project.png
+++ b/docs/solutions/reference-designs/eval-ad5940/images/select_project.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c39d91a105c358770ff62e3e931e1f74c33a53ec278840a445b39d2b0d892268
+size 121858

--- a/docs/solutions/reference-designs/eval-ad5940/images/sensorpal_ecg.png
+++ b/docs/solutions/reference-designs/eval-ad5940/images/sensorpal_ecg.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7e34035fe1d7e86236f70ba9610c41611f7a163e8108ddafda51d77ef15f97b8
+size 198916

--- a/docs/solutions/reference-designs/eval-ad5940/images/sensorpalinstaller_analog_com.png
+++ b/docs/solutions/reference-designs/eval-ad5940/images/sensorpalinstaller_analog_com.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cf36f4fb5b94d416c1651734ecc201db64fcef57d79478077d99d06d523d9dcb
+size 132311

--- a/docs/solutions/reference-designs/eval-ad5940/images/setup1.png
+++ b/docs/solutions/reference-designs/eval-ad5940/images/setup1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ac6d36ded4d5416e426e0f5495b48c96ec837dda03d13a34a45e0326cc558323
+size 148516

--- a/docs/solutions/reference-designs/eval-ad5940/images/setup2.png
+++ b/docs/solutions/reference-designs/eval-ad5940/images/setup2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1fd3b6993206537c290bb0dd7a74b45c87b5f8ba3751f336f61b0f19aad9125b
+size 27075

--- a/docs/solutions/reference-designs/eval-ad5940/images/setup3.png
+++ b/docs/solutions/reference-designs/eval-ad5940/images/setup3.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cc143c2ae6057e3ca9539a619b50ed0b740c497633905df0a05a3ba7e081b51b
+size 70136

--- a/docs/solutions/reference-designs/eval-ad5940/images/setup4.png
+++ b/docs/solutions/reference-designs/eval-ad5940/images/setup4.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0f061562a61a690834ebc4c91f6b8ff6b802e900552a98b3151448d90540b0ef
+size 40371

--- a/docs/solutions/reference-designs/eval-ad5940/images/setup6.png
+++ b/docs/solutions/reference-designs/eval-ad5940/images/setup6.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c17a7361aa40bdfb0b9ba8791d9a5ec5d5dd6754add782314dcaabb7bc397d2f
+size 24915

--- a/docs/solutions/reference-designs/eval-ad5940/images/sqrwavevoltammetry.png
+++ b/docs/solutions/reference-designs/eval-ad5940/images/sqrwavevoltammetry.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a66c7e61b5c654ac62b2a1ce92cfe9c6a8aad85251355911ca88c5e3c55d458f
+size 58274

--- a/docs/solutions/reference-designs/eval-ad5940/index.rst
+++ b/docs/solutions/reference-designs/eval-ad5940/index.rst
@@ -1,8 +1,27 @@
-EVAL-AD5940
-===========
+.. _eval_ad5940 eval:
+
+EVAL AD5940
+===================================================================
+
+.. TODO: Add a picture of the chip/board
+
+Overview
+-------------------------------------------------------------------------------
+
+.. TODO: Describe in max 10 rows the main features and applications.
+
+Features:
+
+- feature 1
+- feature 2
+
+Applications:
+
+- application 1
+- application 2
 
 .. toctree::
-   :titlesonly:
+   :hidden:
 
    calibration_routines
    calibration_routines/adc_cal
@@ -33,3 +52,22 @@ EVAL-AD5940
    tools/keil_setup_guide
    tools/porting_source_code
    tools/sensorpal_setup_guide
+
+Recommendations
+-------------------------------------------------------------------------------
+
+People who follow the flow that is outlined, have a much better experience with
+things. However, like many things, documentation is never as complete as it
+should be. If you have any questions, feel free to ask on our
+:ref:`EngineerZone forums <help-and-support>`, but before that, please make
+sure you read our documentation thoroughly.
+
+Warning
+-------------------------------------------------------------------------------
+
+.. esd-warning::
+
+Help and support
+-------------------------------------------------------------------------------
+
+Please go to :ref:`Help and Support <help-and-support>` page.

--- a/docs/solutions/reference-designs/eval-ad5940/index.rst
+++ b/docs/solutions/reference-designs/eval-ad5940/index.rst
@@ -1,0 +1,35 @@
+EVAL-AD5940
+===========
+
+.. toctree::
+   :titlesonly:
+
+   calibration_routines
+   calibration_routines/adc_cal
+   calibration_routines/hsdac_cal
+   calibration_routines/hstia_cal
+   calibration_routines/lfosc_cal
+   calibration_routines/lptia_cal
+   calibration_routines/lptia_offset_cal
+   hardware
+   hardware/eval-ad5940bioz
+   hardware/eval-ad5940elcz
+   hardware/eval-ad5941elcz
+   hardware/power_connections
+   help_and_support
+   introduction
+   software_examples
+   software_examples/ad5940_amperometric
+   software_examples/ad5940_bia
+   software_examples/ad5940_chronoamperometric
+   software_examples/ad5940_ecg
+   software_examples/ad5940_eda
+   software_examples/ad5940_impedance
+   software_examples/ad5940_ramp
+   software_examples/ad5940_swv
+   tools
+   tools/downloading_source_code
+   tools/iar_setup_guide
+   tools/keil_setup_guide
+   tools/porting_source_code
+   tools/sensorpal_setup_guide

--- a/docs/solutions/reference-designs/eval-ad5940/introduction.rst
+++ b/docs/solutions/reference-designs/eval-ad5940/introduction.rst
@@ -1,10 +1,32 @@
 Introduction
 ============
 
-| The :adi:`EVAL-AD5940` evaluation platform are Arduino form-factor based evaluation boards designed to provide a familiar development system to customers. Each AD5940 evaluation board is targeted at a particular end application, for example the EVAL-AD5940BIOZ targets Bio-Impedance measurements. Each AD5940 evaluation boards comes packaged with the :adi:`EVAL-ADICUP3029` which is an Arduino-like development platform based on the :adi:`ADUCM3029` ultra low power microcontroller (MCU). This MCU is used to configure and communicate with the AD5940 through the SPI peripheral. For initial evaluation there is a Graphical User Interface (GUI) tool, SensorPal, provided to quickly make measurements with graphing and data capture capabilities. There are also a larger number of example projects written in embedded C with instructions on how to set the programming environment and run the examples
-| This guide is structured as follows:
+The :adi:`EVAL-AD5940` evaluation platform are Arduino form-factor based
+evaluation boards designed to provide a familiar development system to
+customers. Each AD5940 evaluation board is targeted at a particular end
+application, for example the EVAL-AD5940BIOZ targets Bio-Impedance
+measurements. Each AD5940 evaluation boards comes packaged with the
+:adi:`EVAL-ADICUP3029` which is an Arduino-like development platform based on
+the :adi:`ADUCM3029` ultra low power microcontroller (MCU). This MCU is used
+to configure and communicate with the AD5940 through the SPI peripheral. For
+initial evaluation there is a Graphical User Interface (GUI) tool, SensorPal,
+provided to quickly make measurements with graphing and data capture
+capabilities. There are also a larger number of example projects written in
+embedded C with instructions on how to set the programming environment and run
+the examples
 
--  :doc:`Tools and Driver Details </solutions/reference-designs/eval-ad5940/tools>` - Provides all the necessary steps to download/install/use SensorPal GUI tool quickly begin making measurements. Also included are instructions on how to download/install/use popular development IDE's Kiel and IAR.
--  :doc:`Hardware Details </solutions/reference-designs/eval-ad5940/hardware>` - Contains hardware-related information about the base board and the various available AD5940 shields.
--  :doc:`AD5940 Example Projects </solutions/reference-designs/eval-ad5940/software_examples>` - Contains sample code for various application specific example projects with instructions on how to set up and carry out the measurements
--  :doc:`Help and Support </solutions/reference-designs/eval-ad5940/help_and_support>` - Provides info on where to get support on any questions you might have regarding the hardware, software, and tools
+This guide is structured as follows:
+
+-  :doc:`Tools and Driver Details </solutions/reference-designs/eval-ad5940/tools>`
+   - Provides all the necessary steps to download/install/use SensorPal GUI
+   tool quickly begin making measurements. Also included are instructions on
+   how to download/install/use popular development IDE's Kiel and IAR.
+-  :doc:`Hardware Details </solutions/reference-designs/eval-ad5940/hardware>`
+   - Contains hardware-related information about the base board and the
+   various available AD5940 shields.
+-  :doc:`AD5940 Example Projects </solutions/reference-designs/eval-ad5940/software_examples>`
+   - Contains sample code for various application specific example projects
+   with instructions on how to set up and carry out the measurements
+-  :doc:`Help and Support </solutions/reference-designs/eval-ad5940/help_and_support>`
+   - Provides info on where to get support on any questions you might have
+   regarding the hardware, software, and tools

--- a/docs/solutions/reference-designs/eval-ad5940/introduction.rst
+++ b/docs/solutions/reference-designs/eval-ad5940/introduction.rst
@@ -1,0 +1,10 @@
+Introduction
+============
+
+| The :adi:`EVAL-AD5940` evaluation platform are Arduino form-factor based evaluation boards designed to provide a familiar development system to customers. Each AD5940 evaluation board is targeted at a particular end application, for example the EVAL-AD5940BIOZ targets Bio-Impedance measurements. Each AD5940 evaluation boards comes packaged with the :adi:`EVAL-ADICUP3029` which is an Arduino-like development platform based on the :adi:`ADUCM3029` ultra low power microcontroller (MCU). This MCU is used to configure and communicate with the AD5940 through the SPI peripheral. For initial evaluation there is a Graphical User Interface (GUI) tool, SensorPal, provided to quickly make measurements with graphing and data capture capabilities. There are also a larger number of example projects written in embedded C with instructions on how to set the programming environment and run the examples
+| This guide is structured as follows:
+
+-  :doc:`Tools and Driver Details </solutions/reference-designs/eval-ad5940/tools>` - Provides all the necessary steps to download/install/use SensorPal GUI tool quickly begin making measurements. Also included are instructions on how to download/install/use popular development IDE's Kiel and IAR.
+-  :doc:`Hardware Details </solutions/reference-designs/eval-ad5940/hardware>` - Contains hardware-related information about the base board and the various available AD5940 shields.
+-  :doc:`AD5940 Example Projects </solutions/reference-designs/eval-ad5940/software_examples>` - Contains sample code for various application specific example projects with instructions on how to set up and carry out the measurements
+-  :doc:`Help and Support </solutions/reference-designs/eval-ad5940/help_and_support>` - Provides info on where to get support on any questions you might have regarding the hardware, software, and tools

--- a/docs/solutions/reference-designs/eval-ad5940/resources/02-057011-01-a-1.pdf
+++ b/docs/solutions/reference-designs/eval-ad5940/resources/02-057011-01-a-1.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dbb3fa155c6464d61b08aef01aa037deabb0d3413f9ce5e5b2438d149bb0bd43
+size 320610

--- a/docs/solutions/reference-designs/eval-ad5940/resources/02_049988b_top.pdf
+++ b/docs/solutions/reference-designs/eval-ad5940/resources/02_049988b_top.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:62114d8e38bad78f6ba9bd9dfcd16fbf7a5d4886f3b537afa7b194d6d992b8f0
+size 385193

--- a/docs/solutions/reference-designs/eval-ad5940/resources/02_050193b.pdf
+++ b/docs/solutions/reference-designs/eval-ad5940/resources/02_050193b.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:667df961aa47440d68624b1ca9a898ba467931892eb41464a08b0d5ca962080c
+size 59185

--- a/docs/solutions/reference-designs/eval-ad5940/resources/08-049988-01-b.pdf
+++ b/docs/solutions/reference-designs/eval-ad5940/resources/08-049988-01-b.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:42a7757977b863e18ba2c1b4045c34c596b4560340457531235303d02638e56e
+size 1231357

--- a/docs/solutions/reference-designs/eval-ad5940/resources/08-050193a.pdf
+++ b/docs/solutions/reference-designs/eval-ad5940/resources/08-050193a.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1f2534ad4169c16c59274ac394b6c598c437f8bf328e0c6139507412450de61e
+size 1213243

--- a/docs/solutions/reference-designs/eval-ad5940/resources/08-057011-01-a-1.pdf
+++ b/docs/solutions/reference-designs/eval-ad5940/resources/08-057011-01-a-1.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:02e35a32c8c444efd263b982173d1e091ee9d737847b5a642f547b7fb5f45eea
+size 934981

--- a/docs/solutions/reference-designs/eval-ad5940/resources/09-057011-01a.zip
+++ b/docs/solutions/reference-designs/eval-ad5940/resources/09-057011-01a.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e68c198b6da7e18b48ead34363e6c776adb0b8467e481107ef7cce724fc81efb
+size 521030

--- a/docs/solutions/reference-designs/eval-ad5940/resources/ad5940_z_test.pdf
+++ b/docs/solutions/reference-designs/eval-ad5940/resources/ad5940_z_test.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4ef757e966aa5645fe982f3015e61ec51cd00a4eac7f031af9687265ad45764d
+size 753837

--- a/docs/solutions/reference-designs/eval-ad5940/resources/ad5940_z_test_.pdf
+++ b/docs/solutions/reference-designs/eval-ad5940/resources/ad5940_z_test_.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e1f374108c2ec75ac168c7d2dafa1b5cfcd790f13ca9d49ab204af298164d498
+size 282973

--- a/docs/solutions/reference-designs/eval-ad5940/resources/eval-ad5940bioz_fabrication.zip
+++ b/docs/solutions/reference-designs/eval-ad5940/resources/eval-ad5940bioz_fabrication.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:362d95651e4d6088c3bf6a86d82d3a34c2e2e5afdf10717dfca20106a3dd780b
+size 308144

--- a/docs/solutions/reference-designs/eval-ad5940/resources/eval-ad5940elcz_fabriaction.zip
+++ b/docs/solutions/reference-designs/eval-ad5940/resources/eval-ad5940elcz_fabriaction.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cffddb766698182ee8d5442cf2192209e8d2440da302726fe79af5b072721bd7
+size 387192

--- a/docs/solutions/reference-designs/eval-ad5940/software_examples.rst
+++ b/docs/solutions/reference-designs/eval-ad5940/software_examples.rst
@@ -1,0 +1,14 @@
+Software Examples
+=================
+
+The AD5940 evaluation environment consists of a large number of application
+specific example projects. These example projects were written in Embedded C to
+work on the ADuCM3029 micro-controller. Each sub-section describes the software
+example, how to setup the hardware, how to obtain the source code and finally
+how to compile and run it.
+
+The following projects are currently available:
+
+-  :doc:`Body Impedance Analysis </solutions/reference-designs/eval-ad5940/software_examples/ad5940_bia>`
+-  :doc:`Electrodermal Activity </solutions/reference-designs/eval-ad5940/software_examples/ad5940_eda>`
+-  :doc:`Electrocardiograph </solutions/reference-designs/eval-ad5940/software_examples/ad5940_ecg>`

--- a/docs/solutions/reference-designs/eval-ad5940/software_examples/ad5940_amperometric.rst
+++ b/docs/solutions/reference-designs/eval-ad5940/software_examples/ad5940_amperometric.rst
@@ -1,7 +1,8 @@
 AD5940_Amperometric
 ===================
 
-This example will use **EVAL-ADICUP3029** and **EVAL_AD5940ELCZ** to carry put Amperometric measurements.
+This example will use **EVAL-ADICUP3029** and **EVAL_AD5940ELCZ** to carry
+put Amperometric measurements.
 
 Overview
 --------
@@ -43,7 +44,8 @@ The following is a list of items required to carry out the measurement.
 Setting up the Hardware
 -----------------------
 
--  Set switch S2 to USB Arduino function in order to view data over UART. The UART baud rate is **230400**
+-  Set switch S2 to USB Arduino function in order to view data over UART. The
+   UART baud rate is **230400**
 -  Set S5 to Wall/USB to power the board from the USB cable
 
 .. image:: ../images/img_20170612_144023_hdr.jpg
@@ -68,9 +70,9 @@ The source code and include files for the project can be found on Git
 .. admonition:: Download
    :class: download
 
-   
+
    `AD5940 Source Code <https://github.com/analogdevicesinc/ad5940-examples>`_
-   
+
 
 Configuring the Software
 ------------------------

--- a/docs/solutions/reference-designs/eval-ad5940/software_examples/ad5940_amperometric.rst
+++ b/docs/solutions/reference-designs/eval-ad5940/software_examples/ad5940_amperometric.rst
@@ -1,0 +1,122 @@
+AD5940_Amperometric
+===================
+
+This example will use **EVAL-ADICUP3029** and **EVAL_AD5940ELCZ** to carry put Amperometric measurements.
+
+Overview
+--------
+
+This example project is designed to carry out amperometric measurements.
+Amperometric measurement is a basic electrochemical measurement where a bias
+voltage is applied to a sensor and the response current is monitored. Some
+sensors require no bias and are referred to zero bias sensors. The AD5940 uses
+its low power DAC, potentiostat amplifier, and low power TIA (LPTIA) to set a
+voltage on the sensor and measure the current. The low power DAC is a dual
+output DAC with a 12-bit option and a 6-bit option. The 12-bit output, known as
+VBIAS, sets the voltage on the counter and reference electrode. The 6-bit
+output, known as VZERO, sets the voltage on the working electrode, also known as
+the sense electrode (SE0). For zero bias sensors, the VBIAS and VZERO¬ outputs
+are set to the same value, which is optimally 1.1 V for the AD5940. For a
+nonzero bias sensor, the bias across the sensor is set by adjusting VBIAS and
+VZERO. In general the current measured on the sense electrode (SE0) is directly
+proportional to what is being measured.
+
+Measurement Requirements
+------------------------
+
+The following is a list of items required to carry out the measurement.
+
+-  Hardware
+
+   -  EVAL-ADICUP3029
+   -  EVAL-AD5940ELCZ
+   -  Mirco USB to USB cable
+   -  PC or Laptop with a USB port
+   -  Custom Cables (Optional)
+
+-  Software
+
+   -  AD5940_Amperometric Example Project (Git Lab)
+   -  Serial Terminal Program, Such as Putty or RealTerm
+   -  IDE such as IAR or Keil
+
+Setting up the Hardware
+-----------------------
+
+-  Set switch S2 to USB Arduino function in order to view data over UART. The UART baud rate is **230400**
+-  Set S5 to Wall/USB to power the board from the USB cable
+
+.. image:: ../images/img_20170612_144023_hdr.jpg
+   :align: center
+   :width: 800
+
+-  Place the **EVAL-AD5940ELCZ** on top of the **EVAL-ADICUP3029**.
+-  Ensure jumper on JP10 and JP11 is on PIN2 and PIN4
+-  Place jumper in position B on JP6 to connect 1k||3k between RE0 and SE0
+-  Plug in the micro USB cable into the (P10) USB port on the EVAL-ADICUP3029,
+   and the other end into the PC or laptop.
+
+.. image:: ../images/ad5940elcz.jpg
+   :align: center
+   :width: 600
+
+Obtaining the Source Code
+-------------------------
+
+The source code and include files for the project can be found on Git
+
+.. admonition:: Download
+   :class: download
+
+   
+   `AD5940 Source Code <https://github.com/analogdevicesinc/ad5940-examples>`_
+   
+
+Configuring the Software
+------------------------
+
+To compile and run the example open the project in either Keil or IAR. The
+AD5940AMPStructInit() function is used to configure application parameters
+including, SensorBias and RtiaValue.
+
+.. image:: ../images/keil_amperometric.png
+   :align: center
+   :width: 600
+
+Outputting Data
+---------------
+
+The measurement results are sent to the PC via UART. To establish connection
+over UART, connect the Micro-USB cable to the PC and to the EVAL-ADICUP3029
+board. A terminal program such as RealTerm or Putty is required to display the
+results
+
+Following is the UART configuration.
+
+::
+
+     Select COM Port
+     Baud rate: 230400
+     Data: 8 bit
+     Parity: none
+     Stop: 1 bit
+     Flow Control: none
+
+The data on the terminal consists of the Frequency of the excitation signal, the
+magnitude of the impedance and the phase of the impedance in degrees as in below
+screenshot.
+
+|image1|
+
+Gas Sensor
+----------
+
+The EVAL-AD5940ELCZ contains a footprint to connect an electrochemical gas
+sensor. To carry out amperometric measurements on a gas sensor connect the gas
+sensor to M1 as shown in image below. Move the jumpers on JP10 and JP11 to PIN1
+and PIN2. Note the specified bias voltage for the sensor in the sensor
+datasheet. Modify the SensorBias variable in the AD5940_Amperometric firmware to
+correspond.
+
+.. |image1| image:: ../images/realterm_amperometric.png
+   :width: 600

--- a/docs/solutions/reference-designs/eval-ad5940/software_examples/ad5940_bia.rst
+++ b/docs/solutions/reference-designs/eval-ad5940/software_examples/ad5940_bia.rst
@@ -1,0 +1,242 @@
+AD5940_BIA
+==========
+
+This demo will use **EVAL-ADICUP3029**, **EVAL_AD5940BIOZ** and **Impedance-Test** board to carry out BIA measurements.
+
+Overview
+--------
+
+This example project is designed to carry out body impedance analysis (BIA)
+measurements. The Impedance Test board is provided with the hardware which
+models body impedance. It consists of a range of resistors and capacitors which
+can be used to model body impedance, contact impedance and electrode impedance.
+
+Alternatively, the custom cables can be connected to the body to measure actual
+body impedance.
+
+Measurement Requirements
+------------------------
+
+The following is a list of items required to carry out the measurement.
+
+-  Hardware
+
+   -  EVAL-ADICUP3029
+   -  EVAL-AD5940BIOZ
+   -  Z-Test Board
+   -  Micro USB to USB cable
+   -  PC or Laptop with a USB port
+   -  Custom Cables (Optional)
+
+-  Software
+
+   -  AD5940_BIA Example Project (Git Lab)
+   -  Serial Terminal Program, Such as Putty or RealTerm
+   -  IDE such as IAR or Keil
+
+Setting up the Hardware
+-----------------------
+
+-  Set switch S2 to USB Arduino function in order to view data over UART. The UART baud rate is **230400**
+-  Set S5 to Wall/USB to power the board from the USB cable
+
+.. image:: ../images/img_20170612_144023_hdr.jpg
+   :align: center
+   :width: 800
+
+-  Place the **EVAL-AD5940BIOZ** on top of the **EVAL-ADICUP3029**.
+
+.. image:: ../images/eval-ad5940bioz.jpg
+   :align: center
+   :width: 800
+
+-  Connect the AD5940 Z Test board to the EVAL-AD5940BIOZ board
+-  All jumpers should be in their default position
+-  Plug in the micro USB cable into the (P10) USB port on the EVAL-ADICUP3029,
+   and the other end into the PC or laptop.
+
+AD5940 Z Test Board
+~~~~~~~~~~~~~~~~~~~
+
+The AD5940 Z Test board is designed to model skin impedance, body impedance,
+electrode contact impedance and electrode impedance. There are 5 banks of
+switches on the board labelled S1, S2, S3, S4 and S5. The function of each bank
+is described in the following table:
+
+=========== ===============================================
+Switch Bank Bank Function
+=========== ===============================================
+S1          Used to model Body Impedance
+S2          Used to model contact impedance on F+ electrode
+S3          Used to model contact impedance on S+ electrode
+S4          Used to model contact impedance on F- electrode
+S5          Used to model contact impedance on S- electrode
+=========== ===============================================
+
+The following tables indicate the resistor or capacitor value associated with
+each switch in the bank. Moving the switch to the ON position connects the
+corresponding resistor or capacitor value in series on the signal path. If more
+than one switch is active the corresponding resistor values are connected in
+series.
+
+.. container:: column
+
+   
+   ======= ===========================
+   S1 Bank Corresponding Res/Cap Value
+   ======= ===========================
+   S1      100 Ω
+   S2      200 Ω
+   S3      300 Ω
+   S4      340 Ω
+   S5      510 Ω
+   S6      1 kΩ
+   S7      2 kΩ
+   S8      3.01 kΩ
+   S9      4.02 kΩ
+   S10     4.99 kΩ
+   S11     1000 pF
+   S12     0.01 μF
+   ======= ===========================
+   
+
+.. container:: column
+
+   
+   ======= ===========================
+   S2 Bank Corresponding Res/Cap Value
+   ======= ===========================
+   S1      100 Ω
+   S2      200 Ω
+   S3      300 Ω
+   S4      402 Ω
+   S5      10 kΩ
+   S6      23.7 kΩ
+   S7      42.2 kΩ
+   S8      42.2 kΩ
+   S9      100 kΩ
+   S10     200 kΩ
+   S11     1000 pF
+   S12     0.01 μF
+   ======= ===========================
+   
+
+.. container:: column
+
+   
+   ======= ===========================
+   S3 Bank Corresponding Res/Cap Value
+   ======= ===========================
+   S1      100 Ω
+   S2      200 Ω
+   S3      300 Ω
+   S4      402 Ω
+   S5      4.22 MΩ
+   S6      4.22 MΩ
+   S7      1.43 MΩ
+   S8      1 MΩ
+   S9      300 kΩ
+   S10     300 kΩ
+   S11     1000 pF
+   S12     0.01 μF
+   ======= ===========================
+   
+
+.. container:: column
+
+   
+   ======= ===========================
+   S4 Bank Corresponding Res/Cap Value
+   ======= ===========================
+   S1      100 Ω
+   S2      200 Ω
+   S3      300 Ω
+   S4      402 Ω
+   S5      499 Ω
+   S6      1 kΩ
+   S7      2 kΩ
+   S8      3.01 kΩ
+   S9      4.02 kΩ
+   S10     4.99 kΩ
+   S11     1000 pF
+   S12     0.01 μF
+   ======= ===========================
+   
+
+.. container:: column
+
+   
+   ======= ===========================
+   S5 Bank Corresponding Res/Cap Value
+   ======= ===========================
+   S1      100 Ω
+   S2      200 Ω
+   S3      300 Ω
+   S4      402 Ω
+   S5      499 Ω
+   S6      1 kΩ
+   S7      2 kΩ
+   S8      3.01 kΩ
+   S9      4.02 kΩ
+   S10     4.99 kΩ
+   S11     1000 pF
+   S12     0.01 μF
+   ======= ===========================
+   
+
+AD5940 Z Test Schematic and Layout
+----------------------------------
+
+.. admonition:: Download
+   :class: download
+
+   
+   `Schematic <../resources/ad5940_z_test_.pdf>`_
+   
+   `Layout <../resources/ad5940_z_test.pdf>`_
+
+Obtaining the Source Code
+-------------------------
+
+The source code and include files for the project can be found on Git
+
+.. admonition:: Download
+   :class: download
+
+   
+   `AD5940 Source Code <https://github.com/analogdevicesinc/ad5940-examples>`_
+
+Configuring the Software
+------------------------
+
+To compile and run the example open the project in either Keil or IAR. The
+AD5940BIAStructInit() function configures the main application parameters. These
+include the sample frequency (BiaODR), and number of samples to feed to DFT
+block (DFT_Num). Compile the project and download to the hardware.
+
+Outputting Data
+---------------
+
+The measurement results are sent to the PC via UART. To establish connection
+over UART, connect the Micro-USB cable to the PC and to the EVAL-ADICUP3029
+board. A terminal program such as RealTerm or Putty is required to display the
+results
+
+Following is the UART configuration.
+
+::
+
+     Select COM Port
+     Baud rate: 230400
+     Data: 8 bit
+     Parity: none
+     Stop: 1 bit
+     Flow Control: none
+
+The data on the terminal consists of the Frequency of the excitation signal, the
+magnitude of the impedance and the phase of the impedance in degrees as in below
+screenshot.
+
+.. image:: ../images/bia_terminal.png
+   :align: center
+   :width: 400

--- a/docs/solutions/reference-designs/eval-ad5940/software_examples/ad5940_bia.rst
+++ b/docs/solutions/reference-designs/eval-ad5940/software_examples/ad5940_bia.rst
@@ -1,7 +1,8 @@
 AD5940_BIA
 ==========
 
-This demo will use **EVAL-ADICUP3029**, **EVAL_AD5940BIOZ** and **Impedance-Test** board to carry out BIA measurements.
+This demo will use **EVAL-ADICUP3029**, **EVAL_AD5940BIOZ** and
+**Impedance-Test** board to carry out BIA measurements.
 
 Overview
 --------
@@ -37,7 +38,8 @@ The following is a list of items required to carry out the measurement.
 Setting up the Hardware
 -----------------------
 
--  Set switch S2 to USB Arduino function in order to view data over UART. The UART baud rate is **230400**
+-  Set switch S2 to USB Arduino function in order to view data over UART. The
+   UART baud rate is **230400**
 -  Set S5 to Wall/USB to power the board from the USB cable
 
 .. image:: ../images/img_20170612_144023_hdr.jpg
@@ -81,7 +83,7 @@ series.
 
 .. container:: column
 
-   
+
    ======= ===========================
    S1 Bank Corresponding Res/Cap Value
    ======= ===========================
@@ -98,11 +100,11 @@ series.
    S11     1000 pF
    S12     0.01 μF
    ======= ===========================
-   
+
 
 .. container:: column
 
-   
+
    ======= ===========================
    S2 Bank Corresponding Res/Cap Value
    ======= ===========================
@@ -119,11 +121,11 @@ series.
    S11     1000 pF
    S12     0.01 μF
    ======= ===========================
-   
+
 
 .. container:: column
 
-   
+
    ======= ===========================
    S3 Bank Corresponding Res/Cap Value
    ======= ===========================
@@ -140,11 +142,11 @@ series.
    S11     1000 pF
    S12     0.01 μF
    ======= ===========================
-   
+
 
 .. container:: column
 
-   
+
    ======= ===========================
    S4 Bank Corresponding Res/Cap Value
    ======= ===========================
@@ -161,11 +163,11 @@ series.
    S11     1000 pF
    S12     0.01 μF
    ======= ===========================
-   
+
 
 .. container:: column
 
-   
+
    ======= ===========================
    S5 Bank Corresponding Res/Cap Value
    ======= ===========================
@@ -182,7 +184,7 @@ series.
    S11     1000 pF
    S12     0.01 μF
    ======= ===========================
-   
+
 
 AD5940 Z Test Schematic and Layout
 ----------------------------------
@@ -190,9 +192,9 @@ AD5940 Z Test Schematic and Layout
 .. admonition:: Download
    :class: download
 
-   
+
    `Schematic <../resources/ad5940_z_test_.pdf>`_
-   
+
    `Layout <../resources/ad5940_z_test.pdf>`_
 
 Obtaining the Source Code
@@ -203,7 +205,7 @@ The source code and include files for the project can be found on Git
 .. admonition:: Download
    :class: download
 
-   
+
    `AD5940 Source Code <https://github.com/analogdevicesinc/ad5940-examples>`_
 
 Configuring the Software

--- a/docs/solutions/reference-designs/eval-ad5940/software_examples/ad5940_chronoamperometric.rst
+++ b/docs/solutions/reference-designs/eval-ad5940/software_examples/ad5940_chronoamperometric.rst
@@ -1,0 +1,110 @@
+AD5940_ChronoAmperometric
+=========================
+
+This example will use **EVAL-ADICUP3029** and **EVAL_AD5940ELCZ** to carry put Chrono-amperometric measurements.
+
+Overview
+--------
+
+Chrono-amperometric, or pulse test, is a test in which the voltage across the
+counter electrode and sense electrode is pulsed, disturbing the normal bias for
+the electrochemical cell. The current response is measured on the sense
+electrode through the LPTIA. The measurement technique can have a number of
+applications. In the case of an electrochemical gas sensor this test checks that
+the passage of charge between electrodes through the internal electrolyte during
+oxidation and reduction is operating properly In normal operation, the AD5940
+sets the voltage on the counter electrode via VBIAS and the voltage on the sense
+electrode is set via VZERO. These are typically set to 1.1 V for a zero bias
+sensor. Then a pulse is applied on VBIAS for a defined duration. The response
+current is measured using the low power TIA or the high speed TIA, depending on
+the speed of the response required. In this application the LPTIA is used.
+
+Measurement Requirements
+------------------------
+
+The following is a list of items required to carry out the measurement.
+
+-  Hardware
+
+   -  EVAL-ADICUP3029
+   -  EVAL-AD5940ELCZ
+   -  Mirco USB to USB cable
+   -  PC or Laptop with a USB port
+   -  Custom Cables (Optional)
+
+-  Software
+
+   -  AD5940_Amperometric Example Project (Git Lab)
+   -  Serial Terminal Program, Such as Putty or RealTerm
+   -  IDE such as IAR or Keil
+
+Setting up the Hardware
+-----------------------
+
+-  Set switch S2 to USB Arduino function in order to view data over UART. The UART baud rate is **230400**
+-  Set S5 to Wall/USB to power the board from the USB cable
+
+.. image:: ../images/img_20170612_144023_hdr.jpg
+   :align: center
+   :width: 800
+
+-  Place the **EVAL-AD5940ELCZ** on top of the **EVAL-ADICUP3029**.
+-  Ensure jumper on JP10 and JP11 is on PIN2 and PIN4
+-  Place jumper in position A on JP6 to connect 6.8K resistor in series with a 10uF capacitor between RE0 and SE0
+-  Plug in the micro USB cable into the (P10) USB port on the EVAL-ADICUP3029,
+   and the other end into the PC or laptop.
+
+.. image:: ../images/ad5940elcz.jpg
+   :align: center
+   :width: 600
+
+Obtaining the Source Code
+-------------------------
+
+The source code and include files for the project can be found on Git
+
+.. admonition:: Download
+   :class: download
+
+   
+   `AD5940 Source Code <https://github.com/analogdevicesinc/ad5940-examples>`_
+   
+
+Configuring the Software
+------------------------
+
+To compile and run the example open the project in either Keil or IAR. The
+AD5940AMPStructInit() function is used to configure application parameters
+including, pulseAmplitude and pulseLength.
+
+.. image:: ../images/keil_amperometric.png
+   :align: center
+   :width: 600
+
+Outputting Data
+---------------
+
+The measurement results are sent to the PC via UART. To establish connection
+over UART, connect the Micro-USB cable to the PC and to the EVAL-ADICUP3029
+board. A terminal program such as RealTerm or Putty is required to display the
+results
+
+Following is the UART configuration.
+
+::
+
+     Select COM Port
+     Baud rate: 230400
+     Data: 8 bit
+     Parity: none
+     Stop: 1 bit
+     Flow Control: none
+
+The data on the terminal consists of the Frequency of the excitation signal, the
+magnitude of the impedance and the phase of the impedance in degrees as in below
+screenshot.
+
+|image1|
+
+.. |image1| image:: ../images/realterm_amperometric.png
+   :width: 600

--- a/docs/solutions/reference-designs/eval-ad5940/software_examples/ad5940_chronoamperometric.rst
+++ b/docs/solutions/reference-designs/eval-ad5940/software_examples/ad5940_chronoamperometric.rst
@@ -1,7 +1,8 @@
 AD5940_ChronoAmperometric
 =========================
 
-This example will use **EVAL-ADICUP3029** and **EVAL_AD5940ELCZ** to carry put Chrono-amperometric measurements.
+This example will use **EVAL-ADICUP3029** and **EVAL_AD5940ELCZ** to carry
+put Chrono-amperometric measurements.
 
 Overview
 --------
@@ -41,7 +42,8 @@ The following is a list of items required to carry out the measurement.
 Setting up the Hardware
 -----------------------
 
--  Set switch S2 to USB Arduino function in order to view data over UART. The UART baud rate is **230400**
+-  Set switch S2 to USB Arduino function in order to view data over UART. The
+   UART baud rate is **230400**
 -  Set S5 to Wall/USB to power the board from the USB cable
 
 .. image:: ../images/img_20170612_144023_hdr.jpg
@@ -50,7 +52,8 @@ Setting up the Hardware
 
 -  Place the **EVAL-AD5940ELCZ** on top of the **EVAL-ADICUP3029**.
 -  Ensure jumper on JP10 and JP11 is on PIN2 and PIN4
--  Place jumper in position A on JP6 to connect 6.8K resistor in series with a 10uF capacitor between RE0 and SE0
+-  Place jumper in position A on JP6 to connect 6.8K resistor in series
+   with a 10uF capacitor between RE0 and SE0
 -  Plug in the micro USB cable into the (P10) USB port on the EVAL-ADICUP3029,
    and the other end into the PC or laptop.
 
@@ -66,9 +69,9 @@ The source code and include files for the project can be found on Git
 .. admonition:: Download
    :class: download
 
-   
+
    `AD5940 Source Code <https://github.com/analogdevicesinc/ad5940-examples>`_
-   
+
 
 Configuring the Software
 ------------------------

--- a/docs/solutions/reference-designs/eval-ad5940/software_examples/ad5940_ecg.rst
+++ b/docs/solutions/reference-designs/eval-ad5940/software_examples/ad5940_ecg.rst
@@ -1,7 +1,10 @@
 AD5940_ECG
 ==========
 
-This demo will use **EVAL-ADICUP3029** and **EVAL_AD5940BIOZ** boards to carry out ECG measurements. Note an ECG simulator is also required to provide the ECG signal. The AD5940 evaluation kit must never be connected to the human body.
+This demo will use **EVAL-ADICUP3029** and **EVAL_AD5940BIOZ** boards to
+carry out ECG measurements. Note an ECG simulator is also required to provide
+the ECG signal. The AD5940 evaluation kit must never be connected to the human
+body.
 
 Overview
 --------
@@ -35,7 +38,8 @@ The following is a list of items required to carry out the measurement.
 Setting up the Hardware
 -----------------------
 
--  Set switch S2 to USB Arduino function in order to view data over UART. The UART baud rate is **230400**
+-  Set switch S2 to USB Arduino function in order to view data over UART. The
+   UART baud rate is **230400**
 -  Set S5 to Wall/USB to power the board from the USB cable
 
 .. image:: ../images/img_20170612_144023_hdr.jpg
@@ -50,7 +54,8 @@ Setting up the Hardware
 
 -  Connect the provided ECG cables to an ECG simulator as per above image.
 -  There are a number of jumpers that can figure the AD8233 in different configuration. For optimum performance leave them in the default configuration. Optionally refer to the :adi:`AD8233 <media/en/technical-documentation/data-sheets/ad8233.pdf>` datasheet and the :doc:`AD5940 Bio-Electric Shield </solutions/reference-designs/eval-ad5940/hardware/eval-ad5940bioz>` board page for details
--  Plug in the micro USB cable into the (P10) USB port on the EVAL-ADICUP3029, and the other end into the PC or laptop.
+-  Plug in the micro USB cable into the (P10) USB port on the EVAL-ADICUP3029, and the other end
+   into the PC or laptop.
 -  The following table shows the jumper settins to configure the ECG measurement
    system
 
@@ -96,9 +101,9 @@ The source code and include files for the project can be found on Git
 .. admonition:: Download
    :class: download
 
-   
+
    `AD5940 Source Code <https://github.com/analogdevicesinc/ad5940-examples>`_
-   
+
 
 Configuring the Software
 ------------------------

--- a/docs/solutions/reference-designs/eval-ad5940/software_examples/ad5940_ecg.rst
+++ b/docs/solutions/reference-designs/eval-ad5940/software_examples/ad5940_ecg.rst
@@ -1,0 +1,114 @@
+AD5940_ECG
+==========
+
+This demo will use **EVAL-ADICUP3029** and **EVAL_AD5940BIOZ** boards to carry out ECG measurements. Note an ECG simulator is also required to provide the ECG signal. The AD5940 evaluation kit must never be connected to the human body.
+
+Overview
+--------
+
+This example project is designed to carry out electrocardiograph (ECG)
+measurements. The EVAL-AD5940BIOZ evaluation board has both the AD5940 and also
+the AD8233 ECG front end devices. The AD8233 filters the ECG signal and is
+connected to the AD5940 which measures the output of the AD8233 through it's SAR
+ADC.
+
+Measurement Requirements
+------------------------
+
+The following is a list of items required to carry out the measurement.
+
+-  Hardware
+
+   -  EVAL-ADICUP3029
+   -  EVAL-AD5940BIOZ
+   -  Mirco USB to USB cable
+   -  PC or Laptop with a USB port
+   -  Custom Cables connected to ECG simulator
+
+-  Software
+
+   -  AD5940_ECG Example Project (Git Lab)
+   -  SensoPal
+   -  Serial Terminal Program, Such as Putty or RealTerm
+   -  IDE such as IAR or Keil
+
+Setting up the Hardware
+-----------------------
+
+-  Set switch S2 to USB Arduino function in order to view data over UART. The UART baud rate is **230400**
+-  Set S5 to Wall/USB to power the board from the USB cable
+
+.. image:: ../images/img_20170612_144023_hdr.jpg
+   :align: center
+   :width: 800
+
+-  Place the **EVAL-AD5940BIOZ** on top of the **EVAL-ADICUP3029**.
+
+.. image:: ../images/eval-ad5940bioz_ecg.jpg
+   :align: center
+   :width: 600
+
+-  Connect the provided ECG cables to an ECG simulator as per above image.
+-  There are a number of jumpers that can figure the AD8233 in different configuration. For optimum performance leave them in the default configuration. Optionally refer to the :adi:`AD8233 <media/en/technical-documentation/data-sheets/ad8233.pdf>` datasheet and the :doc:`AD5940 Bio-Electric Shield </solutions/reference-designs/eval-ad5940/hardware/eval-ad5940bioz>` board page for details
+-  Plug in the micro USB cable into the (P10) USB port on the EVAL-ADICUP3029, and the other end into the PC or laptop.
+-  The following table shows the jumper settins to configure the ECG measurement
+   system
+
++------------------------+----------------+------------------------------------------------------------+
+| Connector              | Jmpr Position. | Description                                                |
++========================+================+============================================================+
+| JP5 (Default DNI)      | A              | Pull up resistor (R25) connected to electrode bias         |
++------------------------+----------------+------------------------------------------------------------+
+|                        | B              | Pull down resistor (R25)connected electrode bias           |
++------------------------+----------------+------------------------------------------------------------+
+| JP6 (Default DNI)      | A              | Pull up resistor (R42) connected to electrode bias         |
++------------------------+----------------+------------------------------------------------------------+
+|                        | B              | Pull down resistor (R42)connected electrode bias           |
++------------------------+----------------+------------------------------------------------------------+
+| JP7 (Bias Select)      | 3-1            | Electrode bias connected to REFOUTS                        |
++------------------------+----------------+------------------------------------------------------------+
+|                        | 3-4            | Electrode bias connected RLD                               |
++------------------------+----------------+------------------------------------------------------------+
+|                        | 3-5            | Electrode bias connected to VDD (Default)                  |
++------------------------+----------------+------------------------------------------------------------+
+| P7 (AC/DC pin control) | 1-2            | ACDC connected to DVDD (ac leads off mode)(Default)        |
++------------------------+----------------+------------------------------------------------------------+
+|                        | 2-3            | ACDC connected to DGND (dc leads off mode)                 |
++------------------------+----------------+------------------------------------------------------------+
+| P10 (AD8233 Power)     | 1-2            | AD8233 supply connected to AVDD (Default)                  |
++------------------------+----------------+------------------------------------------------------------+
+|                        | 2-3            | AD8233 supply connected to LDO_OUT)                        |
++------------------------+----------------+------------------------------------------------------------+
+| P16                    | 1-2            | Pull up resistor R46 for ECG_P to electrode bias (Default) |
++------------------------+----------------+------------------------------------------------------------+
+|                        | 2-3            | Pull down resistor R46 for ECG_P to GND                    |
++------------------------+----------------+------------------------------------------------------------+
+| P17                    | 1-2            | Pull up resistor R23 for ECG_N to electrode bias (Default) |
++------------------------+----------------+------------------------------------------------------------+
+|                        | 2-3            | Pull down resistor R23 for ECG_N to GND                    |
++------------------------+----------------+------------------------------------------------------------+
+
+Obtaining the Source Code
+-------------------------
+
+The source code and include files for the project can be found on Git
+
+.. admonition:: Download
+   :class: download
+
+   
+   `AD5940 Source Code <https://github.com/analogdevicesinc/ad5940-examples>`_
+   
+
+Configuring the Software
+------------------------
+
+The SDK provides firmware to measure the ECG signal. However the firmware is
+configured to send the raw ADC results to a terminal program. For an ECG
+measurement SensorPal will configure the ECG measurement and graph the results.
+The following image shows the ECG results in SensoPal
+
+|image1|
+
+.. |image1| image:: ../images/sensorpal_ecg.png
+   :width: 600

--- a/docs/solutions/reference-designs/eval-ad5940/software_examples/ad5940_eda.rst
+++ b/docs/solutions/reference-designs/eval-ad5940/software_examples/ad5940_eda.rst
@@ -1,7 +1,8 @@
 AD5940_EDA
 ==========
 
-This demo will use **EVAL-ADICUP3029**, **EVAL_AD5940BIOZ** and **Impedance-Test** board to carry out EDA measurements.
+This demo will use **EVAL-ADICUP3029**, **EVAL_AD5940BIOZ** and
+**Impedance-Test** board to carry out EDA measurements.
 
 Overview
 --------
@@ -38,7 +39,8 @@ The following is a list of items required to carry out the measurement.
 Setting up the Hardware
 -----------------------
 
--  Set switch S2 to USB Arduino function in order to view data over UART. The UART baud rate is **230400**
+-  Set switch S2 to USB Arduino function in order to view data over UART. The
+   UART baud rate is **230400**
 -  Set S5 to Wall/USB to power the board from the USB cable
 
 .. image:: ../images/img_20170612_144023_hdr.jpg
@@ -74,7 +76,7 @@ and on S3 from switch 5 to switch 12.
 
 .. container:: column
 
-   
+
    ======= ===========================
    S2 Bank Corresponding Res/Cap Value
    ======= ===========================
@@ -91,11 +93,11 @@ and on S3 from switch 5 to switch 12.
    S11     1000 pF
    S12     0.01 μF
    ======= ===========================
-   
+
 
 .. container:: column
 
-   
+
    ======= ===========================
    S3 Bank Corresponding Res/Cap Value
    ======= ===========================
@@ -112,7 +114,7 @@ and on S3 from switch 5 to switch 12.
    S11     1000 pF
    S12     0.01 μF
    ======= ===========================
-   
+
 
 Obtaining the Source Code
 -------------------------
@@ -122,9 +124,9 @@ The source code and include files for the project can be found on Git
 .. admonition:: Download
    :class: download
 
-   
+
    `AD5940 Source Code <https://github.com/analogdevicesinc/ad5940-examples>`_
-   
+
 
 Configuring the Software
 ------------------------

--- a/docs/solutions/reference-designs/eval-ad5940/software_examples/ad5940_eda.rst
+++ b/docs/solutions/reference-designs/eval-ad5940/software_examples/ad5940_eda.rst
@@ -1,0 +1,159 @@
+AD5940_EDA
+==========
+
+This demo will use **EVAL-ADICUP3029**, **EVAL_AD5940BIOZ** and **Impedance-Test** board to carry out EDA measurements.
+
+Overview
+--------
+
+This example project is designed to carry out electrodermal activity (EDA)
+measurements. The Impedance Test board is provided with the hardware which
+models skin impedance. It consists of a range of resistors and capacitors which
+can be used to model skin impedance, contact impedance and electrode impedance.
+
+Alternatively, the custom cables can be connected to a human body simulator to
+measure actual body impedance. Note the cables must never be connected to the
+human body.
+
+Measurement Requirements
+------------------------
+
+The following is a list of items required to carry out the measurement.
+
+-  Hardware
+
+   -  EVAL-ADICUP3029
+   -  EVAL-AD5940BIOZ
+   -  Z-Test Board
+   -  Mirco USB to USB cable
+   -  PC or Laptop with a USB port
+   -  Custom Cables (Optional)
+
+-  Software
+
+   -  AD5940_EDA Example Project (Git Lab)
+   -  Serial Terminal Program, Such as Putty or RealTerm
+   -  IDE such as IAR or Keil
+
+Setting up the Hardware
+-----------------------
+
+-  Set switch S2 to USB Arduino function in order to view data over UART. The UART baud rate is **230400**
+-  Set S5 to Wall/USB to power the board from the USB cable
+
+.. image:: ../images/img_20170612_144023_hdr.jpg
+   :align: center
+   :width: 800
+
+-  Place the **EVAL-AD5940BIOZ** on top of the **EVAL-ADICUP3029**.
+
+.. image:: ../images/eval-ad5940bioz.jpg
+   :align: center
+   :width: 800
+
+-  Connect the AD5940 Z Test board to the EVAL-AD5940BIOZ board
+-  All jumpers should be in their default position
+-  Plug in the micro USB cable into the (P10) USB port on the EVAL-ADICUP3029,
+   and the other end into the PC or laptop.
+
+AD5940 Z Test Board
+~~~~~~~~~~~~~~~~~~~
+
+The AD5940 Z Test board is designed to model skin impedance, body impedance,
+electrode contact impedance and electrode impedance. There are 5 banks of
+switches on the board labelled S1, S2, S3, S4 and S5. For EDA application only
+S2 and S3 banks are applicable. The following tables indicate the resistor or
+capacitor value associated with each switch in bank 1 and bank 2. By default,
+all switches on S2 and S3 are in the ON position. No resistor or capacitor is
+connected to the measurement loop. Moving the switch to the Off position
+connects the corresponding resistor or capacitor value in series on the signal
+path. If more than one switch is closed the corresponding resistor values are
+connected in series. Typical impedance ranges for EDA measurements is 20kΩ up to
+10MΩ. With this in mind the applicable switches are on S2 switch 6 to switch 12
+and on S3 from switch 5 to switch 12.
+
+.. container:: column
+
+   
+   ======= ===========================
+   S2 Bank Corresponding Res/Cap Value
+   ======= ===========================
+   S1      100 Ω
+   S2      200 Ω
+   S3      300 Ω
+   S4      402 Ω
+   S5      10 kΩ
+   S6      23.7 kΩ
+   S7      42.2 kΩ
+   S8      42.2 kΩ
+   S9      100 kΩ
+   S10     200 kΩ
+   S11     1000 pF
+   S12     0.01 μF
+   ======= ===========================
+   
+
+.. container:: column
+
+   
+   ======= ===========================
+   S3 Bank Corresponding Res/Cap Value
+   ======= ===========================
+   S1      100 Ω
+   S2      200 Ω
+   S3      300 Ω
+   S4      402 Ω
+   S5      4.22 MΩ
+   S6      4.22 MΩ
+   S7      1.43 MΩ
+   S8      1 MΩ
+   S9      300 kΩ
+   S10     300 kΩ
+   S11     1000 pF
+   S12     0.01 μF
+   ======= ===========================
+   
+
+Obtaining the Source Code
+-------------------------
+
+The source code and include files for the project can be found on Git
+
+.. admonition:: Download
+   :class: download
+
+   
+   `AD5940 Source Code <https://github.com/analogdevicesinc/ad5940-examples>`_
+   
+
+Configuring the Software
+------------------------
+
+To compile and run the example open the project in either Keil or IAR.
+
+Outputting Data
+---------------
+
+The measurement results are sent to the PC via UART. To establish connection
+over UART, connect the Micro-USB cable to the PC and to the EVAL-ADICUP3029
+board. A terminal program such as RealTerm or Putty is required to display the
+results
+
+Following is the UART configuration.
+
+::
+
+     Select COM Port
+     Baud rate: 230400
+     Data: 8 bit
+     Parity: none
+     Stop: 1 bit
+     Flow Control: none
+
+The data on the terminal consists of the Frequency of the excitation signal, the
+magnitude of the impedance and the phase of the impedance in degrees as in below
+screenshot.
+
+.. image:: ../images/bia_terminal.png
+   :align: center
+   :width: 400

--- a/docs/solutions/reference-designs/eval-ad5940/software_examples/ad5940_impedance.rst
+++ b/docs/solutions/reference-designs/eval-ad5940/software_examples/ad5940_impedance.rst
@@ -1,7 +1,8 @@
 AD5940_Impedance
 ================
 
-This example will use **EVAL-ADICUP3029** and **EVAL_AD5940ELCZ** to carry out a 2-wire Impedance measurement.
+This example will use **EVAL-ADICUP3029** and **EVAL_AD5940ELCZ** to carry
+out a 2-wire Impedance measurement.
 
 Overview
 --------
@@ -39,7 +40,8 @@ The following is a list of items required to carry out the measurement.
 Setting up the Hardware
 -----------------------
 
--  Set switch S2 to USB Arduino function in order to view data over UART. The UART baud rate is **230400**
+-  Set switch S2 to USB Arduino function in order to view data over UART. The
+   UART baud rate is **230400**
 -  Set S5 to Wall/USB to power the board from the USB cable
 
 .. image:: ../images/img_20170612_144023_hdr.jpg
@@ -47,8 +49,11 @@ Setting up the Hardware
    :width: 800
 
 -  Place the **EVAL-AD5940ELCZ** on top of the **EVAL-ADICUP3029**.
--  Ensure jumper on JP10 and JP11 is on PIN2 and PIN4 (to use the USB connected probe with EVAL-AD5940ELCZ, JP9,JP10 and JP11 should be configured to position C - pins 5 and 6)
--  Place jumper in position A on JP6 to connect 6.8K resistor in series with a 10uF capacitor between RE0 and SE0
+-  Ensure jumper on JP10 and JP11 is on PIN2 and PIN4 (to use the USB connected
+   probe with EVAL-AD5940ELCZ, JP9,JP10 and JP11 should be configured to
+   position C - pins 5 and 6)
+-  Place jumper in position A on JP6 to connect 6.8K resistor in series
+   with a 10uF capacitor between RE0 and SE0
 -  Plug in the micro USB cable into the (P10) USB port on the EVAL-ADICUP3029,
    and the other end into the PC or laptop.
 
@@ -64,9 +69,9 @@ The source code and include files for the project can be found on Git
 .. admonition:: Download
    :class: download
 
-   
+
    `AD5940 Source Code <https://github.com/analogdevicesinc/ad5940-examples>`_
-   
+
 
 Configuring the Software
 ------------------------

--- a/docs/solutions/reference-designs/eval-ad5940/software_examples/ad5940_impedance.rst
+++ b/docs/solutions/reference-designs/eval-ad5940/software_examples/ad5940_impedance.rst
@@ -1,0 +1,111 @@
+AD5940_Impedance
+================
+
+This example will use **EVAL-ADICUP3029** and **EVAL_AD5940ELCZ** to carry out a 2-wire Impedance measurement.
+
+Overview
+--------
+
+A standard 2-wire impedance measurement implements a ratio metric measurement. A
+signal is applied across the known resistor, (RCAL), and the response current is
+measured. The same signal is then applied across the unknown impedance and
+response current is measured. A DFT is performed on the response currents to
+determine the magnitude and phase values of each. The unknown impedance can then
+be calculated using the following equation:
+
+|image1|
+
+For more details refer to the application note, AN-1563.
+
+Measurement Requirements
+------------------------
+
+The following is a list of items required to carry out the measurement.
+
+-  Hardware
+
+   -  EVAL-ADICUP3029
+   -  EVAL-AD5940ELCZ
+   -  Mirco USB to USB cable
+   -  PC or Laptop with a USB port
+   -  Custom Cables (Optional)
+
+-  Software
+
+   -  AD5940_Amperometric Example Project (Git Lab)
+   -  Serial Terminal Program, Such as Putty or RealTerm
+   -  IDE such as IAR or Keil
+
+Setting up the Hardware
+-----------------------
+
+-  Set switch S2 to USB Arduino function in order to view data over UART. The UART baud rate is **230400**
+-  Set S5 to Wall/USB to power the board from the USB cable
+
+.. image:: ../images/img_20170612_144023_hdr.jpg
+   :align: center
+   :width: 800
+
+-  Place the **EVAL-AD5940ELCZ** on top of the **EVAL-ADICUP3029**.
+-  Ensure jumper on JP10 and JP11 is on PIN2 and PIN4 (to use the USB connected probe with EVAL-AD5940ELCZ, JP9,JP10 and JP11 should be configured to position C - pins 5 and 6)
+-  Place jumper in position A on JP6 to connect 6.8K resistor in series with a 10uF capacitor between RE0 and SE0
+-  Plug in the micro USB cable into the (P10) USB port on the EVAL-ADICUP3029,
+   and the other end into the PC or laptop.
+
+.. image:: ../images/ad5940elcz.jpg
+   :align: center
+   :width: 600
+
+Obtaining the Source Code
+-------------------------
+
+The source code and include files for the project can be found on Git
+
+.. admonition:: Download
+   :class: download
+
+   
+   `AD5940 Source Code <https://github.com/analogdevicesinc/ad5940-examples>`_
+   
+
+Configuring the Software
+------------------------
+
+To compile and run the example open the project in either Keil or IAR. The
+AD5940ImpedanceStructInit() function is used to configure application
+parameters. These include setting the value of the RCAL, setting sine wave
+frequency, configuring the switch matrix and more.
+
+.. image:: ../images/keil_impedance.png
+   :align: center
+   :width: 600
+
+Outputting Data
+---------------
+
+The measurement results are sent to the PC via UART. To establish connection
+over UART, connect the Micro-USB cable to the PC and to the EVAL-ADICUP3029
+board. A terminal program such as RealTerm or Putty is required to display the
+results
+
+Following is the UART configuration.
+
+::
+
+     Select COM Port
+     Baud rate: 230400
+     Data: 8 bit
+     Parity: none
+     Stop: 1 bit
+     Flow Control: none
+
+The data on the terminal consists of the Frequency of the excitation signal, the
+magnitude of the impedance and the phase of the impedance in degrees as in below
+screenshot.
+
+|image2|
+
+.. |image1| image:: ../images/impedance_equation.png
+   :width: 400
+.. |image2| image:: ../images/realterm_impedance.png
+   :width: 600

--- a/docs/solutions/reference-designs/eval-ad5940/software_examples/ad5940_ramp.rst
+++ b/docs/solutions/reference-designs/eval-ad5940/software_examples/ad5940_ramp.rst
@@ -1,0 +1,124 @@
+AD5940_Ramp
+===========
+
+This example will use **EVAL-ADICUP3029** and **EVAL_AD5940ELCZ** to carry out a cyclic voltammetry measurement. Note, the corresponding application example in the SDK is the AD5940_Ramp project.
+
+Overview
+--------
+
+Cyclic voltammetry is an electrochemical measurement in which the voltage
+applied to an electrochemical cell is incremented, then decremented, linearly in
+a triangular shape to a point. The response current on the working electrode is
+measured. To carry out this measurement on the AD5940, VZERO is set to output a
+voltage of 1.3 V. VBIAS can sweep from 0.3 V to 2.3 V, giving a ±1 V sweep. The
+response current is measured using the LPTIA.
+
+For more details refer to the application note, AN-1563.
+
+Measurement Requirements
+------------------------
+
+The following is a list of items required to carry out the measurement.
+
+-  Hardware
+
+   -  EVAL-ADICUP3029
+   -  EVAL-AD5940ELCZ
+   -  Mirco USB to USB cable
+   -  PC or Laptop with a USB port
+   -  Custom Cables (Optional)
+
+-  Software
+
+   -  AD5940_Ramp Example Project (Git Lab)
+   -  Serial Terminal Program, Such as Putty or RealTerm
+   -  IDE such as IAR or Keil
+
+Setting up the Hardware
+-----------------------
+
+-  Set switch S2 to USB Arduino function in order to view data over UART. The UART baud rate is **230400**
+-  Set S5 to Wall/USB to power the board from the USB cable
+
+.. image:: ../images/img_20170612_144023_hdr.jpg
+   :align: center
+   :width: 800
+
+-  Place the **EVAL-AD5940ELCZ** on top of the **EVAL-ADICUP3029**.
+-  Ensure jumper on JP10 and JP11 is on PIN2 and PIN4 to connect the dummy sensor to the AD5940 (to use the USB connected probe with EVAL-AD5940ELCZ, JP9,JP10 and JP11 should be configured to position C - pins 5 and 6)
+-  Place jumper in position B on JP6 to connect the 10kΩ||10kΩ resistor divider between RE0 and SE0
+-  Plug in the micro USB cable into the (P10) USB port on the EVAL-ADICUP3029,
+   and the other end into the PC or laptop.
+
+.. image:: ../images/ad5940elcz.jpg
+   :align: center
+   :width: 600
+
+Obtaining the Source Code
+-------------------------
+
+The source code and include files for the project can be found on Git
+
+.. admonition:: Download
+   :class: download
+
+   `AD5940 Source Code <https://github.com/analogdevicesinc/ad5940-examples>`_
+
+   
+
+Configuring the Software
+------------------------
+
+To compile and run the example open the project in either Keil or IAR. The
+AD5940RampStructInit() function is used to configure the main application
+parameters that control the excitation signal and the data acquisition. The
+parameters and their description are explained in the table below:
+
++---------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| Variable Name in Firmware | Description                                                                                                                                                                                                    |
++===========================+================================================================================================================================================================================================================+
+| RampStartVolt             | This variable sets the voltage at which the excitation signal begins                                                                                                                                           |
++---------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| RampPeakVolt              | This sets the peak voltage of the signal.                                                                                                                                                                      |
++---------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| VzeroStart                | This sets the peak voltage of Vzero. Optimully set to 1.3V. The Actual start voltage on the sensor pin is VzeroStart + RampStartVolt                                                                           |
++---------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| VzeroPeak                 | This sets the start voltage on Vzero. Optimully 1.3V. The Actual peak voltage on the sensor pin is VzeroPeak + RampPeakVolt                                                                                    |
++---------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| StepNumber                | This sets the number of steps in the signal. The size of each step is (RampPeakVolt-RampStartVolt)/StepNumber                                                                                                  |
++---------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| RampDuration              | This variable sets the duration for the total signal. The unit is in milliseconds. The duration of each is the RampDuration/StepNumber                                                                         |
++---------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| SampleDelay               | This variable sets the duration from when the step is applied to when the ADC measures the response current. Note, the SampleDelay must be shorter than the total step width. There are no checks in firmware. |
++---------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+
+.. image:: ../images/keil_ramp.png
+   :align: center
+   :width: 600
+
+Outputting Data
+---------------
+
+The measurement results are sent to the PC via UART. To establish connection
+over UART, connect the Micro-USB cable to the PC and to the EVAL-ADICUP3029
+board. A terminal program such as RealTerm or Putty is required to display the
+results
+
+Following is the UART configuration.
+
+::
+
+     Select COM Port
+     Baud rate: 230400
+     Data: 8 bit
+     Parity: none
+     Stop: 1 bit
+     Flow Control: none
+
+The data on the terminal indicates the index number of the data point and the
+current measured in µA.
+
+|image1|
+
+.. |image1| image:: ../images/realterm_ramp.png
+   :width: 600

--- a/docs/solutions/reference-designs/eval-ad5940/software_examples/ad5940_ramp.rst
+++ b/docs/solutions/reference-designs/eval-ad5940/software_examples/ad5940_ramp.rst
@@ -1,7 +1,9 @@
 AD5940_Ramp
 ===========
 
-This example will use **EVAL-ADICUP3029** and **EVAL_AD5940ELCZ** to carry out a cyclic voltammetry measurement. Note, the corresponding application example in the SDK is the AD5940_Ramp project.
+This example will use **EVAL-ADICUP3029** and **EVAL_AD5940ELCZ** to carry
+out a cyclic voltammetry measurement. Note, the corresponding application
+example in the SDK is the AD5940_Ramp project.
 
 Overview
 --------
@@ -37,7 +39,8 @@ The following is a list of items required to carry out the measurement.
 Setting up the Hardware
 -----------------------
 
--  Set switch S2 to USB Arduino function in order to view data over UART. The UART baud rate is **230400**
+-  Set switch S2 to USB Arduino function in order to view data over UART. The
+   UART baud rate is **230400**
 -  Set S5 to Wall/USB to power the board from the USB cable
 
 .. image:: ../images/img_20170612_144023_hdr.jpg
@@ -45,8 +48,11 @@ Setting up the Hardware
    :width: 800
 
 -  Place the **EVAL-AD5940ELCZ** on top of the **EVAL-ADICUP3029**.
--  Ensure jumper on JP10 and JP11 is on PIN2 and PIN4 to connect the dummy sensor to the AD5940 (to use the USB connected probe with EVAL-AD5940ELCZ, JP9,JP10 and JP11 should be configured to position C - pins 5 and 6)
--  Place jumper in position B on JP6 to connect the 10kΩ||10kΩ resistor divider between RE0 and SE0
+-  Ensure jumper on JP10 and JP11 is on PIN2 and PIN4 to connect the dummy
+   sensor to the AD5940 (to use the USB connected probe with EVAL-AD5940ELCZ,
+   JP9,JP10 and JP11 should be configured to position C - pins 5 and 6)
+-  Place jumper in position B on JP6 to connect the 10kΩ||10kΩ resistor divider
+   between RE0 and SE0
 -  Plug in the micro USB cable into the (P10) USB port on the EVAL-ADICUP3029,
    and the other end into the PC or laptop.
 
@@ -64,7 +70,7 @@ The source code and include files for the project can be found on Git
 
    `AD5940 Source Code <https://github.com/analogdevicesinc/ad5940-examples>`_
 
-   
+
 
 Configuring the Software
 ------------------------

--- a/docs/solutions/reference-designs/eval-ad5940/software_examples/ad5940_swv.rst
+++ b/docs/solutions/reference-designs/eval-ad5940/software_examples/ad5940_swv.rst
@@ -1,0 +1,130 @@
+AD5940_SqrWveVoltammetry
+========================
+
+This example will use **EVAL-ADICUP3029** and **EVAL_AD5940ELCZ** to carry out a square wave voltammetry measurement. Note, the corresponding application example in the SDK is the AD5940_SqrWveVoltammetry project.
+
+Overview
+--------
+
+Square wave voltammetry is an electrochemical technique where the voltage
+between the reference and sense electrode is incremented in a square wave
+fashion as in figure below. The response current on the working electrode is
+measured after each half step.
+
+.. image:: ../images/sqrwavevoltammetry.png
+   :align: center
+   :width: 200
+
+For more details refer to the application note, AN-1563.
+
+Measurement Requirements
+------------------------
+
+The following is a list of items required to carry out the measurement.
+
+-  Hardware
+
+   -  EVAL-ADICUP3029
+   -  EVAL-AD5940ELCZ
+   -  Mirco USB to USB cable
+   -  PC or Laptop with a USB port
+   -  Custom Cables (Optional)
+
+-  Software
+
+   -  AD5940_SqrWveVoltammetry Example Project (Git Lab)
+   -  Serial Terminal Program, Such as Putty or RealTerm
+   -  IDE such as IAR or Keil
+
+Setting up the Hardware
+-----------------------
+
+-  Set switch S2 to USB Arduino function in order to view data over UART. The UART baud rate is **230400**
+-  Set S5 to Wall/USB to power the board from the USB cable
+
+.. image:: ../images/img_20170612_144023_hdr.jpg
+   :align: center
+   :width: 800
+
+-  Place the **EVAL-AD5940ELCZ** on top of the **EVAL-ADICUP3029**.
+-  Ensure jumper on JP10 and JP11 is on PIN2 and PIN4
+-  Place jumper in position B on JP6 to connect the 1kΩ||3kΩ RE0 and SE0
+-  Plug in the micro USB cable into the (P10) USB port on the EVAL-ADICUP3029,
+   and the other end into the PC or laptop.
+
+.. image:: ../images/ad5940elcz.jpg
+   :align: center
+   :width: 600
+
+Obtaining the Source Code
+-------------------------
+
+The source code and include files for the project can be found on Git
+
+The source code and include files of the **AD5940_SqrWveVoltammetry** can be found in the SDK below:
+
+.. admonition:: Download
+   :class: download
+
+   
+   `AD5940 SDK Source Code <https://github.com/analogdevicesinc/ad5940-examples>`_
+   
+
+Configuring the Software
+------------------------
+
+To compile and run the example open the project in either Keil or IAR. The
+AD5940RampStructInit() function is used to configure the main application
+parameters that control the excitation signal and the data acquisition. The
+parameters and their description are explained in the table below:
+
++-----------------------------+-----------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| Variable Name in Firmware . | Name on diagram | Description                                                                                                                                                                                                    |
++=============================+=================+================================================================================================================================================================================================================+
+| RampStartVolt               | E1              | This variable sets the voltage at which the excitation signal begins                                                                                                                                           |
++-----------------------------+-----------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| RampPeakVolt                | E2              | This sets the peak voltage of the signal. T                                                                                                                                                                    |
++-----------------------------+-----------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| VzeroStart                  |                 | This sets the start voltage of Vzero. Optimully set to 1.3V. The Actual start voltage on the sensor pin is VzeroStart + RampStartVolt                                                                          |
++-----------------------------+-----------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| VzeroPeak                   |                 | This sets the peak voltage of Vzero. Optimully set to 1.3V. The Actual peak voltage on the sensor pin is VzeroPeak + RampPeakVolt                                                                              |
++-----------------------------+-----------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| Frequency                   | Frequency       | This sets the frequency of the square wave signal                                                                                                                                                              |
++-----------------------------+-----------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| SqrWvAmplitude              | Ep              | This sets the amplitude of the square wave signal                                                                                                                                                              |
++-----------------------------+-----------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| SqrWvIncrement              | Estep           | This sets the increment voltage step after each square wave                                                                                                                                                    |
++-----------------------------+-----------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| SampleDelay                 | t               | This variable sets the duration from when the step is applied to when the ADC measures the response current. Note, the SampleDelay must be shorter than the total step width. There are no checks in firmware. |
++-----------------------------+-----------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+
+.. image:: ../images/sqrwavevoltammetry.png
+   :align: center
+   :width: 600
+
+Outputting Data
+---------------
+
+The measurement results are sent to the PC via UART. To establish connection
+over UART, connect the Micro-USB cable to the PC and to the EVAL-ADICUP3029
+board. A terminal program such as RealTerm or Putty is required to display the
+results
+
+Following is the UART configuration.
+
+::
+
+     Select COM Port
+     Baud rate: 230400
+     Data: 8 bit
+     Parity: none
+     Stop: 1 bit
+     Flow Control: none
+
+The data on the terminal indicates the index number of the data point and the
+current measured in µA.
+
+|image1|
+
+.. |image1| image:: ../images/realterm_ramp.png
+   :width: 600

--- a/docs/solutions/reference-designs/eval-ad5940/software_examples/ad5940_swv.rst
+++ b/docs/solutions/reference-designs/eval-ad5940/software_examples/ad5940_swv.rst
@@ -1,7 +1,9 @@
 AD5940_SqrWveVoltammetry
 ========================
 
-This example will use **EVAL-ADICUP3029** and **EVAL_AD5940ELCZ** to carry out a square wave voltammetry measurement. Note, the corresponding application example in the SDK is the AD5940_SqrWveVoltammetry project.
+This example will use **EVAL-ADICUP3029** and **EVAL_AD5940ELCZ** to carry
+out a square wave voltammetry measurement. Note, the corresponding application
+example in the SDK is the AD5940_SqrWveVoltammetry project.
 
 Overview
 --------
@@ -39,7 +41,8 @@ The following is a list of items required to carry out the measurement.
 Setting up the Hardware
 -----------------------
 
--  Set switch S2 to USB Arduino function in order to view data over UART. The UART baud rate is **230400**
+-  Set switch S2 to USB Arduino function in order to view data over UART. The
+   UART baud rate is **230400**
 -  Set S5 to Wall/USB to power the board from the USB cable
 
 .. image:: ../images/img_20170612_144023_hdr.jpg
@@ -61,14 +64,15 @@ Obtaining the Source Code
 
 The source code and include files for the project can be found on Git
 
-The source code and include files of the **AD5940_SqrWveVoltammetry** can be found in the SDK below:
+The source code and include files of the **AD5940_SqrWveVoltammetry** can be
+found in the SDK below:
 
 .. admonition:: Download
    :class: download
 
-   
+
    `AD5940 SDK Source Code <https://github.com/analogdevicesinc/ad5940-examples>`_
-   
+
 
 Configuring the Software
 ------------------------

--- a/docs/solutions/reference-designs/eval-ad5940/tools.rst
+++ b/docs/solutions/reference-designs/eval-ad5940/tools.rst
@@ -1,0 +1,12 @@
+Tools and Driver Details
+========================
+
+This chapter provides all the necessary steps to download, install, and setup
+the software environment from Analog Devices. There is also information on the
+different USB modes and drivers needed.
+
+It contains three main sections:
+
+-  :doc:`SensorPal GUI Tool </solutions/reference-designs/eval-ad5940/tools/sensorpal_setup_guide>` - Provides all the necessary instructions on how to download and install SensorPal
+-  :doc:`Using IAR Embedded Workbench </solutions/reference-designs/eval-ad5940/tools/iar_setup_guide>` - Provides information about using the IAR Workbench IDE, in particular, the process of opening, building and debugging user applications for the EVAL-ADICUP3029 and EVAL-AD5940.
+-  :doc:`Using Keil IDE </solutions/reference-designs/eval-ad5940/tools/keil_setup_guide>` - Provides information about using the Keil IDE, in particular, the process of opening, building and debugging user applications for the EVAL-ADICUP3029 and EVAL-AD5940.

--- a/docs/solutions/reference-designs/eval-ad5940/tools/downloading_source_code.rst
+++ b/docs/solutions/reference-designs/eval-ad5940/tools/downloading_source_code.rst
@@ -13,7 +13,7 @@ are not available on the AD5941.
 .. admonition:: Download
    :class: download
 
-   
+
    `AD5940 Source Code <https://github.com/analogdevicesinc/ad5940-examples>`_
 
 Repository Structure
@@ -37,7 +37,8 @@ How to clone the AD5940 Git Repository
 To clone the AD5940 code repository
 
 -  Navigate to the link above and copy the URL.
--  Open Git bash or your preferred Git tool and change directory to where you want to save the files
--  Type in "git clone --recursive `ad5940-examples <https://github.com/analogdevicesinc/ad5940-examples>`_.git"
+-  Open Git bash or your preferred Git tool and change directory to where you
+   want to save the files
+-  Type in ``git clone --recursive`` `ad5940-examples <https://github.com/analogdevicesinc/ad5940-examples>`_ ``.git``
 -  This command copies the entire ad5940 module and sub-modules into the folder
 -  The source code should now be downloaded in the specified folder

--- a/docs/solutions/reference-designs/eval-ad5940/tools/downloading_source_code.rst
+++ b/docs/solutions/reference-designs/eval-ad5940/tools/downloading_source_code.rst
@@ -1,0 +1,43 @@
+How to Download AD594x Source Code
+==================================
+
+The AD594x is an SPI slave device that is controlled by a host microcontroller.
+The microcontroller supplied with the AD594x evaluation kits is the ADuCM3029.
+There are a number of example projects developed which run on the ADuCM3029 to
+control the AD594x. The source code is stored and version controlled on
+GitHub.com.
+
+Both the AD5940 and AD5941 share the same code base. Note that AIN6 and GP3-GP7
+are not available on the AD5941.
+
+.. admonition:: Download
+   :class: download
+
+   
+   `AD5940 Source Code <https://github.com/analogdevicesinc/ad5940-examples>`_
+
+Repository Structure
+--------------------
+
+The repository has 3 main folders
+
+-  LICENSE - this has details on the license of the source code
+-  doc - has available documentation
+-  examples - contains all the example programs
+
+Within the examples folder there is a folder called ad5940lib. This is a
+sub-module and is source controlled in a separate repository. It is important to
+do a recursive clone of the repository to ensure this sub-module is cloned also.
+If downloading the source code via a zip or tar file the ad5940lib will need to
+be downloaded separately and added the the ad5940lib folder in examples
+
+How to clone the AD5940 Git Repository
+--------------------------------------
+
+To clone the AD5940 code repository
+
+-  Navigate to the link above and copy the URL.
+-  Open Git bash or your preferred Git tool and change directory to where you want to save the files
+-  Type in "git clone --recursive `ad5940-examples <https://github.com/analogdevicesinc/ad5940-examples>`_.git"
+-  This command copies the entire ad5940 module and sub-modules into the folder
+-  The source code should now be downloaded in the specified folder

--- a/docs/solutions/reference-designs/eval-ad5940/tools/iar_setup_guide.rst
+++ b/docs/solutions/reference-designs/eval-ad5940/tools/iar_setup_guide.rst
@@ -1,0 +1,140 @@
+How to setup and use IAR Embedded Workbench
+===========================================
+
+IAR Workbench is the IDE of choice for developing firmware for the AD5940. IAR
+provides an evaluation licence that is free but limits the code size to 32 kB.
+Currently, none of the evaluation examples in the AD5940 development pack exceed
+this.
+
+How to Download IAR
+-------------------
+
+To download IAR Workbench click on the following `link <https://artifactory.analog.com/ui/native/iar-binaries-generic/full_network_version/9.50.2>`_
+
+This will begin downloading the latest IAR installer. The file is large so may
+take some time depending on Internet Download speed.
+
+How to Install IAR
+------------------
+
+Once the download has complete double click on the .exe file to begin the
+installation procedure. Then click on Install IAR Embedded Workbench® for ARM.\
+
+|image1|
+
+.. image:: ../images/setup2.png
+   :align: center
+   :width: 400
+
+Click Next. The installation procedure may take some time as it is a large
+program.
+
+How to Register for IAR Evaluation License
+------------------------------------------
+
+To register for the IAR free evaluation license follow these instructions:
+
+-  Open IAR Workbench
+-  Navigate to Help->License Manager
+-  When the License Manager opens go to License->Get Evaluation License
+
+.. image:: ../images/setup3.png
+   :align: center
+   :width: 400
+
+-  The user must register with IAR to get the evaluation licence. Follow online
+   registration instructions. Select size limited licence as opposed to time
+   limited licence. An email is sent with a link. Click this link to reveal the
+   license number. A similar window to the one below should be displayed with
+   the license number.
+
+.. image:: ../images/setup4.png
+   :align: center
+   :width: 400
+
+-  Then go back to IAR license manager and go to License->Activate License
+
+.. image:: ../images/setup6.png
+   :align: center
+   :width: 400
+
+-  Enter the new license number and click ok.
+
+IAR Workbench is now ready to use with a 32KB code size limit.
+
+How to edit and run example code in IAR
+---------------------------------------
+
+To edit and run example code in IAR Workbench follow these steps:
+
+-  Download the AD5940 SDK from the the GitHub repository:
+
+.. admonition:: Download
+   :class: download
+
+   
+   `AD5940 SDK Source Code <https://github.com/analogdevicesinc/ad5940-examples>`_
+   
+
+-  Navigate to the **examples** folder
+-  Double click on ADICUP3029.eww file. This opens all the example projects in the IAR Workspace
+-  On first time opening the project, the IAR CMSIS pack manager will open with
+   a screen like this
+
+.. image:: ../images/pack_manager.png
+   :align: center
+   :width: 600
+
+-  Click on Packs and expand the Device Specific option.
+-  Install the AnalogDevices.ADuCM302x_DFP as highlighted below
+
+.. image:: ../images/pack_installation.png
+   :align: center
+   :width: 600
+
+-  Once installed exit the Pack Manager window and display the main IAR Workbench program.
+-  All the example projects are shown in the Workspace view
+
+.. image:: ../images/project_display.png
+   :align: center
+   :width: 600
+
+-  To select a project to run, right click on it and select "Set as Active"
+
+.. image:: ../images/select_project.png
+   :align: center
+   :width: 600
+
+-  Expand the project to see the structure. It is divided into 4 sub sections:
+
+   -  **AD5940Lib** - This conatins the AD5940.c source file which has all the AD5940 library functions. This file is common to all examples. The ADICUP3029Port.c file is located here also and contains port functions for the ADuCM3029 microcontroller.
+   -  **Application** - This sub section contains the application code and main.c file.
+   -  **CMSIS-Pack** - This pack contains the necessary files for the ADuCM3029 to function including the startup.c and system.c files
+   -  **Output** - This contains the c.out file. This file should not be changed.
+
+.. image:: ../images/iar.png
+   :align: center
+   :width: 600
+
+-  Double click on AD5940_ADCPolling.c to open the file in the editor.
+-  Modify code as required.
+-  To compile and build the project go to Project->Rebuild All. IT may take a couple fo seconds to fully compile all the source code.
+-  To download the code to the evaluation boards first ensure the boards are
+   connected to the PC or laptop. Then click on the green "Play" button on the
+   top toolbar. Note, if the "play" button is greyed out cloise IAR Workbench
+   and re-open it.
+
+.. image:: ../images/iar_debug.png
+   :align: center
+   :width: 600
+
+-  To set breakpoints click to the left of the line of code. A red dot will appear as in above screenshot.
+-  The code will be loaded onto the ADuCM3029 microcontroller. To begin
+   executing press the blue "Go" button.
+
+.. image:: ../images/iar_debugger.png
+   :align: center
+   :width: 600
+
+.. |image1| image:: ../images/setup1.png
+   :width: 400

--- a/docs/solutions/reference-designs/eval-ad5940/tools/iar_setup_guide.rst
+++ b/docs/solutions/reference-designs/eval-ad5940/tools/iar_setup_guide.rst
@@ -18,7 +18,7 @@ How to Install IAR
 ------------------
 
 Once the download has complete double click on the .exe file to begin the
-installation procedure. Then click on Install IAR Embedded Workbench® for ARM.\
+installation procedure. Then click on Install IAR Embedded Workbench® for ARM.
 
 |image1|
 
@@ -72,12 +72,13 @@ To edit and run example code in IAR Workbench follow these steps:
 .. admonition:: Download
    :class: download
 
-   
+
    `AD5940 SDK Source Code <https://github.com/analogdevicesinc/ad5940-examples>`_
-   
+
 
 -  Navigate to the **examples** folder
--  Double click on ADICUP3029.eww file. This opens all the example projects in the IAR Workspace
+-  Double click on ADICUP3029.eww file. This opens all the example projects
+   in the IAR Workspace
 -  On first time opening the project, the IAR CMSIS pack manager will open with
    a screen like this
 
@@ -92,7 +93,8 @@ To edit and run example code in IAR Workbench follow these steps:
    :align: center
    :width: 600
 
--  Once installed exit the Pack Manager window and display the main IAR Workbench program.
+-  Once installed exit the Pack Manager window and display the main IAR
+   Workbench program.
 -  All the example projects are shown in the Workspace view
 
 .. image:: ../images/project_display.png
@@ -107,10 +109,16 @@ To edit and run example code in IAR Workbench follow these steps:
 
 -  Expand the project to see the structure. It is divided into 4 sub sections:
 
-   -  **AD5940Lib** - This conatins the AD5940.c source file which has all the AD5940 library functions. This file is common to all examples. The ADICUP3029Port.c file is located here also and contains port functions for the ADuCM3029 microcontroller.
-   -  **Application** - This sub section contains the application code and main.c file.
-   -  **CMSIS-Pack** - This pack contains the necessary files for the ADuCM3029 to function including the startup.c and system.c files
-   -  **Output** - This contains the c.out file. This file should not be changed.
+   -  **AD5940Lib** - This conatins the AD5940.c source file which has all
+      the AD5940 library functions. This file is common to all examples. The
+      ADICUP3029Port.c file is located here also and contains port functions
+      for the ADuCM3029 microcontroller.
+   -  **Application** - This sub section contains the application code and
+      main.c file.
+   -  **CMSIS-Pack** - This pack contains the necessary files for the
+      ADuCM3029 to function including the startup.c and system.c files
+   -  **Output** - This contains the c.out file. This file should not be
+      changed.
 
 .. image:: ../images/iar.png
    :align: center
@@ -118,7 +126,8 @@ To edit and run example code in IAR Workbench follow these steps:
 
 -  Double click on AD5940_ADCPolling.c to open the file in the editor.
 -  Modify code as required.
--  To compile and build the project go to Project->Rebuild All. IT may take a couple fo seconds to fully compile all the source code.
+-  To compile and build the project go to Project->Rebuild All. IT may take
+   a couple fo seconds to fully compile all the source code.
 -  To download the code to the evaluation boards first ensure the boards are
    connected to the PC or laptop. Then click on the green "Play" button on the
    top toolbar. Note, if the "play" button is greyed out cloise IAR Workbench
@@ -128,7 +137,8 @@ To edit and run example code in IAR Workbench follow these steps:
    :align: center
    :width: 600
 
--  To set breakpoints click to the left of the line of code. A red dot will appear as in above screenshot.
+-  To set breakpoints click to the left of the line of code. A red dot will
+   appear as in above screenshot.
 -  The code will be loaded onto the ADuCM3029 microcontroller. To begin
    executing press the blue "Go" button.
 

--- a/docs/solutions/reference-designs/eval-ad5940/tools/keil_setup_guide.rst
+++ b/docs/solutions/reference-designs/eval-ad5940/tools/keil_setup_guide.rst
@@ -1,0 +1,86 @@
+How to setup and use Keil IDE
+=============================
+
+The AD5940 SDK provides support for Keil IDE to develop firmware. Keil provides
+an evaluation licence that is free but limits the code size to 32 kB. Currently,
+none of the evaluation examples in the AD5940 development pack exceed this.
+
+How to Download Keil
+--------------------
+
+To download Keil IDE click on the following link https://www.keil.com/demo/eval/arm.htm
+
+This will open up a form which must be filled out to download the software.
+Click Submit when complete to begin the download process. Once the software has
+downloaded an evaluation licence is required. Keil offers two different
+evaluation licences, time limited and size limited. Choose the size limited
+licence. This limits the allowable code size to 32kB. All the AD5940 example
+projects are within this limitation.
+
+The latest versions of Keil use the ARM compiler v6, but the example code still uses v5, and refuses to compile under v6. Therefore, you will also need to download the legacy compiler, and install it at the correct location (not the default location), as shown in https://developer.arm.com/documentation/ka005073/latest
+
+How to edit and run example code in Keil
+----------------------------------------
+
+To edit and run example code in Keil follow these steps:
+
+-  Download the AD5940 SDK from the the GitLab repository:
+
+.. admonition:: Download
+   :class: download
+
+   
+   `AD5940 SDK Source Code <https://github.com/analogdevicesinc/ad5940-examples>`_
+   
+
+*(**Hint:** Also download the included submodule in examples/ad5940lib. This can be done with the git bash in one step by executing: "git clone --recurse-submodules* `ad5940-examples <https://github.com/analogdevicesinc/ad5940-examples>`_.git*" (without the double quotes))*
+
+-  Navigate to the **examples->AD5940_ADC->ADICUP3029**
+-  Double click on ADICUP3029.uvprojx file to open the project in Keil [The package at `ad5940-examples <https://github.com/analogdevicesinc/ad5940-examples>`_ doesn't contain ADICUP3029.uvprojx in **examples->AD5940_ADC->ADICUP3029** or other folders]
+-  The project structure is shown in the left hand side of the screen. It is
+   divided into 4 sub sections:
+
+   -  **AD5940Lib** - This contains the AD5940.c source file which has all the AD5940 library functions. This file is common to all examples. The ADICUP3029Port.c file is located here also and contains port functions for the ADuCM3029 microcontroller.
+   -  **Application** - This sub section contains the application code and main.c file.
+   -  **CMSIS** - This contains the arm CMSIS math library.
+   -  **Device** - This folder contains the startup code for the ADuCM3029 micrcontroller. These files should not be modified.
+
+.. image:: ../images/keil_adc.png
+   :align: center
+   :width: 600
+
+-  Double click on AD5940_ADCPolling.c to open the file in the editor.
+-  Modify code as required.
+-  To compile and build the project go to **Project->Rebuild all target files**. It may take a couple of seconds to fully compile all the source code.
+-  If you see build errors like 'Fatal Error[Pe1696]: cannot open source file
+   "adi_cycle_counting_config.h"', you need to add/adjust include paths:
+
+   -  Click Menu > Project > Options > C/C++ Compiler > Preprocessor > Additional include directories (click on the three dots on the right)
+   -  Click on '<Click to add>'
+   -  Find the file on your computer and add it, e.g. navigate to (and then select): 'C:\\ad5940-examples\\examples\\AD5940_BATImpedance\\ADICUP3029\\RTE\\Device\\ADuCM3029' (adjust the path depending on where you stored the example folder, which example project you use and which include file is missing)
+   -  Click OK twice, then Menu > Project > Clean
+   -  Click Menu > Project > Rebuild All
+
+-  To download the code to the evaluation boards first ensure the boards are
+   connected to the PC or laptop. Then click on the red icon in the toolbar to
+   download the source code and begin the debugging session.
+
+.. image:: ../images/keil_debug.png
+   :align: center
+   :width: 600
+
+-  To set breakpoints click to the left of the line of code. A red dot will appear as in below screenshot.
+-  To begin executing press the "Run" button which is highlighted in below
+   screenshot.
+
+.. image:: ../images/keil_debugger.png
+   :align: center
+   :width: 600
+
+-  Hint: If downloading the code didn't work because of an error like this:
+   'Failed to load flash loader:
+   C:/Users/YourUsername/IAR-CMSIS-Packs/AnalogDevices/ADUCM302x_DFP/3.2.0/\\ARM\\config\\flashloader\\AnalogDevices\\FlashADUCM3029.flash':
+
+   -  Try this method instead: `adicup3029_hw_drivers <https://wiki.analog.com/resources/eval/user-guides/eval-adicup3029/tools/adicup3029_hw_drivers>`_
+   -  If your board doesn't start after this, give flashing/debugging using the
+      steps described above another try - sometimes it works again.

--- a/docs/solutions/reference-designs/eval-ad5940/tools/keil_setup_guide.rst
+++ b/docs/solutions/reference-designs/eval-ad5940/tools/keil_setup_guide.rst
@@ -17,7 +17,11 @@ evaluation licences, time limited and size limited. Choose the size limited
 licence. This limits the allowable code size to 32kB. All the AD5940 example
 projects are within this limitation.
 
-The latest versions of Keil use the ARM compiler v6, but the example code still uses v5, and refuses to compile under v6. Therefore, you will also need to download the legacy compiler, and install it at the correct location (not the default location), as shown in https://developer.arm.com/documentation/ka005073/latest
+The latest versions of Keil use the ARM compiler v6, but the example code
+still uses v5, and refuses to compile under v6. Therefore, you will also need
+to download the legacy compiler, and install it at the correct location (not
+the default location), as shown in
+https://developer.arm.com/documentation/ka005073/latest
 
 How to edit and run example code in Keil
 ----------------------------------------
@@ -29,21 +33,33 @@ To edit and run example code in Keil follow these steps:
 .. admonition:: Download
    :class: download
 
-   
-   `AD5940 SDK Source Code <https://github.com/analogdevicesinc/ad5940-examples>`_
-   
 
-*(**Hint:** Also download the included submodule in examples/ad5940lib. This can be done with the git bash in one step by executing: "git clone --recurse-submodules* `ad5940-examples <https://github.com/analogdevicesinc/ad5940-examples>`_.git*" (without the double quotes))*
+   `AD5940 SDK Source Code <https://github.com/analogdevicesinc/ad5940-examples>`_
+
+
+.. note::
+
+   Also download the included submodule in examples/ad5940lib. This can be
+   done with the git bash in one step by executing:
+   ``git clone --recurse-submodules ad5940-examples.git``
+
 
 -  Navigate to the **examples->AD5940_ADC->ADICUP3029**
--  Double click on ADICUP3029.uvprojx file to open the project in Keil [The package at `ad5940-examples <https://github.com/analogdevicesinc/ad5940-examples>`_ doesn't contain ADICUP3029.uvprojx in **examples->AD5940_ADC->ADICUP3029** or other folders]
+-  Double click on ADICUP3029.uvprojx file to open the project in Keil. Note:
+   the package at `ad5940-examples <https://github.com/analogdevicesinc/ad5940-examples>`_ doesn't contain ADICUP3029.uvprojx in **examples->AD5940_ADC->ADICUP3029**
+   or other folders.
 -  The project structure is shown in the left hand side of the screen. It is
    divided into 4 sub sections:
 
-   -  **AD5940Lib** - This contains the AD5940.c source file which has all the AD5940 library functions. This file is common to all examples. The ADICUP3029Port.c file is located here also and contains port functions for the ADuCM3029 microcontroller.
-   -  **Application** - This sub section contains the application code and main.c file.
+   -  **AD5940Lib** - This contains the AD5940.c source file which has all
+      the AD5940 library functions. This file is common to all examples. The
+      ADICUP3029Port.c file is located here also and contains port functions
+      for the ADuCM3029 microcontroller.
+   -  **Application** - This sub section contains the application code and
+      main.c file.
    -  **CMSIS** - This contains the arm CMSIS math library.
-   -  **Device** - This folder contains the startup code for the ADuCM3029 micrcontroller. These files should not be modified.
+   -  **Device** - This folder contains the startup code for the ADuCM3029
+      micrcontroller. These files should not be modified.
 
 .. image:: ../images/keil_adc.png
    :align: center
@@ -51,13 +67,19 @@ To edit and run example code in Keil follow these steps:
 
 -  Double click on AD5940_ADCPolling.c to open the file in the editor.
 -  Modify code as required.
--  To compile and build the project go to **Project->Rebuild all target files**. It may take a couple of seconds to fully compile all the source code.
+-  To compile and build the project go to **Project->Rebuild all target
+   files**. It may take a couple of seconds to fully compile all the source
+   code.
 -  If you see build errors like 'Fatal Error[Pe1696]: cannot open source file
    "adi_cycle_counting_config.h"', you need to add/adjust include paths:
 
-   -  Click Menu > Project > Options > C/C++ Compiler > Preprocessor > Additional include directories (click on the three dots on the right)
+   -  Click Menu > Project > Options > C/C++ Compiler > Preprocessor >
+      Additional include directories (click on the three dots on the right)
    -  Click on '<Click to add>'
-   -  Find the file on your computer and add it, e.g. navigate to (and then select): 'C:\\ad5940-examples\\examples\\AD5940_BATImpedance\\ADICUP3029\\RTE\\Device\\ADuCM3029' (adjust the path depending on where you stored the example folder, which example project you use and which include file is missing)
+   -  Find the file on your computer and add it, e.g. navigate to (and then
+      select): 'C:\\ad5940-examples\\examples\\AD5940_BATImpedance\\ADICUP3029\\RTE\\Device\\ADuCM3029'
+      (adjust the path depending on where you stored the example folder, which
+      example project you use and which include file is missing)
    -  Click OK twice, then Menu > Project > Clean
    -  Click Menu > Project > Rebuild All
 
@@ -69,7 +91,8 @@ To edit and run example code in Keil follow these steps:
    :align: center
    :width: 600
 
--  To set breakpoints click to the left of the line of code. A red dot will appear as in below screenshot.
+-  To set breakpoints click to the left of the line of code. A red dot will
+   appear as in below screenshot.
 -  To begin executing press the "Run" button which is highlighted in below
    screenshot.
 

--- a/docs/solutions/reference-designs/eval-ad5940/tools/porting_source_code.rst
+++ b/docs/solutions/reference-designs/eval-ad5940/tools/porting_source_code.rst
@@ -1,0 +1,138 @@
+How to port AD594x Firmware Examples to other Micro controller Families
+=======================================================================
+
+The AD594x example projects are written for the ADuCM3029 micro controller.
+There are also examples written for the NUCLEO-F411RE board. The example
+projects are designed to be easily ported to other micro controllers. This
+document details the steps involved.
+
+Source Code Structure
+---------------------
+
+This section describes the file structure for the firmware examples. The
+following image is a capture from the AD5940_BIA example project opened in Keil
+IDE.\
+
+|image1|
+
+-  **AD5940Lib**
+
+   -  *ad5940.c*
+
+      -  This is the main AD5940 library file and contains all library function.
+         No modifications should be made to this file.
+
+   -  *ADICUP3029.c*
+
+      -  Contains specific functions for the ADuCM3029 microcontroller. The
+         functions defined in this file will need to be modified according to
+         the MCU. Descriptions of each function are outlined below.
+
+-  **Application**
+
+   -  *main.c*
+
+      -  This is the main file in the program that handles the MCU core
+         initialization functions such as configuring Uart interface and MCU
+         system clocks. This file needs to be re-written for a new MCU
+
+   -  *AD5940Main.c*
+
+      -  This file provides high level application control functions such as
+         dealing with interrupts and transmitting data. This does not need to be
+         modified when porting to a new MCU.
+
+   -  *BodyImpedance.c*
+
+      -  This file handles the core measurement sequences including sequencer
+         configuration, reading data from the FIFO and processing the data. This
+         file does not need to be modified when porting to a new MCU.
+
+-  CMSIS
+
+   -  This is the CMSIS pack for the selected MCU. This CMSIS pack should be
+      imported for the particular MCU and should not be edited
+
+-  Device
+
+   -  This folder has the startup file for the chosen MCU and should not be
+      edited.
+
+Porting Functions in ADICUP3029Port.c
+-------------------------------------
+
+The main port file between the MCU and AD5940 is the ADICUP3029Port.c file. The
+following are the main functions and their purpose:
+
+-  **AD5940_ReadWriteNBytes(unsigned char \*pSendBuffer,unsigned char \*pRecvBuff,unsigned long length)**
+
+   -  This function simply transmits N number of bytes to the AD5940 on the MOSI line and receives the response on the MISO line.
+   -  The function has 3 input parameters. **\*pSendBuffer** is a pointer to the buffer used to store the data to be transmitted. **\*pRecvBuff** is a pointer to the buffer used to store the results. **length** is the number of bytes in the buffer to be sent.
+
+-  **AD5940_CsClr(void)**
+
+   -  This function simply drives the GPIO pin connected to the AD5940's CS pin
+      low
+
+-  **AD5940_CsSet(void)**
+
+   -  This function sets the GPIO pin connected to the AD5940 CS pin high.
+
+-  **AD5940_RstSet(void)**
+
+   -  This function drives the GPIO connected to the AD5940 reset pin high.
+
+-  **AD5940_RstClr(void)**
+
+   -  This function drives the GPIO pin connected the AD5940 reset pin low to
+      initiate a hardware reset
+
+-  **AD5940_Delay10us(uint32_t time)**
+
+   -  This function implements a wait period using the systick timer on the
+      cortex core. This function will vary depending on MCU. Take care that this
+      function is implemented correctly to ensure the AD5940 library functions
+      correctly.
+
+-  **AD5940_GetMCUIntFlag(void)**
+
+   -  This function returns the status of the interrupt flag that is set in the
+      external interrupt handler to indicate the AD5940 has generated an
+      interrupt.
+
+-  **AD5940_ClrMCUIntFlag(void)**
+
+   -  This function clears the interrupt status flag.
+
+-  **AD5940_MCUResourceInit(void \*pCfg)**
+
+   -  This function initializes and configures the main peripherals for the
+      functions defined above.
+
+      -  The GPIOs are configured accordingly for the SPI interface, Reset pin and external interrupt pin
+      -  The SPI is configured according to the AD5940 datasheet
+      -  The external interrupt source is enable in the NVIC on the cortex core
+      -  The CS pin and Reset pin are set high.
+
+-  **Ext_Int0_Handler()**
+
+   -  The interrupt handler handles the interrupt to the MCU when the AD5940
+      INTC pin generates an interrupt to alert the MCU that data is ready. It
+      sets the ucInterrupted flag to 1.
+
+Porting Functions in main.c
+---------------------------
+
+The main.c file only implements 2 functions:
+
+-  **MCUPlatformInit(void \*pCfg)**
+
+   -  This function initializes the core clocks on the MCU
+
+-  **UrtCfg(int iBaud)**
+
+   -  This function initializes the the Uart interface on the MCU to print
+      results to the Uart.
+
+.. |image1| image:: ../images/folder_structure.png
+   :width: 300

--- a/docs/solutions/reference-designs/eval-ad5940/tools/sensorpal_setup_guide.rst
+++ b/docs/solutions/reference-designs/eval-ad5940/tools/sensorpal_setup_guide.rst
@@ -1,12 +1,18 @@
 How to setup and use SensorPal
 ==============================
 
-SensorPal is an easy to use configuration tool designed to work with the the **EVAL-AD5940BIOZ, EVAL-AD5940ELCZ, EVAl-AD5941ELCZ** and **EVAL-AD5941BATZ** evaluation kits. It provides an intuitive graphical user interface to facilitate rapid measurement prototyping and results analysis through graph form.
+SensorPal is an easy to use configuration tool designed to work with the the
+**EVAL-AD5940BIOZ, EVAL-AD5940ELCZ, EVAl-AD5941ELCZ** and **EVAL-AD5941BATZ**
+evaluation kits. It provides an intuitive graphical user interface to
+facilitate rapid measurement prototyping and results analysis through graph
+form.
 
 Download Instructions
 ---------------------
 
-To download the latest SensorPal installer click on the link below. **Note**, if the link do not open correctly, try using an alternative browser such as Google Chrome, Microsoft Edge, etc.
+To download the latest SensorPal installer click on the link below. **Note**,
+if the link do not open correctly, try using an alternative browser such as
+Google Chrome, Microsoft Edge, etc.
 
 -  AD5940 :adi:`SensorPal GUI Installer <en/products/ad5940.html#product-requirement>`
 
@@ -17,7 +23,8 @@ To download the latest SensorPal installer click on the link below. **Note**, if
 Installation Instructions
 -------------------------
 
--  Navigate to the folder where the installer was downloaded and double click on SensorPal Installer_v2100.exe to launch the executable
+-  Navigate to the folder where the installer was downloaded and double click
+   on SensorPal Installer_v2100.exe to launch the executable
 -  Follow the Install Wizard instructions to complete the setup.
 -  When complete click Finish
 
@@ -39,7 +46,8 @@ How to Use SensorPal
    :align: center
    :width: 600
 
--  Once the firmware is loaded plug out the evaluation kit from the PC and reconnect to power cycle the hardware.
+-  Once the firmware is loaded plug out the evaluation kit from the
+   PC and reconnect to power cycle the hardware.
 -  In the center of the screen hit the refresh symbol beside the Com port
    drop-down text box. Then select the com port the ADICUP3029 microcontroller
    is connected to from the drop down list.
@@ -48,7 +56,10 @@ How to Use SensorPal
    :align: center
    :width: 600
 
--  To select an application to run, drag it from the left hand column of techniques and drop into the Work Area. A number of configurable parameters are available. Modify them as required.
--  To begin a measurement click on the green Measure button to the right side of the GUI.
+-  To select an application to run, drag it from the left hand column of
+   techniques and drop into the Work Area. A number of configurable
+   parameters are available. Modify them as required.
+-  To begin a measurement click on the green Measure button to
+   the right side of the GUI.
 -  The measurement results will be displayed in the graph window.
 -  To stop a measurement click on the Abort Measurement button.

--- a/docs/solutions/reference-designs/eval-ad5940/tools/sensorpal_setup_guide.rst
+++ b/docs/solutions/reference-designs/eval-ad5940/tools/sensorpal_setup_guide.rst
@@ -1,0 +1,54 @@
+How to setup and use SensorPal
+==============================
+
+SensorPal is an easy to use configuration tool designed to work with the the **EVAL-AD5940BIOZ, EVAL-AD5940ELCZ, EVAl-AD5941ELCZ** and **EVAL-AD5941BATZ** evaluation kits. It provides an intuitive graphical user interface to facilitate rapid measurement prototyping and results analysis through graph form.
+
+Download Instructions
+---------------------
+
+To download the latest SensorPal installer click on the link below. **Note**, if the link do not open correctly, try using an alternative browser such as Google Chrome, Microsoft Edge, etc.
+
+-  AD5940 :adi:`SensorPal GUI Installer <en/products/ad5940.html#product-requirement>`
+
+.. image:: ../images/sensorpalinstaller_analog_com.png
+   :align: center
+   :width: 600
+
+Installation Instructions
+-------------------------
+
+-  Navigate to the folder where the installer was downloaded and double click on SensorPal Installer_v2100.exe to launch the executable
+-  Follow the Install Wizard instructions to complete the setup.
+-  When complete click Finish
+
+How to Use SensorPal
+--------------------
+
+-  To launch SensorPal go to the start menu-> All Programs->SensorPal
+-  To get started ensure the AD5940 evaluation kit is connected to the PC. Click
+   on the Firmware Load button in the top toolbar as per below screenshot.
+
+.. image:: ../images/firmware_load.png
+   :align: center
+   :width: 600
+
+-  Select the correct board, it should be similar to DAPLINK(E:\\). Then click
+   Update Firmware
+
+.. image:: ../images/firmware_load_2.png
+   :align: center
+   :width: 600
+
+-  Once the firmware is loaded plug out the evaluation kit from the PC and reconnect to power cycle the hardware.
+-  In the center of the screen hit the refresh symbol beside the Com port
+   drop-down text box. Then select the com port the ADICUP3029 microcontroller
+   is connected to from the drop down list.
+
+.. image:: ../images/comm_port.png
+   :align: center
+   :width: 600
+
+-  To select an application to run, drag it from the left hand column of techniques and drop into the Work Area. A number of configurable parameters are available. Modify them as required.
+-  To begin a measurement click on the green Measure button to the right side of the GUI.
+-  The measurement results will be displayed in the graph window.
+-  To stop a measurement click on the Abort Measurement button.


### PR DESCRIPTION
## Summary
- Move eval-ad5940 wiki documentation to `solutions/reference-designs/eval-ad5940/`
- 30 RST files with 50 localized images
- Generated stub `index.rst` with toctree

## Test plan
- [ ] Sphinx build passes without errors
- [ ] All toctree entries resolve correctly
- [ ] Images render properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)