### PR TITLE
reference-designs/eval-ad7175-8ardz: Add eval-ad7175-8ardz documentation

### DIFF
--- a/docs/solutions/reference-designs/eval-ad7175-8ardz/hardware_guide.rst
+++ b/docs/solutions/reference-designs/eval-ad7175-8ardz/hardware_guide.rst
@@ -1,0 +1,274 @@
+Hardware Guide
+==============
+
+Device Description
+------------------
+
+The :adi:`AD7175-8 <en/products/ad7175-8.html>` a highly accurate, high resolution, multiplexed, 8-/16-channel (full/pseudo differential) Σ-Δ ADC. The :adi:`AD7175-8 <en/products/ad7175-8.html>` has a maximum channel-to-channel scan rate of 50 kSPS (20 µs) for fully settled data The output data rates range from 5 SPS to 250 kSPS. The device includes integrated analog input and reference buffers, an integrated precision 2.5 V reference, and an integrated oscillator.
+
+Set-up Procedures
+-----------------
+
+After following the instructions in the Software Installation Procedures
+section, set up the evaluation board and the SDP-K1 board as detailed in this
+section.
+
+.. important::
+
+   The ACE software and drivers must be installed before connecting the
+   EVAL-AD7175-8ARDZ and the EVAL-SDP-CK1Z board to the USB port of the PC to
+   ensure that the PC correctly recognizes the evaluation system
+
+**Configuring the Evaluation and SDP Boards** Use the following procedure to configure the boards
+
+-  Connect the SDP-K1 to the Arduino headers of the evaluation board.
+-  If using the SDP-K1 board the Arduino headers can also be used to connect to the board
+-  Connect the SDP board to the PC using the USB cable.
+
+Evaluation Board
+----------------
+
+.. image:: images/65002_2.jpg
+   :align: center
+   :width: 600
+
+Hardware Link Options
+---------------------
+
++-------------+------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| Link Number | Default Position | Description                                                                                                                                                                                                                                                                                                                                     |
++=============+==================+=================================================================================================================================================================================================================================================================================================================================================+
+| LK1         | B                | Selects the voltage applied to the AVDD1 pin. Operates using the AVDD 5V supply (default). When inserted in **Position A**, sets the AVDD1 voltage to the 3.3V supply from the ADP150 (U6) regulator. Setting AVDD1 = 3.3V is not allowed when AVSS = -2.5V.                                                                                    |
++-------------+------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| LK2         | B                | Selects the voltage applied to the AVDD2 pin. Operates using the AVDD 5V supply (default). When inserted in **Position A**, sets the AVDD2 voltage to the 3.3V supply from the ADP150 (U6) regulator. Setting AVDD2 = 3.3V is not allowed when AVSS = -2.5V.                                                                                    |
++-------------+------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| LK3         | B                | Selects the external clock input or internal clock output (default). When inserted in **Position A**, selects the CRYSTAL OPTION.                                                                                                                                                                                                               |
++-------------+------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| LK4         | Inserted         | Insert to connect REF- to AVSS.                                                                                                                                                                                                                                                                                                                 |
++-------------+------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| LK5         | B                | Connects REF+ to 5V external reference (default). When inserted in **Position A**, REF+ is connected to 2.5V internal reference.                                                                                                                                                                                                                |
++-------------+------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| LK6         | A                | Turns ON the :adi:`LTC3129 <en/products/LTC3129.html>` (U3) to supply 7V to the LDO linear regulators (default). When inserted in **Position B**, turns OFF the :adi:`LTC3129 <en/products/LTC3129.html>` (U3).                                                                                                                                 |
++-------------+------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| LK7         | B                | Shifts the voltage of AVDD 5.5V to 7V when inserted in **Position A**. When inserted in **Position B**, AVDD 5.5V is set to 5.5V (default).                                                                                                                                                                                                     |
++-------------+------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| LK8         | A                | Turns ON the :adi:`ADP7118 <en/products/ADP7118.html>` (U10) to supply for AVDD 5.5V. The AVDD 5.5V is supplied with 5.5V from ADP7118 regulator (default). When inserted in **Position B**, turns OFF the :adi:`ADP7118 <en/products/ADP7118.html>` (U10).                                                                                     |
++-------------+------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| LK9         | A                | Turns ON the 5V LDO to supply for AVDD 5V. The AVDD 5V is supplied with 5V from :adi:`ADP7118 <en/products/ADP7118.html>` (U11) regulator (default). When inserted in **Position B**, turns OFF the :adi:`ADP7118 <en/products/ADP7118.html>` (U11).                                                                                            |
++-------------+------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| LK10        | A                | Turns ON the 2.5V LDO to supply for AVDD 2.5V. The AVDD 2.5V is supplied with 2.5V from :adi:`LT1962 <en/products/LT1962.html>` (U4) regulator (default). When inserted in **Position B**, turns OFF the :adi:`LT1962 <en/products/LT1962.html>` (U4).                                                                                          |
++-------------+------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| LK11        | A                | Turns ON the :adi:`LT1983 <en/products/LT1983.html>` (U2) to supply for the ADP7182 (U5) 2.5V linear regulator (default). When inserted in **Position B**, turns OFF the :adi:`LT1983 <en/products/LT1983.html>` (U2).                                                                                                                          |
++-------------+------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| LK12        | A                | Turns ON the :adi:`ADP7182 <en/products/ADP7182.html>` (U5) to supply for -2.5V. The -2.5V is supplied with -2.5V from the ADP7182 regulator (default); AVSS can be connected to ground depending on S1. When inserted in **Position B**, turns OFF the :adi:`ADP7182 <en/products/ADP7182.html>` (U5).                                         |
++-------------+------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| LK13        | A                | Turns ON the 3.3V LDO to supply for IOVDD 3.3V. The IOVDD 3.3V is supplied with 3.3V from :adi:`ADP150 <en/products/ADP150.html>` (U6) regulator (default). When inserted in **Position B**, turns OFF the :adi:`ADP150 <en/products/ADP150.html>` (U6).                                                                                        |
++-------------+------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| LK14        | Removed          | Insert LK14 when performing Noise Test.                                                                                                                                                                                                                                                                                                         |
++-------------+------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| LK15        | A                | Set to **A**, connects REFOUT to VCM (default). Set to **B**, connects REFOUT to A0. **Remove** LK15 when using an external VCM from J15.                                                                                                                                                                                                       |
++-------------+------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| LK16        | B                | Set to **A**, connects AIN0 to ADC Driver. Set to **B**, connects/directs AIN0 to ADC (default). **Remove** LK16 when connecting AIN0 to surfboard.                                                                                                                                                                                             |
++-------------+------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| LK17        | B                | Set to **A**, connects AIN1 to ADC Driver. Set to **B**, connects/directs AIN1 to ADC (default). **Remove** LK17 when connecting AIN0 to surfboard.                                                                                                                                                                                             |
++-------------+------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| LK18        | A                | Set to **A**, connects -VS to GND (default). Set to **B**, connects -VS to -2.5 V. **Remove** LK18 when using external supply.                                                                                                                                                                                                                  |
++-------------+------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| LK19        | B                | Set to **A**, connects +VS to AVDD 5 V. Set to **B**, connects +VS to AVDD 5.5 V (default). **Remove** LK19 when using external supply.                                                                                                                                                                                                         |
++-------------+------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| LK20        | Inserted         | When **inserted**, initiates power down for the :adi:`ADA4945 <en/products/ADA4945.html>`/:adi:`ADA4940 <en/products/ADA4940.html>`. **Remove** when using the ADC DRIVER. **Insert** LK20 when performing Noise Test or when Surfboard is connected.                                                                                           |
++-------------+------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| LK21        | A                | Set to **A**, connects SCLK to standard Arduino connection (default). Set to **B** when using multiple boards; connects SCLK to alternative Arduino connection.                                                                                                                                                                                 |
++-------------+------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| LK22        | A                | Set to **A**, connects DOUT to standard Arduino connection (default). Set to **B** when using multiple boards; connects DOUT to alternative Arduino connection.                                                                                                                                                                                 |
++-------------+------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| LK23        | A                | Set to **A**, connects DIN to standard Arduino connection (default). Set to **B** when using multiple boards; connects DIN to alternative Arduino connection.                                                                                                                                                                                   |
++-------------+------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| LK24        | A                | Set to **A**, connects CS to standard Arduino connection (default). Otherwise, select different CS for stacking multiple boards.                                                                                                                                                                                                                |
++-------------+------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+
+On Board Connections
+--------------------
+
++-------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------+-------------------------------------------------------------+
+| Connector   | Function                                                                                                                                                             | Connector Type                                              |
++=============+======================================================================================================================================================================+=============================================================+
+| J1          | External clock input or ADC internal clock output                                                                                                                    | SMB Connector Jack, Male Pin 50Ω Through Hole Solder        |
++-------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------+-------------------------------------------------------------+
+| J2          | External bench top voltage supply option for AVDD 5V, AVDD 2.5V, AVSS -2.5V, and IOVDD inputs on the :adi:`AD7175-8 <en/products/ad7175-8.html>`                     | Screw terminal block, 2.54 mm pitch                         |
++-------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------+-------------------------------------------------------------+
+| J4          | Arduino Headers (Power)                                                                                                                                              | 8 Position Receptacle Connector, 2.54mm pitch               |
++-------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------+-------------------------------------------------------------+
+| J5          | Arduino Header (Digital 1)                                                                                                                                           | 10 Position Receptacle Connector, 2.54mm pitch              |
++-------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------+-------------------------------------------------------------+
+| J6          | Arduino Header (Analog)                                                                                                                                              | 6 Position Receptacle Connector, 2.54mm pitch               |
++-------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------+-------------------------------------------------------------+
+| J7          | Arduino Header (Digital 0)                                                                                                                                           | 8 Position Receptacle Connector, 2.54mm pitch               |
++-------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------+-------------------------------------------------------------+
+| J8          | PMOD form factor                                                                                                                                                     | 12-pin header, 2.54mm pitch                                 |
++-------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------+-------------------------------------------------------------+
+| J9          | Arduino Header (IFCSP)                                                                                                                                               | 6 Position, 2 row, Receptable Connector, 2.54mm pitch       |
++-------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------+-------------------------------------------------------------+
+| J15 and J17 | Analog input terminal block; wired connection to external source or sensor                                                                                           | Power socket block, 8-pin, 2.54 mm pitch, 3.5mm solder tail |
++-------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------+-------------------------------------------------------------+
+| J16         | Analog input terminal block; wired connection to external source or sensor                                                                                           | Power socket block, 6-pin, 2.54 mm pitch, 3.5mm solder tail |
++-------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------+-------------------------------------------------------------+
+| J18         | GPIO terminal                                                                                                                                                        | 4 Position 1 Row vertical PCB header, 2.54mm pitch          |
++-------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------+-------------------------------------------------------------+
+| J19         | Surfboard header (optional)                                                                                                                                          | 7-way, 2.54 mm pin socket                                   |
++-------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------+-------------------------------------------------------------+
+| J20         | Surfboard header (optional)                                                                                                                                          | 7-way, 2.54 mm pin header                                   |
++-------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------+-------------------------------------------------------------+
+
+Power Supplies
+==============
+
+The evaluation board receives power through the controller board when connected
+to the PC via 5V USB. Linear regulators generate the required power supply
+levels from the applied USB voltage.
+
+-  Each regulator can be shut down using their shut down links highlighted in
+   orange below.
+
+AVDD1 and AVSS selection (S1)
+-----------------------------
+
+-  **5V supply (DEFAULT)**
+
+   -  Position switch (S1) to **SINGLE** on the board
+
+      -  5V regulator supplies AVDD1
+      -  AVSS tied to AGND
+
+-  **±2.5V split supply**
+
+   -  Position switch (S1) to **SPLIT** on the board
+
+      -  2.5V regulator supplies AVDD1
+      -  -3V regulator -2.5V regulator supplies AVSS
+
+===AVDD1 and AVDD2 selection (LK1 and LK2)===
+
+-  **5V supply (DEFAULT)**
+
+   -  Set LK1 and/or LK2 to **position B**
+
+      -  5V regulator supplies AVDD1
+
+-  **3.3V supply**
+
+   -  Set LK1 and/or LK2 to **position A**
+
+      -  3.3V regulator supplies IOVDD
+
+-  **External AVDD/AVSS**
+
+   -  Set LK1, LK2, LK9, LK10, LK11, LK12, and LKL13 to **position B**
+
+      -  When using external AVDD only, set S1 to **SINGLE**, and connect external AVDD pin 1 of J2.
+      -  When using external AVDD and AVSS, set S1 to **SPLIT**, and connect external AVDD and AVSSS to pins 2 and 3 of J2 respectively.
+
++-----------------+--------------------------------------------------------------------------+----------------+
+| Supply          | Regulator                                                                | Shut down Link |
++=================+==========================================================================+================+
+| 5V regulator    | :adi:`ADP7118ACPZN5.0-R7 <en/products/adp7118.html>`                     | LK9            |
++-----------------+--------------------------------------------------------------------------+----------------+
+| 2.5V regulator  | :adi:`LT1962EMS8-2.5#PBF <en/products/ltc1962.html>`                     | L10            |
++-----------------+--------------------------------------------------------------------------+----------------+
+| -2.5V regulator | :adi:`ADP7182AUJZ-2.5-R7 <en/products/adp7182.html>`                     | L12            |
++-----------------+--------------------------------------------------------------------------+----------------+
+| 3.3V regulator  | :adi:`ADP150ACBZ-3.3-R7 <en/products/adp150.html>`                       | LK13           |
++-----------------+--------------------------------------------------------------------------+----------------+
+
+Serial Interface
+~~~~~~~~~~~~~~~~
+
+There are four primary signals: CS, SCLK, MOSI/DIN, and MISO/DOUT (all are
+inputs, except for MISO/DOUT, which is an output). The EVAL-AD7175-8ARDZ
+evaluation board connects to any microcontroller board that uses the Arduino
+standard headers. This can be developed user code in for a variety of platforms.
+
+Serial communication options
+----------------------------
+
+-  Arduino connection using the SDP-K1
+-  PMOD connector
+-  Standalone mode
+
+     \* Removing the links LK21, LK22, LK23, and LK24, then using J5 to access
+     all SPI signals and set the input/output voltage levels.
+
+For an introduction to the Serial Peripheral Interface (SPI), click :adi:`here <en/analog-dialogue/articles/introduction-to-spi-interface.html>`
+
+.. image:: images/spi.png
+   :align: center
+   :width: 600
+
+Analog Inputs
+=============
+
+The :adi:`EVAL-AD7175-8ARDZ <en/design-center/evaluation-hardware-and-software/evaluation-boards-kits/EVAL-AD7175-8.html>` primary analog inputs can be applied on J15, J16, and J17 which are at the left side of the board. Differential analog inputs are applied on AIN0 and AIN1 when using the ADC driver (when using ADC driver, enable AIN+/- buffers). The :adi:`AD7175-8 <en/products/ad7175-8.html>` evaluation software is set up to analyze dc inputs to the ADC. The AD7175-8 input buffers work for dc input signals.
+
+Reference Options
+=================
+
+-  :adi:`AD7175-8 <en/products/ad7175-8.html>` internal 2.5V reference.
+-  **DEFAULT** :adi:`ADR4550 <en/products/ADR4550.html>` on board external reference.
+-  External reference connector J17 through AIN1/REF2+ and AIN0/REF2− pins.
+
+Selecting the reference source:
+-------------------------------
+
+Software
+~~~~~~~~
+
+Example shows setting reference for Channel 0, for channel n, go to register
+SETUPCON[n]
+
+-  Board should be correctly connected to ACE.
+-  Open AD7175-8 memory map (Memory Map Side-By-Side)
+-  Search for the SETUPCON[0] register
+-  Set the REF_SEL_N[0] to the desired reference source or the Data(hex) to the
+   relevant bits
+
+   -  **On board External reference 1** REF+/- (Hex value 00, Binary Value 00).
+
+      -  **External reference 2** REF2+/− (Hex value 01, Binary Value 01).
+      -  **Internal 2.5V reference** REFOUT, AVSS (Hex Value 02, Binary Value 10).
+      -  **AVDD to AVSS** (Hex Value 03, Binary Value 11).
+
+.. image:: images/ref_figure.png
+   :align: center
+   :width: 600
+
+Hardware
+~~~~~~~~
+
++--------------+------+------------------+----------------------------------------------------------------------------------------------------------------------+
+| Link Numbers | Type | Default Position | Descirption                                                                                                          |
++==============+======+==================+======================================================================================================================+
+| LK4          | Link | Inserted         | Inserted: Connects REF- to AVSS                                                                                      |
+|              |      |                  | Removed: Disconnects REF- to AVSS                                                                                    |
++--------------+------+------------------+----------------------------------------------------------------------------------------------------------------------+
+| LK5          | Link | B                | REF+/- connections:                                                                                                  |
+|              |      |                  | Set to A: Connects REF+ to REFOUT                                                                                    |
+|              |      |                  | Set to B: Connects REF+ to on board :adi:`ADR4550 <en/products/ADR4550.html>` external reference                     |
++--------------+------+------------------+----------------------------------------------------------------------------------------------------------------------+
+
+Schematic, PCB Layout, Bill of Materials
+========================================
+
+.. admonition:: Download
+   :class: download
+
+   EVAL-AD7175-8ARDZ Rev B Design and Integration Files
+
+   
+   -  `Schematic.pdf <https://wiki.analog.com/_media/resources/eval/user-guides/eval-ad7175-8ardz/Schematic.pdf>`_
+   
+   -  `Layout.pdf <https://wiki.analog.com/_media/resources/eval/user-guides/eval-ad7175-8ardz/Layout.pdf>`_
+   
+   -  `Bill of Materials.xlsx <https://wiki.analog.com/_media/resources/eval/user-guides/eval-ad7175-8ardz/Bill of Materials.xlsx>`_
+   
+
+:doc:`Continue to Software Guide </solutions/reference-designs/eval-ad7175-8ardz/software>` `Return to Homepage <https://wiki.analog.com/resources/eval/eval-ad7175-8ardz>`_

--- a/docs/solutions/reference-designs/eval-ad7175-8ardz/hardware_guide.rst
+++ b/docs/solutions/reference-designs/eval-ad7175-8ardz/hardware_guide.rst
@@ -4,7 +4,13 @@ Hardware Guide
 Device Description
 ------------------
 
-The :adi:`AD7175-8 <en/products/ad7175-8.html>` a highly accurate, high resolution, multiplexed, 8-/16-channel (full/pseudo differential) Σ-Δ ADC. The :adi:`AD7175-8 <en/products/ad7175-8.html>` has a maximum channel-to-channel scan rate of 50 kSPS (20 µs) for fully settled data The output data rates range from 5 SPS to 250 kSPS. The device includes integrated analog input and reference buffers, an integrated precision 2.5 V reference, and an integrated oscillator.
+The :adi:`AD7175-8 <en/products/ad7175-8.html>` a highly accurate, high
+resolution, multiplexed, 8-/16-channel (full/pseudo differential) Σ-Δ ADC.
+The :adi:`AD7175-8 <en/products/ad7175-8.html>` has a maximum
+channel-to-channel scan rate of 50 kSPS (20 µs) for fully settled data
+The output data rates range from 5 SPS to 250 kSPS. The device includes
+integrated analog input and reference buffers, an integrated precision 2.5 V
+reference, and an integrated oscillator.
 
 Set-up Procedures
 -----------------
@@ -19,7 +25,8 @@ section.
    EVAL-AD7175-8ARDZ and the EVAL-SDP-CK1Z board to the USB port of the PC to
    ensure that the PC correctly recognizes the evaluation system
 
-**Configuring the Evaluation and SDP Boards** Use the following procedure to configure the boards
+**Configuring the Evaluation and SDP Boards** Use the following procedure to
+configure the boards
 
 -  Connect the SDP-K1 to the Arduino headers of the evaluation board.
 -  If using the SDP-K1 board the Arduino headers can also be used to connect to the board
@@ -121,7 +128,7 @@ On Board Connections
 +-------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------+-------------------------------------------------------------+
 
 Power Supplies
-==============
+--------------
 
 The evaluation board receives power through the controller board when connected
 to the PC via 5V USB. Linear regulators generate the required power supply
@@ -147,7 +154,8 @@ AVDD1 and AVSS selection (S1)
       -  2.5V regulator supplies AVDD1
       -  -3V regulator -2.5V regulator supplies AVSS
 
-===AVDD1 and AVDD2 selection (LK1 and LK2)===
+AVDD1 and AVDD2 selection (LK1 and LK2)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 -  **5V supply (DEFAULT)**
 
@@ -181,7 +189,7 @@ AVDD1 and AVSS selection (S1)
 +-----------------+--------------------------------------------------------------------------+----------------+
 
 Serial Interface
-~~~~~~~~~~~~~~~~
+----------------
 
 There are four primary signals: CS, SCLK, MOSI/DIN, and MISO/DOUT (all are
 inputs, except for MISO/DOUT, which is an output). The EVAL-AD7175-8ARDZ
@@ -189,7 +197,7 @@ evaluation board connects to any microcontroller board that uses the Arduino
 standard headers. This can be developed user code in for a variety of platforms.
 
 Serial communication options
-----------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 -  Arduino connection using the SDP-K1
 -  PMOD connector
@@ -205,12 +213,18 @@ For an introduction to the Serial Peripheral Interface (SPI), click :adi:`here <
    :width: 600
 
 Analog Inputs
-=============
+-------------
 
-The :adi:`EVAL-AD7175-8ARDZ <en/design-center/evaluation-hardware-and-software/evaluation-boards-kits/EVAL-AD7175-8.html>` primary analog inputs can be applied on J15, J16, and J17 which are at the left side of the board. Differential analog inputs are applied on AIN0 and AIN1 when using the ADC driver (when using ADC driver, enable AIN+/- buffers). The :adi:`AD7175-8 <en/products/ad7175-8.html>` evaluation software is set up to analyze dc inputs to the ADC. The AD7175-8 input buffers work for dc input signals.
+The :adi:`EVAL-AD7175-8ARDZ <en/design-center/evaluation-hardware-and-software/evaluation-boards-kits/EVAL-AD7175-8.html>`
+primary analog inputs can be applied on J15, J16, and J17 which are at the
+left side of the board. Differential analog inputs are applied on AIN0 and
+AIN1 when using the ADC driver (when using ADC driver, enable AIN+/- buffers).
+The :adi:`AD7175-8 <en/products/ad7175-8.html>` evaluation software is set up
+to analyze dc inputs to the ADC. The AD7175-8 input buffers work for dc input
+signals.
 
 Reference Options
-=================
+-----------------
 
 -  :adi:`AD7175-8 <en/products/ad7175-8.html>` internal 2.5V reference.
 -  **DEFAULT** :adi:`ADR4550 <en/products/ADR4550.html>` on board external reference.
@@ -256,19 +270,19 @@ Hardware
 +--------------+------+------------------+----------------------------------------------------------------------------------------------------------------------+
 
 Schematic, PCB Layout, Bill of Materials
-========================================
+-----------------------------------------
 
 .. admonition:: Download
    :class: download
 
    EVAL-AD7175-8ARDZ Rev B Design and Integration Files
 
-   
-   -  `Schematic.pdf <https://wiki.analog.com/_media/resources/eval/user-guides/eval-ad7175-8ardz/Schematic.pdf>`_
-   
-   -  `Layout.pdf <https://wiki.analog.com/_media/resources/eval/user-guides/eval-ad7175-8ardz/Layout.pdf>`_
-   
-   -  `Bill of Materials.xlsx <https://wiki.analog.com/_media/resources/eval/user-guides/eval-ad7175-8ardz/Bill of Materials.xlsx>`_
-   
 
-:doc:`Continue to Software Guide </solutions/reference-designs/eval-ad7175-8ardz/software>` `Return to Homepage <https://wiki.analog.com/resources/eval/eval-ad7175-8ardz>`_
+   -  `Schematic.pdf <https://wiki.analog.com/_media/resources/eval/user-guides/eval-ad7175-8ardz/Schematic.pdf>`_
+
+   -  `Layout.pdf <https://wiki.analog.com/_media/resources/eval/user-guides/eval-ad7175-8ardz/Layout.pdf>`_
+
+   -  `Bill of Materials.xlsx <https://wiki.analog.com/_media/resources/eval/user-guides/eval-ad7175-8ardz/Bill of Materials.xlsx>`_
+
+
+:doc:`Continue to Software Guide </solutions/reference-designs/eval-ad7175-8ardz/software>`

--- a/docs/solutions/reference-designs/eval-ad7175-8ardz/images/65002_2.jpg
+++ b/docs/solutions/reference-designs/eval-ad7175-8ardz/images/65002_2.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ebb7b60d408b43ca70623dbafaa21caef1b3e2b59b80950f95c69607d1dcc9cb
+size 441516

--- a/docs/solutions/reference-designs/eval-ad7175-8ardz/images/ace_figure_5.png
+++ b/docs/solutions/reference-designs/eval-ad7175-8ardz/images/ace_figure_5.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a43b10697303ffe1112c222bbbc5cb1e596ffa2f0b62553ca2eb1a8b46759cd0
+size 116793

--- a/docs/solutions/reference-designs/eval-ad7175-8ardz/images/ace_figure_6.png
+++ b/docs/solutions/reference-designs/eval-ad7175-8ardz/images/ace_figure_6.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2674b78b9e3a3b6cbe334407e2ec09100b59c01c0dde89ee846413b9c833d121
+size 125419

--- a/docs/solutions/reference-designs/eval-ad7175-8ardz/images/ad4111_documentation_button.png
+++ b/docs/solutions/reference-designs/eval-ad7175-8ardz/images/ad4111_documentation_button.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:56fb693ebecf2b0ae28144a6377915f54a67a834eeb292f437206760ba38926c
+size 811

--- a/docs/solutions/reference-designs/eval-ad7175-8ardz/images/libiio.png
+++ b/docs/solutions/reference-designs/eval-ad7175-8ardz/images/libiio.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ab34db14ee038d79d6229c6b06a1ab905b9e57a95ca6ffe23735247095810122
+size 64998

--- a/docs/solutions/reference-designs/eval-ad7175-8ardz/images/libiio_drivers.png
+++ b/docs/solutions/reference-designs/eval-ad7175-8ardz/images/libiio_drivers.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:693221cc8d45eddc1d53b16eed11d44c4dc41b09d8ac5c791df6c148e4be2bc2
+size 57735

--- a/docs/solutions/reference-designs/eval-ad7175-8ardz/images/ref_figure.png
+++ b/docs/solutions/reference-designs/eval-ad7175-8ardz/images/ref_figure.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cd86e3b1bd34197bda85408fc438a2cda075e8a9bebaac48a7a8ed7d83b77b16
+size 123830

--- a/docs/solutions/reference-designs/eval-ad7175-8ardz/images/slide1.jpg
+++ b/docs/solutions/reference-designs/eval-ad7175-8ardz/images/slide1.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6b106e117b303d704967bccc98c2177c8a9804a0c70987716b4a6aac28190c80
+size 176474

--- a/docs/solutions/reference-designs/eval-ad7175-8ardz/images/slide2.jpg
+++ b/docs/solutions/reference-designs/eval-ad7175-8ardz/images/slide2.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9b4005404451d33923127dadeeab944050b6d8f76765046cf5bd2b08749024ef
+size 208007

--- a/docs/solutions/reference-designs/eval-ad7175-8ardz/images/slide3.jpg
+++ b/docs/solutions/reference-designs/eval-ad7175-8ardz/images/slide3.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ac16ee4405e1febaa95ae80e45f5c8b84d218edda1037c5655c625e456304ae5
+size 160364

--- a/docs/solutions/reference-designs/eval-ad7175-8ardz/images/slide4.jpg
+++ b/docs/solutions/reference-designs/eval-ad7175-8ardz/images/slide4.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:983fd7036b6012b9c5653e3d808db3cece0e29ea2486bd186f1d93832648328e
+size 202171

--- a/docs/solutions/reference-designs/eval-ad7175-8ardz/images/spi.png
+++ b/docs/solutions/reference-designs/eval-ad7175-8ardz/images/spi.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:43f4bf2dcb24434a5e601c57ef179cf6ef5ef10d4c6494a31c8852cd05e9e151
+size 67960

--- a/docs/solutions/reference-designs/eval-ad7175-8ardz/index.rst
+++ b/docs/solutions/reference-designs/eval-ad7175-8ardz/index.rst
@@ -1,0 +1,8 @@
+EVAL-AD7175-8ARDZ
+=================
+
+.. toctree::
+   :titlesonly:
+
+   hardware_guide
+   software

--- a/docs/solutions/reference-designs/eval-ad7175-8ardz/index.rst
+++ b/docs/solutions/reference-designs/eval-ad7175-8ardz/index.rst
@@ -1,8 +1,46 @@
-EVAL-AD7175-8ARDZ
-=================
+.. _eval_ad7175_8ardz eval:
+
+EVAL AD7175 8ARDZ
+=======================================================================================================
+
+.. TODO: Add a picture of the chip/board
+
+Overview
+-------------------------------------------------------------------------------
+
+.. TODO: Describe in max 10 rows the main features and applications.
+
+Features:
+
+- feature 1
+- feature 2
+
+Applications:
+
+- application 1
+- application 2
 
 .. toctree::
-   :titlesonly:
+   :hidden:
 
    hardware_guide
    software
+
+Recommendations
+-------------------------------------------------------------------------------
+
+People who follow the flow that is outlined, have a much better experience with
+things. However, like many things, documentation is never as complete as it
+should be. If you have any questions, feel free to ask on our
+:ref:`EngineerZone forums <help-and-support>`, but before that, please make
+sure you read our documentation thoroughly.
+
+Warning
+-------------------------------------------------------------------------------
+
+.. esd-warning::
+
+Help and support
+-------------------------------------------------------------------------------
+
+Please go to :ref:`Help and Support <help-and-support>` page.

--- a/docs/solutions/reference-designs/eval-ad7175-8ardz/software.rst
+++ b/docs/solutions/reference-designs/eval-ad7175-8ardz/software.rst
@@ -2,11 +2,13 @@ Software Guide
 ==============
 
 ACE Software
-============
+------------
 
 The ACE software is available :adi:`Here. <en/design-center/evaluation-hardware-and-software/evaluation-development-platforms/ace-software.html>`
 
-The quick start guide is available on the landing page here `(Quick Start Guide) <https://wiki.analog.com/resources/eval/eval-ad7175-8ardz>`_ or for the step by step install guide see the below.
+The quick start guide is available on the landing page here
+`(Quick Start Guide) <https://wiki.analog.com/resources/eval/eval-ad7175-8ardz>`_
+or for the step by step install guide see the below.
 
 Installation Guide
 ------------------
@@ -16,7 +18,7 @@ to be installed before using the EVAL-AD7175-8ARDZ evaluation board.
 
 .. important::
 
-   \ Warning: The evaluation software and drivers must be installed before
+   The evaluation software and drivers must be installed before
    connecting both the evaluation board and the SDP-K1 board to the PC. This
    ensures that the evaluations system is correctly recognized when it is
    connected to the PC.
@@ -69,7 +71,12 @@ steps to set up the SDP-K1 and evaluation board together.
 Software Operation
 ~~~~~~~~~~~~~~~~~~
 
-To start the ACE evaluation software, from the Windows Start menu, click Analog Devices > ACE. The software window opens (See Figure 5) until the software recognizes the AD7175-8 evaluation board. When the software recognizes the board, double-click on the icon in the **Start** view to open the main window seen in Figure 6. Make sure that you already have the AD717x-8 plugin in the plugin manager.
+To start the ACE evaluation software, from the Windows Start menu, click
+Analog Devices > ACE. The software window opens (See Figure 5) until the
+software recognizes the AD7175-8 evaluation board. When the software
+recognizes the board, double-click on the icon in the **Start** view to open
+the main window seen in Figure 6. Make sure that you already have the AD717x-8
+plugin in the plugin manager.
 
 By clicking on the part in the main ACE evaluation software window (See Figure
 6), the chip view will be opened (Figure 7).
@@ -93,7 +100,9 @@ elements on the Chip view of the software window.
 CONFIGURATION TAB
 ~~~~~~~~~~~~~~~~~
 
-The **Configuration tab** shows a block diagram of the AD7175-8. This tab allows the user to select inputs, set up the ADC, reset the ADC, and view errors present, as well as configure the device.
+The **Configuration tab** shows a block diagram of the AD7175-8. This tab
+allows the user to select inputs, set up the ADC, reset the ADC, and view
+errors present, as well as configure the device.
 
 Functional Block Diagram (1)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -143,7 +152,10 @@ Waveform Analysis Button (9)
 WAVEFORM TAB
 ~~~~~~~~~~~~
 
-The **Waveform tab** can display the different waveforms for voltage input, current input and select the channel. The waveform tab graph the conversions gathered and processes the data, calculating the peak-to-peak noise, rms noise, and resolution.
+The **Waveform tab** can display the different waveforms for voltage input,
+current input and select the channel. The waveform tab graph the conversions
+gathered and processes the data, calculating the peak-to-peak noise, rms
+noise, and resolution.
 
 Waveform Graph and Controls (10, 11)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -168,7 +180,13 @@ Serial Interface and Internal Reference (13)
 Run (14)
 ^^^^^^^^
 
--  Click **Run Once or Run Continuously** (Label 14 in Figure 8) to start gathering ADC results. If **Run Once** is clicked, the ADC returns the number of samples specified by the Samples control. If **Run Continuously**, the ADC continuously returns samples until stopped by the user. Samples specifies the amounts of samples to be shown on the data graph. This control is unrelated to the ADC mode. Results appear in the waveform graph (Label 10 in Figure 8).
+-  Click **Run Once or Run Continuously** (Label 14 in Figure 8) to start
+   gathering ADC results. If **Run Once** is clicked, the ADC returns the
+   number of samples specified by the Samples control. If **Run
+   Continuously**, the ADC continuously returns samples until stopped by the
+   user. Samples specifies the amounts of samples to be shown on the data
+   graph. This control is unrelated to the ADC mode. Results appear in the
+   waveform graph (Label 10 in Figure 8).
 
 Channel Selection (15)
 ^^^^^^^^^^^^^^^^^^^^^^
@@ -187,7 +205,9 @@ Display Units and Axis Controls (16)
 Results Pane (17)
 ^^^^^^^^^^^^^^^^^
 
--  The **RESULTS** pane (Label 17 in Figure 8) displays parametric values for the selected display format. The bottom of the **RESULTS** pane also has buttons that allow the user to import or export sample data.
+-  The **RESULTS** pane (Label 17 in Figure 8) displays parametric values for
+   the selected display format. The bottom of the **RESULTS** pane also has
+   buttons that allow the user to import or export sample data.
 
 .. image:: images/slide2.jpg
    :align: center
@@ -260,7 +280,12 @@ Register and Bit Field Control (24, 25, 26, 27)
 Documentation (28)
 ^^^^^^^^^^^^^^^^^^
 
--  The Bitfield Documentation (Label 28 in Figure 10) contains the documentation for the register or the bit field selected. This field can be updated by selecting a register or bit field in the register tree or hovering over the register or bit field in the register tree or register control. This documentation will be displayed by clicking the |image2| button (Label 28 in Figure 10).
+-  The Bitfield Documentation (Label 28 in Figure 10) contains the
+   documentation for the register or the bit field selected. This field can be
+   updated by selecting a register or bit field in the register tree or
+   hovering over the register or bit field in the register tree or register
+   control. This documentation will be displayed by clicking the |image2|
+   button (Label 28 in Figure 10).
 
 Import and Export (29)
 ^^^^^^^^^^^^^^^^^^^^^^
@@ -275,7 +300,7 @@ Import and Export (29)
 
 **Figure 10. Memory Map**
 
-:doc:`Return to Hardware Guide </solutions/reference-designs/eval-ad7175-8ardz/hardware_guide>` `Return to Homepage <https://wiki.analog.com/resources/eval/eval-ad7175-8ardz>`_
+:doc:`Return to Hardware Guide </solutions/reference-designs/eval-ad7175-8ardz/hardware_guide>`
 
 .. |image1| image:: images/libiio_drivers.png
    :width: 400

--- a/docs/solutions/reference-designs/eval-ad7175-8ardz/software.rst
+++ b/docs/solutions/reference-designs/eval-ad7175-8ardz/software.rst
@@ -1,0 +1,283 @@
+Software Guide
+==============
+
+ACE Software
+============
+
+The ACE software is available :adi:`Here. <en/design-center/evaluation-hardware-and-software/evaluation-development-platforms/ace-software.html>`
+
+The quick start guide is available on the landing page here `(Quick Start Guide) <https://wiki.analog.com/resources/eval/eval-ad7175-8ardz>`_ or for the step by step install guide see the below.
+
+Installation Guide
+------------------
+
+The EVAL-AD7175-8ARDZ evaluation kit includes a link to the software that needs
+to be installed before using the EVAL-AD7175-8ARDZ evaluation board.
+
+.. important::
+
+   \ Warning: The evaluation software and drivers must be installed before
+   connecting both the evaluation board and the SDP-K1 board to the PC. This
+   ensures that the evaluations system is correctly recognized when it is
+   connected to the PC.
+
+Installing the ACE Software
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To install the **ACE** software,
+
+-  With the SDP board disconnected from the USB port of the PC, download the ACE evaluation software package to start the ACE evaluation software installation
+-  Click on **Download ACE Installer**
+-  Run the installer and follow the instructions to complete the software
+   installation process
+
+During the installation process, be sure to select Precision Converter
+Components when prompted and enable the LibIIO Wrapper to ensure that all
+necessary software components are installed.
+
+.. tip::
+
+   The LibIIO Wrapper must be installed for ACE to detect the connected
+   hardware. If you need to install the LibIIO Wrapper after ACE has been
+   installed, click the 'Help' button in the main ACE window. In the 'ACE Help'
+   panel that appears expand the 'Application Resources' section, and you will
+   find a link to run a local copy of the LibIIO Wrapper Installer.
+
+.. image:: images/libiio.png
+   :align: center
+   :width: 400
+
+**Figure 3. Select Precision Converter Components during ACE installation**
+
+When the following prompt appears, be sure to select **LibIIO** and **LibIIODrivers** options, then click **Install**.
+
+|image1|
+
+**Figure 4. Select LibIIO components during ACE installation**
+
+Evaluation Hardware Setup
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When the ACE evaluation software installation is complete, take the following
+steps to set up the SDP-K1 and evaluation board together.
+
+-  Connect the SDP-K1 and evaluation board using the Arduino headers.
+-  Connect the power supplies configuration.
+-  Connect the USB cable to the SDP-K1.
+-  Open the ACE software.
+
+Software Operation
+~~~~~~~~~~~~~~~~~~
+
+To start the ACE evaluation software, from the Windows Start menu, click Analog Devices > ACE. The software window opens (See Figure 5) until the software recognizes the AD7175-8 evaluation board. When the software recognizes the board, double-click on the icon in the **Start** view to open the main window seen in Figure 6. Make sure that you already have the AD717x-8 plugin in the plugin manager.
+
+By clicking on the part in the main ACE evaluation software window (See Figure
+6), the chip view will be opened (Figure 7).
+
+The chip view shows the block diagram of the AD7175-8. This tab allows the user
+to select inputs, set up the ADC, reset the ADC, and view errors present, as
+well as configure the device for different demonstration modes. Figure 7 shows
+the chip view in detail, and the following sections discuss the different
+elements on the Chip view of the software window.
+
+.. image:: images/ace_figure_5.png
+   :width: 800
+
+**Figure 5. ACE Evaluation Select Interface Window**
+
+.. image:: images/ace_figure_6.png
+   :width: 800
+
+**Figure 6. ACE Evaluation Software Main Window**
+
+CONFIGURATION TAB
+~~~~~~~~~~~~~~~~~
+
+The **Configuration tab** shows a block diagram of the AD7175-8. This tab allows the user to select inputs, set up the ADC, reset the ADC, and view errors present, as well as configure the device.
+
+Functional Block Diagram (1)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+-  The functional block diagram of the AD7175-8 (Label 1 in Figure 7) shows each
+   of the functional blocks within the AD7175-8. Clicking a functional block on
+   this diagram opens the configuration pop-up window for that block.
+
+Configuration Pop-Up Button (2)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+-  Each block has a pop-up window (Label 2 in Figure 7) which opens a different
+   window to configure the relevant block.
+
+External Parameters (3, 4, 5, 6)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+-  There are three external parameters that are set by the EVAL-AD7175-8ARDZ but
+   must be entered into the software: the AVDD1 and AVDD2 (Label 3 in Figure 7),
+   external reference (Label 4 in Figure 7), IOVDD (Label 5 in Figure 7)and AVSS
+   (Label 6 in Figure 7). The external reference on the EVAL-AD7175-8ARDZ is set
+   to 2.5 V by using an ADR4525. If bypassing the ADR4525 on the board, change
+   the external reference voltage value in the software to ensure correct
+   calculation of results in the Waveform and Histogram tabs in the Waveform
+   Analysis window.
+
+Status Bar (7)
+^^^^^^^^^^^^^^
+
+-  The status bar (Label 7 in Figure 7) displays status updates.
+
+Memory Map Button (8)
+^^^^^^^^^^^^^^^^^^^^^
+
+-  Opens the Memory Map tab.
+
+Waveform Analysis Button (9)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+-  Opens the Waveform tab.
+
+.. image:: images/slide1.jpg
+   :width: 900
+
+**Figure 7. AD7175-8 Functional Block Diagram**
+
+WAVEFORM TAB
+~~~~~~~~~~~~
+
+The **Waveform tab** can display the different waveforms for voltage input, current input and select the channel. The waveform tab graph the conversions gathered and processes the data, calculating the peak-to-peak noise, rms noise, and resolution.
+
+Waveform Graph and Controls (10, 11)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+-  The data waveform graph (Label 10 in Figure 8) shows each successive sample
+   of the ADC output. Zoom in on the data in the graph using the control toolbar
+   (Label 11 in Figure 8). Change the scales on the graph by typing values into
+   the x-axis and y-axis fields.
+
+Samples (12)
+^^^^^^^^^^^^
+
+-  The Samples numeric control (Label 12 in Figure 8) set the number of samples
+   gathered per batch.
+
+Serial Interface and Internal Reference (13)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+-  Sets the ADC mode, enables DATA_STAT and Internal Reference (Label 13 in
+   Figure 8).
+
+Run (14)
+^^^^^^^^
+
+-  Click **Run Once or Run Continuously** (Label 14 in Figure 8) to start gathering ADC results. If **Run Once** is clicked, the ADC returns the number of samples specified by the Samples control. If **Run Continuously**, the ADC continuously returns samples until stopped by the user. Samples specifies the amounts of samples to be shown on the data graph. This control is unrelated to the ADC mode. Results appear in the waveform graph (Label 10 in Figure 8).
+
+Channel Selection (15)
+^^^^^^^^^^^^^^^^^^^^^^
+
+-  The Channel Selection control (Label 15 in Figure 8) selects which channel/s
+   is displayed on the data waveform. These controls only affect the waveform
+   graphs and have no effect on the channel settings in the ADC register map.
+
+Display Units and Axis Controls (16)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+-  Click the Units dropdown box (Label 16 in Figure 8) to select whether the
+   data graph displays in units of voltages/amps or codes. This control is
+   independent for each graph.
+
+Results Pane (17)
+^^^^^^^^^^^^^^^^^
+
+-  The **RESULTS** pane (Label 17 in Figure 8) displays parametric values for the selected display format. The bottom of the **RESULTS** pane also has buttons that allow the user to import or export sample data.
+
+.. image:: images/slide2.jpg
+   :align: center
+   :width: 1000
+
+**Figure 8. AD7175-8 Waveform Tab**
+
+HISTOGRAM TAB
+~~~~~~~~~~~~~
+
+The Histogram tab generates a histogram using the gathered samples and processes
+the data, calculating the peak-to-peak noise, rms noise, and resolution.
+
+Histogram Graph and Controls (18, 19)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+-  The data histogram graph (Label 18 in Figure 9) shows the number of times
+   each sample of the ADC output occurs. Zoom in on the data using the control
+   toolbar (Label 19 in Figure 9) in the graph.
+
+Channel Selection (20)
+^^^^^^^^^^^^^^^^^^^^^^
+
+-  The Channel Selection control (Label 15 in Figure 8) selects which channel/s
+   is displayed on the data waveform. These controls only affect the waveform
+   graphs and have no effect on the channel settings in the ADC register map.
+
+Display Units and Axis Controls (21)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+-  Click the Units dropdown box (Label 21 in Figure 9) to select whether the
+   data graph displays in units of voltages/amps or codes. This control is
+   independent for each graph.
+
+.. image:: images/slide3.jpg
+   :align: center
+   :width: 1000
+
+**Figure 9. Histogram Tab**
+
+Memory Map
+~~~~~~~~~~
+
+Register Tree (22)
+^^^^^^^^^^^^^^^^^^
+
+-  The register maps nested list (Label 22 in Figure 10) shows the full register
+   map in a tree control. Each register is shown. Clicking the expand button
+   next to each register shows all the bit fields contained within that
+   register.
+
+Register Tree Search (23)
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+-  The register tree search box (Label 23 in Figure 10) allows the user to
+   search the tree for any register or bit field. Enter a value into this field
+   to filter the register tree.
+
+Register and Bit Field Control (24, 25, 26, 27)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+-  The register and bit field control section (Label 24 in Figure 10) allows the
+   user to change the individual bit of the register selected in the register
+   tree by clicking the bits or by programming the register value directly into
+   the number control field (Label 25 in Figure 10). This control also shows all
+   bit fields for the selected register. Change the values by using a dropdown
+   box (Label 26 in Figure 10) or by selecting or clearing a checkbox (Label 27
+   in Figure 10).
+
+Documentation (28)
+^^^^^^^^^^^^^^^^^^
+
+-  The Bitfield Documentation (Label 28 in Figure 10) contains the documentation for the register or the bit field selected. This field can be updated by selecting a register or bit field in the register tree or hovering over the register or bit field in the register tree or register control. This documentation will be displayed by clicking the |image2| button (Label 28 in Figure 10).
+
+Import and Export (29)
+^^^^^^^^^^^^^^^^^^^^^^
+
+-  Save and Load (Label 29 in Figure 10) allow the user to save the current
+   register map setting to a file and to load the setting from the same file,
+   respectively.
+
+.. image:: images/slide4.jpg
+   :align: center
+   :width: 1000
+
+**Figure 10. Memory Map**
+
+:doc:`Return to Hardware Guide </solutions/reference-designs/eval-ad7175-8ardz/hardware_guide>` `Return to Homepage <https://wiki.analog.com/resources/eval/eval-ad7175-8ardz>`_
+
+.. |image1| image:: images/libiio_drivers.png
+   :width: 400
+.. |image2| image:: images/ad4111_documentation_button.png
+   :width: 20


### PR DESCRIPTION
## Summary
- Move eval-ad7175-8ardz wiki documentation to `solutions/reference-designs/eval-ad7175-8ardz/`
- 3 RST files with 12 localized images
- Generated stub `index.rst` with toctree

## Test plan
- [ ] Sphinx build passes without errors
- [ ] All toctree entries resolve correctly
- [ ] Images render properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)