### PR TITLE
reference-designs/eval-ad7441x0: Add eval-ad7441x0 documentation

### DIFF
--- a/docs/solutions/reference-designs/eval-ad7441x0/images/load_confirmation_of_control_valve.png
+++ b/docs/solutions/reference-designs/eval-ad7441x0/images/load_confirmation_of_control_valve.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f7e0a87e4a5af1a5a84a98257464858e8b18607708cc666d7def25d1c4cfaa0f
+size 134290

--- a/docs/solutions/reference-designs/eval-ad7441x0/images/load_confirmation_of_rtd.png
+++ b/docs/solutions/reference-designs/eval-ad7441x0/images/load_confirmation_of_rtd.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6e0a11ac85ab8e891a57f007a2f5f198faab0e3c590755550f5f80fac82dd14f
+size 6360

--- a/docs/solutions/reference-designs/eval-ad7441x0/images/temp_control_process.png
+++ b/docs/solutions/reference-designs/eval-ad7441x0/images/temp_control_process.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e59bbdac1b1be2994d1b77e5754e1180ce7e60a5b32baa6504d5e967c6519408
+size 65309

--- a/docs/solutions/reference-designs/eval-ad7441x0/index.rst
+++ b/docs/solutions/reference-designs/eval-ad7441x0/index.rst
@@ -1,0 +1,7 @@
+EVAL-AD7441X0
+=============
+
+.. toctree::
+   :titlesonly:
+
+   tools/commissioning

--- a/docs/solutions/reference-designs/eval-ad7441x0/index.rst
+++ b/docs/solutions/reference-designs/eval-ad7441x0/index.rst
@@ -1,7 +1,45 @@
-EVAL-AD7441X0
-=============
+.. _eval_ad7441x0 eval:
+
+EVAL AD7441X0
+===============================================================================
+
+.. TODO: Add a picture of the chip/board
+
+Overview
+-------------------------------------------------------------------------------
+
+.. TODO: Describe in max 10 rows the main features and applications.
+
+Features:
+
+- feature 1
+- feature 2
+
+Applications:
+
+- application 1
+- application 2
 
 .. toctree::
-   :titlesonly:
+   :hidden:
 
    tools/commissioning
+
+Recommendations
+-------------------------------------------------------------------------------
+
+People who follow the flow that is outlined, have a much better experience with
+things. However, like many things, documentation is never as complete as it
+should be. If you have any questions, feel free to ask on our
+:ref:`EngineerZone forums <help-and-support>`, but before that, please make
+sure you read our documentation thoroughly.
+
+Warning
+-------------------------------------------------------------------------------
+
+.. esd-warning::
+
+Help and support
+-------------------------------------------------------------------------------
+
+Please go to :ref:`Help and Support <help-and-support>` page.

--- a/docs/solutions/reference-designs/eval-ad7441x0/tools/commissioning.rst
+++ b/docs/solutions/reference-designs/eval-ad7441x0/tools/commissioning.rst
@@ -1,0 +1,76 @@
+Commissioning made easy with AD74412R/13R
+=========================================
+
+Introduction
+------------
+
+| During the installation stage of a process or building control system, sensors and actuators need to be connected to their respective control/monitor channels. This can be a complex and error prone exercise. This is especially true when sensors and actuators are located large distances from control modules, or in difficult to access areas.
+| The Analog Devices Software Configurable I/O product family has 2 quad-channel Software Configurable I/O parts for building and process control applications, the AD74412R and the AD74413R. Each channel can be configured for voltage output, current output, voltage input, current input, RTD measurement and digital input. This document outlines how the variety of configuration options and on-board diagnostics can be used to confirm the sensors and actuators connected to each channel at the commissioning stage.
+| By using the flexibility of the AD74412R/13R, a variety of configuration options and on-board diagnostics can be combined with knowledge of the electrical properties of the components being installed to determine which channel corresponds to each of the components, and then configure the AD74412R/13R to correctly match them, thus dramatically simplifying the installation process.
+
+Case Study: Load Identification in a Temperate Control Process
+--------------------------------------------------------------
+
+| An example scenario of a Temperature Control Process is used to demonstrate load confirmation capability. This is a common process in production lines where precise temperature control of water or other liquid is required. In the example, shown in Figure 1, a water mixing tank has a constant input flow of cold water, along with an adjustable input flow of hot water from a boiler, which is controlled with a ball valve to regulate water temperature. A temperature probe is placed in the tank to monitor the water temperature. An emergency stop button is also placed near the tank to shut off input flow in case of an emergency. All components are connected to the control module for the process, which uses a quad channel Software Configurable IO, AD7441xR.
+
+.. image:: ../images/temp_control_process.png
+   :alt: Temp Control Process.png
+   :align: center
+
+| Figure 1: Temperature Control Process Diagram
+
+Understanding the Instrument Characteristics
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+| To begin, the characteristics of the sensors and actuators required for this process should be determined. Once the characteristics are understood, the instruments can be differentiated.
+
+-  A typical Control Valve for this process requires two channels, one to sense the position state of the valve using a voltage input channel, and one to control the actuator of the valve using a current output channel
+-  The temperature probe uses a Pt100 RTD, which is measured using a resistance measurement channel. A Pt100 has a resistance of 100-138Ω for 0°C to 100 °C temperature range.
+-  The Emergency Stop Button is a generic latching push-to-break button which is
+   monitored with a digital input channel. The emergency stop button will
+   electrically present as an open-circuit or short-circuit, which can be
+   detected with on-board diagnostics of the AD74412R/AD74413R.
+
+Determining how the Channels are Configured
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+| Now that the characteristics of the sensors & actuators are understood, the next step is to determine which channel is connected to which instrument. This example starts with the Control Valve as it uses 2 channels which have a “cause and effect” relationship that can be used for confirmation. The valve is controlled by a current in 4mA – 20mA range. The position sensor returns a voltage corresponding to the position of the valve.
+| A current is sourced (using current output mode) on a single channel while monitoring the voltage (using voltage input mode) on the other 3 channels for a correlating input signal. This is repeated for subsequent channels until a correlating input signal is observed.
+| Figure 2 shows the response on all 4 channels when sourcing a current on Channel C. No response is noted on Channels A & B, a voltage response is captured on Channels C & D. The Channel C measurement is the voltage response from the actuator (based on the fixed current applied). A correlating voltage input is also observed on Channel D, confirming Channel C as the actuator control channel and Channel D as the position sensor channel. Confirmation of these channels is achieved in a maximum of 4 attempts.
+
+.. image:: ../images/load_confirmation_of_control_valve.png
+   :alt: load_confirmation_of_control_valve.png
+   :align: center
+
+| Figure 2: Determining channels used for Control Valve
+
+To confirm which channel is connected to the RTD, the remaining channels (A & B)
+are configured in resistance measurement mode and results are scanned for the
+expected resistance value. In this case, a Pt100 is expected to be in the range
+of 100Ω-138Ω for 0-100 °C water temperature range. Figure 3 shows that Channel B
+measures a resistance of 127Ω, indicating that the RTD is connected to Channel
+B.
+
+.. image:: ../images/load_confirmation_of_rtd.png
+   :alt: load_confirmation_of_rtd.png
+   :align: center
+
+| Figure 2: Determining channel used for RTD
+
+By a process of elimination, Channel A is identified as the emergency stop
+button. The on-board diagnostics can be used to confirm this:
+
+-  If the emergency button is pushed, the switch appears as an open circuit. An open-circuit alert will have been observed while determining control valve channels using Current Output mode. The alert condition is asserted in the ALERT_STATUS register of the AD74412R/AD74413R.
+-  If the emergency button is not pushed, the switch appears as a short circuit.
+   Configure the channel in voltage output mode and check for short-circuit
+   error alert.
+
+| This is an example of confirmation, not determination. Prior knowledge of the sensors/actuators connected to the channels is required in order to infer the relationships between the sensors and the expected electrical indicators. Sensor sensitivity should also be considered when devising a confirmation routine to ensure that large currents are not sourced to sensitive components.
+
+Conclusion
+----------
+
+| By using simple electrical properties of the connected instruments and the on-board configuration and diagnostic tools of the AD74412R/AD74413R products, connections on I/O channels are quickly confirmed, without the need for manual intervention.
+| This process highlights the flexibility and value of the AD7441xR Software Configurable I/O parts and can dramatically reduce the installation time and avoid mis-wire problems seen during installation, saving significant time and expense.
+
+`Back to AD74412R/AD74413R Table of Contents <https://wiki.analog.com/resources/eval/user-guides/ad7441x>`_

--- a/docs/solutions/reference-designs/eval-ad7441x0/tools/commissioning.rst
+++ b/docs/solutions/reference-designs/eval-ad7441x0/tools/commissioning.rst
@@ -4,25 +4,53 @@ Commissioning made easy with AD74412R/13R
 Introduction
 ------------
 
-| During the installation stage of a process or building control system, sensors and actuators need to be connected to their respective control/monitor channels. This can be a complex and error prone exercise. This is especially true when sensors and actuators are located large distances from control modules, or in difficult to access areas.
-| The Analog Devices Software Configurable I/O product family has 2 quad-channel Software Configurable I/O parts for building and process control applications, the AD74412R and the AD74413R. Each channel can be configured for voltage output, current output, voltage input, current input, RTD measurement and digital input. This document outlines how the variety of configuration options and on-board diagnostics can be used to confirm the sensors and actuators connected to each channel at the commissioning stage.
-| By using the flexibility of the AD74412R/13R, a variety of configuration options and on-board diagnostics can be combined with knowledge of the electrical properties of the components being installed to determine which channel corresponds to each of the components, and then configure the AD74412R/13R to correctly match them, thus dramatically simplifying the installation process.
+During the installation stage of a process or building control system,
+sensors and actuators need to be connected to their respective
+control/monitor channels. This can be a complex and error prone exercise. This
+is especially true when sensors and actuators are located large distances from
+control modules, or in difficult to access areas.
+
+The Analog Devices Software Configurable I/O product family has 2 quad-channel
+Software Configurable I/O parts for building and process control applications,
+the AD74412R and the AD74413R. Each channel can be configured for voltage
+output, current output, voltage input, current input, RTD measurement and
+digital input. This document outlines how the variety of configuration options
+and on-board diagnostics can be used to confirm the sensors and actuators
+connected to each channel at the commissioning stage.
+
+By using the flexibility of the AD74412R/13R, a variety of configuration
+options and on-board diagnostics can be combined with knowledge of the
+electrical properties of the components being installed to determine which
+channel corresponds to each of the components, and then configure the
+AD74412R/13R to correctly match them, thus dramatically simplifying the
+installation process.
 
 Case Study: Load Identification in a Temperate Control Process
 --------------------------------------------------------------
 
-| An example scenario of a Temperature Control Process is used to demonstrate load confirmation capability. This is a common process in production lines where precise temperature control of water or other liquid is required. In the example, shown in Figure 1, a water mixing tank has a constant input flow of cold water, along with an adjustable input flow of hot water from a boiler, which is controlled with a ball valve to regulate water temperature. A temperature probe is placed in the tank to monitor the water temperature. An emergency stop button is also placed near the tank to shut off input flow in case of an emergency. All components are connected to the control module for the process, which uses a quad channel Software Configurable IO, AD7441xR.
+An example scenario of a Temperature Control Process is used to demonstrate
+load confirmation capability. This is a common process in production lines
+where precise temperature control of water or other liquid is required. In the
+example, shown in Figure 1, a water mixing tank has a constant input flow of
+cold water, along with an adjustable input flow of hot water from a boiler,
+which is controlled with a ball valve to regulate water temperature. A
+temperature probe is placed in the tank to monitor the water temperature. An
+emergency stop button is also placed near the tank to shut off input flow in
+case of an emergency. All components are connected to the control module for
+the process, which uses a quad channel Software Configurable IO, AD7441xR.
 
 .. image:: ../images/temp_control_process.png
    :alt: Temp Control Process.png
    :align: center
 
-| Figure 1: Temperature Control Process Diagram
+Figure 1: Temperature Control Process Diagram
 
 Understanding the Instrument Characteristics
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-| To begin, the characteristics of the sensors and actuators required for this process should be determined. Once the characteristics are understood, the instruments can be differentiated.
+To begin, the characteristics of the sensors and actuators required for this
+process should be determined. Once the characteristics are understood, the
+instruments can be differentiated.
 
 -  A typical Control Valve for this process requires two channels, one to sense the position state of the valve using a voltage input channel, and one to control the actuator of the valve using a current output channel
 -  The temperature probe uses a Pt100 RTD, which is measured using a resistance measurement channel. A Pt100 has a resistance of 100-138Ω for 0°C to 100 °C temperature range.
@@ -34,15 +62,31 @@ Understanding the Instrument Characteristics
 Determining how the Channels are Configured
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-| Now that the characteristics of the sensors & actuators are understood, the next step is to determine which channel is connected to which instrument. This example starts with the Control Valve as it uses 2 channels which have a “cause and effect” relationship that can be used for confirmation. The valve is controlled by a current in 4mA – 20mA range. The position sensor returns a voltage corresponding to the position of the valve.
-| A current is sourced (using current output mode) on a single channel while monitoring the voltage (using voltage input mode) on the other 3 channels for a correlating input signal. This is repeated for subsequent channels until a correlating input signal is observed.
-| Figure 2 shows the response on all 4 channels when sourcing a current on Channel C. No response is noted on Channels A & B, a voltage response is captured on Channels C & D. The Channel C measurement is the voltage response from the actuator (based on the fixed current applied). A correlating voltage input is also observed on Channel D, confirming Channel C as the actuator control channel and Channel D as the position sensor channel. Confirmation of these channels is achieved in a maximum of 4 attempts.
+Now that the characteristics of the sensors & actuators are understood, the
+next step is to determine which channel is connected to which instrument. This
+example starts with the Control Valve as it uses 2 channels which have a
+“cause and effect” relationship that can be used for confirmation. The valve
+is controlled by a current in 4mA – 20mA range. The position sensor returns a
+voltage corresponding to the position of the valve.
+
+A current is sourced (using current output mode) on a single channel while
+monitoring the voltage (using voltage input mode) on the other 3 channels for
+a correlating input signal. This is repeated for subsequent channels until a
+correlating input signal is observed.
+
+Figure 2 shows the response on all 4 channels when sourcing a current on
+Channel C. No response is noted on Channels A & B, a voltage response is
+captured on Channels C & D. The Channel C measurement is the voltage response
+from the actuator (based on the fixed current applied). A correlating voltage
+input is also observed on Channel D, confirming Channel C as the actuator
+control channel and Channel D as the position sensor channel. Confirmation of
+these channels is achieved in a maximum of 4 attempts.
 
 .. image:: ../images/load_confirmation_of_control_valve.png
    :alt: load_confirmation_of_control_valve.png
    :align: center
 
-| Figure 2: Determining channels used for Control Valve
+Figure 2: Determining channels used for Control Valve
 
 To confirm which channel is connected to the RTD, the remaining channels (A & B)
 are configured in resistance measurement mode and results are scanned for the
@@ -55,22 +99,34 @@ B.
    :alt: load_confirmation_of_rtd.png
    :align: center
 
-| Figure 2: Determining channel used for RTD
+Figure 2: Determining channel used for RTD
 
 By a process of elimination, Channel A is identified as the emergency stop
 button. The on-board diagnostics can be used to confirm this:
 
--  If the emergency button is pushed, the switch appears as an open circuit. An open-circuit alert will have been observed while determining control valve channels using Current Output mode. The alert condition is asserted in the ALERT_STATUS register of the AD74412R/AD74413R.
+-  If the emergency button is pushed, the switch appears as an open circuit.
+   An open-circuit alert will have been observed while determining control
+   valve channels using Current Output mode. The alert condition is asserted
+   in the ALERT_STATUS register of the AD74412R/AD74413R.
 -  If the emergency button is not pushed, the switch appears as a short circuit.
    Configure the channel in voltage output mode and check for short-circuit
    error alert.
 
-| This is an example of confirmation, not determination. Prior knowledge of the sensors/actuators connected to the channels is required in order to infer the relationships between the sensors and the expected electrical indicators. Sensor sensitivity should also be considered when devising a confirmation routine to ensure that large currents are not sourced to sensitive components.
+This is an example of confirmation, not determination. Prior knowledge of the
+sensors/actuators connected to the channels is required in order to infer the
+relationships between the sensors and the expected electrical indicators.
+Sensor sensitivity should also be considered when devising a confirmation
+routine to ensure that large currents are not sourced to sensitive components.
 
 Conclusion
 ----------
 
-| By using simple electrical properties of the connected instruments and the on-board configuration and diagnostic tools of the AD74412R/AD74413R products, connections on I/O channels are quickly confirmed, without the need for manual intervention.
-| This process highlights the flexibility and value of the AD7441xR Software Configurable I/O parts and can dramatically reduce the installation time and avoid mis-wire problems seen during installation, saving significant time and expense.
+By using simple electrical properties of the connected instruments and the
+on-board configuration and diagnostic tools of the AD74412R/AD74413R products,
+connections on I/O channels are quickly confirmed, without the need for manual
+intervention.
 
-`Back to AD74412R/AD74413R Table of Contents <https://wiki.analog.com/resources/eval/user-guides/ad7441x>`_
+This process highlights the flexibility and value of the AD7441xR Software
+Configurable I/O parts and can dramatically reduce the installation time and
+avoid mis-wire problems seen during installation, saving significant time and
+expense.


### PR DESCRIPTION
## Summary
- Move eval-ad7441x0 wiki documentation to `solutions/reference-designs/eval-ad7441x0/`
- 2 RST files with 3 localized images
- Generated stub `index.rst` with toctree

## Test plan
- [ ] Sphinx build passes without errors
- [ ] All toctree entries resolve correctly
- [ ] Images render properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)