### PR TITLE
reference-designs/eval-ade120x: Add eval-ade120x documentation

### DIFF
--- a/docs/solutions/reference-designs/eval-ade120x/hardware/eval-ade1202.rst
+++ b/docs/solutions/reference-designs/eval-ade120x/hardware/eval-ade1202.rst
@@ -1,0 +1,37 @@
+ADE1202 Evaluation Board User Guide
+===================================
+
+.. image:: ../images/eval-ade1202.png
+   :align: center
+   :width: 400
+
+Introduction
+------------
+
+The EVAL-ADE1202EBZ reference design board allows the performance of the ADE1202
+Binary Input IC to be evaluated in a context very similar to a real binary input
+interface application. The kit requires purchasing a second board: the
+controller board for the system demonstration platform (EVAL-SDP-B). The ADE1202
+evaluation kit includes evaluation software, written in LabVIEW®, which provides
+access to the registers and features of the device using a PC interface. The
+EVAL-SDP-B is required to use LabView. Also available are software drivers
+written in C which can be compiled and loaded to the EVAL-SDP-K1 evaluation
+board through the MBED online development environment.
+
+Refer to UG-1679 for further instructions on setting up and using the evaluation
+hardware.
+
+Schematics, PCB Layout, Bill of Materials
+-----------------------------------------
+
+.. admonition:: Download
+   :class: download
+
+   
+   EVAL-ADE1202EBZ Rev B Design Files
+   
+   -  `Schematics (PDF) <../resources/02-050322-01-c.pdf>`_
+   -  `Layout (PDF) <../resources/050322c_pcb_layout.pdf>`_
+   -  `Bill of Materials (Excel) <../images/bom_05-050322-01-c.xlsx>`_
+   -  `Fabrication Files (zip) <../resources/gerbers_09-050322-01c.zip>`_
+   

--- a/docs/solutions/reference-designs/eval-ade120x/hardware/eval-ade1202.rst
+++ b/docs/solutions/reference-designs/eval-ade120x/hardware/eval-ade1202.rst
@@ -27,11 +27,11 @@ Schematics, PCB Layout, Bill of Materials
 .. admonition:: Download
    :class: download
 
-   
+
    EVAL-ADE1202EBZ Rev B Design Files
-   
+
    -  `Schematics (PDF) <../resources/02-050322-01-c.pdf>`_
    -  `Layout (PDF) <../resources/050322c_pcb_layout.pdf>`_
    -  `Bill of Materials (Excel) <../images/bom_05-050322-01-c.xlsx>`_
    -  `Fabrication Files (zip) <../resources/gerbers_09-050322-01c.zip>`_
-   
+

--- a/docs/solutions/reference-designs/eval-ade120x/help_and_support.rst
+++ b/docs/solutions/reference-designs/eval-ade120x/help_and_support.rst
@@ -1,0 +1,4 @@
+Help and Support
+================
+
+To find answers to some common question refer to our :ez:`FAQ page <energy-metering/w/documents/15242/ade1202-faqs>`

--- a/docs/solutions/reference-designs/eval-ade120x/images/ade120x_mbed.png
+++ b/docs/solutions/reference-designs/eval-ade120x/images/ade120x_mbed.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:15f57a1f57027da20b3e9a98c34a07b6ca6779afdcb16a1cded51a3b0771d9d2
+size 61317

--- a/docs/solutions/reference-designs/eval-ade120x/images/bom_05-050322-01-c.xlsx
+++ b/docs/solutions/reference-designs/eval-ade120x/images/bom_05-050322-01-c.xlsx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:090610c92f0d870288b8859fa7e984354383b9b28a874d5644b71694fcd86e6e
+size 21043

--- a/docs/solutions/reference-designs/eval-ade120x/images/eval-ade1202.png
+++ b/docs/solutions/reference-designs/eval-ade120x/images/eval-ade1202.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:905cb0205339827692bbdcf9f5d4c1f57e366ba0f5f4c86ed094d6b37a244cac
+size 808767

--- a/docs/solutions/reference-designs/eval-ade120x/images/labview.png
+++ b/docs/solutions/reference-designs/eval-ade120x/images/labview.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ea1c1527efcbae8a7236eb59de01d1310c19e2140855650f74a122ecc671bf5c
+size 124856

--- a/docs/solutions/reference-designs/eval-ade120x/images/mbed_workspace.png
+++ b/docs/solutions/reference-designs/eval-ade120x/images/mbed_workspace.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ee0a9463e9490854d1a7fa551b3bba267181ddceeb2d47bc1051b187b1501f03
+size 36342

--- a/docs/solutions/reference-designs/eval-ade120x/index.rst
+++ b/docs/solutions/reference-designs/eval-ade120x/index.rst
@@ -1,0 +1,11 @@
+EVAL-ADE120X
+============
+
+.. toctree::
+   :titlesonly:
+
+   hardware/eval-ade1202
+   help_and_support
+   tools
+   tools/labview_setup_guide
+   tools/software_drivers

--- a/docs/solutions/reference-designs/eval-ade120x/index.rst
+++ b/docs/solutions/reference-designs/eval-ade120x/index.rst
@@ -1,11 +1,49 @@
-EVAL-ADE120X
-============
+.. _eval_ade120x eval:
+
+EVAL ADE120X
+=========================================================================
+
+.. TODO: Add a picture of the chip/board
+
+Overview
+-------------------------------------------------------------------------------
+
+.. TODO: Describe in max 10 rows the main features and applications.
+
+Features:
+
+- feature 1
+- feature 2
+
+Applications:
+
+- application 1
+- application 2
 
 .. toctree::
-   :titlesonly:
+   :hidden:
 
    hardware/eval-ade1202
    help_and_support
    tools
    tools/labview_setup_guide
    tools/software_drivers
+
+Recommendations
+-------------------------------------------------------------------------------
+
+People who follow the flow that is outlined, have a much better experience with
+things. However, like many things, documentation is never as complete as it
+should be. If you have any questions, feel free to ask on our
+:ref:`EngineerZone forums <help-and-support>`, but before that, please make
+sure you read our documentation thoroughly.
+
+Warning
+-------------------------------------------------------------------------------
+
+.. esd-warning::
+
+Help and support
+-------------------------------------------------------------------------------
+
+Please go to :ref:`Help and Support <help-and-support>` page.

--- a/docs/solutions/reference-designs/eval-ade120x/resources/02-050322-01-c.pdf
+++ b/docs/solutions/reference-designs/eval-ade120x/resources/02-050322-01-c.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:97b169e78b94d3f71b37302ef1a2c141658de064bf6b5860007cbf17b05aea03
+size 576250

--- a/docs/solutions/reference-designs/eval-ade120x/resources/050322c_pcb_layout.pdf
+++ b/docs/solutions/reference-designs/eval-ade120x/resources/050322c_pcb_layout.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5b79208d177d94b0339935aba3e63cbd201867d8a0bf95f4e46e5343e052d0e8
+size 797711

--- a/docs/solutions/reference-designs/eval-ade120x/resources/gerbers_09-050322-01c.zip
+++ b/docs/solutions/reference-designs/eval-ade120x/resources/gerbers_09-050322-01c.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5586d71156aebee13e115837fb440804e2179475a91c6621fe607b0fd6d9c499
+size 670836

--- a/docs/solutions/reference-designs/eval-ade120x/tools.rst
+++ b/docs/solutions/reference-designs/eval-ade120x/tools.rst
@@ -1,0 +1,10 @@
+Tools and Driver Details
+========================
+
+This chapter provides all the necessary steps to download, install, and setup
+the software environment from Analog Devices.
+
+It contains two main sections:
+
+-  :doc:`LabVIEW GUI Tool </solutions/reference-designs/eval-ade120x/tools/labview_setup_guide>` - Provides all the necessary instructions on how to download and install the LabVIEW GUI
+-  :doc:`Using ADE120x Software Drivers </solutions/reference-designs/eval-ade120x/tools/software_drivers>` - Provides information about using the provided software drivers to control the ADE120x devices using a microcontroller and embedded code

--- a/docs/solutions/reference-designs/eval-ade120x/tools.rst
+++ b/docs/solutions/reference-designs/eval-ade120x/tools.rst
@@ -6,5 +6,9 @@ the software environment from Analog Devices.
 
 It contains two main sections:
 
--  :doc:`LabVIEW GUI Tool </solutions/reference-designs/eval-ade120x/tools/labview_setup_guide>` - Provides all the necessary instructions on how to download and install the LabVIEW GUI
--  :doc:`Using ADE120x Software Drivers </solutions/reference-designs/eval-ade120x/tools/software_drivers>` - Provides information about using the provided software drivers to control the ADE120x devices using a microcontroller and embedded code
+-  :doc:`LabVIEW GUI Tool </solutions/reference-designs/eval-ade120x/tools/labview_setup_guide>`
+   - Provides all the necessary instructions on how to download and install
+   the LabVIEW GUI
+-  :doc:`Using ADE120x Software Drivers </solutions/reference-designs/eval-ade120x/tools/software_drivers>`
+   - Provides information about using the provided software drivers to control
+   the ADE120x devices using a microcontroller and embedded code

--- a/docs/solutions/reference-designs/eval-ade120x/tools/labview_setup_guide.rst
+++ b/docs/solutions/reference-designs/eval-ade120x/tools/labview_setup_guide.rst
@@ -1,7 +1,8 @@
 How to setup and use the LabVIEW GUI Tool
 =========================================
 
-To download the latest LAbVIEW GUI installer click on `this link <https://wiki.analog.com/_media/ftp/ftp.analog.com/pub/microconverter/ade120x/eval-ade1201ebz%20evaluation%20software%20installer.zip>`_
+To download the latest LabVIEW GUI installer click on
+`this link <https://wiki.analog.com/_media/ftp/ftp.analog.com/pub/microconverter/ade120x/eval-ade1201ebz%20evaluation%20software%20installer.zip>`_
 
 The LabVIEW GUI is designed to work with the EVAL-ADE1202EBZ evaluation board.
 It provides an interface to allow the user to access all the functionality of

--- a/docs/solutions/reference-designs/eval-ade120x/tools/labview_setup_guide.rst
+++ b/docs/solutions/reference-designs/eval-ade120x/tools/labview_setup_guide.rst
@@ -1,0 +1,17 @@
+How to setup and use the LabVIEW GUI Tool
+=========================================
+
+To download the latest LAbVIEW GUI installer click on `this link <https://wiki.analog.com/_media/ftp/ftp.analog.com/pub/microconverter/ade120x/eval-ade1201ebz%20evaluation%20software%20installer.zip>`_
+
+The LabVIEW GUI is designed to work with the EVAL-ADE1202EBZ evaluation board.
+It provides an interface to allow the user to access all the functionality of
+the ADE1202.
+
+Note, the EVAL-SDP-B is required also and needs to be purchased separately
+
+Refer to UG-1679 for detailed instructions on how to download and use the GUI
+tool
+
+.. image:: ../images/labview.png
+   :align: center
+   :width: 400

--- a/docs/solutions/reference-designs/eval-ade120x/tools/software_drivers.rst
+++ b/docs/solutions/reference-designs/eval-ade120x/tools/software_drivers.rst
@@ -1,0 +1,34 @@
+How to Use ADE120x Software Drivers
+===================================
+
+The software drivers for the ADE120x products were written using the MBED
+platform. MBED is an open source, online development environment that supports a
+large array of controller boards with ARM core processors. The SDP-K1 is a
+controller board developed by ADI and is designed to be used to develop drivers
+and example programs for ADI evaluation boards.
+
+The MBED code was written to run on the EVAL-SDP-K1 evaluation board connected
+to the EVAL-ADE1202EBZ evaluation boards. Note, EVAL-SDP-K1 needs to be
+purchased separately.
+
+Note, the EVAL-SDP-K1 needs to be purchased separately
+
+For further details refer to `this link <https://confluence.analog.com/display/MBED/Mbed%3A+Instructions+for+Users+and+Customers>`_
+
+Getting Started
+---------------
+
+-  To use the EVAl-SDP-K1 with the MBED online compiler a user account must be set up firstly. TO set up an account navigate to `MBED <https://www.mbed.com/en/>`_
+-  Follow `this link <https://wiki.analog.com/resources/tools-software/mbed>`_ for instructions on setting up the SDP-K1 within the MBED environment.
+-  The ADE1202 example application can be found `here <https://os.mbed.com/teams/AnalogDevices/code/EVAL-ADE120x/>`_
+-  To get started click on the Import Into Compiler button
+
+.. image:: ../images/ade120x_mbed.png
+   :align: center
+   :width: 400
+
+-  Once imported into the compiler the screen should look like the following: |image1| On the left hand side is the Program Workspace and will display any programs you have imported into the workspace.
+-  Double click on the main.cpp file to open the main program code.
+
+.. |image1| image:: ../images/mbed_workspace.png
+   :width: 400

--- a/docs/solutions/reference-designs/eval-ade120x/tools/software_drivers.rst
+++ b/docs/solutions/reference-designs/eval-ade120x/tools/software_drivers.rst
@@ -18,8 +18,11 @@ For further details refer to `this link <https://confluence.analog.com/display/M
 Getting Started
 ---------------
 
--  To use the EVAl-SDP-K1 with the MBED online compiler a user account must be set up firstly. TO set up an account navigate to `MBED <https://www.mbed.com/en/>`_
--  Follow `this link <https://wiki.analog.com/resources/tools-software/mbed>`_ for instructions on setting up the SDP-K1 within the MBED environment.
+-  To use the EVAL-SDP-K1 with the MBED online compiler a user account must
+   be set up first. To set up an account navigate to
+   `MBED <https://www.mbed.com/en/>`_
+-  Follow `this link <https://wiki.analog.com/resources/tools-software/mbed>`_
+   for instructions on setting up the SDP-K1 within the MBED environment.
 -  The ADE1202 example application can be found `here <https://os.mbed.com/teams/AnalogDevices/code/EVAL-ADE120x/>`_
 -  To get started click on the Import Into Compiler button
 
@@ -27,7 +30,12 @@ Getting Started
    :align: center
    :width: 400
 
--  Once imported into the compiler the screen should look like the following: |image1| On the left hand side is the Program Workspace and will display any programs you have imported into the workspace.
+-  Once imported into the compiler the screen should look like the following:
+
+   |image1|
+
+   On the left hand side is the Program Workspace and will display any
+   programs you have imported into the workspace.
 -  Double click on the main.cpp file to open the main program code.
 
 .. |image1| image:: ../images/mbed_workspace.png


### PR DESCRIPTION
## Summary
- Move eval-ade120x wiki documentation to `solutions/reference-designs/eval-ade120x/`
- 6 RST files with 5 localized images
- Generated stub `index.rst` with toctree

## Test plan
- [ ] Sphinx build passes without errors
- [ ] All toctree entries resolve correctly
- [ ] Images render properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)