### PR TITLE
reference-designs/eval-adf4377: Add eval-adf4377 documentation

### DIFF
--- a/docs/solutions/reference-designs/eval-adf4377/eval-adf4377.png
+++ b/docs/solutions/reference-designs/eval-adf4377/eval-adf4377.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3e0e44b240c81dfeb8962e0602d140dc2ead072e95f1b6b69e319603ec159b51
+size 191175

--- a/docs/solutions/reference-designs/eval-adf4377/index.rst
+++ b/docs/solutions/reference-designs/eval-adf4377/index.rst
@@ -1,0 +1,7 @@
+EVAL-ADF4377
+============
+
+.. toctree::
+   :titlesonly:
+
+   software/no-os-setup

--- a/docs/solutions/reference-designs/eval-adf4377/index.rst
+++ b/docs/solutions/reference-designs/eval-adf4377/index.rst
@@ -1,7 +1,68 @@
+.. _eval-adf4377:
+
 EVAL-ADF4377
-============
+=========================================================================
+
+Microwave Wideband Synthesizer with Integrated VCO
+
+.. image:: eval-adf4377.png
+   :align: center
+   :width: 500
+
+Overview
+-------------------------------------------------------------------------------
+
+The :adi:`EV-ADF4377SD1Z` evaluation board evaluates the performance of the
+:adi:`ADF4377`, a high performance, ultralow jitter, dual output integer-N
+phase-locked loop (PLL) with an integrated voltage controlled oscillator (VCO)
+ideally suited for data converter and mixed signal front end (MxFE) clock
+applications. The high performance PLL has a figure of merit of -239 dBc/Hz,
+ultralow 1/f noise, and a high phase frequency detector (PFD) frequency that
+can achieve ultralow in-band noise and integrated jitter. The fundamental VCO
+and output divider generate frequencies from 800 MHz to 12.8 GHz.
+
+Features:
+
+- Output frequency range: 800 MHz to 12.8 GHz
+- Ultralow jitter: 18 fs RMS (100 Hz to 100 MHz integration bandwidth)
+- Wideband noise floor: -160 dBc/Hz at 12 GHz
+- Normalized in-band phase noise floor: -239 dBc/Hz
+- Phase detector frequency up to 500 MHz
+- Reference input frequency up to 1000 MHz
+- Multichip output phase alignment
+- 3.3 V and 5 V power supplies
+
+Applications:
+
+- High performance data converter and MxFE clocking
+- Wireless infrastructure (MC-GSM, 5G)
+- Test and measurement
+
+Software
+-------------------------------------------------------------------------------
+
+- :doc:`no-OS Setup <software/no-os-setup>`
 
 .. toctree::
-   :titlesonly:
+   :hidden:
 
    software/no-os-setup
+
+Recommendations
+-------------------------------------------------------------------------------
+
+People who follow the flow that is outlined, have a much better experience with
+things. However, like many things, documentation is never as complete as it
+should be. If you have any questions, feel free to ask on our
+:ref:`EngineerZone forums <help-and-support>`, but before that, please make
+sure you read our documentation thoroughly.
+
+Warning
+-------------------------------------------------------------------------------
+
+.. esd-warning::
+
+Help and support
+-------------------------------------------------------------------------------
+
+Please go to :ref:`Help and Support <help-and-support>` page.

--- a/docs/solutions/reference-designs/eval-adf4377/software/no-os-setup.rst
+++ b/docs/solutions/reference-designs/eval-adf4377/software/no-os-setup.rst
@@ -1,14 +1,20 @@
 Evaluating the ADF4377 Microware Wideband Synthesizer with Integrated VCO
 =========================================================================
 
-The :adi:`EV-ADF4377SD1Z` evaluates the pefromance of the\ :adi:`ADF4377` frequency synthesizer with an integrated voltage controlled oscillator (VCO) for phase-locked loops (PLLs).
+The :adi:`EV-ADF4377SD1Z` evaluates the performance of the
+:adi:`ADF4377` frequency synthesizer with an integrated voltage controlled
+oscillator (VCO) for phase-locked loops (PLLs).
 
-The evaluation board contains the :adi:`ADF4377` frequency synthesizer with an integrated VCO, a USB interface, power supply connectors, and subminiature Version A (SMA) connectors.
+The evaluation board contains the :adi:`ADF4377` frequency synthesizer with
+an integrated VCO, a USB interface, power supply connectors, and subminiature
+Version A (SMA) connectors.
 
-This board requires an :adi:`SDP-S` board (not supplied with the kit). The :adi:`SDP-S` allows software programming of the :adi:`EV-ADF4377SD1Z` board with :adi:`ACE` software.
+This board requires an :adi:`SDP-S` board (not supplied with the kit). The
+:adi:`SDP-S` allows software programming of the :adi:`EV-ADF4377SD1Z` board
+with :adi:`ACE` software.
 
 Supported Carriers
-==================
+------------------
 
 -  `ZedBoard <https://www.avnet.com/wps/portal/us/products/avnet-boards/avnet-board-families/zedboard/>`_
 
@@ -28,9 +34,10 @@ Required Software
 Build Application
 -----------------
 
-In order to build the application and generate the .elf file, please follow the `NO-OS Build Guide <https://wiki.analog.com/resources/no-os/build>`_.
+In order to build the application and generate the .elf file, please follow
+the :external+no-OS:doc:`no-OS build guide <build_guide>`.
 
-Source files for the application can be found in the :doc:`Downloads </solutions/reference-designs/eval-adf4377/software/no-os-setup>` section.
+Source files for the application can be found in the `Source code`_ section.
 
 Run Application
 ---------------
@@ -43,12 +50,8 @@ the elf file. An output example of the application is provided below:
    ADF4377 Successfully initialized!
    Output Frequency Locked!
 
-Downloads
-=========
+Source code
+-----------
 
-.. admonition:: Download
-   :class: download
+-  :git-no-OS:`ADF4377 Application <projects/adf4377_sdz>`
 
-   
-   -  :git-no-OS:`ADF4377 Application <projects/adf4377_sdz>`
-   

--- a/docs/solutions/reference-designs/eval-adf4377/software/no-os-setup.rst
+++ b/docs/solutions/reference-designs/eval-adf4377/software/no-os-setup.rst
@@ -1,0 +1,54 @@
+Evaluating the ADF4377 Microware Wideband Synthesizer with Integrated VCO
+=========================================================================
+
+The :adi:`EV-ADF4377SD1Z` evaluates the pefromance of the\ :adi:`ADF4377` frequency synthesizer with an integrated voltage controlled oscillator (VCO) for phase-locked loops (PLLs).
+
+The evaluation board contains the :adi:`ADF4377` frequency synthesizer with an integrated VCO, a USB interface, power supply connectors, and subminiature Version A (SMA) connectors.
+
+This board requires an :adi:`SDP-S` board (not supplied with the kit). The :adi:`SDP-S` allows software programming of the :adi:`EV-ADF4377SD1Z` board with :adi:`ACE` software.
+
+Supported Carriers
+==================
+
+-  `ZedBoard <https://www.avnet.com/wps/portal/us/products/avnet-boards/avnet-board-families/zedboard/>`_
+
+Required Hardware
+-----------------
+
+-  :adi:`EV-ADF4377SD1Z` board & Power supply
+-  :adi:`SDP-I-FMC` Interposer
+-  ZedBoard
+
+Required Software
+-----------------
+
+-  Xilinx SDK / Xilinx Vitis.
+-  A UART terminal (Tera Term/PuTTY/Hyperterminal), Baud rate 115200.
+
+Build Application
+-----------------
+
+In order to build the application and generate the .elf file, please follow the `NO-OS Build Guide <https://wiki.analog.com/resources/no-os/build>`_.
+
+Source files for the application can be found in the :doc:`Downloads </solutions/reference-designs/eval-adf4377/software/no-os-setup>` section.
+
+Run Application
+---------------
+
+Start a UART terminal (set to 115200 baud rate), and program the device and run
+the elf file. An output example of the application is provided below:
+
+::
+
+   ADF4377 Successfully initialized!
+   Output Frequency Locked!
+
+Downloads
+=========
+
+.. admonition:: Download
+   :class: download
+
+   
+   -  :git-no-OS:`ADF4377 Application <projects/adf4377_sdz>`
+   


### PR DESCRIPTION
## Summary
- Move eval-adf4377 wiki documentation to `solutions/reference-designs/eval-adf4377/`
- 2 RST files with 0 localized images
- Generated stub `index.rst` with toctree

## Test plan
- [ ] Sphinx build passes without errors
- [ ] All toctree entries resolve correctly
- [ ] Images render properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)