### PR TITLE
reference-designs/eval-adf5902: Add eval-adf5902 documentation

### DIFF
--- a/docs/solutions/reference-designs/eval-adf5902/eval-adf5902.png
+++ b/docs/solutions/reference-designs/eval-adf5902/eval-adf5902.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:565886d85b6de4cdd5dfef9a24abe7ae463189749203a591eb631c0376f22442
+size 603027

--- a/docs/solutions/reference-designs/eval-adf5902/index.rst
+++ b/docs/solutions/reference-designs/eval-adf5902/index.rst
@@ -1,0 +1,7 @@
+EVAL-ADF5902
+============
+
+.. toctree::
+   :titlesonly:
+
+   software/no-os-setup

--- a/docs/solutions/reference-designs/eval-adf5902/index.rst
+++ b/docs/solutions/reference-designs/eval-adf5902/index.rst
@@ -1,7 +1,71 @@
+.. _eval-adf5902:
+
 EVAL-ADF5902
-============
+=========================================================================
+
+24 GHz, ISM Band, Multichannel FMCW Radar Transmitter
+
+.. image:: eval-adf5902.png
+   :align: center
+   :width: 500
+
+Overview
+-------------------------------------------------------------------------------
+
+The :adi:`EVAL-ADF5902` evaluation board allows the user to evaluate the
+performance of the :adi:`ADF5902`, a 24 GHz transmitter (Tx) monolithic
+microwave integrated circuit (MMIC) with an on-chip, 24 GHz voltage controlled
+oscillator (VCO). The VCO features a fractional-N frequency synthesizer with
+waveform generation capability, programmable grid array (PGA), and dual
+transmitter channels for radar systems. The on-chip 24 GHz VCO generates the
+24 GHz signal for the two transmitter channels and the local oscillator (LO)
+output. Each transmitter channel contains a power control circuit. There is also
+an on-chip temperature sensor.
+
+Features:
+
+- 24 GHz to 24.25 GHz VCO (ISM band)
+- 2-channel 24 GHz power amplifier with 8 dBm output
+- Single-ended outputs with mux and mute function
+- Programmable output power
+- LO output buffer
+- High and low speed FMCW ramp generation
+- 25-bit fixed modulus allows subhertz frequency resolution
+- Auxiliary 8-bit ADC
+- Power control detector
+- ±5°C temperature sensor
+
+Applications:
+
+- Automotive radars
+- Industrial radars
+- Microwave radar sensors
+
+Software
+-------------------------------------------------------------------------------
+
+- :doc:`no-OS Setup <software/no-os-setup>`
 
 .. toctree::
-   :titlesonly:
+   :hidden:
 
    software/no-os-setup
+
+Recommendations
+-------------------------------------------------------------------------------
+
+People who follow the flow that is outlined, have a much better experience with
+things. However, like many things, documentation is never as complete as it
+should be. If you have any questions, feel free to ask on our
+:ref:`EngineerZone forums <help-and-support>`, but before that, please make
+sure you read our documentation thoroughly.
+
+Warning
+-------------------------------------------------------------------------------
+
+.. esd-warning::
+
+Help and support
+-------------------------------------------------------------------------------
+
+Please go to :ref:`Help and Support <help-and-support>` page.

--- a/docs/solutions/reference-designs/eval-adf5902/software/no-os-setup.rst
+++ b/docs/solutions/reference-designs/eval-adf5902/software/no-os-setup.rst
@@ -1,10 +1,13 @@
 Evaluating the ADF5902, 24 GHz, ISM Band, Multichannel FMCW Radar Transmitter
 =============================================================================
 
-The :adi:`EVAL-ADF5902` evaluation board allows the user to evaluate the performance of the :adi:`ADF5902` 24 GHz voltage controlled oscillator (VCO) programmable gain amplifier (PGA) with a 2-channel power amplifier (PA) output and ramping phase-locked loop (PLL).
+The :adi:`EVAL-ADF5902` evaluation board allows the user to evaluate the
+performance of the :adi:`ADF5902` 24 GHz voltage controlled oscillator (VCO)
+programmable gain amplifier (PGA) with a 2-channel power amplifier (PA)
+output and ramping phase-locked loop (PLL).
 
 Supported Carriers
-==================
+------------------
 
 -  `ZedBoard <https://www.avnet.com/wps/portal/us/products/avnet-boards/avnet-board-families/zedboard/>`_
 
@@ -13,7 +16,7 @@ Required Hardware
 
 -  :adi:`EVAL-ADF5902` board & Power supply
 -  :adi:`SDP-I-FMC` Interposer
--  ZedBoard
+-  `ZedBoard <https://www.avnet.com/wps/portal/us/products/avnet-boards/avnet-board-families/zedboard/>`_
 
 Required Software
 -----------------
@@ -24,9 +27,10 @@ Required Software
 Build Application
 -----------------
 
-In order to build the application and generate the .elf file, please follow the `NO-OS Build Guide <https://wiki.analog.com/resources/no-os/build>`_.
+In order to build the application and generate the .elf file, please follow
+the :external+no-OS:doc:`no-OS build guide <build_guide>`.
 
-Source files for the application can be found in the :doc:`Downloads </solutions/reference-designs/eval-adf5902/software/no-os-setup>` section.
+Source files for the application can be found in the `Source code`_ section.
 
 Run Application
 ---------------
@@ -40,12 +44,8 @@ the elf file. An output example of the application is provided below:
    ADF5902 Locked Frequency: 24024999936 Hz
    ADF5902 Temperature value: 27.07 degC
 
-Downloads
-=========
+Source code
+-----------
 
-.. admonition:: Download
-   :class: download
+-  :git-no-OS:`ADF5902 Application <projects/adf5902_sdz>`
 
-   
-   -  :git-no-OS:`ADF5902 Application <projects/adf5902_sdz>`
-   

--- a/docs/solutions/reference-designs/eval-adf5902/software/no-os-setup.rst
+++ b/docs/solutions/reference-designs/eval-adf5902/software/no-os-setup.rst
@@ -1,0 +1,51 @@
+Evaluating the ADF5902, 24 GHz, ISM Band, Multichannel FMCW Radar Transmitter
+=============================================================================
+
+The :adi:`EVAL-ADF5902` evaluation board allows the user to evaluate the performance of the :adi:`ADF5902` 24 GHz voltage controlled oscillator (VCO) programmable gain amplifier (PGA) with a 2-channel power amplifier (PA) output and ramping phase-locked loop (PLL).
+
+Supported Carriers
+==================
+
+-  `ZedBoard <https://www.avnet.com/wps/portal/us/products/avnet-boards/avnet-board-families/zedboard/>`_
+
+Required Hardware
+-----------------
+
+-  :adi:`EVAL-ADF5902` board & Power supply
+-  :adi:`SDP-I-FMC` Interposer
+-  ZedBoard
+
+Required Software
+-----------------
+
+-  Xilinx SDK / Xilinx Vitis.
+-  A UART terminal (Tera Term/PuTTY/Hyperterminal), Baud rate 115200.
+
+Build Application
+-----------------
+
+In order to build the application and generate the .elf file, please follow the `NO-OS Build Guide <https://wiki.analog.com/resources/no-os/build>`_.
+
+Source files for the application can be found in the :doc:`Downloads </solutions/reference-designs/eval-adf5902/software/no-os-setup>` section.
+
+Run Application
+---------------
+
+Start a UART terminal (set to 115200 baud rate), and program the device and run
+the elf file. An output example of the application is provided below:
+
+::
+
+   ADF5902 Successfully initialized!
+   ADF5902 Locked Frequency: 24024999936 Hz
+   ADF5902 Temperature value: 27.07 degC
+
+Downloads
+=========
+
+.. admonition:: Download
+   :class: download
+
+   
+   -  :git-no-OS:`ADF5902 Application <projects/adf5902_sdz>`
+   


### PR DESCRIPTION
## Summary
- Move eval-adf5902 wiki documentation to `solutions/reference-designs/eval-adf5902/`
- 2 RST files with 0 localized images
- Generated stub `index.rst` with toctree

## Test plan
- [ ] Sphinx build passes without errors
- [ ] All toctree entries resolve correctly
- [ ] Images render properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)