### PR TITLE
reference-designs/eval-adpaq3029: Add eval-adpaq3029 documentation

### DIFF
--- a/docs/solutions/reference-designs/eval-adpaq3029/eval-adpaq3029.rst
+++ b/docs/solutions/reference-designs/eval-adpaq3029/eval-adpaq3029.rst
@@ -1,0 +1,10 @@
+EVAL-ADPAQ3029 User Guide [under construction]
+==============================================
+
+-  :doc:`Introduction </solutions/reference-designs/eval-adpaq3029/introduction>`
+-  :doc:`Hardware setup </solutions/reference-designs/eval-adpaq3029/hw_setup>`
+-  :doc:`Software tools setup </solutions/reference-designs/eval-adpaq3029/sw_tools_setup>`
+-  :doc:`Firmware development </solutions/reference-designs/eval-adpaq3029/fw_dev>`
+-  :doc:`Tile (mobile app GUI) development </solutions/reference-designs/eval-adpaq3029/tile_dev>`
+-  :doc:`Running your first application [RGB LED </solutions/reference-designs/eval-adpaq3029/first_app>`]
+-  :doc:`Resources </solutions/reference-designs/eval-adpaq3029/resources>`

--- a/docs/solutions/reference-designs/eval-adpaq3029/eval-adpaq3029.rst
+++ b/docs/solutions/reference-designs/eval-adpaq3029/eval-adpaq3029.rst
@@ -6,5 +6,5 @@ EVAL-ADPAQ3029 User Guide [under construction]
 -  :doc:`Software tools setup </solutions/reference-designs/eval-adpaq3029/sw_tools_setup>`
 -  :doc:`Firmware development </solutions/reference-designs/eval-adpaq3029/fw_dev>`
 -  :doc:`Tile (mobile app GUI) development </solutions/reference-designs/eval-adpaq3029/tile_dev>`
--  :doc:`Running your first application [RGB LED </solutions/reference-designs/eval-adpaq3029/first_app>`]
+-  :doc:`Running your first application (RGB LED) </solutions/reference-designs/eval-adpaq3029/first_app>`
 -  :doc:`Resources </solutions/reference-designs/eval-adpaq3029/resources>`

--- a/docs/solutions/reference-designs/eval-adpaq3029/first_app.rst
+++ b/docs/solutions/reference-designs/eval-adpaq3029/first_app.rst
@@ -1,0 +1,55 @@
+EVAL-ADPAQ3029 - First application [RGB LED]
+============================================
+
+-  Setup the hardware as shown :doc:`here. </solutions/reference-designs/eval-adpaq3029/hw_setup>`
+-  Make sure to use Dev module with LED. Here is the schematics for one such board - `Nexpaq_Glue_Micro_Dev_Board. <resources/dev_board.pdf>`_
+-  Download the following projects from the :doc:`resources </solutions/reference-designs/eval-adpaq3029/resources>` section.
+
+   -  Bootloader
+   -  MDK source code
+
+-  Download firmware and Tile application from below
+
+.. admonition:: Download
+   :class: download
+
+   \ `RGB led Firmware <resources/ledapp.zip>`_
+
+   
+   `Tile GUI application <resources/moduware.tile.example-led-rgb.zip>`_\
+
+-  The mapping of the RGB LED with the ADPAQ GPIOs is given below
+
+.. container:: round box
+
+   
+   ========= ==============
+   LED color GPIO port used
+   ========= ==============
+   Red       P1_08
+   Green     P0_14
+   Blue      P1_09
+   ========= ==============
+   
+
+-  Launch the CCES IDE and import the first 3 projects into CCES as explained :doc:`here </solutions/reference-designs/eval-adpaq3029/fw_dev/import_prj>`.
+-  Build and flash the firmware binary (\*.bin) as explained :doc:`here </solutions/reference-designs/eval-adpaq3029/fw_dev>`
+-  Deploy the tile application as explained\ :doc:`here </solutions/reference-designs/eval-adpaq3029/tile_dev>`
+-  Launch the ``Moduware`` app and pair to the gateway (Mini Dev board)
+-  Now you should be able to see tile with ``DevMod``.
+
+`image <images/tile5.png>`_
+
+-  Long Press on the ``DevMod`` Tile. Select the ``RGB LED`` tile.
+
+`image <images/app1.png>`_
+
+-  The tile of the RGBLED app which was uploaded earlier will appear as shown in
+   the image.
+
+.. image:: images/app2.png
+   :align: center
+   :width: 400
+
+-  Test the application using GUI, by pressing R, G and B color buttons to
+   observe change in the LED color in ADPAQ Dev module.

--- a/docs/solutions/reference-designs/eval-adpaq3029/first_app.rst
+++ b/docs/solutions/reference-designs/eval-adpaq3029/first_app.rst
@@ -13,16 +13,14 @@ EVAL-ADPAQ3029 - First application [RGB LED]
 .. admonition:: Download
    :class: download
 
-   \ `RGB led Firmware <resources/ledapp.zip>`_
+   `RGB led Firmware <resources/ledapp.zip>`_
 
-   
-   `Tile GUI application <resources/moduware.tile.example-led-rgb.zip>`_\
+   `Tile GUI application <resources/moduware.tile.example-led-rgb.zip>`_
 
 -  The mapping of the RGB LED with the ADPAQ GPIOs is given below
 
 .. container:: round box
 
-   
    ========= ==============
    LED color GPIO port used
    ========= ==============
@@ -30,19 +28,22 @@ EVAL-ADPAQ3029 - First application [RGB LED]
    Green     P0_14
    Blue      P1_09
    ========= ==============
-   
 
 -  Launch the CCES IDE and import the first 3 projects into CCES as explained :doc:`here </solutions/reference-designs/eval-adpaq3029/fw_dev/import_prj>`.
 -  Build and flash the firmware binary (\*.bin) as explained :doc:`here </solutions/reference-designs/eval-adpaq3029/fw_dev>`
--  Deploy the tile application as explained\ :doc:`here </solutions/reference-designs/eval-adpaq3029/tile_dev>`
+-  Deploy the tile application as explained :doc:`here </solutions/reference-designs/eval-adpaq3029/tile_dev>`
 -  Launch the ``Moduware`` app and pair to the gateway (Mini Dev board)
 -  Now you should be able to see tile with ``DevMod``.
 
-`image <images/tile5.png>`_
+.. image:: images/tile5.png
+   :align: center
+   :width: 400
 
 -  Long Press on the ``DevMod`` Tile. Select the ``RGB LED`` tile.
 
-`image <images/app1.png>`_
+.. image:: images/app1.png
+   :align: center
+   :width: 400
 
 -  The tile of the RGBLED app which was uploaded earlier will appear as shown in
    the image.

--- a/docs/solutions/reference-designs/eval-adpaq3029/fw_dev.rst
+++ b/docs/solutions/reference-designs/eval-adpaq3029/fw_dev.rst
@@ -61,7 +61,7 @@ The following API's must be implemented by Application:
 The following API's can be optionally implemented by Application:
 
 -  ``void np_api_start(void);`` *Runs when operation starts*
--  ''void np_api_stop(void); '' *Runs when operation stops*
+-  ``void np_api_stop(void);`` *Runs when operation stops*
 
 Other API's available for application:
 
@@ -95,7 +95,9 @@ Building
 -  In the properties tab go to ``C/C++ Build`` -> ``Settings`` -> ``Cross Core GCC ARM Embedded C Linker``-> ``Libraries``.
 -  Select build steps. Type ``arm-none-eabi-objcopy -O binary ${ProjName} ${ProjName}.bin`` in the command of post build steps. Click on OK.
 
-`image <images/sw14.png>`_
+.. image:: images/sw14.png
+   :align: center
+   :width: 600
 
 -  Now, building the project again should generate the binary (\*.bin) file in
    the same directory as makefile
@@ -110,27 +112,37 @@ Debugging
 -  As shown in :doc:`hardware setup </solutions/reference-designs/eval-adpaq3029/hw_setup>` section, connect the debugger between PC and Dev Module.
 -  The debugger should show up as ``DAPLINK``.
 
-`image <images/deb3.png>`_
+.. image:: images/deb3.png
+   :align: center
+   :width: 600
 
 -  Go to Run -> Debug Configurations.
 
-`image <images/deb4.png>`_
+.. image:: images/deb4.png
+   :align: center
+   :width: 600
 
 -  In the Debug Configurations window, select Application with GDB and
    OpenOCD(Emulator) on the left.
 
-`image <images/deb5.png>`_
+.. image:: images/deb5.png
+   :align: center
+   :width: 600
 
 -  In the Target tab, set the Target (Processor) to Analog Devices ADuCM3029 and the Interface to ARM CMSIS-DAP complaint adapter and click ``Apply`` and then on ``Debug``.
 -  The debug perspective is opened. By default, the breakpoint will be inserted at the main function.
 -  To change the default breakpoint settings, goto ``Startup`` tab in the same window as target tab, change “Set breakpoint at” option. (Example, reset_handler).
 
-`image <images/deb6.png>`_
+.. image:: images/deb6.png
+   :align: center
+   :width: 600
 
 -  The execution halts when it hits the breakpoint. The execution can be resumed
    by clicking on the resume button as shown in the image.
 
-`image <images/deb7.png>`_
+.. image:: images/deb7.png
+   :align: center
+   :width: 600
 
 -  The breakpoints can be inserted (or removed) to (or from) any line of the
    code by double clicking on the beginning of the line. The “step into”
@@ -138,7 +150,9 @@ Debugging
    window->show view, the values associated with different expressions,
    registers, memory etc can be observed.
 
-`image <images/deb8.png>`_
+.. image:: images/deb8.png
+   :align: center
+   :width: 600
 
 Firmware deployment/flashing
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/solutions/reference-designs/eval-adpaq3029/fw_dev.rst
+++ b/docs/solutions/reference-designs/eval-adpaq3029/fw_dev.rst
@@ -1,0 +1,154 @@
+EVAL-ADPAQ3029 - Firmware development
+=====================================
+
+1. Overview
+-----------
+
+The firmware consists of 3 parts:
+
+-  Bootloader,
+-  MDK (Moduware Developers Kit) and
+-  main application.
+
+The bootloader carries out different system initialization functions and module
+application upgrades. The MDK is the window of communication between the module
+application and the gateway. The communication between the module application
+and the gateway is facilitated by MDK APIs. The MDK also processes the message
+received from the application by invoking the callback functions.
+
+Mainly, the following MDK APIs have been used in the ADPAQ projects:
+
+-  ``unsigned char np_api_register()``: *This API is used to register the command and the function. When the MDK receives a command/message, it calls the associated callback function.*
+-  ``void np_api_setup()``: *It consists of initial functions of the module application. For example, this API may contain a timer initialization function*
+-  ``void np_api_loop()``: *It consists of the code which implements the module functionality.*
+
+.. important::
+
+   Whenever a command is registered, it is important to make sure that it is
+   within 0x2700 to 0x27ff as defined in the MDK standard.
+
+2. Memory map
+-------------
+
+The :adi:`ADuCM3029` Microcontroller has 256KB of Flash Memory, 32KB of Data SRAM and 32KB of Instruction SRAM. The memory map of the moduware framework is depicted in the current section. Inside the Flash Memory,
+
+-  62KB is reserved for the Bootloader
+-  384 Bytes is reserved for the MDK/app vector table
+-  192KB-384 bytes (63,487 bytes) is reserved for the MDK/Application
+-  2KB is reserved as Information Memory which contains the UUID of ADPAQ.
+
+.. image:: images/fw1.png
+   :align: center
+   :width: 300
+
+The 32KB Data SRAM is divided into 2 parts, 16KB for the Bootloader and 16KB for
+the MDK/Application.
+
+.. image:: images/fw2.png
+   :align: center
+   :width: 300
+
+3. MDK library
+--------------
+
+As explained previously, MDK library provides an interface for application (firmware) running on :adi:`ADuCM3029` to control Gateway through SPI commands. The Gateway on the other end, controls the Tile Application (explained in next section) running on smartphone through BLE (Bluetooth) interface.
+
+The following API's must be implemented by Application:
+
+-  ``extern void np_api_setup(void);`` *Runs once on module power-up*
+-  ``extern void np_api_loop(void);`` *Non-command callback function -- runs several times*
+
+The following API's can be optionally implemented by Application:
+
+-  ``void np_api_start(void);`` *Runs when operation starts*
+-  ''void np_api_stop(void); '' *Runs when operation stops*
+
+Other API's available for application:
+
+-  ``void np_api_set_app_version(uint8_t major, uint8_t minor, uint8_t revision);`` *Let the user set their own app version (optional)*
+-  ``uint8_t np_api_register(MDK_REGISTER_CMD *table, uint8_t size);`` *Register the user's command callback functions*
+-  ``uint8_t np_api_upload(uint16_t command, uint8_t *data, uint8_t length);`` *Send data to the last source*
+-  ``void np_api_pm_automode_set(void);`` *Enable power management mode*
+-  ``void np_api_pm_automode_clear(void);`` *Disable power management mode*
+-  ``uint8_t np_api_run_loop_once(void);`` *Run the loop again before sleeping (unnecessary for free running mode)*
+
+4. Application development
+--------------------------
+
+This is the main application running on :adi:`ADuCM3029`. Below are the steps that will help you in writing your own application using MDK library. Please see :doc:`resources </solutions/reference-designs/eval-adpaq3029/resources>` section to download source code.
+
+:doc:`Guide to import the source code and setup library paths </solutions/reference-designs/eval-adpaq3029/fw_dev/import_prj>`
+
+-  Declare any functions and global variables in the Dev Module header (\*.h) file.
+-  Program the newly declared function in the corresponding source (\*.c) file. The function can be now be referenced from the continuously looping main function used by Modpack.
+-  The mdk files reference all Modpack related functionality. Within the header file all modpack specific functions are declared.
+-  In the mdk.c file the system functions are given register addresses from 0x2700-0x27FF. The function addresses are referenced directly within the continuous main loop or from the tile side.
+-  Create the program function in ``np_api_loop()``. The continuous function will check any conditions set or poll any hardware via access to the functions created in the modules .c file mentioned in part 2.
+-  Initialize any values or hardware in ``np_api_setup()``
+-  ``np_api_loop()``: continuous loop retrieving data and uploading that data to Nexpaq API (np_api_upload(0x2800,[data],size). The data sent is retrieved on the tile side based on the addresses specified (source 0x2800+).
+
+Building
+~~~~~~~~
+
+-  In order to build the project, click ``Project`` -> ``Build Project`` or press F7.
+-  In order to generate executable binary file (\*.bin) for :adi:`ADuCM3029`, Right click on ``Dev Module`` project -> ``properties``.
+-  In the properties tab go to ``C/C++ Build`` -> ``Settings`` -> ``Cross Core GCC ARM Embedded C Linker``-> ``Libraries``.
+-  Select build steps. Type ``arm-none-eabi-objcopy -O binary ${ProjName} ${ProjName}.bin`` in the command of post build steps. Click on OK.
+
+`image <images/sw14.png>`_
+
+-  Now, building the project again should generate the binary (\*.bin) file in
+   the same directory as makefile
+
+.. important::
+
+   It is advised to clean the project before building by right clicking project -> ``Clean Project``. This deletes old build files.
+
+Debugging
+~~~~~~~~~
+
+-  As shown in :doc:`hardware setup </solutions/reference-designs/eval-adpaq3029/hw_setup>` section, connect the debugger between PC and Dev Module.
+-  The debugger should show up as ``DAPLINK``.
+
+`image <images/deb3.png>`_
+
+-  Go to Run -> Debug Configurations.
+
+`image <images/deb4.png>`_
+
+-  In the Debug Configurations window, select Application with GDB and
+   OpenOCD(Emulator) on the left.
+
+`image <images/deb5.png>`_
+
+-  In the Target tab, set the Target (Processor) to Analog Devices ADuCM3029 and the Interface to ARM CMSIS-DAP complaint adapter and click ``Apply`` and then on ``Debug``.
+-  The debug perspective is opened. By default, the breakpoint will be inserted at the main function.
+-  To change the default breakpoint settings, goto ``Startup`` tab in the same window as target tab, change “Set breakpoint at” option. (Example, reset_handler).
+
+`image <images/deb6.png>`_
+
+-  The execution halts when it hits the breakpoint. The execution can be resumed
+   by clicking on the resume button as shown in the image.
+
+`image <images/deb7.png>`_
+
+-  The breakpoints can be inserted (or removed) to (or from) any line of the
+   code by double clicking on the beginning of the line. The “step into”
+   function can be used to execute the code step by step. By clicking on the
+   window->show view, the values associated with different expressions,
+   registers, memory etc can be observed.
+
+`image <images/deb8.png>`_
+
+Firmware deployment/flashing
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+-  After successful building/debugging, the generated executable binary file (\*.bin) should be copied to ``DAPLINK`` USB drive.
+-  After copying, the USB driver will automatically flash the copied binary file to the ADuCM3029 microcontroller.
+-  Then USB drive gets refreshed and opens again. If the copied binary file is
+   not visible, then flashing is successful, if the file is still visible then
+   flashing is not successful.
+
+.. important::
+
+   Many a times, the modules may not be recognized as ``DAPLINK`` but will be shown as ``MAINTENANCE``. In this case, just disconnect the power cable from the modules and connect them back again.

--- a/docs/solutions/reference-designs/eval-adpaq3029/fw_dev/import_prj.rst
+++ b/docs/solutions/reference-designs/eval-adpaq3029/fw_dev/import_prj.rst
@@ -1,7 +1,7 @@
 EVAL-ADPAQ3029 - Importing CCES project
 =======================================
 
-Please see the `resource <https://wiki.analog.com/../resources>`_ section to download source code.
+Please see the :doc:`resources </solutions/reference-designs/eval-adpaq3029/resources>` section to download source code.
 
 -  Launch the CCES IDE on your host & create a new workspace.
 -  Click on ``File`` -> ``Import..`` or click ``Import an existing CCES project`` from homepage as shown below.
@@ -30,9 +30,11 @@ Setup path variables
 -  In the properties tab, go to ``C/C++ Build`` -> ``Settings`` -> ``Cross Core GCC ARM Embedded C Linker``-> ``Libraries``.
 -  Click on ``add`` (at the top right section inside settings tab) and then ``File system``. Then search for the required files from the workspace and add them.
 
-`image <../images/sw12.png>`_
+.. image:: ../images/sw12.png
+   :align: center
+   :width: 600
 
--  Below image shows the paths to be added. Make sure that you add the path from the workspace. In the figure shown below,\ ``C:\Users\psirivan\Desktop`` is the path to the workspace, ``6Feb6`` is the name of the workspace.
+-  Below image shows the paths to be added. Make sure that you add the path from the workspace. In the figure shown below, ``C:\Users\psirivan\Desktop`` is the path to the workspace, ``6Feb6`` is the name of the workspace.
 -  Semihosting support should be ``nosys.specs``, as shown in the figure below.
 
 .. important::

--- a/docs/solutions/reference-designs/eval-adpaq3029/fw_dev/import_prj.rst
+++ b/docs/solutions/reference-designs/eval-adpaq3029/fw_dev/import_prj.rst
@@ -1,0 +1,45 @@
+EVAL-ADPAQ3029 - Importing CCES project
+=======================================
+
+Please see the `resource <https://wiki.analog.com/../resources>`_ section to download source code.
+
+-  Launch the CCES IDE on your host & create a new workspace.
+-  Click on ``File`` -> ``Import..`` or click ``Import an existing CCES project`` from homepage as shown below.
+-  Then select ``General``-> ``Existing Projects into Workspace``.
+-  Then choose the source code directory to import one or more projects from the
+   selected directory
+
+.. image:: ../images/sw10.png
+   :align: center
+   :width: 600
+
+The module application runs on the bootloader and the MDK provides APIs required
+for communication with the gateway. The bootloader and the MDK projects have to
+be added to the workspace. They can be downloaded from the resource page along
+with application source code. To add them to the workspace, follow the procedure
+described as above.
+
+.. image:: ../images/sw11.png
+   :align: center
+   :width: 400
+
+Setup path variables
+--------------------
+
+-  Open CCES, right click on the desired project and select ``Properties``.
+-  In the properties tab, go to ``C/C++ Build`` -> ``Settings`` -> ``Cross Core GCC ARM Embedded C Linker``-> ``Libraries``.
+-  Click on ``add`` (at the top right section inside settings tab) and then ``File system``. Then search for the required files from the workspace and add them.
+
+`image <../images/sw12.png>`_
+
+-  Below image shows the paths to be added. Make sure that you add the path from the workspace. In the figure shown below,\ ``C:\Users\psirivan\Desktop`` is the path to the workspace, ``6Feb6`` is the name of the workspace.
+-  Semihosting support should be ``nosys.specs``, as shown in the figure below.
+
+.. important::
+
+   Make sure that the libraries and objects are not enclosed within inverted
+   commas.
+
+.. image:: ../images/sw13.png
+   :align: center
+   :width: 600

--- a/docs/solutions/reference-designs/eval-adpaq3029/hw_setup.rst
+++ b/docs/solutions/reference-designs/eval-adpaq3029/hw_setup.rst
@@ -1,0 +1,77 @@
+EVAL-ADPAQ3029 - Hardware setup
+===============================
+
+The **EVAL-ADPAQ3029** evaluation kit mainly consists of below 2 parts.
+
+.. image:: images/hw1.png
+   :align: center
+   :width: 400
+
+1. ADPAQ Development module
+---------------------------
+
+The ADPAQ development module, allows us to build applications on :adi:`ADuCM3029` microcontroller from Analog Devices that is compatible with the Moduware development platform. The :adi:`ADuCM3029` has the following features/resources-
+
+-  ARM Cortex-M3 processor with a Memory Protection Unit (MPU)
+-  Operating frequency upto 26 MHz with serial wire debug interface
+-  256 KB of embedded flash memory with Error Correcting Code (ECC)
+-  64 KB of configurable system SRAM with parity
+-  Hardware cryptographic accelerator supporting AES-128, AES-256, and SHA-256
+-  Three SPI interfaces
+-  I2C and UART interfaces
+-  Serial Port (SPORT) for natively interfacing with converters and radios
+-  Programmable GPIOs
+-  3 general-purpose timers with PWM support
+-  RTC and FLEX_RTC with SensorStrobe and time stamping
+-  12-bit, 8 channel SAR ADC
+
+The ADPAQ module is as shown in the figure below. It mainly consists of 3 evaluation headers namely P1, P2 and P3, a debug connector, an :adi:`ADT7410` IC (it is a temperature sensor) and a Moduware connector. The schematics of the ADPAQ module can be viewed from the `link <https://drive.google.com/open?id=1sXYZnyS9-nxBX6DQjFaG1EM6rq973gTW>`_. It gives more details about the hardware of the module.
+
+|image1| The pin description of the evaluation headers is as shown below: |image2|
+
+2. Moduware gateway (Mini-Dev board)
+------------------------------------
+
+-  The gateway used in this setup is the Mini Dev Board.
+-  The Mini-dev board communicates with the module via SPI and it communicates with the mobile application via BLE (Bluetooth Low Energy).
+-  The Mini-Dev Board is powered on by connecting one end of the USB cable to the Power USB slot on the Mini-dev Board and the other end to the computer.
+-  The Mini-Dev Board is based on MSP-430 (Micro Controller) and has a BLE IC.
+-  The Mini-dev Board has a Moduware connector slot where the module has to be
+   inserted. The SPI communication between the module and the Mini-Dev Board
+   takes place through these pins.
+
+.. image:: images/hw4.png
+   :align: center
+   :width: 500
+
+Setup
+-----
+
+-  The ADPAQ module is inserted onto the gateway with the pins facing inward as shown in the image.
+-  Power the gateway by connecting the USB cable to the Power USB slot.
+-  Once the hardware setup is complete, setting up software toolchain is explained :doc:`here </solutions/reference-designs/eval-adpaq3029/sw_tools_setup>`.
+-  In addition to above setup, in order to debug/flash the firmware, debugger
+   (EVAL-ADPAQ3029EBZ-DBG) must be connected between PC and ADPAQ Dev module.
+
+.. image:: images/deb1.png
+   :align: center
+   :width: 400
+
+-  The ADPAQ module is connected to the debugger via a 10 pin arm debugger cable
+   and the debugger is then powered on through the Power USB port as shown in
+   the figure below.
+
+.. image:: images/deb2.png
+   :align: center
+   :width: 400
+
+-  Once the hardware is set up as described above, the device appears as ``DAPLINK``.
+
+.. important::
+
+   Make sure that the gateway is powered first with the ADPAQ module already inserted on it and then connect it to the debugger. Otherwise the device manager shows ``MAINTENANCE`` instead of ``DAPLINK``.
+
+.. |image1| image:: images/hw2.png
+   :width: 600
+.. |image2| image:: images/hw3.png
+   :width: 600

--- a/docs/solutions/reference-designs/eval-adpaq3029/hw_setup.rst
+++ b/docs/solutions/reference-designs/eval-adpaq3029/hw_setup.rst
@@ -27,7 +27,11 @@ The ADPAQ development module, allows us to build applications on :adi:`ADuCM3029
 
 The ADPAQ module is as shown in the figure below. It mainly consists of 3 evaluation headers namely P1, P2 and P3, a debug connector, an :adi:`ADT7410` IC (it is a temperature sensor) and a Moduware connector. The schematics of the ADPAQ module can be viewed from the `link <https://drive.google.com/open?id=1sXYZnyS9-nxBX6DQjFaG1EM6rq973gTW>`_. It gives more details about the hardware of the module.
 
-|image1| The pin description of the evaluation headers is as shown below: |image2|
+|image1|
+
+The pin description of the evaluation headers is as shown below:
+
+|image2|
 
 2. Moduware gateway (Mini-Dev board)
 ------------------------------------

--- a/docs/solutions/reference-designs/eval-adpaq3029/images/adpaq_platform.png
+++ b/docs/solutions/reference-designs/eval-adpaq3029/images/adpaq_platform.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:10ac0d41622532791d209196d5ad853e1d3e671845eccbdc752c12edeca6d1dc
+size 302503

--- a/docs/solutions/reference-designs/eval-adpaq3029/images/app1.png
+++ b/docs/solutions/reference-designs/eval-adpaq3029/images/app1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0c175550f1a219c4f7f618b42db4806a2f7c7958bb0fd7b17491695e30a7450f
+size 23665

--- a/docs/solutions/reference-designs/eval-adpaq3029/images/app10.png
+++ b/docs/solutions/reference-designs/eval-adpaq3029/images/app10.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d4bcbd5c32b1ea45bbce585d84905362e0307ec08e3c10babf07a455002a5c90
+size 21662

--- a/docs/solutions/reference-designs/eval-adpaq3029/images/app11.png
+++ b/docs/solutions/reference-designs/eval-adpaq3029/images/app11.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b93c880a87990439ee8026c3615b7218e6f495c8159848c540d680f3e81d856e
+size 330032

--- a/docs/solutions/reference-designs/eval-adpaq3029/images/app12.png
+++ b/docs/solutions/reference-designs/eval-adpaq3029/images/app12.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:94675f3b32958b9f8ae4a999a38b7826ad4878f605b5ecc733f79ca6178e4271
+size 330188

--- a/docs/solutions/reference-designs/eval-adpaq3029/images/app2.png
+++ b/docs/solutions/reference-designs/eval-adpaq3029/images/app2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:85c17576b632cd8f9425e85b16e1dc2eb587b053bb2a3ac4409cc09bfda57ef3
+size 47540

--- a/docs/solutions/reference-designs/eval-adpaq3029/images/app3.png
+++ b/docs/solutions/reference-designs/eval-adpaq3029/images/app3.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:41ba4ac64230859383e4290d69eb8d979c5a2fb13d39200e739fc4ae4411f148
+size 32895

--- a/docs/solutions/reference-designs/eval-adpaq3029/images/app4.png
+++ b/docs/solutions/reference-designs/eval-adpaq3029/images/app4.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d06e7672ccf6a9411daf5011c40b1451bfd704e2df1b7261d07e74bd0728259c
+size 100430

--- a/docs/solutions/reference-designs/eval-adpaq3029/images/app5.png
+++ b/docs/solutions/reference-designs/eval-adpaq3029/images/app5.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:20687a59b2f13d12fd648c6340051454f47032bd676e04030b1b20f2180fe915
+size 139263

--- a/docs/solutions/reference-designs/eval-adpaq3029/images/app6.png
+++ b/docs/solutions/reference-designs/eval-adpaq3029/images/app6.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8acb6412ea42ed10bb76669a47f83dfd03e2b69ac8bb0241a49b659658ca76d4
+size 95477

--- a/docs/solutions/reference-designs/eval-adpaq3029/images/app7.png
+++ b/docs/solutions/reference-designs/eval-adpaq3029/images/app7.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e284d0d2c178799d434ef105f8eec7b2fb9a12f0959eac83f3cc0fe6d441ce6f
+size 81569

--- a/docs/solutions/reference-designs/eval-adpaq3029/images/app8.png
+++ b/docs/solutions/reference-designs/eval-adpaq3029/images/app8.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a23bab61c78b4df376f60c1cbf2acc2bf6dcd38486b11e3e5f2ab69a7b4d1434
+size 96903

--- a/docs/solutions/reference-designs/eval-adpaq3029/images/app9.png
+++ b/docs/solutions/reference-designs/eval-adpaq3029/images/app9.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d350d3409147326f807f81feae9428bcfea37df77096d3adb92daf4c1ba06e38
+size 116121

--- a/docs/solutions/reference-designs/eval-adpaq3029/images/deb1.png
+++ b/docs/solutions/reference-designs/eval-adpaq3029/images/deb1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f5ea20c56e330e917e33788dd479335db961715f33db366a383df631a458fb6b
+size 1260412

--- a/docs/solutions/reference-designs/eval-adpaq3029/images/deb2.png
+++ b/docs/solutions/reference-designs/eval-adpaq3029/images/deb2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fd4aab6827192b45f84710e63be98fac7f858527ff1aef9a7f09b5cf224189b4
+size 5157145

--- a/docs/solutions/reference-designs/eval-adpaq3029/images/deb3.png
+++ b/docs/solutions/reference-designs/eval-adpaq3029/images/deb3.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9026d79aa7411088349921ca5e0471a9f822479f0fd5197404b320555612aee7
+size 81705

--- a/docs/solutions/reference-designs/eval-adpaq3029/images/deb4.png
+++ b/docs/solutions/reference-designs/eval-adpaq3029/images/deb4.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e955c06742cae75e30603225bb86656d058e2f6116c2452fe1387e8774261b82
+size 187267

--- a/docs/solutions/reference-designs/eval-adpaq3029/images/deb5.png
+++ b/docs/solutions/reference-designs/eval-adpaq3029/images/deb5.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:44e1b8297a3cb5359f8162f14c793270b28342e028172ceb28bdb1f7c56e37e4
+size 185168

--- a/docs/solutions/reference-designs/eval-adpaq3029/images/deb6.png
+++ b/docs/solutions/reference-designs/eval-adpaq3029/images/deb6.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:167d554a4f389356d7620e5da9ad5639100719fc0e08a2563e7e66006a86e37a
+size 125231

--- a/docs/solutions/reference-designs/eval-adpaq3029/images/deb7.png
+++ b/docs/solutions/reference-designs/eval-adpaq3029/images/deb7.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9022cba2fcfe14ed96db007f56aeef71b98ab024518c3380f8f1d016ba0b1769
+size 109955

--- a/docs/solutions/reference-designs/eval-adpaq3029/images/deb8.png
+++ b/docs/solutions/reference-designs/eval-adpaq3029/images/deb8.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:569b3110871ddabf71edb3e99c572909469556d80069ede3c40232fe65464325
+size 158717

--- a/docs/solutions/reference-designs/eval-adpaq3029/images/fw1.png
+++ b/docs/solutions/reference-designs/eval-adpaq3029/images/fw1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:79fa7020ff76627cb336e7b4c5436b7b9566b0eb5d786c9e831e70b483e9a3e0
+size 52058

--- a/docs/solutions/reference-designs/eval-adpaq3029/images/fw2.png
+++ b/docs/solutions/reference-designs/eval-adpaq3029/images/fw2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:162b075e1a5d4011e74980956e67bc2ecc9e88df7794ae67605125b6e644611c
+size 42672

--- a/docs/solutions/reference-designs/eval-adpaq3029/images/hw1.png
+++ b/docs/solutions/reference-designs/eval-adpaq3029/images/hw1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:18bbdefdeca8acda0255cc1cb85fb62053f0796f658585908ad0dbd31ca78d7b
+size 1910920

--- a/docs/solutions/reference-designs/eval-adpaq3029/images/hw2.png
+++ b/docs/solutions/reference-designs/eval-adpaq3029/images/hw2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:31d9311ed445eba8aae08690c7cde2f39e998abb062dff6f384b70540a24c845
+size 1811687

--- a/docs/solutions/reference-designs/eval-adpaq3029/images/hw3.png
+++ b/docs/solutions/reference-designs/eval-adpaq3029/images/hw3.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:98e33314ca27a6834dafda0d2a72cfd65ed3403b057a63504734a77dcfc6b15a
+size 108740

--- a/docs/solutions/reference-designs/eval-adpaq3029/images/hw4.png
+++ b/docs/solutions/reference-designs/eval-adpaq3029/images/hw4.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:68b045837a123ca40b18014a1ddc098d23099454b53d2e31f5113fa199d43a7b
+size 395075

--- a/docs/solutions/reference-designs/eval-adpaq3029/images/sw10.png
+++ b/docs/solutions/reference-designs/eval-adpaq3029/images/sw10.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4c821746d7574f9c410940b0377f0d040405ad78e08aac8e0f1094b32eee8bb8
+size 304435

--- a/docs/solutions/reference-designs/eval-adpaq3029/images/sw11.png
+++ b/docs/solutions/reference-designs/eval-adpaq3029/images/sw11.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5dcb87346298ee0eb94523b2b9f57bc465f278d92ad547181997890f24987310
+size 67041

--- a/docs/solutions/reference-designs/eval-adpaq3029/images/sw12.png
+++ b/docs/solutions/reference-designs/eval-adpaq3029/images/sw12.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6b1f1ef4506285a386e4fca438705c5099af509ec0bd52177abb5a94b01b539e
+size 110459

--- a/docs/solutions/reference-designs/eval-adpaq3029/images/sw13.png
+++ b/docs/solutions/reference-designs/eval-adpaq3029/images/sw13.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:792bd11044ef8f2204c2feecdc848a4a8aa147fb8dce1d7729a8f6a073e2ef51
+size 119966

--- a/docs/solutions/reference-designs/eval-adpaq3029/images/sw14.png
+++ b/docs/solutions/reference-designs/eval-adpaq3029/images/sw14.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f902a4ebb5e42f134eddf96cfe313052cb1c8f8450d75141e72a545683698636
+size 80287

--- a/docs/solutions/reference-designs/eval-adpaq3029/images/sw15.png
+++ b/docs/solutions/reference-designs/eval-adpaq3029/images/sw15.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b0439a8f3233fd5eb94f4024685172d7e6971e42731348090e5dd725e0abb957
+size 131167

--- a/docs/solutions/reference-designs/eval-adpaq3029/images/sw16.png
+++ b/docs/solutions/reference-designs/eval-adpaq3029/images/sw16.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:703fcdf227b3df55114a846838c30e1373796f11f997b8d0e963a26d9010f8f9
+size 99346

--- a/docs/solutions/reference-designs/eval-adpaq3029/images/sw3.png
+++ b/docs/solutions/reference-designs/eval-adpaq3029/images/sw3.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d60fe1fca0bfa842ed9626a9511057885f7bdf05a104e9b8c408f0e1ec9a42e7
+size 203981

--- a/docs/solutions/reference-designs/eval-adpaq3029/images/sw4.png
+++ b/docs/solutions/reference-designs/eval-adpaq3029/images/sw4.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1e447876388a464330f4b752cee413e27fb40fc8c19497c3facfc1758d6f03ae
+size 105565

--- a/docs/solutions/reference-designs/eval-adpaq3029/images/sw5.png
+++ b/docs/solutions/reference-designs/eval-adpaq3029/images/sw5.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d9cccc1e68ba518fe66b8e7b5028af0b2d33abe310bf5d84ceada25df4e9e054
+size 35166

--- a/docs/solutions/reference-designs/eval-adpaq3029/images/sw6.png
+++ b/docs/solutions/reference-designs/eval-adpaq3029/images/sw6.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:adb53e513e50c5b463a09f8afb94d785f350916c7832531f717aed71dd4918ec
+size 80847

--- a/docs/solutions/reference-designs/eval-adpaq3029/images/sw7.png
+++ b/docs/solutions/reference-designs/eval-adpaq3029/images/sw7.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4341683cbb29eb7403875ac3b6baea2e5724bc799fc88eeec8e34813db23d642
+size 220170

--- a/docs/solutions/reference-designs/eval-adpaq3029/images/sw8.png
+++ b/docs/solutions/reference-designs/eval-adpaq3029/images/sw8.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e31a9b66b8a92149818bfd486bf38a75e47bf4621d233966eb00e5860054237d
+size 70042

--- a/docs/solutions/reference-designs/eval-adpaq3029/images/sw9.png
+++ b/docs/solutions/reference-designs/eval-adpaq3029/images/sw9.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1b52d981fb33aa91ccf3d62fccf50b069a56d83088a0536c14787029eb9e7f72
+size 262842

--- a/docs/solutions/reference-designs/eval-adpaq3029/images/tile10.png
+++ b/docs/solutions/reference-designs/eval-adpaq3029/images/tile10.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1ca167d41a899c15c6e231fb60a30a015c9fb5dc9c094f1b1c240f4d94f4bb99
+size 24184

--- a/docs/solutions/reference-designs/eval-adpaq3029/images/tile11.png
+++ b/docs/solutions/reference-designs/eval-adpaq3029/images/tile11.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:842aea78a7286394a6560406b196cba32bf1a59fffbab20263e96634c2c535b7
+size 23750

--- a/docs/solutions/reference-designs/eval-adpaq3029/images/tile12.png
+++ b/docs/solutions/reference-designs/eval-adpaq3029/images/tile12.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3083a751ef4c9ee48121a0d1be5462f75dd597757490dd88276e274b8a7c95d4
+size 32456

--- a/docs/solutions/reference-designs/eval-adpaq3029/images/tile13.png
+++ b/docs/solutions/reference-designs/eval-adpaq3029/images/tile13.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:516a75f476fe4aa9c84fdafee2ca4443d2bbd8076a6c5d2a92f80c0636773490
+size 24913

--- a/docs/solutions/reference-designs/eval-adpaq3029/images/tile14.png
+++ b/docs/solutions/reference-designs/eval-adpaq3029/images/tile14.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:94c64610c35d0001a2a13f69e9c372c7086a9bd37467e615e6b6ed12c6db6722
+size 21256

--- a/docs/solutions/reference-designs/eval-adpaq3029/images/tile15.png
+++ b/docs/solutions/reference-designs/eval-adpaq3029/images/tile15.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1d04ca7c67c0239f0e204c4643b8edeb4c527b6e5394b477fc42ee8594d5e62e
+size 23443

--- a/docs/solutions/reference-designs/eval-adpaq3029/images/tile16.png
+++ b/docs/solutions/reference-designs/eval-adpaq3029/images/tile16.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:487174a87acd94e00d00219b1972b6756e43cb510f06aa92866a97ecf17e4c78
+size 16216

--- a/docs/solutions/reference-designs/eval-adpaq3029/images/tile2.png
+++ b/docs/solutions/reference-designs/eval-adpaq3029/images/tile2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:438f1ba0a7d7e6e7aed105cecc405d25ecfc2e8a51b3a7cfdb25b885db3b245a
+size 34876

--- a/docs/solutions/reference-designs/eval-adpaq3029/images/tile3.png
+++ b/docs/solutions/reference-designs/eval-adpaq3029/images/tile3.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7f55e005122dee9a1d191ab2488d2cbd70fa0ac9e05944680193299d9999a1a6
+size 28509

--- a/docs/solutions/reference-designs/eval-adpaq3029/images/tile4.png
+++ b/docs/solutions/reference-designs/eval-adpaq3029/images/tile4.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:778aea1c1600caf32f104b8ccddd12db8c2940549e0fa660aa20aecd13eaf9fe
+size 29781

--- a/docs/solutions/reference-designs/eval-adpaq3029/images/tile5.png
+++ b/docs/solutions/reference-designs/eval-adpaq3029/images/tile5.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:98933f21095c70c00c33684fd63ac17cf7e6b35fd9de9036baf24390e27b4956
+size 13109

--- a/docs/solutions/reference-designs/eval-adpaq3029/images/tile6.png
+++ b/docs/solutions/reference-designs/eval-adpaq3029/images/tile6.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d1c466460443a581b74e754ea827108b242912ddf45689b54531cd011afe00a3
+size 26586

--- a/docs/solutions/reference-designs/eval-adpaq3029/index.rst
+++ b/docs/solutions/reference-designs/eval-adpaq3029/index.rst
@@ -1,0 +1,20 @@
+EVAL-ADPAQ3029 User Guide [under construction]
+==============================================
+
+.. toctree::
+   :titlesonly:
+
+   eval-adpaq3029
+   first_app
+   fw_dev
+   fw_dev/import_prj
+   hw_setup
+   introduction
+   resources
+   resources/app_adc
+   resources/app_hc_sr04
+   resources/app_servo
+   resources/app_sht20
+   resources/app_uart
+   sw_tools_setup
+   tile_dev

--- a/docs/solutions/reference-designs/eval-adpaq3029/index.rst
+++ b/docs/solutions/reference-designs/eval-adpaq3029/index.rst
@@ -1,8 +1,27 @@
-EVAL-ADPAQ3029 User Guide [under construction]
-==============================================
+.. _eval_adpaq3029 eval:
+
+EVAL ADPAQ3029
+=====================================================================================
+
+.. TODO: Add a picture of the chip/board
+
+Overview
+-------------------------------------------------------------------------------
+
+.. TODO: Describe in max 10 rows the main features and applications.
+
+Features:
+
+- feature 1
+- feature 2
+
+Applications:
+
+- application 1
+- application 2
 
 .. toctree::
-   :titlesonly:
+   :hidden:
 
    eval-adpaq3029
    first_app
@@ -18,3 +37,22 @@ EVAL-ADPAQ3029 User Guide [under construction]
    resources/app_uart
    sw_tools_setup
    tile_dev
+
+Recommendations
+-------------------------------------------------------------------------------
+
+People who follow the flow that is outlined, have a much better experience with
+things. However, like many things, documentation is never as complete as it
+should be. If you have any questions, feel free to ask on our
+:ref:`EngineerZone forums <help-and-support>`, but before that, please make
+sure you read our documentation thoroughly.
+
+Warning
+-------------------------------------------------------------------------------
+
+.. esd-warning::
+
+Help and support
+-------------------------------------------------------------------------------
+
+Please go to :ref:`Help and Support <help-and-support>` page.

--- a/docs/solutions/reference-designs/eval-adpaq3029/introduction.rst
+++ b/docs/solutions/reference-designs/eval-adpaq3029/introduction.rst
@@ -1,0 +1,16 @@
+EVAL-ADPAQ3029 - Introduction
+=============================
+
+The EVAL-ADPAQ3029 module is a development/evaluation board specifically designed to work with `Moduware Platform <https://moduware.com>`_. The EVAL-ADPAQ3029 module combined with Moduware platform allows users, hobbyists & makers to realize their ideas centered around IoT applications. For more information on Moduware platform development refer to `Moduware Platform Developer page <https://moduware.com>`_.
+
+The EVAL-ADPAQ3029 module is based on :adi:`ADuCM3029` microcontroller. Various types of sensors/actuators/transducers can be interfaced with this module. The EVAL-ADPAQ3029 development module connects to Moduware gateway using SPI interface, which in turn connects to a smartphone through BLE connection.
+
+The Gateway collects the data from the development module and communicates the
+data to the mobile application via Bluetooth Low Energy (BLE) interface.
+
+The mobile application can send commands to get data from sensors connected to
+the development module or send actuation commands to the actuators.
+
+.. image:: images/adpaq_platform.png
+   :align: center
+   :width: 600

--- a/docs/solutions/reference-designs/eval-adpaq3029/resources.rst
+++ b/docs/solutions/reference-designs/eval-adpaq3029/resources.rst
@@ -1,0 +1,22 @@
+EVAL-ADPAQ3029 - Resources
+==========================
+
+Bootloader and MDK
+------------------
+
+This is same for all applications.
+
+.. admonition:: Download
+   :class: download
+
+   `Download Bootloader and MDK source code <resources/src.zip>`_
+
+Example projects
+----------------
+
+-  :doc:`RGB LED </solutions/reference-designs/eval-adpaq3029/first_app>` - Control the color of LED on ADPAQ development module
+-  :doc:`ADC </solutions/reference-designs/eval-adpaq3029/resources/app_adc>` - Control the ADC converter output using knob in GUI
+-  :doc:`HC-SR04 </solutions/reference-designs/eval-adpaq3029/resources/app_hc_sr04>` - Receive the ultrasonic sensor measurement
+-  :doc:`SHT20 (I2C) </solutions/reference-designs/eval-adpaq3029/resources/app_sht20>` - Receive the temperature and humidity sensor measurement
+-  :doc:`Servo motor </solutions/reference-designs/eval-adpaq3029/resources/app_servo>` - Control the rotation of servo motor by sending frequency value from GUI
+-  :doc:`UART </solutions/reference-designs/eval-adpaq3029/resources/app_uart>` - Control LED at the Arduino output by sending UART commands from ADPAQ to Arduino

--- a/docs/solutions/reference-designs/eval-adpaq3029/resources/adc.zip
+++ b/docs/solutions/reference-designs/eval-adpaq3029/resources/adc.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:89662ad372278185f813a4cd0019d236fa49834474d1fc7a99f8108664866453
+size 375121

--- a/docs/solutions/reference-designs/eval-adpaq3029/resources/app_adc.rst
+++ b/docs/solutions/reference-designs/eval-adpaq3029/resources/app_adc.rst
@@ -6,12 +6,11 @@ EVAL-ADPAQ3029 - ADC demo
 .. admonition:: Download
    :class: download
 
-   \ `ADC Firmware <adc.zip>`_
+   `ADC Firmware <adc.zip>`_
 
-   
-   `Tile GUI application <moduware.tile.example-adc.zip>`_\
+   `Tile GUI application <moduware.tile.example-adc.zip>`_
 
--  Follow the same steps as given `here <https://wiki.analog.com/../first_app>`_
+-  Follow the same steps as given :doc:`here </solutions/reference-designs/eval-adpaq3029/first_app>`
 -  A potentiometer has been used in this project to modify the analog voltage
    values.
 
@@ -29,7 +28,6 @@ EVAL-ADPAQ3029 - ADC demo
 
 .. container:: round box
 
-   
    ================== ============== =================
    Potentiometer Pins GPIO port used ADPAQ Header Pins
    ================== ============== =================
@@ -37,7 +35,6 @@ EVAL-ADPAQ3029 - ADC demo
    B                  ADC0_Vin0      P1-ADC0_Vin0
    C                  GND            P1-GND_POWER
    ================== ============== =================
-   
 
 -  Build and run the project
 -  If the knob of the potentiometer is rotated, the ADC value should vary

--- a/docs/solutions/reference-designs/eval-adpaq3029/resources/app_adc.rst
+++ b/docs/solutions/reference-designs/eval-adpaq3029/resources/app_adc.rst
@@ -1,0 +1,49 @@
+EVAL-ADPAQ3029 - ADC demo
+=========================
+
+-  Download firmware and Tile application from below
+
+.. admonition:: Download
+   :class: download
+
+   \ `ADC Firmware <adc.zip>`_
+
+   
+   `Tile GUI application <moduware.tile.example-adc.zip>`_\
+
+-  Follow the same steps as given `here <https://wiki.analog.com/../first_app>`_
+-  A potentiometer has been used in this project to modify the analog voltage
+   values.
+
+.. image:: ../images/app3.png
+   :align: center
+   :width: 200
+
+-  The potentiometer has to be interfaced with the ADPAQ module. The connections
+   between the potentiometer and the ADPAQ module are described in the table
+   below.
+
+.. image:: ../images/app4.png
+   :align: center
+   :width: 300
+
+.. container:: round box
+
+   
+   ================== ============== =================
+   Potentiometer Pins GPIO port used ADPAQ Header Pins
+   ================== ============== =================
+   A                  VCC            P1-3.3V
+   B                  ADC0_Vin0      P1-ADC0_Vin0
+   C                  GND            P1-GND_POWER
+   ================== ============== =================
+   
+
+-  Build and run the project
+-  If the knob of the potentiometer is rotated, the ADC value should vary
+   between 0-4095 for the corresponding analog voltage variations from 0 to
+   3.3V.
+
+.. image:: ../images/tile12.png
+   :align: center
+   :width: 300

--- a/docs/solutions/reference-designs/eval-adpaq3029/resources/app_hc_sr04.rst
+++ b/docs/solutions/reference-designs/eval-adpaq3029/resources/app_hc_sr04.rst
@@ -1,0 +1,46 @@
+EVAL-ADPAQ3029 - HC-SR04 demo
+=============================
+
+-  Download firmware and Tile application from below
+
+.. admonition:: Download
+   :class: download
+
+   \ `HC-SR04 Firmware <hc-sr04.zip>`_
+
+   
+   `Tile GUI application <moduware.tile.example-hcsr04.zip>`_\
+
+-  Follow the same steps as given `here <https://wiki.analog.com/../first_app>`_
+-  In this project, an Ultrasonic Sensor – HC-SR04 has been used.
+
+.. image:: ../images/app5.png
+   :align: center
+   :width: 300
+
+-  The connections between the Ultrasonic Sensor and ADPAQ module are made as
+   described in the table below.
+
+.. image:: ../images/app6.png
+   :align: center
+   :width: 400
+
+.. container:: round box
+
+   
+   ============ ============== =================
+   HC-SR04 Pins GPIO port used ADPAQ Header Pins
+   ============ ============== =================
+   Vcc          3.3V           P1-3.3V
+   Trig         P0_0           P2-5
+   Echo         P2_1           P3-1
+   Gnd          GND            P1-GND_POWER
+   ============ ============== =================
+   
+
+-  Build and run the project
+-  The Ultrasonic Sensor measurement is displayed on tile in “cm”.
+
+.. image:: ../images/tile10.png
+   :align: center
+   :width: 400

--- a/docs/solutions/reference-designs/eval-adpaq3029/resources/app_hc_sr04.rst
+++ b/docs/solutions/reference-designs/eval-adpaq3029/resources/app_hc_sr04.rst
@@ -6,12 +6,11 @@ EVAL-ADPAQ3029 - HC-SR04 demo
 .. admonition:: Download
    :class: download
 
-   \ `HC-SR04 Firmware <hc-sr04.zip>`_
+   `HC-SR04 Firmware <hc-sr04.zip>`_
 
-   
-   `Tile GUI application <moduware.tile.example-hcsr04.zip>`_\
+   `Tile GUI application <moduware.tile.example-hcsr04.zip>`_
 
--  Follow the same steps as given `here <https://wiki.analog.com/../first_app>`_
+-  Follow the same steps as given :doc:`here </solutions/reference-designs/eval-adpaq3029/first_app>`
 -  In this project, an Ultrasonic Sensor – HC-SR04 has been used.
 
 .. image:: ../images/app5.png
@@ -27,7 +26,6 @@ EVAL-ADPAQ3029 - HC-SR04 demo
 
 .. container:: round box
 
-   
    ============ ============== =================
    HC-SR04 Pins GPIO port used ADPAQ Header Pins
    ============ ============== =================
@@ -36,7 +34,6 @@ EVAL-ADPAQ3029 - HC-SR04 demo
    Echo         P2_1           P3-1
    Gnd          GND            P1-GND_POWER
    ============ ============== =================
-   
 
 -  Build and run the project
 -  The Ultrasonic Sensor measurement is displayed on tile in “cm”.

--- a/docs/solutions/reference-designs/eval-adpaq3029/resources/app_servo.rst
+++ b/docs/solutions/reference-designs/eval-adpaq3029/resources/app_servo.rst
@@ -6,12 +6,11 @@ EVAL-ADPAQ3029 - Servo motor demo
 .. admonition:: Download
    :class: download
 
-   \ `Servo motor Firmware <servo.zip>`_
+   `Servo motor Firmware <servo.zip>`_
 
-   
-   `Tile GUI application <moduware.tile.example-servo.zip>`_\
+   `Tile GUI application <moduware.tile.example-servo.zip>`_
 
--  Follow the same steps as given `here <https://wiki.analog.com/../first_app>`_
+-  Follow the same steps as given :doc:`here </solutions/reference-designs/eval-adpaq3029/first_app>`
 -  In this project, a Servo motor is used.
 
 .. image:: ../images/app9.png
@@ -26,7 +25,6 @@ EVAL-ADPAQ3029 - Servo motor demo
 
 .. container:: round box
 
-   
    ================ ============== =================
    Servo motor Pins GPIO port used ADPAQ Header Pins
    ================ ============== =================
@@ -34,14 +32,15 @@ EVAL-ADPAQ3029 - Servo motor demo
    B                P0_1           P2-5
    C                GND            P2-10
    ================ ============== =================
-   
 
 -  Build and run the project
 -  The tile has a “Freq” button and an input value option. We can set the
    frequency of the servo any value between 0-100 and the servo motor rotates
    accordingly.
 
-`image <../images/tile13.png>`_
+.. image:: ../images/tile13.png
+   :align: center
+   :width: 400
 
 |image1|
 

--- a/docs/solutions/reference-designs/eval-adpaq3029/resources/app_servo.rst
+++ b/docs/solutions/reference-designs/eval-adpaq3029/resources/app_servo.rst
@@ -1,0 +1,49 @@
+EVAL-ADPAQ3029 - Servo motor demo
+=================================
+
+-  Download firmware and Tile application from below
+
+.. admonition:: Download
+   :class: download
+
+   \ `Servo motor Firmware <servo.zip>`_
+
+   
+   `Tile GUI application <moduware.tile.example-servo.zip>`_\
+
+-  Follow the same steps as given `here <https://wiki.analog.com/../first_app>`_
+-  In this project, a Servo motor is used.
+
+.. image:: ../images/app9.png
+   :align: center
+   :width: 200
+
+-  The connections between the Servo Motor and the ADPAQ module are made as
+   shown below.
+
+.. image:: ../images/app10.png
+   :width: 300
+
+.. container:: round box
+
+   
+   ================ ============== =================
+   Servo motor Pins GPIO port used ADPAQ Header Pins
+   ================ ============== =================
+   A                5V             P2-1
+   B                P0_1           P2-5
+   C                GND            P2-10
+   ================ ============== =================
+   
+
+-  Build and run the project
+-  The tile has a “Freq” button and an input value option. We can set the
+   frequency of the servo any value between 0-100 and the servo motor rotates
+   accordingly.
+
+`image <../images/tile13.png>`_
+
+|image1|
+
+.. |image1| image:: ../images/tile14.png
+   :width: 400

--- a/docs/solutions/reference-designs/eval-adpaq3029/resources/app_sht20.rst
+++ b/docs/solutions/reference-designs/eval-adpaq3029/resources/app_sht20.rst
@@ -6,12 +6,11 @@ EVAL-ADPAQ3029 - SHT20 [I2C] demo
 .. admonition:: Download
    :class: download
 
-   \ `SHT20 Firmware <sht20.zip>`_
+   `SHT20 Firmware <sht20.zip>`_
 
-   
-   `Tile GUI application <moduware.tile.example-i2c.zip>`_\
+   `Tile GUI application <moduware.tile.example-i2c.zip>`_
 
--  Follow the same steps as given `here <https://wiki.analog.com/../first_app>`_
+-  Follow the same steps as given :doc:`here </solutions/reference-designs/eval-adpaq3029/first_app>`
 -  In this project, SHT20 (Temperature and Humidity Sensor) is used.
 
 .. image:: ../images/app7.png
@@ -27,7 +26,6 @@ EVAL-ADPAQ3029 - SHT20 [I2C] demo
 
 .. container:: round box
 
-   
    ========== ============== =================
    SHT20 Pins GPIO port used ADPAQ Header Pins
    ========== ============== =================
@@ -36,12 +34,13 @@ EVAL-ADPAQ3029 - SHT20 [I2C] demo
    SDA        I2C_SDA        P2-8
    Gnd        GND            P1-10
    ========== ============== =================
-   
 
 -  Build and run the project
 -  The Sensor will give the Temperature value in ``degree celsius`` and Humidity in ``%RH``.
 
-`image <../images/tile11.png>`_
+.. image:: ../images/tile11.png
+   :align: center
+   :width: 400
 
 |image1|
 

--- a/docs/solutions/reference-designs/eval-adpaq3029/resources/app_sht20.rst
+++ b/docs/solutions/reference-designs/eval-adpaq3029/resources/app_sht20.rst
@@ -1,0 +1,49 @@
+EVAL-ADPAQ3029 - SHT20 [I2C] demo
+=================================
+
+-  Download firmware and Tile application from below
+
+.. admonition:: Download
+   :class: download
+
+   \ `SHT20 Firmware <sht20.zip>`_
+
+   
+   `Tile GUI application <moduware.tile.example-i2c.zip>`_\
+
+-  Follow the same steps as given `here <https://wiki.analog.com/../first_app>`_
+-  In this project, SHT20 (Temperature and Humidity Sensor) is used.
+
+.. image:: ../images/app7.png
+   :align: center
+   :width: 300
+
+-  The connections between the SHT20 and the ADPAQ module are made as described
+   below.
+
+.. image:: ../images/app8.png
+   :align: center
+   :width: 200
+
+.. container:: round box
+
+   
+   ========== ============== =================
+   SHT20 Pins GPIO port used ADPAQ Header Pins
+   ========== ============== =================
+   Vcc        3.3V           P1-1
+   SCL        I2C_SCL        P2-9
+   SDA        I2C_SDA        P2-8
+   Gnd        GND            P1-10
+   ========== ============== =================
+   
+
+-  Build and run the project
+-  The Sensor will give the Temperature value in ``degree celsius`` and Humidity in ``%RH``.
+
+`image <../images/tile11.png>`_
+
+|image1|
+
+.. |image1| image:: ../images/tile12.png
+   :width: 400

--- a/docs/solutions/reference-designs/eval-adpaq3029/resources/app_uart.rst
+++ b/docs/solutions/reference-designs/eval-adpaq3029/resources/app_uart.rst
@@ -1,0 +1,54 @@
+EVAL-ADPAQ3029 - UART(Arduino) demo
+===================================
+
+-  Download firmware and Tile application from below
+
+.. admonition:: Download
+   :class: download
+
+   \ `UART (Arduino) Firmware <uart.zip>`_
+
+   
+   `Tile GUI application <moduware.tile.example-uart.zip>`_
+   
+   `Arduino code <https://wiki.analog.com/_media/resources/eval/user-guides/eval-adpaq3029/Uart.ino.zip>`_\
+
+-  Follow the same steps as given `here <https://wiki.analog.com/../first_app>`_
+-  In this project, an Arduino board has been used.
+
+.. image:: ../images/app11.png
+   :align: center
+   :width: 200
+
+-  Upload the ``Arduino code`` into ``Arduino Uno`` board using Arduino IDE.
+-  The connections between the Arduino and ADPAQ Board are made as described
+   below.
+
+.. container:: round box
+
+   
+   =================== ============== =================
+   Arduino Pins        GPIO port used ADPAQ Header Pins
+   =================== ============== =================
+   Digital pin 10 (RX) UART0_TX       P2-2
+   Digital pin 11 (TX) UART0_RX       P2-3
+   GND                 GND            P2-10
+   =================== ============== =================
+   
+
+-  Apart from these connections, an led along with a 10k resistor has to be
+   connected between the Digital pin 12 of Arduino and Ground.
+
+.. image:: ../images/app12.png
+   :width: 400
+
+-  Build and run the project
+-  The tile has 2 buttons “On” and “Off” buttons. By clicking on those buttons,
+   we can control the led that is connected to the pin 12 of Arduino.
+
+`image <../images/tile15.png>`_
+
+|image1|
+
+.. |image1| image:: ../images/tile16.png
+   :width: 400

--- a/docs/solutions/reference-designs/eval-adpaq3029/resources/app_uart.rst
+++ b/docs/solutions/reference-designs/eval-adpaq3029/resources/app_uart.rst
@@ -6,14 +6,13 @@ EVAL-ADPAQ3029 - UART(Arduino) demo
 .. admonition:: Download
    :class: download
 
-   \ `UART (Arduino) Firmware <uart.zip>`_
+   `UART (Arduino) Firmware <uart.zip>`_
 
-   
    `Tile GUI application <moduware.tile.example-uart.zip>`_
-   
-   `Arduino code <https://wiki.analog.com/_media/resources/eval/user-guides/eval-adpaq3029/Uart.ino.zip>`_\
 
--  Follow the same steps as given `here <https://wiki.analog.com/../first_app>`_
+   `Arduino code <uart.ino.zip>`_
+
+-  Follow the same steps as given :doc:`here </solutions/reference-designs/eval-adpaq3029/first_app>`
 -  In this project, an Arduino board has been used.
 
 .. image:: ../images/app11.png
@@ -26,7 +25,6 @@ EVAL-ADPAQ3029 - UART(Arduino) demo
 
 .. container:: round box
 
-   
    =================== ============== =================
    Arduino Pins        GPIO port used ADPAQ Header Pins
    =================== ============== =================
@@ -34,7 +32,6 @@ EVAL-ADPAQ3029 - UART(Arduino) demo
    Digital pin 11 (TX) UART0_RX       P2-3
    GND                 GND            P2-10
    =================== ============== =================
-   
 
 -  Apart from these connections, an led along with a 10k resistor has to be
    connected between the Digital pin 12 of Arduino and Ground.
@@ -46,7 +43,9 @@ EVAL-ADPAQ3029 - UART(Arduino) demo
 -  The tile has 2 buttons “On” and “Off” buttons. By clicking on those buttons,
    we can control the led that is connected to the pin 12 of Arduino.
 
-`image <../images/tile15.png>`_
+.. image:: ../images/tile15.png
+   :align: center
+   :width: 400
 
 |image1|
 

--- a/docs/solutions/reference-designs/eval-adpaq3029/resources/dev_board.pdf
+++ b/docs/solutions/reference-designs/eval-adpaq3029/resources/dev_board.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:566954a7c3686a6ec907fbc17507e693222e999d9338fe468563683dd971ea70
+size 204273

--- a/docs/solutions/reference-designs/eval-adpaq3029/resources/hc-sr04.zip
+++ b/docs/solutions/reference-designs/eval-adpaq3029/resources/hc-sr04.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9840798739a49f9d694366fd0fce9b4874013050ea531afe8f0ed057606132b7
+size 249771

--- a/docs/solutions/reference-designs/eval-adpaq3029/resources/ledapp.zip
+++ b/docs/solutions/reference-designs/eval-adpaq3029/resources/ledapp.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dd2478c023e623d805f818762df42e8abc34f459ce7e72186ae82b79eda1f1f1
+size 330427

--- a/docs/solutions/reference-designs/eval-adpaq3029/resources/moduware.tile.example-adc.zip
+++ b/docs/solutions/reference-designs/eval-adpaq3029/resources/moduware.tile.example-adc.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:82f6eeb84adb2c6986904de28d89fb125b0f7ed4ba6958eafdf23db9daaf8cbb
+size 15848

--- a/docs/solutions/reference-designs/eval-adpaq3029/resources/moduware.tile.example-hcsr04.zip
+++ b/docs/solutions/reference-designs/eval-adpaq3029/resources/moduware.tile.example-hcsr04.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cc4e5ec4e3186e9f4718d05c14c8f4d0f1baf204536402d16e22681f106c0815
+size 15878

--- a/docs/solutions/reference-designs/eval-adpaq3029/resources/moduware.tile.example-i2c.zip
+++ b/docs/solutions/reference-designs/eval-adpaq3029/resources/moduware.tile.example-i2c.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e22f6f3aa7b02e611ae89c13ced80c4257c06bbbd343a951f65b9412f32fb20c
+size 15878

--- a/docs/solutions/reference-designs/eval-adpaq3029/resources/moduware.tile.example-led-rgb.zip
+++ b/docs/solutions/reference-designs/eval-adpaq3029/resources/moduware.tile.example-led-rgb.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cc1d46428e7afe901f2fb427efc2acef3b000a7efef3206abf5bbbce8fc2f4e2
+size 52837

--- a/docs/solutions/reference-designs/eval-adpaq3029/resources/moduware.tile.example-servo.zip
+++ b/docs/solutions/reference-designs/eval-adpaq3029/resources/moduware.tile.example-servo.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0a820d209896291cfa1869a1ff380813499d9ba2f89ed03fd4952e60d9f8f3ae
+size 51857

--- a/docs/solutions/reference-designs/eval-adpaq3029/resources/moduware.tile.example-uart.zip
+++ b/docs/solutions/reference-designs/eval-adpaq3029/resources/moduware.tile.example-uart.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e3241f1ef5fc627c1606b5bee6f8c3198ae35c6a60a49b237137d0587789a706
+size 51757

--- a/docs/solutions/reference-designs/eval-adpaq3029/resources/servo.zip
+++ b/docs/solutions/reference-designs/eval-adpaq3029/resources/servo.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6ce5eb0dc87355ede6259e4916a49a4bb79c103ad497e404a0849f761077e3e0
+size 172393

--- a/docs/solutions/reference-designs/eval-adpaq3029/resources/sht20.zip
+++ b/docs/solutions/reference-designs/eval-adpaq3029/resources/sht20.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4d5ea56e24bbe61e9d5de209a4f8ae70808e7f1304937ead6e5071266d51325d
+size 273845

--- a/docs/solutions/reference-designs/eval-adpaq3029/resources/src.zip
+++ b/docs/solutions/reference-designs/eval-adpaq3029/resources/src.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b81f5a91d8fc6dff658f28f76c2bd93d76ff966ef19674049b71b250c144b545
+size 721177

--- a/docs/solutions/reference-designs/eval-adpaq3029/resources/uart.ino.zip
+++ b/docs/solutions/reference-designs/eval-adpaq3029/resources/uart.ino.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9d65e8d825d408cdb70f6ba675ec385fc00a7359a0bd23a0d28c86d9942d4276
+size 1260

--- a/docs/solutions/reference-designs/eval-adpaq3029/resources/uart.zip
+++ b/docs/solutions/reference-designs/eval-adpaq3029/resources/uart.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:30028741319bb6861b54bfd27261a1ed559928641857ce301abebe917195c58f
+size 297815

--- a/docs/solutions/reference-designs/eval-adpaq3029/sw_tools_setup.rst
+++ b/docs/solutions/reference-designs/eval-adpaq3029/sw_tools_setup.rst
@@ -23,9 +23,8 @@ following features and many more:
 
    **Getting CCES**
 
-   
    `CCES 2.8.0 Windows Installer(Executable) <http://download.analog.com/tools/CrossCoreEmbeddedStudio/Releases/Release_2.8.0/ADI_CrossCoreEmbeddedStudio-Rel2.8.0.exe>`_
-   
+
    `CCES 2.8.0 Ubuntu Linux Installer(Debian) <http://download.analog.com/tools/CrossCoreEmbeddedStudio/Releases/Release_2.8.0/adi-CrossCoreEmbeddedStudio-linux-x86-2.8.0.deb>`_
 
 Installing on Windows:
@@ -54,7 +53,9 @@ CrossCore Embedded Studio can be installed and used on Ubuntu 14.04+ 32-bit and
 
 -  To install CrossCore Embedded Studio, run the command:
 
-<code> $> sudo dpkg -i adi-CrossCoreEmbeddedStudio-linux-x86-2.8.0.deb </code>
+::
+
+   $> sudo dpkg -i adi-CrossCoreEmbeddedStudio-linux-x86-2.8.0.deb
 
 The Ubuntu Linux Installer(Debian) installs all necessary components to local directory ``/opt/analog/``.
 
@@ -86,43 +87,64 @@ file pre-installed. Download the device family pack from the link below.
 
    Download ``ADuCM3029 IoT Device Family pack``
 
-   
    `ADuCM3029 IoT Device Family pack(PROD) – 1.0.0 R <https://starweb.ad.analog.com/default/IoT/latest/>`_
 
--  Open CCES and click on ``Window`` -> ``Perspective`` -> ``Open Perspective`` -> ``Other``, then select ``CMSIS Pack Manger``. `image1 <images/sw3.png>`_
+-  Open CCES and click on ``Window`` -> ``Perspective`` -> ``Open Perspective`` -> ``Other``, then select ``CMSIS Pack Manger``.
 
-`image2 <images/sw4.png>`_
+.. image:: images/sw3.png
+   :align: center
+   :width: 600
+
+.. image:: images/sw4.png
+   :align: center
+   :width: 600
 
 -  Now close the Welcome Window and click on ``Check for Updates on Web``.
 
-`image <images/sw5.png>`_
+.. image:: images/sw5.png
+   :align: center
+   :width: 600
 
 -  Now select ADuCM3029 from the Devices list.
 
-`image <images/sw6.png>`_
+.. image:: images/sw6.png
+   :align: center
+   :width: 600
 
 -  In ``Packs`` -> ``Generic`` folder, install ``ARM CMSIS version 5.0.1``.
 
-`image <images/sw7.png>`_
+.. image:: images/sw7.png
+   :align: center
+   :width: 600
 
 -  Now click on ``import existing packs`` and add the BSP and Device family packs downloaded from Starweb link provided above.
 
-`image <images/sw8.png>`_
+.. image:: images/sw8.png
+   :align: center
+   :width: 600
 
 -  Ensure that you delete the default ``DFP`` -> ``Analog Devices ADuCM302x_DFP version 2.0.0``.
 
-`image <images/sw9.png>`_
+.. image:: images/sw9.png
+   :align: center
+   :width: 600
 
 The CCES is now ready for ADPAQ firmware development which is explained :doc:`here </solutions/reference-designs/eval-adpaq3029/fw_dev>`.
 
 mbed Serial port driver
 -----------------------
 
-The CrossCore Embedded Studio installer will also install the mBed windows serial driver. Check by going to ``Device manager`` -> ``Ports (COM and LPT)``, ``mbed Serial Port`` should be visible under ``Ports``. `image <images/sw15.png>`_
+The CrossCore Embedded Studio installer will also install the mBed windows serial driver. Check by going to ``Device manager`` -> ``Ports (COM and LPT)``, ``mbed Serial Port`` should be visible under ``Ports``.
+
+.. image:: images/sw15.png
+   :align: center
+   :width: 600
 
 -  If not, it can be installed separately by going to - https://developer.mbed.org/handbook/Windows-serial-configuration
 
-`image <images/sw16.png>`_
+.. image:: images/sw16.png
+   :align: center
+   :width: 600
 
 -  open device manager to check mbed serial port is visible again.
 

--- a/docs/solutions/reference-designs/eval-adpaq3029/sw_tools_setup.rst
+++ b/docs/solutions/reference-designs/eval-adpaq3029/sw_tools_setup.rst
@@ -1,0 +1,132 @@
+EVAL-ADPAQ3029 - Software tools setup
+=====================================
+
+Cross Core Embedded Studio (CCES)
+---------------------------------
+
+The CCES software development environment for EVAL-ADPAQ3029 is based on open
+source tools, and is maintained by Analog Devices. CCES includes support for DSP
+(digital signal processing) and ARM Cortex M- and A- devices, and includes the
+following features and many more:
+
+-  Eclipse based IDE
+-  GNU ARM Embedded Toolchain for Cortex-M core based parts (6-2017-q2-update)
+-  OpenOCD with support for ADuCM3029 and ADuCM4x50 microcontroller (open source SWD)
+-  CMSIS Pack files
+-  Mbed CMSIS-DAP
+-  J-Link Lite
+
+**CrossCore Embedded Studio** is based on **Eclipse**, but because the MBED platform provides a CMSIS-DAP interface to connect to the board, the EVAL-ADPAQ3029 can be used without problems with **IAR Embedded Workbench IDE** or **Keil µVision IDE** as well.
+
+.. admonition:: Download
+   :class: download
+
+   **Getting CCES**
+
+   
+   `CCES 2.8.0 Windows Installer(Executable) <http://download.analog.com/tools/CrossCoreEmbeddedStudio/Releases/Release_2.8.0/ADI_CrossCoreEmbeddedStudio-Rel2.8.0.exe>`_
+   
+   `CCES 2.8.0 Ubuntu Linux Installer(Debian) <http://download.analog.com/tools/CrossCoreEmbeddedStudio/Releases/Release_2.8.0/adi-CrossCoreEmbeddedStudio-linux-x86-2.8.0.deb>`_
+
+Installing on Windows:
+~~~~~~~~~~~~~~~~~~~~~~
+
+To install CrossCore Embedded Studio, double-click ``ADI_CrossCoreEmbeddedStudio-Rel2.8.0.exe``
+
+All the tools will be installed in local directory ``C:\Analog Devices\CrossCore Embedded Studio 2.8.0\``
+
+It is recommended to install the version 2.6.0 and above, since all the sample
+applications provided here are validated on 2.6.0 version.
+
+Installing on Linux:
+~~~~~~~~~~~~~~~~~~~~
+
+CrossCore Embedded Studio can be installed and used on Ubuntu 14.04+ 32-bit and
+64-bit.
+
+-  If you are installing on a 64-bit distribution, then you will also need to
+   install 32-bit support and compatibility libraries:
+
+::
+
+   $> sudo dpkg --add-architecture i386 && apt-get update
+   $> sudo apt-get install -y libc6:i386 libncurses5:i386 libstdc++6:i386 libgtk2.0-0:i386 libxtst6:i386 gtk2-engines-murrine:i386 libcanberra-gtk-module:i386 gtk2-engines:i386 libpng-dev:i386 libssl-dev:i386
+
+-  To install CrossCore Embedded Studio, run the command:
+
+<code> $> sudo dpkg -i adi-CrossCoreEmbeddedStudio-linux-x86-2.8.0.deb </code>
+
+The Ubuntu Linux Installer(Debian) installs all necessary components to local directory ``/opt/analog/``.
+
+Activating CCES
+~~~~~~~~~~~~~~~
+
+The first time you launch CCES, you will be prompted to input a serial number, name, and email address. A full license can be purchased from :adi:`here <en/support/customer-service-resources/sales/buy-products.html>`. To know more about acquiring, activating and managing licenses, see the manual :adi:`here <media/cn/dsp-documentation/software-manuals/cces_1-0-1_licensing_man_rev.1.1.pdf>`.
+
+The New License Wizard will guide you through the process.
+
+-  Select yes to install a license at this time.
+-  Choose “I have a serial number that I would like to activate” and click on next.
+-  Enter the serial number and click on next.
+-  Choose “Install and activate a license on-line all in one step” and click next.
+-  Complete your name and address and click on finish.
+-  On success, you will be prompted with a dialog that tells you that “Your license has been successfully activated”. Click on OK.
+-  Once the serial number has been activated, the CrossCore development tools
+   will allow you full and unlimited access to all the features of the tool when
+   using the Analog Devices family of ARM Cortex Processor.
+
+Installing CMSIS Packs
+~~~~~~~~~~~~~~~~~~~~~~
+
+CCES does not come with the Analog Device specific packs or the ARM CMSIS Pack
+file pre-installed. Download the device family pack from the link below.
+
+.. admonition:: Download
+   :class: download
+
+   Download ``ADuCM3029 IoT Device Family pack``
+
+   
+   `ADuCM3029 IoT Device Family pack(PROD) – 1.0.0 R <https://starweb.ad.analog.com/default/IoT/latest/>`_
+
+-  Open CCES and click on ``Window`` -> ``Perspective`` -> ``Open Perspective`` -> ``Other``, then select ``CMSIS Pack Manger``. `image1 <images/sw3.png>`_
+
+`image2 <images/sw4.png>`_
+
+-  Now close the Welcome Window and click on ``Check for Updates on Web``.
+
+`image <images/sw5.png>`_
+
+-  Now select ADuCM3029 from the Devices list.
+
+`image <images/sw6.png>`_
+
+-  In ``Packs`` -> ``Generic`` folder, install ``ARM CMSIS version 5.0.1``.
+
+`image <images/sw7.png>`_
+
+-  Now click on ``import existing packs`` and add the BSP and Device family packs downloaded from Starweb link provided above.
+
+`image <images/sw8.png>`_
+
+-  Ensure that you delete the default ``DFP`` -> ``Analog Devices ADuCM302x_DFP version 2.0.0``.
+
+`image <images/sw9.png>`_
+
+The CCES is now ready for ADPAQ firmware development which is explained :doc:`here </solutions/reference-designs/eval-adpaq3029/fw_dev>`.
+
+mbed Serial port driver
+-----------------------
+
+The CrossCore Embedded Studio installer will also install the mBed windows serial driver. Check by going to ``Device manager`` -> ``Ports (COM and LPT)``, ``mbed Serial Port`` should be visible under ``Ports``. `image <images/sw15.png>`_
+
+-  If not, it can be installed separately by going to - https://developer.mbed.org/handbook/Windows-serial-configuration
+
+`image <images/sw16.png>`_
+
+-  open device manager to check mbed serial port is visible again.
+
+.. important::
+
+   While installing the mbed serial driver, keep your ADPAQ Board connected to
+   the computer.

--- a/docs/solutions/reference-designs/eval-adpaq3029/tile_dev.rst
+++ b/docs/solutions/reference-designs/eval-adpaq3029/tile_dev.rst
@@ -1,0 +1,87 @@
+EVAL-ADPAQ3029 - Tile (GUI) development
+=======================================
+
+Application development for the Moduware platform consists of two primary parts:
+Firmware and Web based GUI application.
+
+Firmware
+--------
+
+The firmware for the application development can be created in CrossCore Embedded Studio as explained in the previous section. CrossCore Embedded studio works with C programming language to access the hardware of the Dev Module. Using the Dev Module files, the Module Development Kit (MDK) is able to act as a median between the hardware and Web based software. Running a continuous loop, the MDK checks for any events or interrupts and uploads the corresponding data to the API via ``np_api_upload``. After being uploaded, the data response can be pulled from the tile app.
+
+GUI Application
+---------------
+
+Moduware Modpack Tiles are created through the web based application consisting
+of:
+
+-  ``driver.json``: register commands allowing the web based tile to communicate with the hardware registers (0x2700-0x27FF). Formatting of return data (0x2800+)
+-  ``index.html``: User interface (ie: buttons, displays, etc.)
+-  ``NexpaqHeader.js``: Event based functions allowing callbacks
+-  ``Scripts.js``: Custom functions executed based on events ie: Button presses, returns from firmware package
+
+Development
+~~~~~~~~~~~
+
+Please find the example source code for Tile development in :doc:`resources </solutions/reference-designs/eval-adpaq3029/resources>` page.
+
+-  The files that make up the tile can be opened and edited in any text editor.
+-  Begin by initializing any functions declared in the MDK_REGISTER_CMD in the .json file.
+-  In the same .json file create the format for the data to be read.
+-  In the index.html file, the user interface can be created. This is where all buttons, displays, and text is programmed.
+-  Open up the scripts.js file located in the js folder.
+
+   -  Event listeners using the variables declared in index.html i.e: document.addEventListener(‘click’, function(e))
+   -  Event listeners can call other functions within scripts.js
+   -  Functions called by an event listener can remain local or make a callback
+      to the firmware to obtain data or change the state of the hardware
+
+Deployment
+~~~~~~~~~~
+
+Installing Moduware App
+^^^^^^^^^^^^^^^^^^^^^^^
+
+-  Install the basic version of the Moduware app that can be downloaded from the website https://Moduware.com/app/. The app is also available on play store.
+-  Once the application is installed, launch the application. The following GUI
+   is displayed when the application is opened.
+
+`image <images/tile2.png>`_
+
+-  Click on ``FIND MODUWARE`` option to scan the devices available near you. Select the right device (the mini-dev board) and pair it.
+
+`image <images/tile3.png>`_
+
+-  Once the connection is established between phone and the gateway, the screen
+   appears as shown in the image.
+
+`image <images/tile4.png>`_
+
+-  Since the Moduware phone backpack supports up to 6 slots to connect 6
+   different modules, the application shows 6 tiles. Since there is no firmware
+   in the module and no tile has been stored in the mobile device memory, a
+   dummy tile is displayed on the screen.
+
+.. note::
+
+   Make sure you turn on bluetooth before scanning for devices
+
+Installing Tile GUI
+^^^^^^^^^^^^^^^^^^^
+
+Once Tile development is complete and ready to test/run on smartphone:
+
+-  Now, connect the smartphone to PC using USB in File transfer mode.
+-  You should be able to see a new drive where files in Phone memory are visible.
+-  Navigate to ``Moduware`` app directory and copy the whole tile source code directory to it.
+-  If you could not find the ``Moduware`` directory, create a new one.
+-  Make sure that the tile project files are within the folder named ``Moduware.tile.example-name``, where “name” is any project name.
+-  Eject the smartphone drive and launch the moduware app again.
+-  Connect the module/gateway as explained previously.
+-  Now you should be able to see the new Tile GUI showing ``DevMod``.
+
+`image <images/tile5.png>`_
+
+.. note::
+
+   Many a times, there may be a dummy tile being dispalyed on the ``Moduware`` app as seen in the image. In this case, just disconnect the power cable from the modules and connect them back again.\ `image <images/tile6.png>`_

--- a/docs/solutions/reference-designs/eval-adpaq3029/tile_dev.rst
+++ b/docs/solutions/reference-designs/eval-adpaq3029/tile_dev.rst
@@ -46,16 +46,22 @@ Installing Moduware App
 -  Once the application is installed, launch the application. The following GUI
    is displayed when the application is opened.
 
-`image <images/tile2.png>`_
+.. image:: images/tile2.png
+   :align: center
+   :width: 400
 
 -  Click on ``FIND MODUWARE`` option to scan the devices available near you. Select the right device (the mini-dev board) and pair it.
 
-`image <images/tile3.png>`_
+.. image:: images/tile3.png
+   :align: center
+   :width: 400
 
 -  Once the connection is established between phone and the gateway, the screen
    appears as shown in the image.
 
-`image <images/tile4.png>`_
+.. image:: images/tile4.png
+   :align: center
+   :width: 400
 
 -  Since the Moduware phone backpack supports up to 6 slots to connect 6
    different modules, the application shows 6 tiles. Since there is no firmware
@@ -80,8 +86,14 @@ Once Tile development is complete and ready to test/run on smartphone:
 -  Connect the module/gateway as explained previously.
 -  Now you should be able to see the new Tile GUI showing ``DevMod``.
 
-`image <images/tile5.png>`_
+.. image:: images/tile5.png
+   :align: center
+   :width: 400
 
 .. note::
 
-   Many a times, there may be a dummy tile being dispalyed on the ``Moduware`` app as seen in the image. In this case, just disconnect the power cable from the modules and connect them back again.\ `image <images/tile6.png>`_
+   Many a times, there may be a dummy tile being dispalyed on the ``Moduware`` app as seen in the image. In this case, just disconnect the power cable from the modules and connect them back again.\
+.. image:: images/tile6.png
+   :align: center
+   :width: 400
+


### PR DESCRIPTION
## Summary
- Move eval-adpaq3029 wiki documentation to `solutions/reference-designs/eval-adpaq3029/`
- 15 RST files with 53 localized images
- Generated stub `index.rst` with toctree

## Test plan
- [ ] Sphinx build passes without errors
- [ ] All toctree entries resolve correctly
- [ ] Images render properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)