### PR TITLE
reference-designs/eval-adsd3100-nxz-gui: Add eval-adsd3100-nxz-gui documentation

### DIFF
--- a/docs/solutions/reference-designs/eval-adsd3100-nxz-gui/datacollect_cli.rst
+++ b/docs/solutions/reference-designs/eval-adsd3100-nxz-gui/datacollect_cli.rst
@@ -1,0 +1,159 @@
+Data Collect, Eval Kit 6.0.0 or later
+=====================================
+
+Description
+-----------
+
+The Data Collect CLI can collect raw data from the depth module in .bin format. This be run through the `Depth Compute CLI <https://wiki.analog.com/resources/eval/user-guides/eval-adsd3100-nxz/depthcompute_cli>`_ to convert to Depth, IR/AB(Active brightness), and XYZ frames
+
+Use *data_collect --help* to show functionality.
+
+One important change is the removal of ini files. Instead default values are
+used by the system. To change the values the following process can be used:
+
+-  Save the parameters, for example, *data_collect --ip 10.43.0.1 --scf my_params*
+-  Edit the *my_params.json* by finding the mode you want to change.
+-  Use the save parameters, for example, *data_collect --ip 10.43.0.1 --lcf my_params*
+
+Note, you can also use *my_params.json* in the GUI via *Tools->Load Configuration*.
+
+Here is an example of mode of in *my_params.json* file. <blockquote>
+
+::
+
+     "0":    {
+         "depth-compute":    {
+             "abThreshMin":  3,
+             "bitsInAB": 16,
+             "bitsInConf":   0,
+             "bitsInPhaseOrDepth":   12,
+             "confThresh":   25,
+             "depthComputeIspEnable":    1,
+             "inputFormat":  "mipiRaw12_8",
+             "interleavingEnable":   0,
+             "jblfABThreshold":  10,
+             "jblfApplyFlag":    1,
+             "jblfExponentialTerm":  5,
+             "jblfGaussianSigma":    10,
+             "jblfMaxEdge":  12,
+             "jblfWindowSize":   7,
+             "partialDepthEnable":   1,
+             "phaseInvalid": 0,
+             "radialThreshMax":  4200,
+             "radialThreshMin":  30
+         },
+         "configuration-parameters": {
+             "fps":  10,
+             "headerSize":   128,
+             "xyzEnable":    1
+         }
+     },
+
+</blockquote>
+
+Data Collect, Eval Kit 5.0.0
+============================
+
+.. important::
+
+   \ Note: Camera IP is 10.43.0.1 if you are using SDK v5.0.0 or later.
+
+.. important::
+
+   \ Note: In eval kit v5.0.0 --ft option is removed. The output of data collect
+   is a .bin file which contain Active brightness, depth, confidence and point
+   cloud. These frames can be visualized using ADIToFGUI.\
+
+Description
+-----------
+
+The Data Collect CLI can collect raw data from the depth module in .bin format. This be run through the `Depth Compute CLI <https://wiki.analog.com/resources/eval/user-guides/eval-adsd3100-nxz/depthcompute_cli>`_ to convert to Depth, IR/AB(Active brightness), and XYZ frames
+
+Flag descriptions:
+
+-  --f : output data folder
+-  --n : number of frames captured
+-  --m : mode (**Check correct mode numbers for your kit here**: `mode_table <https://wiki.analog.com/resources/eval/user-guides/eval-adtf3175d-nxz/mode_table>`_)
+-  --wt : warmup time (seconds)
+-  --ccb : stores ccb (Calibration parameters) file stored on NVM of imager module. Required for Depth Compute
+-  --ip: Camera IP
+-  --fw: Adsd3500 fw file
+-  --split: Save each frame into a separate file (DEBUG only)
+-  --netlinktest: Used to test network performance (DEBUG only)
+-  --h : Call help string for all options
+
+More information can be found in readme
+
+EVAL-ADTF3175D-NXZ Example
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Since the ADTF3175D eval kit works via ethernet over usb, the user must specify
+the static ip of the camera module
+
+-  Open Command Prompt from start menu and move to bin folder in GUI install location.
+-  **Please check the serial number of your kit to run the correct command**
+
+   -  Run the following command if your serial number is similar to this **026am53200mb0ncca4** : (lr-native, 1 frame capture, get ccb) with latest GUI release:
+
+      -  data_collect.exe --f "data_output" --m 1 --n 1 --ip 10.43.0.1
+         config_adsd3500_adsd3100.json
+
+.. image:: images/adi-tof-data_collect.png
+   :width: 800
+
+--------------
+
+Data Collect, Eval Kit 4.3.0 or earlier
+=======================================
+
+Description
+-----------
+
+The Data Collect CLI can collect raw data from the depth module in .bin format. This be run through the `Depth Compute CLI <https://wiki.analog.com/resources/eval/user-guides/eval-adsd3100-nxz/depthcompute_cli>`_ to convert to Depth, IR/AB(Active brightness), and XYZ frames
+
+Flag descriptions:
+
+-  --f : output data folder
+-  --n : number of frames captured
+-  --m : mode (**Check correct mode numbers for your kit here**: `mode_table <https://wiki.analog.com/resources/eval/user-guides/eval-adtf3175d-nxz/mode_table>`_)
+-  --wt : warmup time (seconds)
+-  --ccb : stores ccb (Calibration parameters) file stored on NVM of imager module. Required for Depth Compute
+-  --ip: Camera IP
+-  --fw: Adsd3500 fw file
+-  --ft: FrameType of saved image (raw/depth/ir/conf) [default: depth]
+-  --h : Call help string for all options
+
+More information can be found in readme
+
+EVAL-ADTF3175D-NXZ Example
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Since the ADTF3175D eval kit works via ethernet over usb, the user must specify
+the static ip of the camera module
+
+-  Open Command Prompt from start menu and move to bin folder in GUI install location.
+-  **Please check the serial number of your kit to run the correct command**
+
+   -  Run the following command if your serial number starts with **DV11** or **CR**: (lr-native (mp), 1 frame capture, get ccb):
+
+      -  data_collect.exe --f "data_output" --m 10 --n 1 --ccb ../crXXX.ccb --ip
+         10.42.0.1 tof-viewer_config.json
+
+   -  Run the following command if your serial number is similar to this **026am53200mb0ncca4** : (lr-native, 1 frame capture, get ccb) with latest GUI release:
+
+      -  data_collect.exe --f "data_output" --m 1 --n 1 --ccb ../crXXX.ccb --ip
+         10.42.0.1 --ft raw config_adsd3500_adsd3100.json
+
+.. important::
+
+   \ Note:
+
+   
+   Version: for 4.3.0, data collect's default output is depth image. To get raw
+   frame use --ft command line argument with 'RAW' option. Refer data_collect
+   --h for mode command line options. The get ccb flag is only required for the
+   first capture. Once the ccb of your module is stored, it can be reused while
+   running tofi_depth_compute.exe
+
+.. image:: images/data_collect_ip.png
+   :align: center

--- a/docs/solutions/reference-designs/eval-adsd3100-nxz-gui/datacollect_cli.rst
+++ b/docs/solutions/reference-designs/eval-adsd3100-nxz-gui/datacollect_cli.rst
@@ -2,7 +2,6 @@ Data Collect, Eval Kit 6.0.0 or later
 =====================================
 
 Description
------------
 
 The Data Collect CLI can collect raw data from the depth module in .bin format. This be run through the `Depth Compute CLI <https://wiki.analog.com/resources/eval/user-guides/eval-adsd3100-nxz/depthcompute_cli>`_ to convert to Depth, IR/AB(Active brightness), and XYZ frames
 
@@ -17,7 +16,7 @@ used by the system. To change the values the following process can be used:
 
 Note, you can also use *my_params.json* in the GUI via *Tools->Load Configuration*.
 
-Here is an example of mode of in *my_params.json* file. <blockquote>
+Here is an example of mode of in *my_params.json* file:
 
 ::
 
@@ -49,20 +48,18 @@ Here is an example of mode of in *my_params.json* file. <blockquote>
          }
      },
 
-</blockquote>
-
 Data Collect, Eval Kit 5.0.0
-============================
+-----------------------------
 
 .. important::
 
-   \ Note: Camera IP is 10.43.0.1 if you are using SDK v5.0.0 or later.
+   Camera IP is 10.43.0.1 if you are using SDK v5.0.0 or later.
 
 .. important::
 
-   \ Note: In eval kit v5.0.0 --ft option is removed. The output of data collect
+   In eval kit v5.0.0 --ft option is removed. The output of data collect
    is a .bin file which contain Active brightness, depth, confidence and point
-   cloud. These frames can be visualized using ADIToFGUI.\
+   cloud. These frames can be visualized using ADIToFGUI.
 
 Description
 -----------
@@ -101,13 +98,9 @@ the static ip of the camera module
 .. image:: images/adi-tof-data_collect.png
    :width: 800
 
---------------
-
 Data Collect, Eval Kit 4.3.0 or earlier
-=======================================
 
 Description
------------
 
 The Data Collect CLI can collect raw data from the depth module in .bin format. This be run through the `Depth Compute CLI <https://wiki.analog.com/resources/eval/user-guides/eval-adsd3100-nxz/depthcompute_cli>`_ to convert to Depth, IR/AB(Active brightness), and XYZ frames
 
@@ -146,9 +139,6 @@ the static ip of the camera module
 
 .. important::
 
-   \ Note:
-
-   
    Version: for 4.3.0, data collect's default output is depth image. To get raw
    frame use --ft command line argument with 'RAW' option. Refer data_collect
    --h for mode command line options. The get ccb flag is only required for the

--- a/docs/solutions/reference-designs/eval-adsd3100-nxz-gui/eval-adsd3100-nxz-gui.rst
+++ b/docs/solutions/reference-designs/eval-adsd3100-nxz-gui/eval-adsd3100-nxz-gui.rst
@@ -1,0 +1,221 @@
+ADIToFGUI Eval Kit 5.0.0 or later
+=================================
+
+With Eval Kit software 5.0.0 there have been some major updates to ADIToFGUI,
+starting with the UX.
+
+Usage
+-----
+
+Connecting
+~~~~~~~~~~
+
+1. Open ADIToFGUI located in the installation "bin" folder.
+
+.. image:: images/adi-tof-nvidia-aditofgui-1.png
+   :width: 600
+
+2. Select "config_adsd3500_adsd3100.json" -> Open
+
+.. image:: images/adi-tof-nvidia-aditofgui-2.png
+   :width: 600
+
+3. Select the desired mode -> Play
+
+.. image:: images/adi-tof-nvidia-aditofgui-3.png
+   :width: 600
+
+4. Streaming frames
+
+.. image:: images/adi-tof-nvidia-aditofgui-4.png
+   :width: 600
+
+New Features
+------------
+
+Adjusting the Ini Parameters
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+It is now possible to adjust some of the configuration parameters during use.
+These parameters are generally stored in ini/JSON files are a per mode basis.
+The ADSD3500 and depth compute libraries receive the changed parameter values.
+
+The **Ini Parameter** window can be selected at any point. Select **Ini Params** in the **Tools** menu.. To do so follow the image below.
+
+.. image:: images/adi-tof-aditofgui-ini-1.png
+   :width: 300
+
+Once opened the **Ini Parameter** window can be use to adjust the parameter.
+
+.. image:: images/adi-tof-aditofgui-ini-2.png
+   :width: 600
+
+**Modify** is needed to write the parameters to the device. Please note, the stream is stopped, the ADSD3500 and depth compute library updated, then the stream is restarted.
+
+**Reset** is used to set the values in the ADSD3500 and depth compute library back to those from the original ini file.
+
+**Save** saves the parameters listed in the window to the a file.
+
+Trouble Shooting
+----------------
+
+Slow Point Cloud Rendering
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If rendering of the point cloud is slow, it may be necessary to ensure the GPU
+is rendering and not the CPU. With an NVIDIA GPU you can do the following.
+
+1. NVIDIA Control Panel -> Manage 3D Settings -> Program Settings -> Add
+
+.. image:: images/adi-tof-nvidia-control_panel_1.png
+   :width: 600
+
+2. Browse
+
+.. image:: images/adi-tof-nvidia-control_panel_2.png
+   :width: 600
+
+3. Select the folder "C:\\Analog
+   Devices\\TOF_Evaluation_ADTF3175D-Rel5.0.0\\bin" -> ADIToFGUI.exe -> Open
+
+.. image:: images/adi-tof-nvidia-control_panel_3.png
+   :width: 600
+
+4. For the select program "ADIToFGUI" -> Select "High-performance NVIDIA
+   processor" -> Apply
+
+.. image:: images/adi-tof-nvidia-control_panel_4.png
+   :width: 600
+
+ADIToFGUI Eval Kit 4.3.0 or earlier
+===================================
+
+This is a guide for the ToF module viewer. This page applies to the viewer for
+the following modules:
+
+-  `eval-adsd3100-nxz <https://wiki.analog.com/resources/eval/user-guides/eval-adsd3100-nxz>`_
+-  `eval-adtf3175-nxz <https://wiki.analog.com/resources/eval/user-guides/eval-adtf3175-nxz>`_
+-  `eval-adtf3175d-nxz <https://wiki.analog.com/resources/eval/user-guides/eval-adtf3175d-nxz>`_
+
+Start
+-----
+
+-  Find the ADIToFGUI.exe in the 'viewer' or 'bin' folder located at the install
+   location
+
+   -  v2.x.x
+
+      -  Default location : C:\\Analog
+         Devices\\TOF_Evaluation_BM-RelX.X.X\\viewer\\
+
+   -  v3.x.x
+
+      -  Default location : C:\\Analog
+         Devices\\TOF_Evaluation_BM-RelX.X.X\\bin\\
+
+-  If you are evaluating the **EVAL-ADTF3175D-NXZ**:
+
+   -  Confirm that an unidentified local network has been discovered by the pc - IP address = 10.42.0.1
+   -  Run TOF_Evaluation_BM-Relx.x.x
+   -  Hit refresh until a Device is found
+   -  **Select .json file based on your kits serial number** - Software Release version 4.2.0+
+
+      -  If your serial number starts with 'DV11' or 'CR' select **tof-viewer_config.json**
+      -  If your serial number starts with 'am' select **tof_crosby_adsd3500_new_modes_config.json**
+
+-  If you are evaluating the following modules : **EVAL-ADTF3175-NXZ** or **EVAL-ADSD3100-NXZ** (only supported with software release 2.1.1)
+
+   -  Start the viewer to get to the window below
+
+      -  If a camera is connected it should show up in the 'Device' drop down menu
+      -  Select your device
+      -  Select correct config file (depends on which module you are using)
+
+         -  `EVAL-ADTF3175-NXZ <https://wiki.analog.com/resources/eval/user-guides/eval-adtf3175-nxz>`_ : **tof-viewer-config-adtf3175.json**
+         -  `EVAL-ADSD3100-NXZ <https://wiki.analog.com/resources/eval/user-guides/eval-adsd3100-nxz>`_ : **tof-viewer-config-adsd3100.json**
+
+      -  Click 'Open Device'
+
+.. image:: images/selecting_config.png
+   :align: center
+
+Run Camera
+----------
+
+-  Once the device has been initialized the 'ToF Camera Options' menu should be available
+-  Available modes will depend on the module serial number : `mode_table <https://wiki.analog.com/resources/eval/user-guides/eval-adtf3175d-nxz/mode_table>`_
+-  Select preferred view option (described below) and click play to run camera
+
+.. image:: images/gui_initialization_screen.png
+
+.. important::
+
+   If the user disconnects the camera via USB-C cable while the GUI has
+   initialized the camera. The user must restart the GUI
+
+Active Brightness and Depth
+---------------------------
+
+-  If this option is selected, the first window will show active brightness/intensity, while the second window will show depth
+-  Depth is shown in mm, the user can hover over the image to see real-time
+   depth data
+
+.. image:: images/ab_and_depth.png
+   :align: center
+
+Mode Switching
+--------------
+
+-  If the user wants to switch modes while the camera is running frames:
+
+   -  Click 'Stop'
+   -  Select mode in drop down menu
+   -  Click 'Play'
+
+Point Cloud and Depth
+---------------------
+
+-  If camera is already running 'Active Brightness and Depth' viewer:
+
+   -  Click 'Stop'
+   -  Select 'Point Cloud and Depth'
+   -  Click 'Play'
+
+-  If this option is selected, the first window will show a point-cloud generated from the depth on the second window.
+-  Point Cloud Controls:
+
+   -  Zoom In/Out
+
+      -  Use the mouse wheel and scroll forward to zoom in, scroll backwards to
+         zoom out.
+
+   -  Grab image and move it in all directions
+
+      -  Hover over the Point Cloud Image and and drag the mouse while the right
+         mouse button is pressed. Move slowly
+
+   -  Rotate image
+
+      -  Drage the mouse while pressing the left mouse button
+
+   -  Increase / Decrease Point Cloud point size
+
+      -  Grab the slider at the bottom of the Point Cloud window and move it
+         left or right to decrease or increase the point size.
+
+   -  Reset View
+
+      -  Press the “Reset View” button to restore to default image size and
+         position
+
+.. image:: images/adtf3175_depth_pc.png
+
+Recording
+---------
+
+-  Recording via the GUI is deprecated, please use :doc:`data_collect </solutions/reference-designs/eval-adsd3100-nxz-gui/datacollect_cli>` for recording data during evaluation.
+
+Troubleshooting
+---------------
+
+-  Visit `Troubleshooting Guide <https://wiki.analog.com/resources/eval/user-guides/aditofgui_ts>`_

--- a/docs/solutions/reference-designs/eval-adsd3100-nxz-gui/eval-adsd3100-nxz-gui.rst
+++ b/docs/solutions/reference-designs/eval-adsd3100-nxz-gui/eval-adsd3100-nxz-gui.rst
@@ -88,7 +88,7 @@ is rendering and not the CPU. With an NVIDIA GPU you can do the following.
    :width: 600
 
 ADIToFGUI Eval Kit 4.3.0 or earlier
-===================================
+------------------------------------
 
 This is a guide for the ToF module viewer. This page applies to the viewer for
 the following modules:

--- a/docs/solutions/reference-designs/eval-adsd3100-nxz-gui/images/ab_and_depth.png
+++ b/docs/solutions/reference-designs/eval-adsd3100-nxz-gui/images/ab_and_depth.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e88e8781d5aa85e851b742bba0675e5d255c111d8fc745a9c7045ef6fca7964e
+size 1976953

--- a/docs/solutions/reference-designs/eval-adsd3100-nxz-gui/images/adi-tof-aditofgui-ini-1.png
+++ b/docs/solutions/reference-designs/eval-adsd3100-nxz-gui/images/adi-tof-aditofgui-ini-1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7faed1cabba8159e2af7ef3cc0616a63d5e763db0dc955b6aeb0699bb93a6699
+size 6742

--- a/docs/solutions/reference-designs/eval-adsd3100-nxz-gui/images/adi-tof-aditofgui-ini-2.png
+++ b/docs/solutions/reference-designs/eval-adsd3100-nxz-gui/images/adi-tof-aditofgui-ini-2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7f9a7f97bae39105a44f9b953ae59aca9a20671a8ddc90bd7e0da429ad391aa7
+size 172282

--- a/docs/solutions/reference-designs/eval-adsd3100-nxz-gui/images/adi-tof-data_collect.png
+++ b/docs/solutions/reference-designs/eval-adsd3100-nxz-gui/images/adi-tof-data_collect.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e2830b26b966cfbcc786bf5e3c1b23b19362947eafdce40ad1f4eb7b6176736e
+size 386912

--- a/docs/solutions/reference-designs/eval-adsd3100-nxz-gui/images/adi-tof-nvidia-aditofgui-1.png
+++ b/docs/solutions/reference-designs/eval-adsd3100-nxz-gui/images/adi-tof-nvidia-aditofgui-1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2f164e4b2828986343761638fd22000bb3c13dd2369645f90a8480a4d06c6254
+size 27439

--- a/docs/solutions/reference-designs/eval-adsd3100-nxz-gui/images/adi-tof-nvidia-aditofgui-2.png
+++ b/docs/solutions/reference-designs/eval-adsd3100-nxz-gui/images/adi-tof-nvidia-aditofgui-2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d9158e700052605f71e60e115a7a6e8a006776c51919f8beb50022bf586ea905
+size 4957

--- a/docs/solutions/reference-designs/eval-adsd3100-nxz-gui/images/adi-tof-nvidia-aditofgui-3.png
+++ b/docs/solutions/reference-designs/eval-adsd3100-nxz-gui/images/adi-tof-nvidia-aditofgui-3.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ff40c9cf0485bcef56a1d94250bbb07f1b4bbf81a55a4dfda0f78dbd77c45cc9
+size 7083

--- a/docs/solutions/reference-designs/eval-adsd3100-nxz-gui/images/adi-tof-nvidia-aditofgui-4.png
+++ b/docs/solutions/reference-designs/eval-adsd3100-nxz-gui/images/adi-tof-nvidia-aditofgui-4.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7c959ee0fa267b2036e1bb49f58126815a2bad966cd9f4a3d41784d972dd8d23
+size 361514

--- a/docs/solutions/reference-designs/eval-adsd3100-nxz-gui/images/adi-tof-nvidia-control_panel_1.png
+++ b/docs/solutions/reference-designs/eval-adsd3100-nxz-gui/images/adi-tof-nvidia-control_panel_1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7988ef55daa485d982ef4cdc18a91aa4f83ee7e80570149660a51499675c9512
+size 75484

--- a/docs/solutions/reference-designs/eval-adsd3100-nxz-gui/images/adi-tof-nvidia-control_panel_2.png
+++ b/docs/solutions/reference-designs/eval-adsd3100-nxz-gui/images/adi-tof-nvidia-control_panel_2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e54f8a988137df5c52c1894f5e25d67bba70cf8f5c645d75bd68574746753b3d
+size 35684

--- a/docs/solutions/reference-designs/eval-adsd3100-nxz-gui/images/adi-tof-nvidia-control_panel_3.png
+++ b/docs/solutions/reference-designs/eval-adsd3100-nxz-gui/images/adi-tof-nvidia-control_panel_3.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:750c603579ec0bed55486899f7af238f4b029a9f05a0598ecf029fbd2a789473
+size 27303

--- a/docs/solutions/reference-designs/eval-adsd3100-nxz-gui/images/adi-tof-nvidia-control_panel_4.png
+++ b/docs/solutions/reference-designs/eval-adsd3100-nxz-gui/images/adi-tof-nvidia-control_panel_4.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f4a29d7e8a459bd6758994b04c95962b49ec8a417afb52cdad0b4dfaf5034e12
+size 83417

--- a/docs/solutions/reference-designs/eval-adsd3100-nxz-gui/images/adtf3175_depth_pc.png
+++ b/docs/solutions/reference-designs/eval-adsd3100-nxz-gui/images/adtf3175_depth_pc.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1dab2b116584dd3ffd9acc09df19631a9af7f94d96ac8b07b657415c43ba618e
+size 415551

--- a/docs/solutions/reference-designs/eval-adsd3100-nxz-gui/images/data_collect_ip.png
+++ b/docs/solutions/reference-designs/eval-adsd3100-nxz-gui/images/data_collect_ip.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d1fdebafa9c37be284a92dc288c215ac331dd0c83862de445dfd5dc51bce1faa
+size 91961

--- a/docs/solutions/reference-designs/eval-adsd3100-nxz-gui/images/gui_initialization_screen.png
+++ b/docs/solutions/reference-designs/eval-adsd3100-nxz-gui/images/gui_initialization_screen.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:23d8e10e1a44a992fefe63bab2033e23f1a4a04c9519456f13770c08e5beb5e5
+size 44201

--- a/docs/solutions/reference-designs/eval-adsd3100-nxz-gui/images/selecting_config.png
+++ b/docs/solutions/reference-designs/eval-adsd3100-nxz-gui/images/selecting_config.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3dddf9f01881fe5bb3f84152f8f9446801f10e11c85cc73debf92e434268666a
+size 28364

--- a/docs/solutions/reference-designs/eval-adsd3100-nxz-gui/index.rst
+++ b/docs/solutions/reference-designs/eval-adsd3100-nxz-gui/index.rst
@@ -1,0 +1,8 @@
+ADIToFGUI Eval Kit 5.0.0 or later
+=================================
+
+.. toctree::
+   :titlesonly:
+
+   eval-adsd3100-nxz-gui
+   datacollect_cli

--- a/docs/solutions/reference-designs/eval-adsd3100-nxz-gui/index.rst
+++ b/docs/solutions/reference-designs/eval-adsd3100-nxz-gui/index.rst
@@ -1,8 +1,46 @@
-ADIToFGUI Eval Kit 5.0.0 or later
-=================================
+.. _eval_adsd3100_nxz_gui eval:
+
+EVAL ADSD3100 NXZ GUI
+===============================================================================================================================
+
+.. TODO: Add a picture of the chip/board
+
+Overview
+-------------------------------------------------------------------------------
+
+.. TODO: Describe in max 10 rows the main features and applications.
+
+Features:
+
+- feature 1
+- feature 2
+
+Applications:
+
+- application 1
+- application 2
 
 .. toctree::
-   :titlesonly:
+   :hidden:
 
    eval-adsd3100-nxz-gui
    datacollect_cli
+
+Recommendations
+-------------------------------------------------------------------------------
+
+People who follow the flow that is outlined, have a much better experience with
+things. However, like many things, documentation is never as complete as it
+should be. If you have any questions, feel free to ask on our
+:ref:`EngineerZone forums <help-and-support>`, but before that, please make
+sure you read our documentation thoroughly.
+
+Warning
+-------------------------------------------------------------------------------
+
+.. esd-warning::
+
+Help and support
+-------------------------------------------------------------------------------
+
+Please go to :ref:`Help and Support <help-and-support>` page.


### PR DESCRIPTION
## Summary
- Move eval-adsd3100-nxz-gui wiki documentation to `solutions/reference-designs/eval-adsd3100-nxz-gui/`
- 3 RST files with 16 localized images
- Generated stub `index.rst` with toctree

## Test plan
- [ ] Sphinx build passes without errors
- [ ] All toctree entries resolve correctly
- [ ] Images render properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)