### PR TITLE
reference-designs/eval_aducm355emcz: Add eval_aducm355emcz documentation

### DIFF
--- a/docs/solutions/reference-designs/eval_aducm355emcz/example_radiated_immunity_demo.rst
+++ b/docs/solutions/reference-designs/eval_aducm355emcz/example_radiated_immunity_demo.rst
@@ -4,21 +4,23 @@ Where to find the example Code used in CN-0425
 After you have installed the evaluation software, the example firmware project
 used in CN-0425 is in the folder \\examples\\M355_RadiatedImmunity_Demo.
 
-|image1|
+.. image:: images/example_pathw.jpg
+   :width: 600
 
-Build, download and debug the example project to IAR via the Midas-Link:
+Build, download and debug the example project to IAR via the Midas-Link
 ------------------------------------------------------------------------
 
-|image2|.png?600\|}}
+.. image:: images/iar_debug1.png
+   :width: 600
 
 What the M355_RadiatedImmunity_Demo project code does
-=====================================================
+------------------------------------------------------
 
 The Project assumes a 3-lead EC sensor is connected to channel 0 of the LP
 Potentiostat loop - 0V bias between RE/WE with 1.1V common mode voltage.
 
-The code has 2x modes of operation:
------------------------------------
+The code has 2x modes of operation
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 ::
 
@@ -45,16 +47,10 @@ The code has 2x modes of operation:
                 Wait several seconds for the results to be transmitted - allowance for sensor to settle first
 
 Mode 1 - output to UART debug terminal
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 In mode 1, debug text is sent periodically to the UART. When viewed in a
 terminal window like Realterm, it looks like this:
 
-|image3|
-
-.. |image1| image:: images/example_pathw.jpg
-   :width: 600
-.. |image2| image:: images/iar_debug1.png
-   :width: 600
-.. |image3| image:: images/capturemode.png
+.. image:: images/capturemode.png
    :width: 600

--- a/docs/solutions/reference-designs/eval_aducm355emcz/example_radiated_immunity_demo.rst
+++ b/docs/solutions/reference-designs/eval_aducm355emcz/example_radiated_immunity_demo.rst
@@ -1,0 +1,60 @@
+Where to find the example Code used in CN-0425
+==============================================
+
+After you have installed the evaluation software, the example firmware project
+used in CN-0425 is in the folder \\examples\\M355_RadiatedImmunity_Demo.
+
+|image1|
+
+Build, download and debug the example project to IAR via the Midas-Link:
+------------------------------------------------------------------------
+
+|image2|.png?600\|}}
+
+What the M355_RadiatedImmunity_Demo project code does
+=====================================================
+
+The Project assumes a 3-lead EC sensor is connected to channel 0 of the LP
+Potentiostat loop - 0V bias between RE/WE with 1.1V common mode voltage.
+
+The code has 2x modes of operation:
+-----------------------------------
+
+::
+
+    Mode 1 (P1.3=1 JP1 2-3) - Sensor Measurements and log to flash
+        First code will initialize the LPDAC, LP potentiostat/LPTIA amplifiers and associated sensors to bias the sensor.
+        Next, it will calibrate the ADC offset error and calibrate the LPTIA0 channel gain error.
+        Then it will enter normal EC sensor measurement mode
+        Once a second, ADC samples EC channel 0 - 10 samples taken @ 160KSPS, results averaged and sent to Flash page
+           For debug purposes, results sent to the UART also
+           UART Baud rate is 57600-N-8
+           Maximum number of logs is 30720 (roughly 8x Hours)
+           AFE Timer 0 used with a 1 second timeout to trigger samples and UART comms.
+           A debug string is sent to the UART reporting the measured voltage (V), the calculated current (uA ) and ppm of gas (80nA/ppm assumed)
+
+::
+
+        ADC results are accumulated in 2x SRAM arrays. When either Array is full, it is moved into flash.
+
+::
+
+      Mode 2 (P1.3=0 JP1 2-1) - Read log from flash to UART
+                Will read from flash location 0x10000 until 0xFFFF detected
+                Values stored to flash are the averaged ADC codes
+                Wait several seconds for the results to be transmitted - allowance for sensor to settle first
+
+Mode 1 - output to UART debug terminal
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+In mode 1, debug text is sent periodically to the UART. When viewed in a
+terminal window like Realterm, it looks like this:
+
+|image3|
+
+.. |image1| image:: images/example_pathw.jpg
+   :width: 600
+.. |image2| image:: images/iar_debug1.png
+   :width: 600
+.. |image3| image:: images/capturemode.png
+   :width: 600

--- a/docs/solutions/reference-designs/eval_aducm355emcz/hardware_details.rst
+++ b/docs/solutions/reference-designs/eval_aducm355emcz/hardware_details.rst
@@ -1,0 +1,24 @@
+Hardware Setup
+==============
+
+HOW TO POWER THE BOARD
+----------------------
+
+P2 pin 1 should be connected to 3V. P2 pin 4 is Ground. There is LDO or power
+regulator on the board. It is not possible to power the board from the 8-pin
+connector, P1.
+
+.. image:: images/powersetuplayout.png
+   :width: 400
+
+HOW TO Program the Board
+------------------------
+
+To program the board, the MIDAS-LINK (or JLINK) is plugged into the
+EVAL-ADuCM355EMCZ via the USB-SWD/UART adapter as shown below. Note, both the
+MIDAS-LINK and USB-SWD/UART needs separate USB connections to your PC.
+
+|image1|
+
+.. |image1| image:: images/power_debug_programmingsetup.jpg
+   :width: 600

--- a/docs/solutions/reference-designs/eval_aducm355emcz/hardware_details.rst
+++ b/docs/solutions/reference-designs/eval_aducm355emcz/hardware_details.rst
@@ -1,7 +1,7 @@
 Hardware Setup
 ==============
 
-HOW TO POWER THE BOARD
+How to Power the Board
 ----------------------
 
 P2 pin 1 should be connected to 3V. P2 pin 4 is Ground. There is LDO or power
@@ -11,14 +11,12 @@ connector, P1.
 .. image:: images/powersetuplayout.png
    :width: 400
 
-HOW TO Program the Board
+How to Program the Board
 ------------------------
 
 To program the board, the MIDAS-LINK (or JLINK) is plugged into the
 EVAL-ADuCM355EMCZ via the USB-SWD/UART adapter as shown below. Note, both the
 MIDAS-LINK and USB-SWD/UART needs separate USB connections to your PC.
 
-|image1|
-
-.. |image1| image:: images/power_debug_programmingsetup.jpg
+.. image:: images/power_debug_programmingsetup.jpg
    :width: 600

--- a/docs/solutions/reference-designs/eval_aducm355emcz/help_and_support.rst
+++ b/docs/solutions/reference-designs/eval_aducm355emcz/help_and_support.rst
@@ -1,0 +1,48 @@
+Help and Support
+================
+
+Do you need help or have general support questions? This page will help you
+resolve these.
+
+This page has a quickstart troubleshooting approach that presents some general
+questions and common pitfalls, but if you have a specific issue which requires
+more information or detail please contact us through EngineerZone or Email.
+(links can be found further down on the page where to direct specific questions)
+
+What to do When Things Go Wrong
+-------------------------------
+
+There are many things that can go wrong, but if you are having issues getting
+the board or software working, here are a few simple things you can try before
+contacting Analog Devices.
+
+-  Check the Power on EVAL-ADuCM355
+
+   -  Check the voltage between P2 connector Pins 1(3.3V) and 4(GND)
+   -  Close the jumper P5 light the power LED DS1.
+
+-  Program the ADuCM355
+
+   -  Program an example project to the ADuCM355 using the programming tools
+      provided.
+
+Hardware, Software, and Documentation Questions
+-----------------------------------------------
+
+If you have any questions regarding the ADuCM355 or issues following any of the **documentation** feel free to ask us a question.
+
+-  :ez:`community/analog-microcontrollers/aducm355` for questions about:
+
+When asking a question please take the time to give a detailed description of
+your problem. If you are experiencing a problem please state the steps you have
+executed, the result you expected you would get and the result you actually got.
+By doing so you enable us to provide you precise and detailed answers in a
+timely manner.
+
+.. tip::
+
+   Before asking questions please take the time to check if somebody else
+   already asked the same question. You might just find your question already
+   answered.
+
+*End of Document*

--- a/docs/solutions/reference-designs/eval_aducm355emcz/help_and_support.rst
+++ b/docs/solutions/reference-designs/eval_aducm355emcz/help_and_support.rst
@@ -45,4 +45,3 @@ timely manner.
    already asked the same question. You might just find your question already
    answered.
 
-*End of Document*

--- a/docs/solutions/reference-designs/eval_aducm355emcz/images/capturemode.png
+++ b/docs/solutions/reference-designs/eval_aducm355emcz/images/capturemode.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:542deec186dc4b73b8a40a614dc7e72425258b009d667468d288042f775a3aa5
+size 25448

--- a/docs/solutions/reference-designs/eval_aducm355emcz/images/example_pathw.jpg
+++ b/docs/solutions/reference-designs/eval_aducm355emcz/images/example_pathw.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e332fc41a6582341968fd8e02b268605ca02d8f83906f838e8c96ff50af48d74
+size 56430

--- a/docs/solutions/reference-designs/eval_aducm355emcz/images/iar_debug1.png
+++ b/docs/solutions/reference-designs/eval_aducm355emcz/images/iar_debug1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9d1e90287ca7f1b710fc57699c55d6eaa9c18f45c1913bd699a77be1be5e8940
+size 78273

--- a/docs/solutions/reference-designs/eval_aducm355emcz/images/power_debug_programmingsetup.jpg
+++ b/docs/solutions/reference-designs/eval_aducm355emcz/images/power_debug_programmingsetup.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:06335c1991ee21b46f72e802e2e43ea6628dea5fc2de4a7f1ba8a10c70b446a9
+size 361055

--- a/docs/solutions/reference-designs/eval_aducm355emcz/images/powersetuplayout.png
+++ b/docs/solutions/reference-designs/eval_aducm355emcz/images/powersetuplayout.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:19d83412def0bbdc7ec8c004e7517224ddfecdd632e145bf9ab495945c85f6e5
+size 118985

--- a/docs/solutions/reference-designs/eval_aducm355emcz/index.rst
+++ b/docs/solutions/reference-designs/eval_aducm355emcz/index.rst
@@ -1,11 +1,49 @@
-EVAL-ADUCM355EMCZ
-=================
+.. _eval_aducm355emcz eval:
+
+EVAL ADUCM355EMCZ
+=======================================================================================================
+
+.. TODO: Add a picture of the chip/board
+
+Overview
+-------------------------------------------------------------------------------
+
+.. TODO: Describe in max 10 rows the main features and applications.
+
+Features:
+
+- feature 1
+- feature 2
+
+Applications:
+
+- application 1
+- application 2
 
 .. toctree::
-   :titlesonly:
+   :hidden:
 
    example_radiated_immunity_demo
    hardware_details
    help_and_support
    introduction
    tools
+
+Recommendations
+-------------------------------------------------------------------------------
+
+People who follow the flow that is outlined, have a much better experience with
+things. However, like many things, documentation is never as complete as it
+should be. If you have any questions, feel free to ask on our
+:ref:`EngineerZone forums <help-and-support>`, but before that, please make
+sure you read our documentation thoroughly.
+
+Warning
+-------------------------------------------------------------------------------
+
+.. esd-warning::
+
+Help and support
+-------------------------------------------------------------------------------
+
+Please go to :ref:`Help and Support <help-and-support>` page.

--- a/docs/solutions/reference-designs/eval_aducm355emcz/index.rst
+++ b/docs/solutions/reference-designs/eval_aducm355emcz/index.rst
@@ -1,0 +1,11 @@
+EVAL-ADUCM355EMCZ
+=================
+
+.. toctree::
+   :titlesonly:
+
+   example_radiated_immunity_demo
+   hardware_details
+   help_and_support
+   introduction
+   tools

--- a/docs/solutions/reference-designs/eval_aducm355emcz/introduction.rst
+++ b/docs/solutions/reference-designs/eval_aducm355emcz/introduction.rst
@@ -1,0 +1,27 @@
+Introduction
+============
+
+| The :adi:`EVAL-ADuCM355EMCZ` evaluation kit is designed for customers to evaluate the radiated immunity performance of the ADuCM355 with an external Sensor. It accompanies the circuit note, CN-0425. It may also be used to evaluate other functions of the ADuCM355 including Impedance Spectroscopy, Voltammetry, Chronoamperometric and Amperometric operations
+| This guide is structured as follows:
+
+-  :doc:`Tools and Driver Details </solutions/reference-designs/eval_aducm355emcz/tools>` - Provides all the necessary steps to download/install/use the ADuCM355 evaluation tools using IAR Embedded Workbench.
+-  Includes:
+
+   -   Tools
+   -  Drivers
+   -  Evaluation Software Link
+
+-  :doc:`hardware_details </solutions/reference-designs/eval_aducm355emcz/hardware_details>` - Shows how to power and setup the hardware.
+
+   -   How to Power the Board
+   -  How to Program the board
+
+-  :doc:`example_radiated_immunity_demo </solutions/reference-designs/eval_aducm355emcz/example_radiated_immunity_demo>` - Example code used to test radiated immunity Performance.
+-  :doc:`Help and Support </solutions/reference-designs/eval_aducm355emcz/help_and_support>` - Provides info on where to get support on any questions you might have regarding the hardware, software, and tools
+
+Registration
+------------
+
+.. tip::
+
+   Receive software update notifications, documentation updates, view the latest videos, and more when you register your hardware. `Register <https://form.analog.com/Form_Pages/FeedBack/EVAL-ADUCM355EMCZ?&v=RevE>`_ to receive all these great benefits and more!

--- a/docs/solutions/reference-designs/eval_aducm355emcz/introduction.rst
+++ b/docs/solutions/reference-designs/eval_aducm355emcz/introduction.rst
@@ -1,8 +1,8 @@
 Introduction
 ============
 
-| The :adi:`EVAL-ADuCM355EMCZ` evaluation kit is designed for customers to evaluate the radiated immunity performance of the ADuCM355 with an external Sensor. It accompanies the circuit note, CN-0425. It may also be used to evaluate other functions of the ADuCM355 including Impedance Spectroscopy, Voltammetry, Chronoamperometric and Amperometric operations
-| This guide is structured as follows:
+The :adi:`EVAL-ADuCM355EMCZ` evaluation kit is designed for customers to evaluate the radiated immunity performance of the ADuCM355 with an external Sensor. It accompanies the circuit note, CN-0425. It may also be used to evaluate other functions of the ADuCM355 including Impedance Spectroscopy, Voltammetry, Chronoamperometric and Amperometric operations.
+This guide is structured as follows:
 
 -  :doc:`Tools and Driver Details </solutions/reference-designs/eval_aducm355emcz/tools>` - Provides all the necessary steps to download/install/use the ADuCM355 evaluation tools using IAR Embedded Workbench.
 -  Includes:

--- a/docs/solutions/reference-designs/eval_aducm355emcz/tools.rst
+++ b/docs/solutions/reference-designs/eval_aducm355emcz/tools.rst
@@ -1,0 +1,31 @@
+Tools
+=====
+
+IAR's Embedded Workbench toolset was used for developing the embedded firmware
+for this demo. The ADuCM355 evaluation firmware has been tested using versions
+7.4 and 8.32.1 of Embedded Workbench for Arm. An evaluation version of the
+Embedded Workbench can be found on the IAR website, www.iar.com If not already
+installed, users should first download and install IAR's Embedded Workbench IDE
+for ARM cores.
+
+Drivers
+=======
+
+The MIDAS-LINK programming pod requires a USB driver to allow it interface to
+your PC. This is installed automatically with the evaluation software provided
+with the ADuCM355 Evaluation kits - both the EVAL-ADuCM355EMCZ and the
+EVAL-ADuCM355QSPZ.
+
+Also a USB driver is required for the programming adapter board provided with
+the EVAL-ADuCM355EMCZ. This board is labeled the USB-SWD/UART. This is installed
+automatically with the evaluation software provided with the ADuCM355 Evaluation
+kits - both the EVAL-ADuCM355EMCZ and the EVAL-ADuCM355QSPZ.
+
+Evaluation Software link
+========================
+
+The ADuCM355 evaluation software can be downloaded and installed from this FTP
+site:
+
+-  FTP Location: ftp://ftp.analog.com/pub/MicroConverter/ADuCM355
+-  Filename: ADuCM355InstallerVx.x.x.zip

--- a/docs/solutions/reference-designs/eval_aducm355emcz/tools.rst
+++ b/docs/solutions/reference-designs/eval_aducm355emcz/tools.rst
@@ -9,7 +9,7 @@ installed, users should first download and install IAR's Embedded Workbench IDE
 for ARM cores.
 
 Drivers
-=======
+-------
 
 The MIDAS-LINK programming pod requires a USB driver to allow it interface to
 your PC. This is installed automatically with the evaluation software provided
@@ -22,7 +22,7 @@ automatically with the evaluation software provided with the ADuCM355 Evaluation
 kits - both the EVAL-ADuCM355EMCZ and the EVAL-ADuCM355QSPZ.
 
 Evaluation Software link
-========================
+------------------------
 
 The ADuCM355 evaluation software can be downloaded and installed from this FTP
 site:


### PR DESCRIPTION
## Summary
- Move eval_aducm355emcz wiki documentation to `solutions/reference-designs/eval_aducm355emcz/`
- 6 RST files with 5 localized images
- Generated stub `index.rst` with toctree

## Test plan
- [ ] Sphinx build passes without errors
- [ ] All toctree entries resolve correctly
- [ ] Images render properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)