### PR TITLE
reference-designs/eval-aducm360-user-guide: Add eval-aducm360-user-guide documentation

### DIFF
--- a/docs/solutions/reference-designs/eval-aducm360-user-guide/eval-aducm360-user-guide.rst
+++ b/docs/solutions/reference-designs/eval-aducm360-user-guide/eval-aducm360-user-guide.rst
@@ -1,0 +1,514 @@
+User Guide for EVAL-ADuCM360
+============================
+
+Introduction
+------------
+
+The :adi:`ADuCM360` is a fully integrated, 4 kSPS, 24-bit data acquisition system that incorporates dual, high performance multichannel sigma-delta (Σ-Δ) analog-to-digital converters (ADCs), a 32-bit ARM Cortex™-M3 processor, and Flash/EE memory on a single chip.
+
+The :adi:`ADuCM360` is designed for direct interfacing to external precision sensors in both wired and battery-powered applications. The :adi:`ADuCM361` contains all the features of the :adi:`ADuCM360` except for the ADC0, which is removed.
+
+Refer to :adi:`ADuCM360`/:adi:`ADuCM361` for future updates. Additional support is available through :ez:`Engineer Zone - Precision Microcontrollers <analog-microcontrollers/precision-microcontrollers>`
+
+General Description
+~~~~~~~~~~~~~~~~~~~
+
+The :adi:`EVAL-ADuCM360 Development System <EVAL-ADuCM360>` allows evaluation of :adi:`ADUCM360` silicon. This getting started guide introduces the support features and the tools supplied with the evaluation kit. In addition, it shows and describes how to connect the evaluation hardware.
+
+This guide works as a tutorial by providing a step-by-step account of how to download evaluation versions of third-party software tools. Instructions are provided on how to load code examples that are supplied on the FTP site. These examples demonstrate simple operation of the :adi:`ADuCM360`.
+
+Working through this guide brings the user to the stage where they can start to
+generate and download their own user code for use in their own unique end-system
+requirements.
+
+|EVAL-ADuCM360 Development System Connected to Analog Devices, inc. J-Link OB Emulator|
+
+.. container:: centeralign
+
+   \ *Figure 1.* :adi:`EVAL-ADuCM360 Development System <EVAL-ADuCM360>` *Connected to Analog Devices, inc. J-Link OB Emulator*\
+
+Development System Contents
+---------------------------
+
+The :adi:`EVAL-ADuCM360QSPZ <EVAL-ADuCM360>` is an evaluation kit for the :adi:`ADuCM360` and :adi:`ADuCM361`. This kit features a mini-board (EVAL-ADuCM360MKZ) and an Analog Devices J-Link OB emulator (USB-SWD/UART-EMUZ) that connects to a PC USB port via a USB cable. A comprehensive set of development tools is included on the FTP server.
+
+The development system contains the following:
+
+-  Unordered List ItemAn ADuCM360 mini-board
+-  An Analog Devices J-Link OB emulator
+-  1 USB cable
+
+Evaluation Board
+~~~~~~~~~~~~~~~~
+
+The :adi:`EVAL-ADuCM360QSPZ <EVAL-ADuCM360>` mini-board facilitates performance evaluation of the device with a minimum of external components.
+
+J-LINK OB Emulator
+~~~~~~~~~~~~~~~~~~
+
+The J-Link OB emulator provides nonintrusive emulation via a serial wire, and
+also provides supply and UART communication with the ADuCM360 mini-board. Figure
+2 shows a top view of the emulator board. J2 connector plugs into the
+ADuCM360mini board. The J2 connector pinout is shown in Figure 3.
+
+|Emulator Top View|
+
+.. container:: centeralign
+
+   \ *Figure 2. Emulator Top View*\
+
+   |J2 Connector|
+
+.. container:: centeralign
+
+   \ *Figure 3. J2 Connector*\
+
+For downloading and debugging, LK1, LK2, LK4, and LK6 must be inserted. LK3 and LK5 are required to communicate via UART. Required software for the J-Link OB is included in the software installation. Note that the J-Link OB emulator replaces the J-Link Lite and related interface boards previously shipped with the :adi:`ADuCM360 development system <EVAL-ADuCM360>`.
+
+Connecting the Hardware
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Do not plug in the emulator and mini-board before the software is installed. See the `Software Installation section <https://wiki.analog.com/eval-aducm360-user-guide>`_.
+
+Software Installation
+---------------------
+
+The development tools can be downloaded from the :adi:`ADuCM360` product website or through the links below.
+
+Software Content Provided
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The table below shows the tools provided.
+
++--------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| Tools                          | Functions                                                                                                                                                                                                                          |
++================================+====================================================================================================================================================================================================================================+
+| Keil μVision                   | For compiling/debugging and code development, a 32 kB limited version. For latest version `Keil Downloads <https://www.keil.com/download/product/>`_                                                                               |
++--------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| IAR Embedded Workbench for ARM | For compiling/debugging and code development, a 32 kB limited version. For latest version `IAR Embedded Workbench for ARM <https://www.iar.com/products/architectures/arm/iar-embedded-workbench-for-arm/>`_                       |
++--------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| Software Pack                  | ADuCM36x Device support and examples. For Keil μVision, it can be downloaded `here <https://www.keil.com/dd2/Pack/>`_ or installed through Keil uVision. For IAR Embedded Workbanchk, it can be installed through the application  |
++--------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| Segger J-Link Software         | J-Link software and documentation pack. Includes USB drivers for the emulator, J-Link commander, K-Link and so on. `J-Link Software and Documentation Pack <https://www.segger.com/downloads/jlink/>`_                             |
++--------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| CM3WSD                         | This utility accepts a hex file and allows it to be downloaded via the USB interface to the :adi:`ADuCM360` device on your evaluation board                                                                                        |
++--------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+
+Software Installation Instructions
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Perform the steps described in this section before plugging in any of the USB
+devices into the PC.
+
+-  Close all open applications.
+-  Download and install the latest version of Keil μVision 5 MDK-ARM or IAR Embedded Workbench for ARM, as preferred.
+-  Download and install the ADuCM36x Software Pack. See :doc:`Installing ADuCM36x Software Pack </solutions/reference-designs/eval-aducm360-user-guide/installing_aducm36x_software_pack>`
+-  Download and install the `J-Link Software and Documentation Pack <https://www.segger.com/downloads/jlink/>`_. This installs the J-Link serial port driver. Keep the default settings that appear in the next Segger messages windows.
+
+The Segger J-Link software is selected by default in the installation menu and
+it is advised to leave it selected. This automatically installs the K-Link
+serial port driver (keep the default settings that appear in the next Segger
+messages windows).
+
+|Installing Segger J-Link Software|
+
+.. container:: centeralign
+
+   \ *Figure 5. Installing Segger J-Link Software*\
+
+Although the Keil™ software can be installed onto any hard drive and into any directory, for the purposes of simplicity, this user guide assumes it is installed at the default location of **C:\\keil_v5**, and the ARM packs are installed in **C:\\Users\\<user>\\AppData\\Local\\Arm\\Packs**
+
+Programs Installed
+~~~~~~~~~~~~~~~~~~
+
+The software described in this section has now been copied or installed.
+
+**CM3WSD.exe** The folder **\\ADuCMxxxV1.3\\Software Tools\\CM3WSD** provides an executable called **CM3WSD.exe**. This software accepts a hex file and allows it to be downloaded via the USB interface to the :adi:`ADuCM360` device on your evaluation board. You may want to add a shortcut link for this executable to your desktop.
+
+**elves.exe** The **\\ADuCMxxxV1.3\\Software Tools\\Elves** folder contains the elves.exe files. These files are useful tools that accompany the software function libraries in **\\ADuCMxxxV1.3\\Code\\ADuCM360\\common**. Again, no installation is required here, but you may want to add a shortcut link for this executable to your desktop.
+
+**Driver** The J-Link OB emulator requires a driver, which is installed automatically when the Segger J-Link Software is selected (see Step 4 of the :doc:`Software Installation Instructions </solutions/reference-designs/eval-aducm360-user-guide/eval-aducm360-user-guide>` section). At this point, check that the driver is installed correctly. Plug in the emulator and check the device manager (see Figure 6). Check that it appears in the Windows Device Manager in both the communications port and the USB controllers lists.
+
+|Device Manager|
+
+.. container:: centeralign
+
+   \ *Figure 6. Device Manager*\
+
+Keil μVision5 Integrated Development Environment
+------------------------------------------------
+
+Introduction
+~~~~~~~~~~~~
+
+The μVision5 Integrated Development Environment (IDE) integrates all the tools necessary to edit, assemble and debug code. The :adi:`ADuCM360` development system supports nonintrusive emulation limited to 32 kB code.
+
+This section describes the project setup steps in order to download and debug code on an :adi:`ADuCM360 Evaluation System <eval-aducm360>`. Analog Devices recommends using the J-Link debugger driver.
+
+Quick Start Steps
+~~~~~~~~~~~~~~~~~
+
+From the **Start Menu**, choose **Keil μVision5**. This loads the μVision5 IDE. the μVision5 executable is located at **C:\\Keil_v5\\UV4\\UV4.exe**
+
+-  To open one of the prepared Keil μVision5, click on the Pack Installer (Figure 7)
+-  Search for **aducm** in the search bar on the left
+-  Select **ADuCM36x Series**
+-  Select the **Examples** tab on the right
+-  Click on **Copy** on the **RTD_Demo** Example (Figure 8)
+-  Select the path where you want the example code to be copied. For example: **C:\\Analog Devices\\ADuCM36x**. Leave **Use Pack Folder Structure** and **Launch μVision** selected and click **OK**
+-  Once the example has been copied, a new instance of Keil μVision5 with the
+   example project opens. (Figure 9)
+
+.. image:: images/keil_package_installer.png
+   :align: center
+
+.. container:: centeralign
+
+   \ *Figure 7. Opening Keil Package Installer*\
+
+   |image1|
+
+.. container:: centeralign
+
+   \ *Figure 8. Copying an example into a new project*\
+
+   |image2|
+
+.. container:: centeralign
+
+   \ *Figure 9. RTD Example Project*\
+
+-  To compile and build all files, select the **Build All** icon.
+
+.. image:: images/build.png
+   :align: center
+
+-  Once the build has completed, the code shown in Figure 10 appears.
+
+.. image:: images/keil_build.png
+   :align: center
+
+.. container:: centeralign
+
+   \ *Figure 10. Build Output*\
+
+-  To download the code to the :adi:`EVAL-ADuCM360MKZ <eval-aducm360>` board and begin a debug session, connect the K-Link OB emulator to the :adi:`EVAL-ADuCM360MKZ <eval-aducm360>` mini-board and to your PC using the provided USB cable.
+-  In μVision, click the **Start/Stop Debug** session icon.
+
+.. image:: images/keil_debug_icon.png
+   :align: center
+
+-  Begin debugging your source code.
+
+.. image:: images/keil_debug.png
+   :align: center
+   :width: 400
+
+.. container:: centeralign
+
+   \ *Figure 10. Debug Source Code*\
+
+Extra Optional Details on Keil μVision
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This section provides a more detailed explanation of the setup described in the :doc:`Quick Start Steps </solutions/reference-designs/eval-aducm360-user-guide/eval-aducm360-user-guide>` sections.
+
+Starting a Project
+^^^^^^^^^^^^^^^^^^
+
+Under the **View** menu, two toolbars are available:
+
+-  File toolbar
+-  Build toolbar/Debug toolbar
+
+The **File** toolbar is always available. The **Build** toolbar is active only when the IDE is in edit/compile mode. The **Debug** toolbar is active only in download/debug mode.
+
+Starting a project
+^^^^^^^^^^^^^^^^^^
+
+-  From the **Project** menu, select **New μVision Project**.
+
+.. image:: images/keil_new_project.png
+   :align: center
+
+.. container:: centeralign
+
+   *Project Menu*
+
+-  Create a new folder (**ADIDemo**). To do so, go to **C:\\Analog Devices\\ADuCM36x\\ADIDemo** and enter **Demo** as the project name.
+
+.. image:: images/keil_new_project_name.png
+   :align: center
+   :width: 400
+
+-  In the **Select Device for Target 'Target 1'** window, select **Software Packs** and select **ADuCM360**
+
+.. image:: images/keil_select_device.png
+   :align: center
+   :width: 400
+
+.. container:: centeralign
+
+   *Select Device*
+
+-  In the **Manage Run-Time Environment** select the desired drivers to import to the project. For our example, select **CMSIS -> CORE**, **Device -> Startup**, and all the drivers in **Device -> Drivers**, and click **OK**.
+
+.. image:: images/keil_manage_runtime.png
+   :align: center
+   :width: 400
+
+.. container:: centeralign
+
+   *Manage Run-Time Environment*
+
+-  In the project window, right-click on **Target1** and select **Options for Target 'Target1...'**
+
+   -  Select the **Target** tab.
+   -  Ensure the **IROM1** and **IRAM1 Start** and **Size** fields are filled as shown in the picture below
+   -  In **ARM Compiler**, select **Use default compiler version 5**
+   -  Ensure that the **Use MicroLIB** option is enabled.
+
+.. image:: images/keil_target.png
+   :align: center
+
+.. container:: centeralign
+
+   *Target Options*
+
+-  Select the **Linker** tab and then select **Use Memory Layout from Target Dialog**
+
+.. image:: images/keil_linker.png
+   :align: center
+
+.. container:: centeralign
+
+   *Linker Options*
+
+-  In the **Output** tab, serlect **Create HEX File**. The hex file can be used by the JLINK Commander. Then select **OK**.
+
+.. image:: images/keil_output.png
+   :align: center
+
+.. container:: centeralign
+
+   *Output Options*
+
+-  Connect the emulator to the ADuCM360 mini-board and to your PC's USB port
+   using a USB cable. Note that an LED on the J-Link OB emulator blinks several
+   times before staying on, indicating that the emulator is communicating
+   correctly with the PC.
+
+Configuring the J-Link Debugger Driver
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+-  In the project window, right-clink on **Target1** and select **Options for Target 'Target1...**
+-  In the **Debug** tab, select **Use:** and then select **J-LINK/J-Trace Cortex**, and tick **Run to main()**. Click on **Settings**.
+
+.. image:: images/keil_debug_options.png
+   :align: center
+
+.. container:: centeralign
+
+   Selecting a debugger// //
+
+-  Configure the **Cortex JLink/JTrace Target Driver Setup** window as in the following picture:
+
+.. image:: images/keil_jlink_driver.png
+   :align: center
+
+.. container:: centeralign
+
+   J-Link Target Driver Setup// //
+
+-  Select **OK**
+-  Under the **Utilities** tab, select **Use Target Driver for Flash Programming**. Then, select **Use Debug Driver** and select the option **Update Target before Debugging**.
+
+.. image:: images/keil_utilities.png
+   :align: center
+
+.. container:: centeralign
+
+   Configuration of the Utilities Menu// //
+
+-  Click on **Settings**, and check that the **Flash Download** tab is configured as the following picture:
+
+.. image:: images/keil_flash_download.png
+   :align: center
+
+.. container:: centeralign
+
+   Flash Download Setup// //
+
+-  Select **OK**. All the options should be properly configured to compile, assemble, download and debug using J-Link Lite.
+
+Adding Project Files
+^^^^^^^^^^^^^^^^^^^^
+
+At this point you can create and add your source code files necessary for your
+development. For this example, we are adding the main source file of an example
+project.
+
+Copy the file **C:\\Users\\rgrau\\AppData\\Local\\Arm\\Packs\\AnalogDevices\\ADuCM36x_DFP\\1.0.4\\Examples\\ADC\\ADCMeter.c** into the new project directory: **C:\\Analog Devices\\ADuCM36x\\ADIDemo**
+
+-  To add the file to the project, right-click on the **Source Group** folder in the **Project** window, and select **Add Existing Files to Group 'Source Group 1...'**
+
+.. image:: images/keil_add_file.png
+   :align: center
+
+.. container:: centeralign
+
+   Adding existing files to the project// //
+
+-  Add the file **ADCMeter.c**
+-  Double click on **ADCMeter.c** in the **Project** window to open the file.
+
+Assembling/Compiling/Downloading Code
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+To compile/link ADCMeter.c, press **Ctrl+F7** or click on the **translate** icon in the toolbar. The file should compile correctly and the **Build Output** Window should say **"ADCMeter.c" - 0 Error(s), 0 Warning(s)**. If there are any errors in your source code, these appear in the status window. To identify the line of code that corresponds to the error, double-click on the error in the **Build Output** window and an arrow highlights the line of code in error.
+
+Before the code can be downloaded to the ADuCM360, the entire project must be build. This is done by clicking on the **Rebuild** icon on the toolbar. It will also create a demo.elf file used by the debugger.
+
+|image3|
+
+.. container:: centeralign
+
+   Build Project Successful// //
+
+The code can now be downloaded into the ADuCM360 clicking on the **Load** icon in the toolbar. Press the **Reset** button on the board, and the code starts running on the ADuCM360. The program measures the input signal applied across AIN0 and AIN1, converts this to a voltage, and sends this information in an ASCII string to the UART - baud rate 9600-8-N-1.
+
+.. image:: images/voltage_reading.png
+   :align: center
+
+IAR Embedded Workbench for ARM IDE
+----------------------------------
+
+The IAR Embedded Workbench IDE for ARM integrates all the tools necessary to edit, assemble, and debug code. The :adi:`ADuCM360` development system supports nonintrusive emulation limited to 32 kB code.
+
+This section describes the project setup steps in order to download and debug code on an :adi:`ADuCM360 Evaluation System <eval-aducm360>`. Analog Devices recommends using the J-Link debugger driver.
+
+Starting IAR Embedded Workbench
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+From the **Start Menu**, choose **IAR Embedded Workbench for ARM -> IAR EW For ARM**. This loads the IAR Embedded Workbench IDE.
+
+Quick Start Steps
+~~~~~~~~~~~~~~~~~
+
+Follow the steps in this section to get up and running with the example code
+provided with the evaluation software.
+
+These steps use the default driver and compiler settings.
+
+-  To open the prepared IAR example projects click on the **CMSIS-Pack Manager**
+
+.. image:: images/iar_cmsis_button.png
+   :align: center
+
+-  A prompt to create a new Workspace will appear. Select the desired Folder and
+   name to save it. (Figure 11)
+
+.. image:: images/iar_workspace.png
+   :align: center
+   :width: 400
+
+.. container:: centeralign
+
+   \ *Figure 11. Creation of a new Workspace*\
+
+-  The CMSIS Manager will launch. Select the **Devices** tab, and search for **aducm** in the **Search Device** bar. Select **ADuCM360**
+
+.. image:: images/iar_device_select.png
+   :align: center
+   :width: 600
+
+-  With the **ADuCM360** device selected, change to the **Examples** tab. Import the desired example, for example **RTD_DEMO**
+
+.. image:: images/iar_import_example.png
+   :align: center
+   :width: 600
+
+-  The example is imported into the workspace, as can be seen in Figure 12.
+
+.. image:: images/iar_example.png
+   :align: center
+   :width: 600
+
+.. container:: centeralign
+
+   \ *Figure 12. RTD_Demo example*\
+
+-  To compile all files, select **Project -> Rebuild All**
+
+.. image:: images/iar_rebuild.png
+   :align: center
+   :width: 400
+
+-  If the Build is successful, the information is displayed in the **Build** details window.
+
+.. image:: images/iar_build.png
+   :align: center
+
+-  To program the device and begin debugging the source code, select **Project -> Download and Debug**
+
+.. image:: images/iar_program.png
+   :align: center
+   :width: 400
+
+Downloading Code into Flash
+---------------------------
+
+Windows Serial Downloader
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The Windows(r) Serial DOwnloader for Cortex-M3 based parts (CM3WSD) is a Windows software program that allows a user to serially download Intel Extended Hex files as created by the assembler/compiler to the :adi:`ADuCM360` via the serial port.
+
+The Intel Extended Hex file is downloaded into the on-chip Flash/EE program
+memory via a selected PC serial port.
+
+Preparing for Download
+^^^^^^^^^^^^^^^^^^^^^^
+
+-  Connect the ADuCM360 mini-board (:adi:`EVAL-ADuCM360MKZ <eval-aducm360>`) to the emulator board, and the emulator board to the PC using a USB cable.
+-  Ensure all the links are inserted in both boards.
+-  Place the ADuCM360 into serial download mode using the following sequence.
+
+   -  Pull P2.2 low.
+   -  Pull the RESET pin low and then high (float).
+   -  P2.2 can be left floating once RESET is high.
+
+Downloading using CM3WSD
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+-  In the **Start Menu**, open **CM3WSD**.
+-  Click on **Browse** and select the desired **.hex** file.
+-  In the **Serial Port** drop-down menu, select **USB Serial Port** and a baudrate of **38400**.
+-  Select **Start** The CM3SWD sends a reset command to the ADuCM360. If the ADuCM360 is in serial download mode and the COM port between the PC and the mini-board is setup correctly, then the CM3WSD starts download the hex file and display a progress bar while the file is downloading. Once the file has been successfully downloaded, the monitor status box is updated with **Flashing Complete Click Reset to run program**.
+
+.. image:: images/cm3swd.png
+   :align: center
+   :width: 400
+
+Running the Downloaded File
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Running using CM3SWD
+""""""""""""""""""""
+
+Select **Reset** with P2.2 floating or pulled high. The monitor status box updates with the message **Running**
+
+Manual Run Option
+"""""""""""""""""
+
+Pull RESET low, then high (or float) on the mini-board to reset the ADuCM360
+with P2.2 floating or pulled high. The program starts running automatically.
+
+.. |EVAL-ADuCM360 Development System Connected to Analog Devices, inc. J-Link OB Emulator| image:: images/board.png
+.. |Emulator Top View| image:: images/emulator.png
+.. |J2 Connector| image:: images/j2_connector.png
+.. |Installing Segger J-Link Software| image:: images/segger.png
+.. |Device Manager| image:: images/drivers.png
+.. |image1| image:: images/keil_copy_example.png
+.. |image2| image:: images/rtd_demo.png
+   :width: 400
+.. |image3| image:: images/keil_build_successful.png

--- a/docs/solutions/reference-designs/eval-aducm360-user-guide/eval-aducm360-user-guide.rst
+++ b/docs/solutions/reference-designs/eval-aducm360-user-guide/eval-aducm360-user-guide.rst
@@ -21,11 +21,11 @@ Working through this guide brings the user to the stage where they can start to
 generate and download their own user code for use in their own unique end-system
 requirements.
 
-|EVAL-ADuCM360 Development System Connected to Analog Devices, inc. J-Link OB Emulator|
+.. image:: images/board.png
 
 .. container:: centeralign
 
-   \ *Figure 1.* :adi:`EVAL-ADuCM360 Development System <EVAL-ADuCM360>` *Connected to Analog Devices, inc. J-Link OB Emulator*\
+   *Figure 1.* :adi:`EVAL-ADuCM360 Development System <EVAL-ADuCM360>` *Connected to Analog Devices, inc. J-Link OB Emulator*
 
 Development System Contents
 ---------------------------
@@ -34,7 +34,7 @@ The :adi:`EVAL-ADuCM360QSPZ <EVAL-ADuCM360>` is an evaluation kit for the :adi:`
 
 The development system contains the following:
 
--  Unordered List ItemAn ADuCM360 mini-board
+-  An ADuCM360 mini-board
 -  An Analog Devices J-Link OB emulator
 -  1 USB cable
 
@@ -51,17 +51,17 @@ also provides supply and UART communication with the ADuCM360 mini-board. Figure
 2 shows a top view of the emulator board. J2 connector plugs into the
 ADuCM360mini board. The J2 connector pinout is shown in Figure 3.
 
-|Emulator Top View|
+.. image:: images/emulator.png
 
 .. container:: centeralign
 
-   \ *Figure 2. Emulator Top View*\
+   *Figure 2. Emulator Top View*
 
-   |J2 Connector|
+.. image:: images/j2_connector.png
 
 .. container:: centeralign
 
-   \ *Figure 3. J2 Connector*\
+   *Figure 3. J2 Connector*
 
 For downloading and debugging, LK1, LK2, LK4, and LK6 must be inserted. LK3 and LK5 are required to communicate via UART. Required software for the J-Link OB is included in the software installation. Note that the J-Link OB emulator replaces the J-Link Lite and related interface boards previously shipped with the :adi:`ADuCM360 development system <EVAL-ADuCM360>`.
 
@@ -110,11 +110,11 @@ it is advised to leave it selected. This automatically installs the K-Link
 serial port driver (keep the default settings that appear in the next Segger
 messages windows).
 
-|Installing Segger J-Link Software|
+.. image:: images/segger.png
 
 .. container:: centeralign
 
-   \ *Figure 5. Installing Segger J-Link Software*\
+   *Figure 5. Installing Segger J-Link Software*
 
 Although the Keil™ software can be installed onto any hard drive and into any directory, for the purposes of simplicity, this user guide assumes it is installed at the default location of **C:\\keil_v5**, and the ARM packs are installed in **C:\\Users\\<user>\\AppData\\Local\\Arm\\Packs**
 
@@ -129,11 +129,11 @@ The software described in this section has now been copied or installed.
 
 **Driver** The J-Link OB emulator requires a driver, which is installed automatically when the Segger J-Link Software is selected (see Step 4 of the :doc:`Software Installation Instructions </solutions/reference-designs/eval-aducm360-user-guide/eval-aducm360-user-guide>` section). At this point, check that the driver is installed correctly. Plug in the emulator and check the device manager (see Figure 6). Check that it appears in the Windows Device Manager in both the communications port and the USB controllers lists.
 
-|Device Manager|
+.. image:: images/drivers.png
 
 .. container:: centeralign
 
-   \ *Figure 6. Device Manager*\
+   *Figure 6. Device Manager*
 
 Keil μVision5 Integrated Development Environment
 ------------------------------------------------
@@ -164,19 +164,20 @@ From the **Start Menu**, choose **Keil μVision5**. This loads the μVision5 IDE
 
 .. container:: centeralign
 
-   \ *Figure 7. Opening Keil Package Installer*\
+   *Figure 7. Opening Keil Package Installer*
 
-   |image1|
-
-.. container:: centeralign
-
-   \ *Figure 8. Copying an example into a new project*\
-
-   |image2|
+.. image:: images/keil_copy_example.png
 
 .. container:: centeralign
 
-   \ *Figure 9. RTD Example Project*\
+   *Figure 8. Copying an example into a new project*
+
+.. image:: images/rtd_demo.png
+   :width: 400
+
+.. container:: centeralign
+
+   *Figure 9. RTD Example Project*
 
 -  To compile and build all files, select the **Build All** icon.
 
@@ -190,7 +191,7 @@ From the **Start Menu**, choose **Keil μVision5**. This loads the μVision5 IDE
 
 .. container:: centeralign
 
-   \ *Figure 10. Build Output*\
+   *Figure 10. Build Output*
 
 -  To download the code to the :adi:`EVAL-ADuCM360MKZ <eval-aducm360>` board and begin a debug session, connect the K-Link OB emulator to the :adi:`EVAL-ADuCM360MKZ <eval-aducm360>` mini-board and to your PC using the provided USB cable.
 -  In μVision, click the **Start/Stop Debug** session icon.
@@ -206,7 +207,7 @@ From the **Start Menu**, choose **Keil μVision5**. This loads the μVision5 IDE
 
 .. container:: centeralign
 
-   \ *Figure 10. Debug Source Code*\
+   *Figure 10. Debug Source Code*
 
 Extra Optional Details on Keil μVision
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -223,8 +224,8 @@ Under the **View** menu, two toolbars are available:
 
 The **File** toolbar is always available. The **Build** toolbar is active only when the IDE is in edit/compile mode. The **Debug** toolbar is active only in download/debug mode.
 
-Starting a project
-^^^^^^^^^^^^^^^^^^
+Creating a New Project
+^^^^^^^^^^^^^^^^^^^^^^
 
 -  From the **Project** menu, select **New μVision Project**.
 
@@ -309,7 +310,7 @@ Configuring the J-Link Debugger Driver
 
 .. container:: centeralign
 
-   Selecting a debugger// //
+   Selecting a debugger
 
 -  Configure the **Cortex JLink/JTrace Target Driver Setup** window as in the following picture:
 
@@ -318,7 +319,7 @@ Configuring the J-Link Debugger Driver
 
 .. container:: centeralign
 
-   J-Link Target Driver Setup// //
+   J-Link Target Driver Setup
 
 -  Select **OK**
 -  Under the **Utilities** tab, select **Use Target Driver for Flash Programming**. Then, select **Use Debug Driver** and select the option **Update Target before Debugging**.
@@ -328,7 +329,7 @@ Configuring the J-Link Debugger Driver
 
 .. container:: centeralign
 
-   Configuration of the Utilities Menu// //
+   Configuration of the Utilities Menu
 
 -  Click on **Settings**, and check that the **Flash Download** tab is configured as the following picture:
 
@@ -337,7 +338,7 @@ Configuring the J-Link Debugger Driver
 
 .. container:: centeralign
 
-   Flash Download Setup// //
+   Flash Download Setup
 
 -  Select **OK**. All the options should be properly configured to compile, assemble, download and debug using J-Link Lite.
 
@@ -357,7 +358,7 @@ Copy the file **C:\\Users\\rgrau\\AppData\\Local\\Arm\\Packs\\AnalogDevices\\ADu
 
 .. container:: centeralign
 
-   Adding existing files to the project// //
+   Adding existing files to the project
 
 -  Add the file **ADCMeter.c**
 -  Double click on **ADCMeter.c** in the **Project** window to open the file.
@@ -369,11 +370,11 @@ To compile/link ADCMeter.c, press **Ctrl+F7** or click on the **translate** icon
 
 Before the code can be downloaded to the ADuCM360, the entire project must be build. This is done by clicking on the **Rebuild** icon on the toolbar. It will also create a demo.elf file used by the debugger.
 
-|image3|
+.. image:: images/keil_build_successful.png
 
 .. container:: centeralign
 
-   Build Project Successful// //
+   Build Project Successful
 
 The code can now be downloaded into the ADuCM360 clicking on the **Load** icon in the toolbar. Press the **Reset** button on the board, and the code starts running on the ADuCM360. The program measures the input signal applied across AIN0 and AIN1, converts this to a voltage, and sends this information in an ASCII string to the UART - baud rate 9600-8-N-1.
 
@@ -414,7 +415,7 @@ These steps use the default driver and compiler settings.
 
 .. container:: centeralign
 
-   \ *Figure 11. Creation of a new Workspace*\
+   *Figure 11. Creation of a new Workspace*
 
 -  The CMSIS Manager will launch. Select the **Devices** tab, and search for **aducm** in the **Search Device** bar. Select **ADuCM360**
 
@@ -436,7 +437,7 @@ These steps use the default driver and compiler settings.
 
 .. container:: centeralign
 
-   \ *Figure 12. RTD_Demo example*\
+   *Figure 12. RTD_Demo example*
 
 -  To compile all files, select **Project -> Rebuild All**
 
@@ -502,13 +503,3 @@ Manual Run Option
 
 Pull RESET low, then high (or float) on the mini-board to reset the ADuCM360
 with P2.2 floating or pulled high. The program starts running automatically.
-
-.. |EVAL-ADuCM360 Development System Connected to Analog Devices, inc. J-Link OB Emulator| image:: images/board.png
-.. |Emulator Top View| image:: images/emulator.png
-.. |J2 Connector| image:: images/j2_connector.png
-.. |Installing Segger J-Link Software| image:: images/segger.png
-.. |Device Manager| image:: images/drivers.png
-.. |image1| image:: images/keil_copy_example.png
-.. |image2| image:: images/rtd_demo.png
-   :width: 400
-.. |image3| image:: images/keil_build_successful.png

--- a/docs/solutions/reference-designs/eval-aducm360-user-guide/images/board.png
+++ b/docs/solutions/reference-designs/eval-aducm360-user-guide/images/board.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:593af649ce3ab6b9e7c98c6bf617a3c470ce516b1fcded45a72d31f61ff10fab
+size 260905

--- a/docs/solutions/reference-designs/eval-aducm360-user-guide/images/build.png
+++ b/docs/solutions/reference-designs/eval-aducm360-user-guide/images/build.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7467036580357b09b44e0d0e5298487caedf51fa1872ad0355a740d6c2e10db2
+size 641

--- a/docs/solutions/reference-designs/eval-aducm360-user-guide/images/cm3swd.png
+++ b/docs/solutions/reference-designs/eval-aducm360-user-guide/images/cm3swd.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c08ad2c60814b1a39a87ff678c09c8643f0c53df846daa3f8aab5c8e8421ca43
+size 10122

--- a/docs/solutions/reference-designs/eval-aducm360-user-guide/images/drivers.png
+++ b/docs/solutions/reference-designs/eval-aducm360-user-guide/images/drivers.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:09acccee078bde40157145e6239bb19f582c388f39f620a1f97c526be84468cf
+size 44605

--- a/docs/solutions/reference-designs/eval-aducm360-user-guide/images/emulator.png
+++ b/docs/solutions/reference-designs/eval-aducm360-user-guide/images/emulator.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:be3659753f14b2b1d4dc9f52b3e02a76dbbc1b816ca6149724fa79011efb2ff9
+size 56569

--- a/docs/solutions/reference-designs/eval-aducm360-user-guide/images/iar_build.png
+++ b/docs/solutions/reference-designs/eval-aducm360-user-guide/images/iar_build.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6ca6785079a08ae812d691d501e325982916620e772973c80a24f9d6f4f51164
+size 3364

--- a/docs/solutions/reference-designs/eval-aducm360-user-guide/images/iar_cmsis.png
+++ b/docs/solutions/reference-designs/eval-aducm360-user-guide/images/iar_cmsis.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f70ac3675cf9b20284ced63f548704a335cf3b1ad08ba4a0b1697f59564acc67
+size 56194

--- a/docs/solutions/reference-designs/eval-aducm360-user-guide/images/iar_cmsis_button.png
+++ b/docs/solutions/reference-designs/eval-aducm360-user-guide/images/iar_cmsis_button.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:04837113f7ebf4a969eba7d60bc6bf10dc4a2033173833e50f047f1b685271fc
+size 10838

--- a/docs/solutions/reference-designs/eval-aducm360-user-guide/images/iar_device_select.png
+++ b/docs/solutions/reference-designs/eval-aducm360-user-guide/images/iar_device_select.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7529f30afb9fdc8fcfb144e2a45c83c000a69de84cb662d22a307aaf29c179d4
+size 43901

--- a/docs/solutions/reference-designs/eval-aducm360-user-guide/images/iar_example.png
+++ b/docs/solutions/reference-designs/eval-aducm360-user-guide/images/iar_example.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:402a519a561414af36d02653c8e842c67a72f01f01a9d181c95d40e7e9be79a2
+size 67696

--- a/docs/solutions/reference-designs/eval-aducm360-user-guide/images/iar_import_example.png
+++ b/docs/solutions/reference-designs/eval-aducm360-user-guide/images/iar_import_example.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:215504027a7a8d42ae7d863bf89b3e19f993b8d8eac466c1e88025fa87df0fdc
+size 54619

--- a/docs/solutions/reference-designs/eval-aducm360-user-guide/images/iar_program.png
+++ b/docs/solutions/reference-designs/eval-aducm360-user-guide/images/iar_program.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9e515e02739555ef8f73a67d4ef1a736c44a412559ef0d95b49b87cf4d439234
+size 34331

--- a/docs/solutions/reference-designs/eval-aducm360-user-guide/images/iar_rebuild.png
+++ b/docs/solutions/reference-designs/eval-aducm360-user-guide/images/iar_rebuild.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:372cce06a1c908790003d27fc9ef3debef1aa3c96d817e5202c7e6b5e4469adb
+size 32213

--- a/docs/solutions/reference-designs/eval-aducm360-user-guide/images/iar_workspace.png
+++ b/docs/solutions/reference-designs/eval-aducm360-user-guide/images/iar_workspace.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bb8e8058b4c41b1837cd5078441615b21abdb0e4deded451ed9917dc6920fccb
+size 31787

--- a/docs/solutions/reference-designs/eval-aducm360-user-guide/images/install_iar_cmsis.png
+++ b/docs/solutions/reference-designs/eval-aducm360-user-guide/images/install_iar_cmsis.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:83a64fe210c3fbd9ca75cc8fdbe5ed9ef4c1b26d3e6d1141222c15b548184bfa
+size 45830

--- a/docs/solutions/reference-designs/eval-aducm360-user-guide/images/install_pack.png
+++ b/docs/solutions/reference-designs/eval-aducm360-user-guide/images/install_pack.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eac06b6904b3c938c64cd5468133c7aafc0a0e5e863f895dc1739a92963f6a6d
+size 11532

--- a/docs/solutions/reference-designs/eval-aducm360-user-guide/images/j2_connector.png
+++ b/docs/solutions/reference-designs/eval-aducm360-user-guide/images/j2_connector.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7c40e2ec83056d1d9a1c555da3c18332b57d523b524f805d424a89cfe6aa155f
+size 28236

--- a/docs/solutions/reference-designs/eval-aducm360-user-guide/images/keil_add_file.png
+++ b/docs/solutions/reference-designs/eval-aducm360-user-guide/images/keil_add_file.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:267c1d70fad9f0ee9ffd63b9cade1857fcaf6c2c7c6bcf86c7846f55fc0c523c
+size 40516

--- a/docs/solutions/reference-designs/eval-aducm360-user-guide/images/keil_build.png
+++ b/docs/solutions/reference-designs/eval-aducm360-user-guide/images/keil_build.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:948665fc94a0d1540c1e838ed34f072222113e78f01463976dce49c157371e39
+size 8646

--- a/docs/solutions/reference-designs/eval-aducm360-user-guide/images/keil_build_successful.png
+++ b/docs/solutions/reference-designs/eval-aducm360-user-guide/images/keil_build_successful.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:220795417c3586f80b90ac88bf889df5e944b2ce236c7481f9b2ab757ed8b13a
+size 12884

--- a/docs/solutions/reference-designs/eval-aducm360-user-guide/images/keil_copy_example.png
+++ b/docs/solutions/reference-designs/eval-aducm360-user-guide/images/keil_copy_example.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4cc94e2f3bdbfaa3c836e679f821a5927c466263e96d7a689898b7c8c172f0c1
+size 79950

--- a/docs/solutions/reference-designs/eval-aducm360-user-guide/images/keil_debug.png
+++ b/docs/solutions/reference-designs/eval-aducm360-user-guide/images/keil_debug.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b4e9c2d1e9623d650e0a0672d1fe1497d309c7a081d50d64ddd1594313a777fb
+size 111377

--- a/docs/solutions/reference-designs/eval-aducm360-user-guide/images/keil_debug_icon.png
+++ b/docs/solutions/reference-designs/eval-aducm360-user-guide/images/keil_debug_icon.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7f1a4917c89d773e8d6963a53cac034a915317478628cde825f46de661f59fbb
+size 764

--- a/docs/solutions/reference-designs/eval-aducm360-user-guide/images/keil_debug_options.png
+++ b/docs/solutions/reference-designs/eval-aducm360-user-guide/images/keil_debug_options.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5d91bfda504c4279419be301ee7a2e813bc84785038cb0d2c9efd8672f46f535
+size 30221

--- a/docs/solutions/reference-designs/eval-aducm360-user-guide/images/keil_flash_download.png
+++ b/docs/solutions/reference-designs/eval-aducm360-user-guide/images/keil_flash_download.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:59e733928477c174bc54ea1fd2f149e1ee10c129764e3cdfad8a37aa7dc8700c
+size 19093

--- a/docs/solutions/reference-designs/eval-aducm360-user-guide/images/keil_jlink_driver.png
+++ b/docs/solutions/reference-designs/eval-aducm360-user-guide/images/keil_jlink_driver.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5b5d716a49e4eff6d880ab4d45994117f7e249e15c9a3609b7d13238329dabc6
+size 35745

--- a/docs/solutions/reference-designs/eval-aducm360-user-guide/images/keil_linker.png
+++ b/docs/solutions/reference-designs/eval-aducm360-user-guide/images/keil_linker.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d08dc9883ce3f7c118ce1c7dbc5bcb8d453326c04a250a1893782c25a2bf55e4
+size 22893

--- a/docs/solutions/reference-designs/eval-aducm360-user-guide/images/keil_manage_runtime.png
+++ b/docs/solutions/reference-designs/eval-aducm360-user-guide/images/keil_manage_runtime.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:86715b5eb4638c78bceec768c381a2469d284bf3a8c631b11bbbe01f1d2bade2
+size 55921

--- a/docs/solutions/reference-designs/eval-aducm360-user-guide/images/keil_new_project.png
+++ b/docs/solutions/reference-designs/eval-aducm360-user-guide/images/keil_new_project.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:10a2e13371bf3e66fd88b3dd13d40421023f7f3d4f38682abaa5edce69586501
+size 7527

--- a/docs/solutions/reference-designs/eval-aducm360-user-guide/images/keil_new_project_name.png
+++ b/docs/solutions/reference-designs/eval-aducm360-user-guide/images/keil_new_project_name.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fbd0d9514b0bf2cde542747240b4ea5eb38e0aae951f1f0b864b8496cebdbe78
+size 31033

--- a/docs/solutions/reference-designs/eval-aducm360-user-guide/images/keil_output.png
+++ b/docs/solutions/reference-designs/eval-aducm360-user-guide/images/keil_output.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cdbee840e57e0b66a83df9eeff776550c21ef7849dc11aac85e710beac0dd05f
+size 16502

--- a/docs/solutions/reference-designs/eval-aducm360-user-guide/images/keil_package_installer.png
+++ b/docs/solutions/reference-designs/eval-aducm360-user-guide/images/keil_package_installer.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a7206829fc610a78ce5f456cd41c0ff741be2ffc5a5f7dd4d72492854d7b7379
+size 11877

--- a/docs/solutions/reference-designs/eval-aducm360-user-guide/images/keil_select_device.png
+++ b/docs/solutions/reference-designs/eval-aducm360-user-guide/images/keil_select_device.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b4db53a48152307c36be096660a6a2d7d1f362029ad03f8c5067732cb5df6a6b
+size 24307

--- a/docs/solutions/reference-designs/eval-aducm360-user-guide/images/keil_target.png
+++ b/docs/solutions/reference-designs/eval-aducm360-user-guide/images/keil_target.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7ac0fc4bcf15b1a51273bc8b031bd5635a5b168b1163c39fdb6dea168e7d4557
+size 28617

--- a/docs/solutions/reference-designs/eval-aducm360-user-guide/images/keil_utilities.png
+++ b/docs/solutions/reference-designs/eval-aducm360-user-guide/images/keil_utilities.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f6aac9404d307649af5fef3e60c9d8680e99cb7008ddf35107316afb0d8b4a4d
+size 21958

--- a/docs/solutions/reference-designs/eval-aducm360-user-guide/images/open_packinstaller.png
+++ b/docs/solutions/reference-designs/eval-aducm360-user-guide/images/open_packinstaller.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ce290ca6e43c89c85f47e8167b20c5712e62f1a5b82f66cbea5fac134a7a9dff
+size 17735

--- a/docs/solutions/reference-designs/eval-aducm360-user-guide/images/packinstaller.png
+++ b/docs/solutions/reference-designs/eval-aducm360-user-guide/images/packinstaller.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5889226a25b2c161a227d36ba6b2ea2ed806db9526db051377fb1d40211b2106
+size 86700

--- a/docs/solutions/reference-designs/eval-aducm360-user-guide/images/rtd_demo.png
+++ b/docs/solutions/reference-designs/eval-aducm360-user-guide/images/rtd_demo.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:281b635b6adce85f71bebc11d401836a733e1dfb2b2dc8180d0f688def8ddc99
+size 117197

--- a/docs/solutions/reference-designs/eval-aducm360-user-guide/images/segger.png
+++ b/docs/solutions/reference-designs/eval-aducm360-user-guide/images/segger.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c5e0606dd805eee4398962a5d3e359c7cba59afa3e2fa4d6eb24959078f4feda
+size 96562

--- a/docs/solutions/reference-designs/eval-aducm360-user-guide/images/voltage_reading.png
+++ b/docs/solutions/reference-designs/eval-aducm360-user-guide/images/voltage_reading.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9ef26171caf35c7c31936d9c9a826391a7e05e6eeb8f1a14939dfd3220dce0db
+size 8584

--- a/docs/solutions/reference-designs/eval-aducm360-user-guide/index.rst
+++ b/docs/solutions/reference-designs/eval-aducm360-user-guide/index.rst
@@ -1,0 +1,8 @@
+User Guide for EVAL-ADuCM360
+============================
+
+.. toctree::
+   :titlesonly:
+
+   eval-aducm360-user-guide
+   installing_aducm36x_software_pack

--- a/docs/solutions/reference-designs/eval-aducm360-user-guide/index.rst
+++ b/docs/solutions/reference-designs/eval-aducm360-user-guide/index.rst
@@ -1,8 +1,46 @@
-User Guide for EVAL-ADuCM360
-============================
+.. _eval_aducm360_user_guide eval:
+
+EVAL ADUCM360 USER GUIDE
+=================================================================================================================================================
+
+.. TODO: Add a picture of the chip/board
+
+Overview
+-------------------------------------------------------------------------------
+
+.. TODO: Describe in max 10 rows the main features and applications.
+
+Features:
+
+- feature 1
+- feature 2
+
+Applications:
+
+- application 1
+- application 2
 
 .. toctree::
-   :titlesonly:
+   :hidden:
 
    eval-aducm360-user-guide
    installing_aducm36x_software_pack
+
+Recommendations
+-------------------------------------------------------------------------------
+
+People who follow the flow that is outlined, have a much better experience with
+things. However, like many things, documentation is never as complete as it
+should be. If you have any questions, feel free to ask on our
+:ref:`EngineerZone forums <help-and-support>`, but before that, please make
+sure you read our documentation thoroughly.
+
+Warning
+-------------------------------------------------------------------------------
+
+.. esd-warning::
+
+Help and support
+-------------------------------------------------------------------------------
+
+Please go to :ref:`Help and Support <help-and-support>` page.

--- a/docs/solutions/reference-designs/eval-aducm360-user-guide/installing_aducm36x_software_pack.rst
+++ b/docs/solutions/reference-designs/eval-aducm360-user-guide/installing_aducm36x_software_pack.rst
@@ -1,0 +1,77 @@
+Installing ADuCM36x Software Pack
+=================================
+
+The ADuCM36x Software Pack includes the C libraries to develop software for the
+ADuCM36x family with Keil μVision5 or IAR Embedded Workbench for ARM, as well as
+example code to help develop applications.
+
+The Software Pack for Keil μVision5 can be installed manually, downloading it from the `Keil MDK5 Software Packs website <https://www.keil.com/dd2/pack/>`_, or it can be installed through the Pack Installer inside Keil μVision5.
+
+The Software Pack for IAR Embedded Workbench can be installed from the IAR
+application.
+
+Installation for Keil μVision5
+------------------------------
+
+Manual Installation
+~~~~~~~~~~~~~~~~~~~
+
+-  Download Analog Devices ADuCM36x Device Support and Examples from `Keil MDK5 Software Packs website <https://www.keil.com/dd2/pack/>`_
+-  Install the ADuCM36x Pack in the default directory
+
+.. image:: images/install_pack.png
+   :alt: Manual installation of ADuCM36x Software Pack
+   :align: center
+
+.. container:: centeralign
+
+   Figure 1. Manual installation of ADuCM36x Software Pack
+
+Installation Through Keil μVision5
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+-  Open Keil μVision5
+-  Open Pack Installer (See Figure 2)
+-  Search for **aducm** in the Search bar
+-  In the Device list on the left-hand side, select **ADuCM36x Series**
+-  In the Packs tab on the right-hand side, expand **Device Specific**
+-  Click **Install** in **AnalogDevices::ADuCM36x_DFP**
+-  Accept the License Agreement
+
+.. image:: images/open_packinstaller.png
+   :alt: Opening Pack Installer
+   :align: center
+
+.. container:: centeralign
+
+   Figure 2. Opening Pack Installer
+
+   |Installing the ADuCM36x Software Pack Trough the Pack Installer|
+
+.. container:: centeralign
+
+   Figure 3. Installing the ADuCM36x Software Pack Trough the Pack Installer
+
+Installation for IAR Embedded Workbench
+---------------------------------------
+
+-  Open IAR Embedded Workbench. This will open IAR Embedded Workbench CMSIS Manager.
+-  In **Devices** -> **Search Device** Search for **aducm** and select **ADuCM36x Series** (Figure 4)
+-  With the device selected, go to **Packs** -> Device Specific*\* and install the pack **AnalogDevices.ADuCM36x_DFP** (Figure 5).
+-  Accept the license agreement.
+
+.. image:: images/iar_cmsis.png
+   :align: center
+
+.. container:: centeralign
+
+   Figure 4. IAR CMSIS Manager. Selecting the ADuCM36x Series Device
+
+   |image1|
+
+.. container:: centeralign
+
+   Figure 3. Installing the ADuCM36x Software Pack
+
+.. |Installing the ADuCM36x Software Pack Trough the Pack Installer| image:: images/packinstaller.png
+.. |image1| image:: images/install_iar_cmsis.png

--- a/docs/solutions/reference-designs/eval-aducm360-user-guide/installing_aducm36x_software_pack.rst
+++ b/docs/solutions/reference-designs/eval-aducm360-user-guide/installing_aducm36x_software_pack.rst
@@ -46,7 +46,7 @@ Installation Through Keil μVision5
 
    Figure 2. Opening Pack Installer
 
-   |Installing the ADuCM36x Software Pack Trough the Pack Installer|
+.. image:: images/packinstaller.png
 
 .. container:: centeralign
 
@@ -57,7 +57,7 @@ Installation for IAR Embedded Workbench
 
 -  Open IAR Embedded Workbench. This will open IAR Embedded Workbench CMSIS Manager.
 -  In **Devices** -> **Search Device** Search for **aducm** and select **ADuCM36x Series** (Figure 4)
--  With the device selected, go to **Packs** -> Device Specific*\* and install the pack **AnalogDevices.ADuCM36x_DFP** (Figure 5).
+-  With the device selected, go to **Packs** -> **Device Specific** and install the pack **AnalogDevices.ADuCM36x_DFP** (Figure 5).
 -  Accept the license agreement.
 
 .. image:: images/iar_cmsis.png
@@ -67,11 +67,8 @@ Installation for IAR Embedded Workbench
 
    Figure 4. IAR CMSIS Manager. Selecting the ADuCM36x Series Device
 
-   |image1|
+.. image:: images/install_iar_cmsis.png
 
 .. container:: centeralign
 
    Figure 3. Installing the ADuCM36x Software Pack
-
-.. |Installing the ADuCM36x Software Pack Trough the Pack Installer| image:: images/packinstaller.png
-.. |image1| image:: images/install_iar_cmsis.png


### PR DESCRIPTION
## Summary
- Move eval-aducm360-user-guide wiki documentation to `solutions/reference-designs/eval-aducm360-user-guide/`
- 3 RST files with 40 localized images
- Generated stub `index.rst` with toctree

## Test plan
- [ ] Sphinx build passes without errors
- [ ] All toctree entries resolve correctly
- [ ] Images render properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)