### PR TITLE
reference-designs/eval-cog-ad3029: Add eval-cog-ad3029 documentation

### DIFF
--- a/docs/solutions/reference-designs/eval-cog-ad3029/images/software_packs_aducm302x_device_block_diagram.png
+++ b/docs/solutions/reference-designs/eval-cog-ad3029/images/software_packs_aducm302x_device_block_diagram.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:27c23ec69a45cd097c1ac6d92530783817e395b2cf11a25c9b0f4b151695ada3
+size 42913

--- a/docs/solutions/reference-designs/eval-cog-ad3029/index.rst
+++ b/docs/solutions/reference-designs/eval-cog-ad3029/index.rst
@@ -1,7 +1,45 @@
-EVAL-COG-AD3029
-===============
+.. _eval_cog_ad3029 eval:
+
+EVAL COG AD3029
+===========================================================================================
+
+.. TODO: Add a picture of the chip/board
+
+Overview
+-------------------------------------------------------------------------------
+
+.. TODO: Describe in max 10 rows the main features and applications.
+
+Features:
+
+- feature 1
+- feature 2
+
+Applications:
+
+- application 1
+- application 2
 
 .. toctree::
-   :titlesonly:
+   :hidden:
 
    software/aducm302x
+
+Recommendations
+-------------------------------------------------------------------------------
+
+People who follow the flow that is outlined, have a much better experience with
+things. However, like many things, documentation is never as complete as it
+should be. If you have any questions, feel free to ask on our
+:ref:`EngineerZone forums <help-and-support>`, but before that, please make
+sure you read our documentation thoroughly.
+
+Warning
+-------------------------------------------------------------------------------
+
+.. esd-warning::
+
+Help and support
+-------------------------------------------------------------------------------
+
+Please go to :ref:`Help and Support <help-and-support>` page.

--- a/docs/solutions/reference-designs/eval-cog-ad3029/index.rst
+++ b/docs/solutions/reference-designs/eval-cog-ad3029/index.rst
@@ -1,0 +1,7 @@
+EVAL-COG-AD3029
+===============
+
+.. toctree::
+   :titlesonly:
+
+   software/aducm302x

--- a/docs/solutions/reference-designs/eval-cog-ad3029/software/aducm302x.rst
+++ b/docs/solutions/reference-designs/eval-cog-ad3029/software/aducm302x.rst
@@ -10,11 +10,6 @@ The following on-chip drivers are provided as part of the ADuCM302x Device
 Family Pack:
 
 -  spi
-
-.. image:: ../images/software_packs_aducm302x_device_block_diagram.png
-   :align: right
-   :width: 600
-
 -  i2c
 -  uart
 -  sport
@@ -27,21 +22,21 @@ Family Pack:
 -  adc
 -  tmr
 
+.. image:: ../images/software_packs_aducm302x_device_block_diagram.png
+   :align: center
+   :width: 600
+
 For detailed information regarding the ADuCM302x DFP, please see our complete
 ADuCM302x software user guide.
 
 .. hint::
 
-   
    `ADuCM302x DFP Release Notes <http://download.analog.com/tools/EZBoards/CM302x/Releases/Release_2.0.0/ADuCM302x_DFP_2.0.0_Release_Notes.pdf>`_
-   
 
 .. important::
 
-   
    You MUST have this software package installed on your laptop or PC in order
    to compile, debug, and run the applications for the EV-COG-AD3029LZ platform.
-   
 
 Downloading the ADuCM302x Software Pack
 ---------------------------------------
@@ -65,10 +60,4 @@ manual installation to install the pack.
 .. admonition:: Download
    :class: download
 
-   
    `ADuCM302x DFP 2.0.0 <http://download.analog.com/tools/EZBoards/CM302x/Releases/AnalogDevices.ADuCM302x_DFP.2.0.0.pack>`_
-   
-
-*End of Document*
-
-`Back <https://wiki.analog.com/resources/eval/user-guides/ev-cog-ad3029lz>`_

--- a/docs/solutions/reference-designs/eval-cog-ad3029/software/aducm302x.rst
+++ b/docs/solutions/reference-designs/eval-cog-ad3029/software/aducm302x.rst
@@ -1,0 +1,74 @@
+ADuCM302x On-Chip Peripheral Drivers & Software
+===============================================
+
+General Description/Overview
+----------------------------
+
+The ADuCM302x Device Family Pack (DFP) provides access to all the necessary on-chip peripheral drivers for both the :adi:`ADuCM3029` and the :adi:`ADuCM3027` devices. This software layer is the foundation layer needed when writing applications using this microprocessor family. When combined with the **EV-COG-AD3029LZ** software pack as well as the Sensors software pack, there are many great **Internet of Things(IoT)** applications and demos that can be replicated using the **EV-COG-AD3029LZ** development platform.
+
+The following on-chip drivers are provided as part of the ADuCM302x Device
+Family Pack:
+
+-  spi
+
+.. image:: ../images/software_packs_aducm302x_device_block_diagram.png
+   :align: right
+   :width: 600
+
+-  i2c
+-  uart
+-  sport
+-  beep
+-  wdt
+-  gpio
+-  rtc
+-  dma
+-  cryto
+-  adc
+-  tmr
+
+For detailed information regarding the ADuCM302x DFP, please see our complete
+ADuCM302x software user guide.
+
+.. hint::
+
+   
+   `ADuCM302x DFP Release Notes <http://download.analog.com/tools/EZBoards/CM302x/Releases/Release_2.0.0/ADuCM302x_DFP_2.0.0_Release_Notes.pdf>`_
+   
+
+.. important::
+
+   
+   You MUST have this software package installed on your laptop or PC in order
+   to compile, debug, and run the applications for the EV-COG-AD3029LZ platform.
+   
+
+Downloading the ADuCM302x Software Pack
+---------------------------------------
+
+The software pack can be installed directly by the tool chain's CMSIS pack
+manager. Optionally, you may download and then use the CMSIS pack manager's
+manual installation to install the pack.
+
+-  Downloaded via the tool chain's CMSIS pack manager
+
+   -  It is **recommended** to download the ADuCM302x software pack through from the tool chain's CMSIS pack manager. That way, all the files, directories structure, and project structure for the various applications is properly saved and accessed. For a detailed description on how to download the ADuCM302x software pack through CrossCore Embedded Studio please see our `CrossCore Embedded Studio Quickstart User Guide <https://wiki.analog.com/resources/eval/user-guides/eval-adicup3029/tools/cces_user_guide>`_.
+
+-  Downloaded to local directory
+
+   -  However if you do decide to download the ADuCM302x software pack to your
+      PC/laptop directly, please use the link below to download the pack file
+      from Keil's website. You will then need to "import" the pack file using
+      your tool chain's CMSIS pack manager's import feature. Note that all
+      software packs can be downloaded from Keil's website.
+
+.. admonition:: Download
+   :class: download
+
+   
+   `ADuCM302x DFP 2.0.0 <http://download.analog.com/tools/EZBoards/CM302x/Releases/AnalogDevices.ADuCM302x_DFP.2.0.0.pack>`_
+   
+
+*End of Document*
+
+`Back <https://wiki.analog.com/resources/eval/user-guides/ev-cog-ad3029lz>`_


### PR DESCRIPTION
## Summary
- Move eval-cog-ad3029 wiki documentation to `solutions/reference-designs/eval-cog-ad3029/`
- 2 RST files with 1 localized images
- Generated stub `index.rst` with toctree

## Test plan
- [ ] Sphinx build passes without errors
- [ ] All toctree entries resolve correctly
- [ ] Images render properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)