### PR TITLE
reference-designs/eval-cog-ad3029lz: Add eval-cog-ad3029lz documentation

### DIFF
--- a/docs/solutions/reference-designs/eval-cog-ad3029lz/cog_hw_userguide.rst
+++ b/docs/solutions/reference-designs/eval-cog-ad3029lz/cog_hw_userguide.rst
@@ -122,7 +122,7 @@ worry about porting their firmware. The figures below capture the pin-mapping
 and jumpers that need to be changed to get external access (via the expansion
 connectors) to GPIO (as well as power/reset, etc).
 
-|image2|\ |image3|
+|image2| |image3|
 
 Jumper Settings
 ---------------
@@ -134,11 +134,11 @@ The MCU Cog offers flexibility in terms of power muxing options and the facility
 MCU Cog Design and Integration Files
 ------------------------------------
 
-\*\ `MCU Cog revB Schematics <resources/21052017-iot-devkit-tile-revb-schematics.pdf>`_
+-  `MCU Cog revB Schematics <resources/21052017-iot-devkit-tile-revb-schematics.pdf>`_
 
-\*\ `MCU Cog revB Gerbers <resources/21052017-mcu-cog-revb-gerbers.zip>`_
+-  `MCU Cog revB Gerbers <resources/21052017-mcu-cog-revb-gerbers.zip>`_
 
-\*\ `MCU Cog revB BOM <resources/21052017-mcu-cog-revb-bom.zip>`_
+-  `MCU Cog revB BOM <resources/21052017-mcu-cog-revb-bom.zip>`_
 
 Add-on (Gear) Template
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -149,9 +149,6 @@ expansion connectors as well as place-bound rules embedded.
 
 `Template Design Files (Cadence Allegro v16.6) <resources/20-047257-01a.zip>`_
 
-| End Document
-
-`Back <https://wiki.analog.com/resources/eval/user-guides/ev-cog-ad3029lz>`_
 
 .. |image1| image:: images/23062017-tile-revb-power-mux-scheme.png
 .. |direct| image:: images/24072017-tile-revb-adp5300-gpio.png

--- a/docs/solutions/reference-designs/eval-cog-ad3029lz/cog_hw_userguide.rst
+++ b/docs/solutions/reference-designs/eval-cog-ad3029lz/cog_hw_userguide.rst
@@ -1,0 +1,162 @@
+EV-COG-AD3029LZ MCU Cog
+=======================
+
+The EV-COG-AD3029LZ is an *MCU Cog* board for the :adi:`ADuCM3029 MCU <en/products/processors-dsp/microcontrollers/precision-microcontrollers/aducm3029.html>`.
+
+Main Features
+-------------
+
+-  :adi:`ADuCM3029` (LFCSP package) - Ultra Low Power ARM Cortex-M3 MCU
+-  Compact form factor (3.5 cm X 7.5 cm) - Easy to deploy.
+-  On board debugger capability (CMSIS DAP compatible)
+-  Multiple power options and current monitoring test-points.
+-  On-board sensors: Accelerometer (ADXL362) and Temperature Sensor (ADT7420)
+-  Optional expansion capability - Using application specific add-on cards (*Gears*)
+-  Optional connectivity options - Using RF modules (*Connectivity Cogs*)
+
+Board
+-----
+
+Front-Side
+~~~~~~~~~~
+
+.. image:: images/25072017-tile-revb-front.png
+   :alt: 25072017-tile-revb-front.png
+
+Back-Side
+~~~~~~~~~
+
+.. image:: images/25072017-tile-revb-back.png
+   :alt: 25072017-tile-revb-back.png
+
+Power
+-----
+
+The MCU Cog board offers flexibility in terms of power supply and power muxing
+options. This is achieved with the use of jumpers on the board. The Cog board
+also offers multiple test points for monitoring current consumption.
+
+Power Supply Options
+~~~~~~~~~~~~~~~~~~~~
+
+The MCU Cog offers the following power supply options:
+
+::
+
+   -5V USB power (USB microB connector)
+   -3V CR2032 Coin cell (Cell holder - BT1)
+   -3V - 6V Rechargeable Li-Ion Battery (JST Connector - P6)
+   -3V - 6V External Supply from an MCU Cog Add-on card (via Connector C1)
+
+Power Muxing Options
+~~~~~~~~~~~~~~~~~~~~
+
+For details of the power muxing scheme, refer to the figure below.
+
+|image1|
+
+.. danger::
+
+   Do not insert shunt b/w positions 5 & 6 of JH4 when using USB supply. Doing
+   so can permanently damage this board.
+
+.. tip::
+
+   Refer to the *Jumper Settings* section further below for details on power related jumpers on the board
+
+Power Regulator
+~~~~~~~~~~~~~~~
+
+The MCU Cog board uses an on-board switching regulator - the :adi:`ADP5300 <en/products/power-management/switching-power-converters/switching-regulators/adp5300.html>`, which is a high efficiency, ultra-low power step down regulator. The MCU has complete control over the switching modes of the regulator via GPIO. The pin-mapping is shown in the table below.
+
+|direct|
+
+Current Measurement Options
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The MCU Cog enables IOT developers to measure and profile current consumption at
+different places on the board to enable isolation of current consumption
+hotspots. The current measure test points shown in the table below can be used
+along with a digital multimeter to profile current consumption.
+
+.. image:: images/24072017-tile-revb-current-test-points.png
+   :alt: 24072017-tile-revb-current-test-points.png
+
+Programming & Debug Options
+---------------------------
+
+The MCU Cog offers the following debug options:
+
+::
+
+   -On-board CMSIS-DAP debugger (USB microB connector)
+   -JLINK-9 Connector for access to SWD interface (P26)
+   -Access to SW interface to an MCU Cog Add-on card (via Connector C2)
+
+.. tip::
+
+   It is possible to route UART over USB through the on-board CMSIS-DAP
+   debugger. The maximum baud rate that can be achieved in this case is 230400
+
+Wireless Connectivity Options
+-----------------------------
+
+The MCU Cog board offers support for ADI RF daughter-cards such as the EV-ADF70301-915AZ via the "EV-COG-BLEINTP1" connectivity Cog board that can be attached at Connector P2. This connectivity Cog board also has on-board BTLE circuit enabling the MCU Cog board to use BTLE communication as well. More details regarding wireless connectivity options are available on the `EV-COG-BLEINTP1 Wiki page <https://wiki.analog.com/resources/eval/user-guides/ev-cog-bleintp1z>`_.
+
+Buttons/LED(s)
+--------------
+
+The MCU Cog offers 2 buttons and 2 LED(s) that can be used by the Application.
+The default GPIO connections are shown in the tables below.
+
+.. image:: images/24072017-tile-revb-buttons-leds2.png
+   :alt: 24072017-tile-revb-buttons-leds2.png
+
+Expansion Connectors
+--------------------
+
+One of the USP of the MCU Cog is access to ALL GPIO via Expansion Connectors
+("C1" and "C2") for an Add-on card to utilize in its Application. This enables
+developers to confidently build final form factor hardware without having to
+worry about porting their firmware. The figures below capture the pin-mapping
+and jumpers that need to be changed to get external access (via the expansion
+connectors) to GPIO (as well as power/reset, etc).
+
+|image2|\ |image3|
+
+Jumper Settings
+---------------
+
+The MCU Cog offers flexibility in terms of power muxing options and the facility to route any GPIO externally via the expansion connectors "C1" and "C2". This is achieved with the use of jumpers. The MCU Cog has two types of jumpers - those labelled "JHx" and which are 2x2 1.27mm pitch headers and those labelled "JPx" and which are solder jumpers. The "JHx" jumpers are expected to be used more frequently than the "JPx" jumpers. The figures below capture the jumper settings. |power-jumpers.png| |image4|
+
+|image5|
+
+MCU Cog Design and Integration Files
+------------------------------------
+
+\*\ `MCU Cog revB Schematics <resources/21052017-iot-devkit-tile-revb-schematics.pdf>`_
+
+\*\ `MCU Cog revB Gerbers <resources/21052017-mcu-cog-revb-gerbers.zip>`_
+
+\*\ `MCU Cog revB BOM <resources/21052017-mcu-cog-revb-bom.zip>`_
+
+Add-on (Gear) Template
+~~~~~~~~~~~~~~~~~~~~~~
+
+For developers designing a Cog add-on board, the template schematic/board files
+below might be a useful starting point. The board file has the placement of the
+expansion connectors as well as place-bound rules embedded.
+
+`Template Design Files (Cadence Allegro v16.6) <resources/20-047257-01a.zip>`_
+
+| End Document
+
+`Back <https://wiki.analog.com/resources/eval/user-guides/ev-cog-ad3029lz>`_
+
+.. |image1| image:: images/23062017-tile-revb-power-mux-scheme.png
+.. |direct| image:: images/24072017-tile-revb-adp5300-gpio.png
+.. |image2| image:: images/c1-conn-mapping.png
+.. |image3| image:: images/c2-conn-mapping.png
+.. |power-jumpers.png| image:: images/power-jumpers.png
+.. |image4| image:: images/10082017-sensor-jumpers.png
+.. |image5| image:: images/10082017-debug-jumpers.png

--- a/docs/solutions/reference-designs/eval-cog-ad3029lz/example_project.rst
+++ b/docs/solutions/reference-designs/eval-cog-ad3029lz/example_project.rst
@@ -1,4 +1,3 @@
 COMING SOON !!
 ==============
 
-`Back <https://wiki.analog.com/resources/eval/user-guides/ev-cog-ad3029lz>`_

--- a/docs/solutions/reference-designs/eval-cog-ad3029lz/example_project.rst
+++ b/docs/solutions/reference-designs/eval-cog-ad3029lz/example_project.rst
@@ -1,0 +1,4 @@
+COMING SOON !!
+==============
+
+`Back <https://wiki.analog.com/resources/eval/user-guides/ev-cog-ad3029lz>`_

--- a/docs/solutions/reference-designs/eval-cog-ad3029lz/hardware_details.rst
+++ b/docs/solutions/reference-designs/eval-cog-ad3029lz/hardware_details.rst
@@ -14,6 +14,3 @@ The following boards are currently available:
 -  `EV-COG-BLEINTP1Z Connectivity Cog <https://wiki.analog.com/resources/eval/user-guides/ev-cog-bleintp1z>`_
 -  `EV-GEAR-EXPANDER1Z Expander Gear <https://wiki.analog.com/resources/eval/user-guides/ev-gear-expander1z>`_
 
-| End Document
-
-`Back <https://wiki.analog.com/resources/eval/user-guides/ev-cog-ad3029lz>`_

--- a/docs/solutions/reference-designs/eval-cog-ad3029lz/hardware_details.rst
+++ b/docs/solutions/reference-designs/eval-cog-ad3029lz/hardware_details.rst
@@ -1,0 +1,19 @@
+Hardware Details
+================
+
+This page contains hardware-related information about the EV-COG-AD3029LZ board
+and the various hardware add on modules which can be used with the board. Each
+sub-section contains a detailed description of the board, connectors, jumpers
+and buttons. It also provides links to the Schematics, Bill of materials, design
+projects, and Technical documentation. It also gives internal links to the
+provided example demo software projects.
+
+The following boards are currently available:
+
+-  `EV-COG-AD3029LZ MCU Cog <https://wiki.analog.com/resources/eval/user-guides/ev-cog-ad3029lz/cog_hw_userguide>`_
+-  `EV-COG-BLEINTP1Z Connectivity Cog <https://wiki.analog.com/resources/eval/user-guides/ev-cog-bleintp1z>`_
+-  `EV-GEAR-EXPANDER1Z Expander Gear <https://wiki.analog.com/resources/eval/user-guides/ev-gear-expander1z>`_
+
+| End Document
+
+`Back <https://wiki.analog.com/resources/eval/user-guides/ev-cog-ad3029lz>`_

--- a/docs/solutions/reference-designs/eval-cog-ad3029lz/help_support.rst
+++ b/docs/solutions/reference-designs/eval-cog-ad3029lz/help_support.rst
@@ -1,0 +1,99 @@
+Help and Support
+================
+
+Do you need help or have general support questions, than I hope this page helps
+you resolve those.
+
+This page has a quickstart troubleshooting approach that goes over some very
+general questions and common pitfalls, but if you have a specific issue which
+requires more information or detail please contact us through EngineerZone or
+Email. (links can be found further down on the page where to direct specific
+questions)
+
+What to do When Things Go Wrong
+-------------------------------
+
+There are many things that can go wrong with an ecosystem this complex, but if
+you are having issues getting the board or software working, here are a few
+simple things you can try before contacting Analog Devices.
+
+-  Check the Power
+
+   -  Do you have the USB cable plugged in? if yes, then check switch (S7) in USB position
+   -  If you are using batteries, is the switch (S7) in the "BATT" position
+
+      -  Try replacing your batteries, and see if the board powers up.
+
+-  Program the EV-COG-AD3029LZ
+
+   -  Sometimes a flashed program doesn't run properly or can make it difficult to run the debugger.
+   -  The first thing to try in this case, is to :doc:`drag and drop </solutions/reference-designs/eval-cog-ad3029lz/tools/hardware_usb>` a known good .HEX or .BIN program into flash.(something with quick visible indicators works best)
+   -  If drag and drop is not working, it may be necessary to erase the flash.
+      To do so:
+
+      -  Download and install the CrossCore Serial Flash Programmer from here: :adi:`en/design-center/processors-and-dsp/evaluation-and-development-software/crosscore-serial-flash-programmer.html#dsp-overview`.
+      -  Make sure that the USB is connected and on UART header (P8) 1 & 2 and 7 & 8 are shorted.
+      -  Power cycle the EV-COG-AD3029LZ board while holding down the boot switch.
+      -  Select the mbed serial COM port in the CrossCore Serial Flash Programmer, and erase the flash.
+      -  Then try :doc:`drag and drop </solutions/reference-designs/eval-cog-ad3029lz/tools/hardware_usb>` a .HEX or .BIN file into flash
+
+   -  If the mass erase didn't work, and you are trying to drag and drop a large
+      .BIN file on EV-COG-AD3029LZ hardware, it's possible that the mbed
+      interface file needs to be updated to support your application.
+
+      -  Please visit the :doc:`Driver Installation for On-board Debugger (CMSIS DAP) </solutions/reference-designs/eval-cog-ad3029lz/tools/hardware_usb>`\ page in order to put the board in update mode.
+      -  Once you are in "maintenance mode" you should drag and drop the latest interface file onto your maintenance drive. That file can be downloaded at the bottom of :doc:`Driver Installation for On-board Debugger (CMSIS DAP) </solutions/reference-designs/eval-cog-ad3029lz/tools/hardware_usb>`.
+
+-  Not receiving/transmitting data to the UART
+
+   -  Make sure that the UART header (P8) is positioned in the correct
+      destination to transmit/receive UART data.
+
+This is just a brief self-help guide to troubleshooting common issues. If you
+have other questions that need answering please direct those requests to the
+locations outlined below.
+
+Hardware, Software, and Documentation Questions
+-----------------------------------------------
+
+If you have any questions regarding the **EV-COG-AD3029LZ**, any of the **shields/pmods** or are experiencing any problems using the **software** or issues following any of the **documentation** feel free to ask us a question.
+
+-  :ez:`ADuCM3029 support community <community/analog-microcontrollers/aducm302x>` for questions about:
+
+   -  EV-COG-AD3029LZ hardware
+   -  ADuCM3029 silicon
+   -  EV-COG-AD3029LZ software
+   -  EV-COG-AD3029LZ documentation
+
+When asking a question please take the time to give a detailed description of
+your problem. If you are experiencing a problem please state the steps you have
+executed, the result you expected you would get and the result you actually got.
+By doing so you enable us to provide you precise and detailed answers in a
+timely manner.
+
+.. tip::
+
+   Before asking questions please take the time to check if somebody else
+   already asked the same question. You might just find your question already
+   answered.
+
+CrossCore Embedded Studio questions
+-----------------------------------
+
+If you have questions regarding the tools and tool chain that is used with the
+EV-COG-AD3029LZ, either post a question or send an email.
+
+-  :ez:`CrossCore Embedded Studio support community <community/dsp/software-and-development-tools/cces>` for questions about:
+
+   -  Download/Install issues
+   -  Build, debug, run, issues
+   -  Other tools related issues
+
+-  The CrossCore Embedded Studio team can also be emailed using the address
+   below:
+
+   -  `processor.tools.support@analog.com <https://wiki.analog.com/mailto/processor.tools.support@analog.com>`_
+
+*End of Document*
+
+`Back <https://wiki.analog.com/resources/eval/user-guides/ev-cog-ad3029lz>`_

--- a/docs/solutions/reference-designs/eval-cog-ad3029lz/help_support.rst
+++ b/docs/solutions/reference-designs/eval-cog-ad3029lz/help_support.rst
@@ -92,8 +92,5 @@ EV-COG-AD3029LZ, either post a question or send an email.
 -  The CrossCore Embedded Studio team can also be emailed using the address
    below:
 
-   -  `processor.tools.support@analog.com <https://wiki.analog.com/mailto/processor.tools.support@analog.com>`_
+   -  `processor.tools.support@analog.com <mailto:processor.tools.support@analog.com>`_
 
-*End of Document*
-
-`Back <https://wiki.analog.com/resources/eval/user-guides/ev-cog-ad3029lz>`_

--- a/docs/solutions/reference-designs/eval-cog-ad3029lz/images/10082017-debug-jumpers.png
+++ b/docs/solutions/reference-designs/eval-cog-ad3029lz/images/10082017-debug-jumpers.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dbae1d16178c152fbc5431c8aad064d277400486f40b7b03f07a7aefb9eeb190
+size 10389

--- a/docs/solutions/reference-designs/eval-cog-ad3029lz/images/10082017-sensor-jumpers.png
+++ b/docs/solutions/reference-designs/eval-cog-ad3029lz/images/10082017-sensor-jumpers.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8d2302f62503ee592158d4a23bd1c19cbf633731b6086c40e6e884ca062d1cea
+size 21046

--- a/docs/solutions/reference-designs/eval-cog-ad3029lz/images/11082017-mcu-cog-revb-horizontal-concept.png
+++ b/docs/solutions/reference-designs/eval-cog-ad3029lz/images/11082017-mcu-cog-revb-horizontal-concept.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5c6f8de11f9d7de05e9211be244b932efa6cee5b68bfa439e61fe90d9ed06a87
+size 69006

--- a/docs/solutions/reference-designs/eval-cog-ad3029lz/images/11082017-mcu-cog-revb-stacking.png
+++ b/docs/solutions/reference-designs/eval-cog-ad3029lz/images/11082017-mcu-cog-revb-stacking.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d1e4525fea1ac3e19d73caa4161c2aee350612ff7be3ad1cf2d82061941ebbb6
+size 17501

--- a/docs/solutions/reference-designs/eval-cog-ad3029lz/images/23062017-tile-revb-power-mux-scheme.png
+++ b/docs/solutions/reference-designs/eval-cog-ad3029lz/images/23062017-tile-revb-power-mux-scheme.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b80c7beca0f4d29d7737d80ac1b89d16d46ea58a74939f7ebaab4e0a3db7a51b
+size 102911

--- a/docs/solutions/reference-designs/eval-cog-ad3029lz/images/24072017-tile-revb-adp5300-gpio.png
+++ b/docs/solutions/reference-designs/eval-cog-ad3029lz/images/24072017-tile-revb-adp5300-gpio.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a34273b077c392ac21ca50141591e65bec0d1fe909298df1c622ba977c3619ac
+size 21068

--- a/docs/solutions/reference-designs/eval-cog-ad3029lz/images/24072017-tile-revb-buttons-leds2.png
+++ b/docs/solutions/reference-designs/eval-cog-ad3029lz/images/24072017-tile-revb-buttons-leds2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f004d1923b6c8b1ee1a196dedcfd9bac5bce493351cb5b3a00d7652101b154d0
+size 3370

--- a/docs/solutions/reference-designs/eval-cog-ad3029lz/images/24072017-tile-revb-current-test-points.png
+++ b/docs/solutions/reference-designs/eval-cog-ad3029lz/images/24072017-tile-revb-current-test-points.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:40f0061866348313528b6f085aca4e24b0c7ddbd5821c63437ddfeaa752fe9b1
+size 8460

--- a/docs/solutions/reference-designs/eval-cog-ad3029lz/images/25072017-tile-revb-back.png
+++ b/docs/solutions/reference-designs/eval-cog-ad3029lz/images/25072017-tile-revb-back.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bb83767c617ca67d94f33a6bc70861493ed44e4ece607d778dcd6e3e54081542
+size 677643

--- a/docs/solutions/reference-designs/eval-cog-ad3029lz/images/25072017-tile-revb-front.png
+++ b/docs/solutions/reference-designs/eval-cog-ad3029lz/images/25072017-tile-revb-front.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7c3928f7fe2526ee9e065cc681747149c161bcc126b4436bece693419e7a6e4d
+size 708749

--- a/docs/solutions/reference-designs/eval-cog-ad3029lz/images/add_pack.jpg
+++ b/docs/solutions/reference-designs/eval-cog-ad3029lz/images/add_pack.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:96ca39243ff844f308fa013e8a7d29754b4418c78315a695c68e8605f4942bd1
+size 149688

--- a/docs/solutions/reference-designs/eval-cog-ad3029lz/images/c1-conn-mapping.png
+++ b/docs/solutions/reference-designs/eval-cog-ad3029lz/images/c1-conn-mapping.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fca315597a717e9c928dcb4105b80f871bbe91eb341920e9715ff035ed13ec60
+size 94457

--- a/docs/solutions/reference-designs/eval-cog-ad3029lz/images/c2-conn-mapping.png
+++ b/docs/solutions/reference-designs/eval-cog-ad3029lz/images/c2-conn-mapping.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9e64cc196eaea73694bb0857c0f5a4f53d1f13efddcb7b2287a81689464ddaa0
+size 87392

--- a/docs/solutions/reference-designs/eval-cog-ad3029lz/images/daplink_windows_explorer.png
+++ b/docs/solutions/reference-designs/eval-cog-ad3029lz/images/daplink_windows_explorer.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a13d3272a9eddcdeb9298a7fa9bf9b7e3bfcb841f060244680fdc59cf9e23f0b
+size 77188

--- a/docs/solutions/reference-designs/eval-cog-ad3029lz/images/device_drivers_install.png
+++ b/docs/solutions/reference-designs/eval-cog-ad3029lz/images/device_drivers_install.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c9ff0ca300a592c7b6b2fc4361e0e261787e01755cf476896c49bb58908c8809
+size 33050

--- a/docs/solutions/reference-designs/eval-cog-ad3029lz/images/device_drivers_install_complete.png
+++ b/docs/solutions/reference-designs/eval-cog-ad3029lz/images/device_drivers_install_complete.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:202cf81daf2751868bdf138167454e5b11f7311a6961028d01d8204e5057ea28
+size 12993

--- a/docs/solutions/reference-designs/eval-cog-ad3029lz/images/device_drivers_install_maintenance.png
+++ b/docs/solutions/reference-designs/eval-cog-ad3029lz/images/device_drivers_install_maintenance.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eabf9ad84490b4f8ce54635eb6372e4d16ae354b09d524a564904aca131476ba
+size 10079

--- a/docs/solutions/reference-designs/eval-cog-ad3029lz/images/device_drivers_install_notification.png
+++ b/docs/solutions/reference-designs/eval-cog-ad3029lz/images/device_drivers_install_notification.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1b63f3b3775b481a5a7433a1003e31de7b579401087111319f94678e459a01ba
+size 7835

--- a/docs/solutions/reference-designs/eval-cog-ad3029lz/images/eval-aducm3029-clone.png
+++ b/docs/solutions/reference-designs/eval-cog-ad3029lz/images/eval-aducm3029-clone.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e53886dc7e6e1924bd56c289280047594780d723fde9e72567a7aa1c78dc21a0
+size 170294

--- a/docs/solutions/reference-designs/eval-cog-ad3029lz/images/eval-aducm3029-cmsis-pack-arm-cmsis-200.png
+++ b/docs/solutions/reference-designs/eval-cog-ad3029lz/images/eval-aducm3029-cmsis-pack-arm-cmsis-200.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:118af17a1cc221a7895bd7da856747869423e49808d80b338d928568dcb71eab
+size 271922

--- a/docs/solutions/reference-designs/eval-cog-ad3029lz/images/eval-aducm3029-cmsis-pack-example-200.png
+++ b/docs/solutions/reference-designs/eval-cog-ad3029lz/images/eval-aducm3029-cmsis-pack-example-200.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:35f29d7c6b4d32de9ee0bf65fe99a1d87d8aefd28eaea28a95a79b879e3b4f15
+size 330884

--- a/docs/solutions/reference-designs/eval-cog-ad3029lz/images/eval-aducm3029-debug-configuration.png
+++ b/docs/solutions/reference-designs/eval-cog-ad3029lz/images/eval-aducm3029-debug-configuration.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bd218c02bb5397edcdf92b023452bfdcdb28d85943732e7fc09aed2cf4a09d71
+size 124031

--- a/docs/solutions/reference-designs/eval-cog-ad3029lz/images/eval-aducm3029-debug-hw-limited.png
+++ b/docs/solutions/reference-designs/eval-cog-ad3029lz/images/eval-aducm3029-debug-hw-limited.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9c794b7428d9862abcb95e59e4490db3ad2222afdadb506fc58d66b025ed481d
+size 41287

--- a/docs/solutions/reference-designs/eval-cog-ad3029lz/images/eval-aducm3029-debug-perspective.png
+++ b/docs/solutions/reference-designs/eval-cog-ad3029lz/images/eval-aducm3029-debug-perspective.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bfe0880c4935ab801ad1a2d503058415bd5cc9221baab016a4c0d896ccf9c724
+size 25989

--- a/docs/solutions/reference-designs/eval-cog-ad3029lz/images/eval-aducm3029-debug-semi-hosting.png
+++ b/docs/solutions/reference-designs/eval-cog-ad3029lz/images/eval-aducm3029-debug-semi-hosting.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e87e371cbf49fec96a1acd7fb77d0957201cde520a80c1d72fef7b51c963c914
+size 30524

--- a/docs/solutions/reference-designs/eval-cog-ad3029lz/images/eval-aducm3029-debug-toolbar-stop.png
+++ b/docs/solutions/reference-designs/eval-cog-ad3029lz/images/eval-aducm3029-debug-toolbar-stop.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2d6aa2e80c2bb63c9656906c62096247c4684c2bb3de201e24a6c8721365ff77
+size 40213

--- a/docs/solutions/reference-designs/eval-cog-ad3029lz/images/eval-aducm3029-debug-toolbar.png
+++ b/docs/solutions/reference-designs/eval-cog-ad3029lz/images/eval-aducm3029-debug-toolbar.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6ce6b3835db7ade67dab8f871df66644e69c959ed51598ee79081117a8c75581
+size 49404

--- a/docs/solutions/reference-designs/eval-cog-ad3029lz/images/eval-aducm3029-debugging.png
+++ b/docs/solutions/reference-designs/eval-cog-ad3029lz/images/eval-aducm3029-debugging.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:36e56e411f8a59e4108a3b1b0d3416627850364a56d68f93cbccc67bb548ee35
+size 225060

--- a/docs/solutions/reference-designs/eval-cog-ad3029lz/images/eval-aducm3029-example-browser.png
+++ b/docs/solutions/reference-designs/eval-cog-ad3029lz/images/eval-aducm3029-example-browser.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b6314518f795fa482806b5f11ab6e3fbcf355e14daab98541bb6a3d24dc78bcc
+size 199290

--- a/docs/solutions/reference-designs/eval-cog-ad3029lz/images/eval-aducm3029-file-import.png
+++ b/docs/solutions/reference-designs/eval-cog-ad3029lz/images/eval-aducm3029-file-import.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:95cd976bceb614450a80254fe5a236fbf19a7a6f1c09e5c63123c5c866901d51
+size 207086

--- a/docs/solutions/reference-designs/eval-cog-ad3029lz/images/eval-aducm3029-openocd-firewall.png
+++ b/docs/solutions/reference-designs/eval-cog-ad3029lz/images/eval-aducm3029-openocd-firewall.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8079ae6e5c36514ceda43fecd2e2d2cffcec76494105139d3533a6879267aa18
+size 71385

--- a/docs/solutions/reference-designs/eval-cog-ad3029lz/images/eval-aducm3029-project-build.png
+++ b/docs/solutions/reference-designs/eval-cog-ad3029lz/images/eval-aducm3029-project-build.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eb3236b8637569c7b89308e20e3e3691831f02782be2167e7f781aa010046205
+size 34753

--- a/docs/solutions/reference-designs/eval-cog-ad3029lz/images/eval-aducm3029-project-configure.png
+++ b/docs/solutions/reference-designs/eval-cog-ad3029lz/images/eval-aducm3029-project-configure.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4f86360da46e2cb5b9c2eaa1c39c4762d53c063a0450f1d3974fb94d90990389
+size 187292

--- a/docs/solutions/reference-designs/eval-cog-ad3029lz/images/eval-aducm3029-project-explorer.png
+++ b/docs/solutions/reference-designs/eval-cog-ad3029lz/images/eval-aducm3029-project-explorer.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ad04a3051e986444815f6c3289f5cf2f59c91d7ac9d01a882a57f88aa5800880
+size 46663

--- a/docs/solutions/reference-designs/eval-cog-ad3029lz/images/eval-aducm3029-project-new.png
+++ b/docs/solutions/reference-designs/eval-cog-ad3029lz/images/eval-aducm3029-project-new.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6c23575e84ec526c86fbd58a9388880acd94fe6cf081e7daaee4977ba7851dbc
+size 169798

--- a/docs/solutions/reference-designs/eval-cog-ad3029lz/images/eval-aducm3029-project-tools-settings.png
+++ b/docs/solutions/reference-designs/eval-cog-ad3029lz/images/eval-aducm3029-project-tools-settings.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dcbc1397e0ca3e8fe28dbe9df05198d018209c35466be6ddddf15be778752956
+size 187110

--- a/docs/solutions/reference-designs/eval-cog-ad3029lz/images/eval-aducm3029-spec.png
+++ b/docs/solutions/reference-designs/eval-cog-ad3029lz/images/eval-aducm3029-spec.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1c76642b62219704bc254cdea104d1ed6823ff62ddf4c5360638a82da1afff30
+size 117686

--- a/docs/solutions/reference-designs/eval-cog-ad3029lz/images/eval-aducm3029-tools-hex.png
+++ b/docs/solutions/reference-designs/eval-cog-ad3029lz/images/eval-aducm3029-tools-hex.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eac983a8f7fba71a58c6ae86d4afb90c2266b54e2fc8d56d5864c21eaa3eee2e
+size 207567

--- a/docs/solutions/reference-designs/eval-cog-ad3029lz/images/eval-aducm3029-tools-semi-hosting.png
+++ b/docs/solutions/reference-designs/eval-cog-ad3029lz/images/eval-aducm3029-tools-semi-hosting.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e06ec3d210aae8dfac0d815806298ca9568ee164fba2857aa115c72193b3d013
+size 132179

--- a/docs/solutions/reference-designs/eval-cog-ad3029lz/images/eval-aducm3029-workspace.png
+++ b/docs/solutions/reference-designs/eval-cog-ad3029lz/images/eval-aducm3029-workspace.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:aadb15dce1a2bfacfb6e5dd94533f2a7ab331787370a5fed739fa9dc044e5f73
+size 33564

--- a/docs/solutions/reference-designs/eval-cog-ad3029lz/images/iar_cmsis-dap_debugger_setup.png
+++ b/docs/solutions/reference-designs/eval-cog-ad3029lz/images/iar_cmsis-dap_debugger_setup.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ad0eda141fd6163fbe26c9be94eecc57b6828aad34e4476c04fd224452cdaad0
+size 195405

--- a/docs/solutions/reference-designs/eval-cog-ad3029lz/images/iar_options_cmsis-dap_debugger.png
+++ b/docs/solutions/reference-designs/eval-cog-ad3029lz/images/iar_options_cmsis-dap_debugger.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bdcf30f9deffe09602241bda21ce94ff7baf07a9ad42ba53a359797cb04df9a0
+size 179820

--- a/docs/solutions/reference-designs/eval-cog-ad3029lz/images/keilcmsisdap.png
+++ b/docs/solutions/reference-designs/eval-cog-ad3029lz/images/keilcmsisdap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0795db43e4a6e2798af65f8283ae49b9f6257e2d1d87e60da80ba81fabe42ca6
+size 19028

--- a/docs/solutions/reference-designs/eval-cog-ad3029lz/images/keildebug.png
+++ b/docs/solutions/reference-designs/eval-cog-ad3029lz/images/keildebug.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:53d8db73a47c75089f2397e67017181dca7cdeb8d8941ce3c713f4db35d6f627
+size 20163

--- a/docs/solutions/reference-designs/eval-cog-ad3029lz/images/maintenance_windows_explorer.png
+++ b/docs/solutions/reference-designs/eval-cog-ad3029lz/images/maintenance_windows_explorer.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9fcb8c556cc5be629098434e9e2a107e4c1af30c6fce0c7b4f46b68072bc8638
+size 78668

--- a/docs/solutions/reference-designs/eval-cog-ad3029lz/images/power-jumpers.png
+++ b/docs/solutions/reference-designs/eval-cog-ad3029lz/images/power-jumpers.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fa8898104d56707be17c342ac509b6e3b89cf1b6fbff9f725d7c3cc46eadf191
+size 21187

--- a/docs/solutions/reference-designs/eval-cog-ad3029lz/images/reset.png
+++ b/docs/solutions/reference-designs/eval-cog-ad3029lz/images/reset.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:48bff46e2d1047367fdc4216e9f9dfcba36ee6185c935bc5e9faeda249947369
+size 17146

--- a/docs/solutions/reference-designs/eval-cog-ad3029lz/index.rst
+++ b/docs/solutions/reference-designs/eval-cog-ad3029lz/index.rst
@@ -1,0 +1,20 @@
+EVAL-COG-AD3029LZ
+=================
+
+.. toctree::
+   :titlesonly:
+
+   cog_hw_userguide
+   example_project
+   hardware_details
+   help_support
+   introduction
+   packs_bsp
+   software/connectivity
+   software/ev-cog-ad3029lz
+   software/sensor
+   tools/cces_download
+   tools/cces_guide
+   tools/hardware_usb
+   tools/other_ide
+   tools_driver

--- a/docs/solutions/reference-designs/eval-cog-ad3029lz/index.rst
+++ b/docs/solutions/reference-designs/eval-cog-ad3029lz/index.rst
@@ -1,8 +1,27 @@
-EVAL-COG-AD3029LZ
-=================
+.. _eval_cog_ad3029lz eval:
+
+EVAL COG AD3029LZ
+=======================================================================================================
+
+.. TODO: Add a picture of the chip/board
+
+Overview
+-------------------------------------------------------------------------------
+
+.. TODO: Describe in max 10 rows the main features and applications.
+
+Features:
+
+- feature 1
+- feature 2
+
+Applications:
+
+- application 1
+- application 2
 
 .. toctree::
-   :titlesonly:
+   :hidden:
 
    cog_hw_userguide
    example_project
@@ -18,3 +37,22 @@ EVAL-COG-AD3029LZ
    tools/hardware_usb
    tools/other_ide
    tools_driver
+
+Recommendations
+-------------------------------------------------------------------------------
+
+People who follow the flow that is outlined, have a much better experience with
+things. However, like many things, documentation is never as complete as it
+should be. If you have any questions, feel free to ask on our
+:ref:`EngineerZone forums <help-and-support>`, but before that, please make
+sure you read our documentation thoroughly.
+
+Warning
+-------------------------------------------------------------------------------
+
+.. esd-warning::
+
+Help and support
+-------------------------------------------------------------------------------
+
+Please go to :ref:`Help and Support <help-and-support>` page.

--- a/docs/solutions/reference-designs/eval-cog-ad3029lz/introduction.rst
+++ b/docs/solutions/reference-designs/eval-cog-ad3029lz/introduction.rst
@@ -1,0 +1,20 @@
+Introduction
+============
+
+The :adi:`EV-COG-AD3029` is a modular Internet of Things (IOT) development platform based on the :adi:`ADUCM3029` ultra low power microcontroller (MCU) with integrated power management for processing, control, and connectivity. The MCU system is based on the ARM Cortex-M3 processor, a collection of digital peripherals, embedded SRAM and flash memory, and an analog subsystem which provides clocking, reset, and power management capability in addition to an analog-to-digital converter (ADC) subsystem. The :adi:`ADUCM3029` has industry leading ultra low power which makes it ideal for developing battery powered and self powered wireless sensor nodes. The *Cog* platform uses CrossCore Embedded Studio, an open source Eclipse based Interactive Development Environment (IDE), which can be downloaded free of charge. The platform contains many hardware and software example projects to make it easier for customers to prototype and create connected systems and solutions for Internet of Things (IoT) applications.
+
+.. image:: images/11082017-mcu-cog-revb-horizontal-concept.png
+
+The *Cog* IOT development platform is modular in nature and comprises of:
+
+-  An MCU *Cog* (such as the :doc:`EV-COG-AD3029LZ </solutions/reference-designs/eval-cog-ad3029lz/cog_hw_userguide>`) which has an on-board debugger and test-points for monitoring energy consumption.
+-  An optional connectivity *Cog* (such as the `EV-COG-BLEINTP1Z <https://wiki.analog.com/resources/eval/user-guides/ev-cog-bleintp1z>`_) which offers BTLE, LPWAN or WiFi connectivity options.
+-  An optional application specific add-on board (*Gear*) which might have an optimized sensor signal chain, specific to the use-case. For example - an add-on board targeted at smart agriculture use-cases might have Light, Temperature and Humidity Sensors. For initial prototyping, a specialized Gear is available which provides access to Arduino and PMOD connectors in addition to debug connectors - see `EV-GEAR-EXPANDER1Z <https://wiki.analog.com/resources/eval/user-guides/ev-gear-expander1z>`_.
+
+This modular nature is depicted in the concept sketches below.
+
+.. image:: images/11082017-mcu-cog-revb-stacking.png
+
+| End Document
+
+`Back <https://wiki.analog.com/resources/eval/user-guides/ev-cog-ad3029lz>`_

--- a/docs/solutions/reference-designs/eval-cog-ad3029lz/introduction.rst
+++ b/docs/solutions/reference-designs/eval-cog-ad3029lz/introduction.rst
@@ -15,6 +15,3 @@ This modular nature is depicted in the concept sketches below.
 
 .. image:: images/11082017-mcu-cog-revb-stacking.png
 
-| End Document
-
-`Back <https://wiki.analog.com/resources/eval/user-guides/ev-cog-ad3029lz>`_

--- a/docs/solutions/reference-designs/eval-cog-ad3029lz/packs_bsp.rst
+++ b/docs/solutions/reference-designs/eval-cog-ad3029lz/packs_bsp.rst
@@ -26,6 +26,3 @@ The Cog software development kit consists of these packs
 
    -  BLE Pack
 
-*End of Document*
-
-`Back <https://wiki.analog.com/resources/eval/user-guides/ev-cog-ad3029lz>`_

--- a/docs/solutions/reference-designs/eval-cog-ad3029lz/packs_bsp.rst
+++ b/docs/solutions/reference-designs/eval-cog-ad3029lz/packs_bsp.rst
@@ -1,0 +1,31 @@
+Software Packs & Board Support Package
+======================================
+
+A modular software framework is provided for quick application prototyping.
+Based on the application use case, developers need to download the respective
+software packs.
+
+.. important::
+
+   Please make sure you install CrossCore Embedded Studio 2.6.0 ® before
+   installing any of the below packs
+
+The Cog software development kit consists of these packs
+
+-  `DFP- Device Family Pack for ADuCM3029 <https://wiki.analog.com/resources/eval/user-guides/ev-cog-ad3029lz/software/aducm302x>`_ - This is a bare minimum pack required to enable working with ADuCM3029 and develop simple applications using the on-chip drivers.
+-  `BSP - Board Support Package for EV-COG-AD3029LZ <https://wiki.analog.com/resources/eval/user-guides/ev-cog-ad3029lz/software/ev-cog-ad3029lz>`_ - This pack along with the DFP is required to develop applications using the on-board drivers.
+-  `SASP - Sensor Application Software Packs <https://wiki.analog.com/resources/eval/user-guides/ev-cog-ad3029lz/software/sensor>`_ - This pack is required only to develop applications using the GEARs. Following Sensor Application are included in the pack.
+
+   -  Accelerometer Demo
+
+      -  Temperature Sensor Demo
+
+         -  Visible Light Sensor Demo
+
+-  `Connectivity Packs <https://wiki.analog.com/resources/eval/user-guides/ev-cog-ad3029lz/software/connectivity>`_ - This pack is required to enable BLE connectivity using EV-COG-BLEINTP1Z connectivity Cog.
+
+   -  BLE Pack
+
+*End of Document*
+
+`Back <https://wiki.analog.com/resources/eval/user-guides/ev-cog-ad3029lz>`_

--- a/docs/solutions/reference-designs/eval-cog-ad3029lz/resources/20-047257-01a.zip
+++ b/docs/solutions/reference-designs/eval-cog-ad3029lz/resources/20-047257-01a.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:58d8879d58e551ed79b1d2bfa98dd5cc907a819853bc0daa0cd8ebd009d4d69a
+size 323517

--- a/docs/solutions/reference-designs/eval-cog-ad3029lz/resources/21052017-iot-devkit-tile-revb-schematics.pdf
+++ b/docs/solutions/reference-designs/eval-cog-ad3029lz/resources/21052017-iot-devkit-tile-revb-schematics.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2e375b26e89e62595d71f8e478aa96f49784acac08c37f91174308dc9c1c3c25
+size 205772

--- a/docs/solutions/reference-designs/eval-cog-ad3029lz/resources/21052017-mcu-cog-revb-bom.zip
+++ b/docs/solutions/reference-designs/eval-cog-ad3029lz/resources/21052017-mcu-cog-revb-bom.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8c4dec39a063f4ef0b89c7c3b69faeab140dd90fe1f0166a9cc2b8dd84c36d33
+size 4754

--- a/docs/solutions/reference-designs/eval-cog-ad3029lz/resources/21052017-mcu-cog-revb-gerbers.zip
+++ b/docs/solutions/reference-designs/eval-cog-ad3029lz/resources/21052017-mcu-cog-revb-gerbers.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ad6b5100950f65d098a71716d6dfcef04036f96bfd964d246c8a68d1c342aeee
+size 601108

--- a/docs/solutions/reference-designs/eval-cog-ad3029lz/software/connectivity.rst
+++ b/docs/solutions/reference-designs/eval-cog-ad3029lz/software/connectivity.rst
@@ -1,0 +1,36 @@
+Connectivity Pack
+=================
+
+General Description/Overview
+----------------------------
+
+Connectivity pack includes Bluetooth Low Energy (BLE) drivers for
+EV-COG-AD3029LZ. Following are the requirements to use BLE drives available in
+the pack.
+
+-  :doc:`EV-COG-AD3029LZ MCU Cog </solutions/reference-designs/eval-cog-ad3029lz/cog_hw_userguide>`
+-  `EV-COG-BLEINTP1Z Connectivity Cog <https://wiki.analog.com/resources/eval/user-guides/ev-cog-bleintp1z>`_
+
+Connectivity Pack for BLE contains the following examples
+
+-  FindMe Target
+-  Proximity Reporter
+-  Data Exchange (Hello World)
+
+Downloading the Sensor Software Pack
+------------------------------------
+
+The software pack can be downloaded in following way.
+
+-  Downloaded via the tools program
+
+   -  It is **recommended** to download the Connectivity software pack through from the tools program you are using. That way, all the files, directories structure, and project structure for the various applications is properly saved and accessed. For a detailed description on how to download the Connectivity software pack through CrossCore Embedded Studio please see our :doc:`Cross Core Embedded Studio Quickstart User Guide </solutions/reference-designs/eval-cog-ad3029lz/tools/cces_guide>`.
+
+.. admonition:: Download
+   :class: download
+
+   Download the Connectivity Software Pack.
+
+   
+   `ADI-BLESoftware pack 1.0.0 <http://download.analog.com/tools/BLE_Software/Releases/>`_
+   

--- a/docs/solutions/reference-designs/eval-cog-ad3029lz/software/ev-cog-ad3029lz.rst
+++ b/docs/solutions/reference-designs/eval-cog-ad3029lz/software/ev-cog-ad3029lz.rst
@@ -15,9 +15,9 @@ EV-COG-AD3029LZ software pack contains the following components:
 -  On-Chip Driver Examples ( GPIO,RTC, SPI, Systick, TMR, UART, WDT)
 -  Bluetooth Profile Examples
 
-   -  \* FindMe Target
-   -  \* Proximity Reporter
-   -  \* Data Exchange (Hello World)
+   -  FindMe Target
+   -  Proximity Reporter
+   -  Data Exchange (Hello World)
 
 -  Android IoTNode application software
 -  Documentation
@@ -28,8 +28,7 @@ our complete EV-COG-AD3029LZ software user guide.
 .. hint::
 
    
-   ADD LINK HERER EV-COG-AD3029LZ BSP Release Notes
-   
+   EV-COG-AD3029LZ BSP Release Notes (link not yet available)
 
 .. important::
 
@@ -61,6 +60,3 @@ The software pack can be downloaded in several ways.
 
    
 
-*End of Document*
-
-`Back <https://wiki.analog.com/resources/eval/user-guides/ev-cog-ad3029lz>`_

--- a/docs/solutions/reference-designs/eval-cog-ad3029lz/software/ev-cog-ad3029lz.rst
+++ b/docs/solutions/reference-designs/eval-cog-ad3029lz/software/ev-cog-ad3029lz.rst
@@ -1,0 +1,66 @@
+EV-COG-AD3029LZ On-Board Peripheral Drivers and Software
+========================================================
+
+General Description/Overview
+----------------------------
+
+The EV-COG-AD3029LZ software pack provides access to all the necessary on-board peripheral drivers for the :adi:`EV-COG-AD3029LZ` development platform. This software layer is the secondary layer needed when writing applications using this development platform. The **EV-COG-AD3029LZ** software pack builds on top of what the ADuCm302x software pack provides. The **EV-COG-AD3029LZ** software pack makes it easier to use the on-board peripherals so creating your application layer is will be easier. Combined with the ADuCM302x and Sensors software pack, there are many great **Internet of Things(IoT)** applications and demos that can be replicated using the **EV-COG-AD3029LZ** development platform.
+
+The drivers and examples in the BSP are designed to work with CrossCore Embedded
+Studio 2.6.0 ® and the ADuCM302x Device Family Pack 2.0.0.
+
+EV-COG-AD3029LZ software pack contains the following components:
+
+-  Bluetooth Companion Module
+-  On-Chip Driver Examples ( GPIO,RTC, SPI, Systick, TMR, UART, WDT)
+-  Bluetooth Profile Examples
+
+   -  \* FindMe Target
+   -  \* Proximity Reporter
+   -  \* Data Exchange (Hello World)
+
+-  Android IoTNode application software
+-  Documentation
+
+For detailed information regarding the EV-COG-AD3029LZ software pack, please see
+our complete EV-COG-AD3029LZ software user guide.
+
+.. hint::
+
+   
+   ADD LINK HERER EV-COG-AD3029LZ BSP Release Notes
+   
+
+.. important::
+
+   
+   You MUST have this software package installed on your laptop or PC in order
+   to compile, debug, and run the applications for the EV-COG-AD3029LZ platform.
+   
+
+Downloading the EV-COG-AD3029LZ Software Pack
+---------------------------------------------
+
+The software pack can be downloaded in several ways.
+
+-  Downloaded via the tools program
+
+   -  It is **recommended** to download the EV-COG-AD3029LZ software pack through from the tools program you are using. That way, all the files, directories structure, and project structure for the various applications is properly saved and accessed. For a detailed description on how to download the EV-COG-AD3029LZ software pack through CrossCore Embedded Studio please see our `CrossCore Embedded Studio Quickstart User Guide <https://wiki.analog.com/resources/eval/user-guides/eval-adicup3029/tools/cces_user_guide>`_.
+
+-  Downloaded to local directory
+
+   -  However if you do decide to download the EV-COG-AD3029LZ software pack to
+      your PC/laptop directly, please use the link below, and make sure you save
+      the software pack to the correct local directory for your
+      applications/projects.
+
+.. admonition:: Download
+   :class: download
+
+   `EV-COG-AD3029LZ BSP 1.0.0 <http://download.analog.com/tools/EZBoards/COG_AD3029/Releases/>`_
+
+   
+
+*End of Document*
+
+`Back <https://wiki.analog.com/resources/eval/user-guides/ev-cog-ad3029lz>`_

--- a/docs/solutions/reference-designs/eval-cog-ad3029lz/software/sensor.rst
+++ b/docs/solutions/reference-designs/eval-cog-ad3029lz/software/sensor.rst
@@ -22,14 +22,13 @@ complete Sensor software user guide.
 .. hint::
 
    
-   ADD LINK HERE Sensor Software Pack Release Notes.
-   
+   Sensor Software Pack Release Notes (link not yet available)
 
 .. important::
 
    
    You MUST have this software package installed on your laptop or PC in order
-   to compile, debug, and run the applications for the EC-COG-AD3029LZ platform.
+   to compile, debug, and run the applications for the EV-COG-AD3029LZ platform.
    
 
 Downloading the Sensor Software Pack
@@ -62,7 +61,5 @@ The software pack can be downloaded in following ways.
    
    Link to Github Repository for Cloning or Viewing.
    
-   ADD GITHUB LINK HERE
-   
+   GitHub Repository (link not yet available)
 
-*End of Document*

--- a/docs/solutions/reference-designs/eval-cog-ad3029lz/software/sensor.rst
+++ b/docs/solutions/reference-designs/eval-cog-ad3029lz/software/sensor.rst
@@ -1,0 +1,68 @@
+Sensor Application Software Packs and Drivers
+=============================================
+
+General Description/Overview
+----------------------------
+
+Sensor software pack contains sensor software components. Sensor components are based on the sensor classes which abstract the functionality across sensor types. The Sensors software pack provides access to all the necessary add-on module digital drivers that attach to the :adi:`EV-COG-AD3029LZ` development platform. This software layer is the highest layer of abstraction from the microprocessor, and because of this can be useful to jump start code development for your application using any microprocessor. For example, if you are using the ADXL362, the Sensor software pack contains drivers and code snippets on the application level, so that can be transported to other microprocessor, with confidence that Analog Devices provided the application framework pieces. When combined with the :adi:`ADuCM3029` and :adi:`EV-COG-AD3029LZ` software packs there are many great Internet of Things(IoT) applications.
+
+ADI Sensor Software requires CrossCore Embedded Studio 2.6.0 ® , ADuCM3029
+Device Family Pack 2.0.0 and EV-COG-AD3029LZ Board Support Package 1.0.0.
+
+The following application examples and sensor drivers are provided as part of
+the Sensor software pack:
+
+-  Accelerometer Demo
+-  Temperature Sensor Demo
+-  Visible Light Sensor Demo
+
+For detailed information regarding the Sensor software pack, please see our
+complete Sensor software user guide.
+
+.. hint::
+
+   
+   ADD LINK HERE Sensor Software Pack Release Notes.
+   
+
+.. important::
+
+   
+   You MUST have this software package installed on your laptop or PC in order
+   to compile, debug, and run the applications for the EC-COG-AD3029LZ platform.
+   
+
+Downloading the Sensor Software Pack
+------------------------------------
+
+The software pack can be downloaded in following ways.
+
+-  Downloaded via the tools program
+
+   -  It is **recommended** to download the Sensor software pack through from the tools program you are using. That way, all the files, directories structure, and project structure for the various applications is properly saved and accessed. For a detailed description on how to download the Sensor software pack through CrossCore Embedded Studio please see our `CrossCore Embedded Studio Quickstart User Guide <https://wiki.analog.com/resources/eval/user-guides/eval-adicup3029/tools/cces_user_guide>`_.
+
+-  Downloaded to local directory
+
+   -  However if you do decide to download the Sensor software pack to your
+      PC/laptop directly, please use the link below, and make sure you save the
+      software pack to the correct local directory for your
+      applications/projects.
+
+-  Cloning the EC-COG-AD3029LZ Github Repository
+
+   -  Cloning a public facing Git repository can be done through the CrossCore Embedded Studios tools or directly from the Github website (which will store it to a local directory on your computer.) The same general rules apply from above, where importing the example from Github through the tools package is **recommended**, over downloading the zip file and storing it to a directory of your choice.
+
+.. admonition:: Download
+   :class: download
+
+   
+   Download the Sensor Software Pack.
+   
+   `Sensor Software Pack 1.1.0 <http://download.analog.com/tools/Sensor_Software/Releases/>`_
+   
+   Link to Github Repository for Cloning or Viewing.
+   
+   ADD GITHUB LINK HERE
+   
+
+*End of Document*

--- a/docs/solutions/reference-designs/eval-cog-ad3029lz/tools/cces_download.rst
+++ b/docs/solutions/reference-designs/eval-cog-ad3029lz/tools/cces_download.rst
@@ -1,0 +1,135 @@
+CrossCore Embedded Studio Download & Install
+============================================
+
+This page provides all the necessary steps to get CrossCore Embedded Studio
+(CCES) software environment up and running on Windows or Linux.
+
+The CCES software development environment for EV-COG-AD3029LZ is based on open
+source tools, and is maintained by Analog Devices. CCES includes support for DSP
+(digital signal processing) and ARM Cortex M- and A- devices, and includes the
+following features and many more:
+
+-  Eclipse based IDE
+-  GNU ARM Embedded Toolchain for Cortex-M core based parts (5-2016-q2-update release)
+-  OpenOCD with support for ADuCM302x and ADuCM4x50 microcontroller (open source SWD)
+-  CMSIS Pack files
+-  Mbed CMSIS-DAP
+-  J-Link Lite
+
+.. important::
+
+   CrossCore Embedded Studio is based on Eclipse, but because the MBED platform
+   provides a CMSIS-DAP interface to connect to the board, the EV-COG-AD3029LZ
+   can be used without problems with IAR Embedded Workbench IDE or Keil µVision
+   IDE as well.
+
+Pre-Requisites and Requirements List
+====================================
+
+There are a few things that you will need for the tools and software to work
+properly.
+
+-  PC or laptop computer
+-  EV-COG-AD3029LZ hardware
+-  Micro USB to USB cables
+
+.. important::
+
+   USB cable needs to have ALL data lines connected, can't use a charging only
+   micro USB cable.
+
+-  Terminal Program to interface your PC with the EV-COG-AD3029LZ
+
+   -  `Putty <http://www.chiark.greenend.org.uk/~sgtatham/putty/download.html>`_
+
+      -  `Tera Term <https://en.osdn.jp/projects/ttssh2/releases/>`_
+      -  Or other favorite Terminal program
+
+CrossCore Embedded Studio Download Packages
+===========================================
+
+.. admonition:: Download
+   :class: download
+
+   
+   The EV-COG-AD3029LZ **requires** the use of Crosscore Embedded Studios version **2.6.0 or higher**. Do not attempt to use earlier versions of the CrossCore tools, due to compatibility issues that will **damage** the EV-COG-AD3029LZ.
+   
+   `CrossCore Embedded Studio 2.6.0 Windows Installer(Executable) <http://download.analog.com/tools/CrossCoreEmbeddedStudio/Releases/Release_2.6.0/ADI_CrossCoreEmbeddedStudio-Rel2.6.0.exe>`_
+   
+   `CrossCore Embedded Studio 2.6.0 Ubuntu Linux Installer(Debian) <http://download.analog.com/tools/CrossCoreEmbeddedStudio/Releases/Release_2.6.0/adi-CrossCoreEmbeddedStudio-linux-x86-2.6.0.deb>`_
+   
+
+The following features are available and supported
+--------------------------------------------------
+
+-  Compilation using the GNU ARM Embedded toolchain for the ADuCM302x and ADuCM4x50 ARM Cortex-M cores.
+-  Debugging ADuCM302x and ADuCM4x50 via the IDE with GDB/OpenOCD.
+-  Development and debugging of bare-metal applications on the ADuCM302x and
+   ADuCM4x50 ARM Cortex-M core.
+
+The following features are only supported via the Windows version
+-----------------------------------------------------------------
+
+-  Use of CrossCore Embedded Studio Add-Ins other than the Linux Add-In
+-  Debugging an Application using the CrossCore Debugger (TPSDK)
+
+CrossCore Embedded Studio Installer Instructions
+================================================
+
+It is best that you save all the files/folders to the default directories
+recommended by the CrossCore Embedded Studios installer. This way all the
+instructions and support provided will be easier.
+
+Installing CrossCore Embedded Studio on Windows
+-----------------------------------------------
+
+-  To install CrossCore Embedded Studio, double-click ADI_CrossCoreEmbeddedStudio-Rel2.6.0.exe
+-  The CrossCore Embedded Studio installer will install the mBed windows serial
+   driver.
+
+   -  It is available separately, if required
+
+      -  https://developer.mbed.org/handbook/Windows-serial-configuration
+
+The executable installs all necessary components to the Analog Devices local
+directory structure which can be found below.
+
+-  CrossCore Embedded Studio installs to **C:\\Analog Devices\\CrossCore Embedded Studio 2.6.0**
+-  Eclipse IDE installs to **C:\\Analog Devices\\CrossCore Embedded Studio 2.6.0\\Eclipse**
+-  GNU ARM Embedded Toolchain for Cortex-M installs to **C:\\Analog Devices\\CrossCore Embedded Studio 2.6.0\\ARM\\gcc-arm-embedded**
+-  OpenOCD installs to **C:\\Analog Devices\\CrossCore Embedded Studio 2.6.0\\ARM\\openocd\\bin**
+-  CMSIS Pack files are installed to **C:\\Analog Devices\\CrossCore Embedded Studio 2.5.1\\ARM\\packs**
+
+Installing CrossCore Embedded Studio on Linux
+---------------------------------------------
+
+-  To install CrossCore Embedded Studio, run the command:
+
+   -  sudo dpkg -i adi-CrossCoreEmbeddedStudio-linux-x86-2.6.0.deb
+
+The Ubuntu Linux Installer(Debian) installs all necessary components to the
+Analog Devices local directory structure which can be found below.
+
+-  CrossCore Embedded Studio installs to **/opt/analog/cces/2.6.0**
+-  Eclipse IDE installs to **/opt/analog/cces/2.6.0/Eclipse**
+-  GNU ARM Embedded Toolchain for Cortex-M installs to **/opt/analog/cces/2.6.0/ARM/gcc-arm-embedded**
+-  OpenOCD installs to **/opt/analog/cces/2.6.0/ARM/openocd/bin**
+-  CMSIS Pack files are installed to **/opt/analog/cces/2.6.0/ARM/packs**
+
+Activating CrossCore Embedded Studio
+====================================
+
+The first time you launch CrossCore Embedded Studio, you will be prompted to input a serial number, name, and email address. The serial number for **ALL** EV-COG-AD3029LZ boards is: EZK-CCES-6XMG-BRRR-7CUS-K3AA-J92U-XK4A-2A01
+
+Once the serial number has been activated, the CrossCore development tools will
+allow you full and unlimited access to all the features of the tool when using
+the Analog Devices family of ARM Cortex Processor.
+
+CrossCore Embedded Studio Support
+=================================
+
+For more details on CrossCore Embedded Studio, updated versions of the tools, release notes, tools documentation, or other support. Please visit the CrossCore :adi:`webpage <cces>`, or email the CrossCore support team at `processor.tools.support@analog.com <https://wiki.analog.com/mailto/processor.tools.support@analog.com>`_
+
+*End of Document*
+
+`Back <https://wiki.analog.com/resources/eval/user-guides/ev-cog-ad3029lz>`_

--- a/docs/solutions/reference-designs/eval-cog-ad3029lz/tools/cces_download.rst
+++ b/docs/solutions/reference-designs/eval-cog-ad3029lz/tools/cces_download.rst
@@ -128,8 +128,5 @@ the Analog Devices family of ARM Cortex Processor.
 CrossCore Embedded Studio Support
 =================================
 
-For more details on CrossCore Embedded Studio, updated versions of the tools, release notes, tools documentation, or other support. Please visit the CrossCore :adi:`webpage <cces>`, or email the CrossCore support team at `processor.tools.support@analog.com <https://wiki.analog.com/mailto/processor.tools.support@analog.com>`_
+For more details on CrossCore Embedded Studio, updated versions of the tools, release notes, tools documentation, or other support. Please visit the CrossCore :adi:`webpage <cces>`, or email the CrossCore support team at `processor.tools.support@analog.com <mailto:processor.tools.support@analog.com>`_
 
-*End of Document*
-
-`Back <https://wiki.analog.com/resources/eval/user-guides/ev-cog-ad3029lz>`_

--- a/docs/solutions/reference-designs/eval-cog-ad3029lz/tools/cces_guide.rst
+++ b/docs/solutions/reference-designs/eval-cog-ad3029lz/tools/cces_guide.rst
@@ -1,0 +1,374 @@
+Cross Core Embedded Studio Quickstart User Guide
+================================================
+
+This page describes how to use the ADuCM302x Device Family Pack (DFP) with
+CrossCore Embedded Studio (CCES) to create, import, build and debug applications
+for the ADuCM302x processor. The ADuCM302x MCU integrates an ARM Cortex-M3
+processor with various on-chip peripherals within a single package.
+
+.. note::
+
+   ADuCM302x family has two versions of the device, ADuCM3027 and ADuCM3029, the
+   DFP supports both these versions
+
+This page describes how to install and work with the Analog Devices ADuCM302x
+DFP to start developing applications for the EV-COG-AD3029LZ.
+
+Additional help documentation can be found by opening CCES and selecting "Help
+Contents" from the CCES Help menu.
+
+This page covers:
+
+-  How to install or upgrade the ADuCM302x Device Family Pack (DFP) for CCES
+-  How to create a new project for the ADuCM3029
+-  How to add startup code and core components to a new project for the ADuCM3029
+-  How to import existing projects into your workspace
+-  How to build projects for programming the ADuCM3029
+-  How to configure the Tools Settings used by an ADuCM3029 project
+-  How to configure the debug session for an ADuCM3029 application
+-  How to start and stop debugging an ADuCM3029 application
+-  How to create an Intel Hex (.hex) file from an ADuCM3029 application
+
+Workspace and Projects
+======================
+
+A CCES workspace is a folder (e.g. c:\\Users\\anon\\cces\\2.6.0) that contains
+project resources and metadata. When projects are created or imported, details
+about that project are stored in the workspace. The workspace metadata also
+includes preferences set through the CCES Preferences dialog box and IDE window
+layouts. By default, CCES creates new projects within your workspace folder.
+
+Each time you start CCES, you will be prompted for a workspace location. You can
+opt to default to a workspace directory by choosing to use a workspace directory
+as your default. You will not be prompted the next time you open CCES.
+
+.. image:: ../images/eval-aducm3029-workspace.png
+   :align: center
+
+How to install or upgrade the ADuCM302x Device Family Pack (DFP) for CCES
+-------------------------------------------------------------------------
+
+CCES 2.6.0 does not comes with the ADuCM302x Device Family Pack (DFP) and ARM
+CMSIS Pack file pre-installed.
+
+-  To install the ADuCM302x DFP:
+-  Switch to the CMSIS Pack Manager perspective by selecting *Window \| Perspective \| Open Perspective \| Other... \| CMSIS Pack Manager*.
+-  Once opened, select *Check for Updates on Web ( blue arrows on the toolbar )*. This may take a minute or two.
+-  Choose *Analog Devices* and *ADuCM302x Series* in the Devices View.
+-  Select the *ADuCM302x CMSIS Pack* version (choose version 2.0.0 or higher) from the Packs View.
+-  Click the *Install* Action.
+
+Alternatively, the ADuCM3029 Device Family Pack (DFP) files can be installed
+using a local download.
+
+After downloading the .pack files from the Keil website (https://www.keil.com/dd2/pack/), select the Import Packs button in the CMSIS Pack Manager's Packs View, choose the .pack file as shown in the screenshot below and click Open.
+
+You will be prompted to accept a license agreement and after agreeing to it, the
+CMSIS-Pack file will be installed into CrossCore Embedded Studio's CMSIS-Pack
+installation directory (e.g. C:\\Analog Devices\\CrossCore Embedded Studio
+2.6.0\\ARM\\packs\\AnalogDevices).
+
+.. image:: ../images/add_pack.jpg
+   :align: center
+
+-  To install the ARM 4.5.0 CMSIS Pack:
+-  Switch to the CMSIS Pack Manager perspective by selecting *Window \| Perspective \| Open Perspective \| Other... \| CMSIS Pack Manager*.
+-  Once opened, select *Check for Updates on Web ( blue arrows on the toolbar )*, if you have not already done so.
+-  Choose *ARM* in the Devices View.
+-  Select the *Generic* and *ARM.CMSIS* from the Packs View, select version 4.5.0
+-  Click the *Install* Action.
+
+.. image:: ../images/eval-aducm3029-cmsis-pack-arm-cmsis-200.png
+   :align: center
+
+ADuCM302x Board Support Packs (BSP)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+There are two Board Support Packs (BSP) available: one for the ADuCM302x EZ-Kit
+and one for the COG-AD3029. These BSPs can be installed in the same way as the
+Device Family Pack (DFP) via the CMSIS Pack Manager perspective.
+
+EV-COG-AD3029LZ Board Support Pack
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The EV-COG-AD3029LZ Board Support Pack (BSP) provides the drivers for off-chip
+peripherals which are on the EV-COG-AD3029LZ Evaluation Board and examples for
+peripherals on the ADcCM3029 processor. The drivers and examples in the BSP are
+designed to work with CrossCore Embedded Studio and the ADuCM302x Device Family
+Pack (DFP).
+
+For more information on the EV-COG-AD3029LZ BSP, please refer to the User's
+Guide in the Documents folder (e.g. C:\\Analog Devices\\CrossCore Embedded
+Studio
+2.6.0\\ARM\\packs\\AnalogDevices\\EV-COG-AD3029LZ_BSP\\1.0.0\\Documents\\EV-COG-AD3029LZ_Users_Guide.pdf)
+
+ADI Sensor Software Pack
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ADI Sensor Software pack contains various sensor software components and
+associated examples. The examples in the sensor pack are designed to work with
+EV-COG-AD3029LZ board and associated sensor shields. ADI Sensor Software
+requires CrossCore Embedded Studio (CCES), ADuCM302x Device Family Pack (DFP)
+and EV-COG-AD3029LZ Board Support Pack (BSP).
+
+For more information on the ADI Sensor Software Pack, please refer to the User's
+Guide in the Documents folder (e.g. C:\\Analog Devices\\CrossCore Embedded
+Studio
+2.6.0\\ARM\\packs\\AnalogDevices\\ADI-SensorSoftware\\1.0.0\\Documents\\SensorSoftware_Users_Guide.pdf)
+
+How to create a new project for the ADuCM3029
+---------------------------------------------
+
+A project for ADuCM3029 can be created using the New CrossCore Project Wizard.
+This wizard will guide you through the steps to create a new project.
+
+.. image:: ../images/eval-aducm3029-project-new.png
+   :align: center
+
+-  To create a new project, go to the menu bar and find *File -> New -> CrossCore Project*.
+-  Choose Processor family ARM and select Processor type ADuCM3029.
+-  Choose your Silicon revision (default is 1.0).
+
+   -  A *SILICON_REVISION* macro will be set in your project's Tools Settings, allowing you to conditionally check the silicon revision in your source code.
+
+-  Project configuration allows you to add additional Add-ins to your project, such as Pin Multiplexing and changing the template language for a generated main function etc.
+-  Finally, press *Finish* and the project will be created and you can begin writing your program.
+
+.. image:: ../images/eval-aducm3029-project-explorer.png
+   :align: center
+
+How to add startup code and core components to a new project for the ADuCM3029
+------------------------------------------------------------------------------
+
+An out-of-the-box ADuCM3029 project does not have startup code or a linker
+description file that maps code and data. It is necessary to add these
+components using the Run-time Environment (RTE) Configuration Editor.
+
+CrossCore Projects created for Analog Devices' Cortex-M based processors, such
+as ADuCM3029 include a system.rteconfig file. Opening this file within the IDE
+will open the RTE Configuration Editor. Components from the CMSIS-Pack, such as
+drivers and services, can be added to a project by selecting them in the editor
+and clicking Save.
+
+At minimum, a new ADuCM3029 project will require the Device::Startup,
+CMSIS::Core and Device::Global Configuration components to be added to the
+project.
+
+-  Double-click on the system.rteconfig to open the RTE Configuration Editor.
+-  Select Device::Startup, CMSIS::Core and Device::Global Configuration.
+-  Click Save (Ctrl+S)
+-  *You can also choose Device::Startup and click the Resolve button to add dependant components*
+
+.. image:: ../images/eval-aducm3029-project-configure.png
+   :align: center
+
+How to import existing projects into your workspace
+---------------------------------------------------
+
+There are three(3) methods for importing existing projects:
+
+-  Examples that you have saved to a local drive on your PC.
+-  Examples that come with the ADuCM3029 Device Family Pack (DFP).
+-  Examples which are in the EV-COG-AD3029LZ GIT repository (most up to date
+   content).
+
+How to Import Existing Projects Saved to a Local Drive
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+-  Select *File \| Import...* from the CCES menu.
+-  A dialog will pop-up with several importing options, choose the *General \| Existing Projects into Workspace* option, and click Next
+-  Select *Browse* in the dialog window and search for the saved project which is on your local drive.
+-  (Optional) If the *Copy projects into workspace* option is checked, the project will be copied to your workspace folder and the newly copied project will be opened and used. This preserves the original version of the project.
+-  Click *Finish*
+
+.. image:: ../images/eval-aducm3029-file-import.png
+   :align: center
+
+How to Import Examples that come with the ADuCM3029 Device Family Pack (DFP) or Board Support Packs (BSP)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Examples are provided with the ADuCM3029 DFP and BSPs and can be opened from the
+CMSIS Pack Manager Perspective Examples View.
+
+-  Open CMSIS Pack Manager perspective by clicking "Open Perspective" icon on tool bar and selecting "CMSIS Pack Manager" in the Open Perspective window (or choose CMSIS Pack Manager perspective if already open).
+-  From the Examples View, select the example that you would like to open.
+-  Click the *Copy* Action button.
+-  A dialog will pop-up showing the location where the example will be copied to. Click *Copy* to copy and open the example project.
+
+.. image:: ../images/eval-aducm3029-cmsis-pack-example-200.png
+   :align: center
+
+The CCES Examples Browser can also be used to open examples by Help \| Browse
+Examples.
+
+-  Select ADuCM302x_DFP[x.y.z] in Product drop-down list, select the example and
+   click Open example. Then the example will be copied to your workspace.
+
+.. image:: ../images/eval-aducm3029-example-browser.png
+   :align: center
+
+How to Import Existing Projects from the GIT Repository
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+( Note that at the time of writing, the EV-COG-AD3029LZ GIT repo. is work In
+Progress )
+
+-  Open the GIT perspective by clicking "Open Perspective" icon on tool bar and selecting "Git" in the Open Perspective window (or choose the GIT perspective if already open).
+-  Clone the Git repository which contains all the latest code and projects
+   associated with the ADuCM3029. Populate the URI field with the following
+   address.
+
+   -   **URL:** - `EV-COG-AD3029LZ <https://github.com/analogdevicesinc/EV-COG-AD3029LZ>`_
+   -  Click *Next*, *Next* and then *Finish*. There may be a pause while the branches are fetched.
+
+-  In the Git Repositories window, *Right Click* on the *Projects* folder and select *Import Projects...*
+-  Select *Import existing Eclipse projects*
+-  Click *Next* and then *Finish*
+
+.. image:: ../images/eval-aducm3029-clone.png
+   :align: center
+
+How to build projects for programming the ADuCM3029
+---------------------------------------------------
+
+-  Open the C perspective by clicking "Open Perspective" icon on tool bar and selecting C in the Open Perspective window (or choose the C perspective if already open).
+-  Right click on the project and select the *Build Project*.
+
+   -  Or click the *Hammer* icon from the toolbar.
+
+.. image:: ../images/eval-aducm3029-project-build.png
+   :align: center
+
+How to configure the Tools Settings used by an ADuCM3029 project
+----------------------------------------------------------------
+
+-  Select the project in the Project Explorer View.
+-  Select the *Cog* icon from the View's toolbar.
+
+   -  Or right-click on the project, select *Properties* and choose *C/C++ Build \| Settings*.
+
+-  After configuring your project, click Apply and/or OK.
+
+.. image:: ../images/eval-aducm3029-project-tools-settings.png
+   :align: center
+
+How to configure the debug session for an ADuCM3029 application
+---------------------------------------------------------------
+
+You will need to create a launch configuration to debug your ADuCM3029 program.
+
+-  If you have already built a project, select that project in the Project Explorer View.
+-  Right-click on the project and choose *Debug As* and *Application with GDB and OpenOCD (Emulator)*
+-  In the *Target* tab, choose *Target (processor)* and in the drop-down select **Analog Devices ADuCM3029**
+-  In the *Target* tab, choose *Interface* and in the drop-down select **ARM CMSIS-DAP compliant adapter**
+-  In the *Main* tab, ensure that your project is selected in the *Project* entry box.
+
+   -  If the correct project is not populated, click the *Browse...* button and choose the project. Note that this is optional and you only need to choose a project if you want the IDE to search a project for the built binaries (programs), otherwise you can leave this entry blank.
+
+-  In the *Main* tab, ensure your binary (program) is selected in the *Application* entry box.
+
+   -  If the correct binary (program) is not populated, click on *Search Project...* and choose the binary (program) from those available in the chosen project.
+   -  If your binary (program) is not populated and it was not built from a project in your workspace (i.e. you have a pre-built binary), then click the *Browse...* button and search for your pre-built binary (program). Click *Open* when you have found and selected the pre-built binary (program).
+
+.. image:: ../images/eval-aducm3029-debug-configuration.png
+   :align: center
+
+Hardware breakpoints are limited in your ADuCM3029 application
+==============================================================
+
+-  When you click Debug or Apply, you will be prompted with a dialog informing your the Hardware Breakpoints are limited. Click *Yes*. You can opt to not show this dialog again.
+
+.. image:: ../images/eval-aducm3029-debug-hw-limited.png
+   :align: center
+
+How to start and stop debugging an ADuCM3029 application
+--------------------------------------------------------
+
+-  Ensure that you have connected your EV-COG-AD3029LZ board to your computer via the **USB** port (the micro USB connected closest to the DC barrel jack).
+-  If you are already in the Debug Configurations dialog, then click *Debug*.
+-  If you are in the C Perspective, then you can launch the last Debug session by clicking the *Beetle* Debug button on the toolbar.
+
+.. image:: ../images/eval-aducm3029-debug-toolbar.png
+   :align: center
+
+-  You will be prompted to switch perspective to the Debug perspective. Click *Yes*. You can opt to not show this dialog again.
+
+.. image:: ../images/eval-aducm3029-debug-perspective.png
+   :align: center
+
+-  If your binary (program) was built with semi-hosting enabled, then CCES will
+   warn you that you need to re-build the program when you want to run the
+   program without a debugger attached.
+
+.. image:: ../images/eval-aducm3029-debug-semi-hosting.png
+   :align: center
+
+-  To disable semi-hosting in your program, visit your project Tools Settings.
+-  Change the *semi-hosting support* option under *Linker \| Libraries* to nosys.specs or None, depending on whether or not your program is currently using semi-hosting (e.g. printf).
+-  After configuring your project, click Apply and/or OK.
+-  Right click on the project and select the *Build Project*.
+
+   -  Or click the *Hammer* icon from the toolbar.
+
+.. image:: ../images/eval-aducm3029-spec.png
+   :align: right
+
+-  If this is the first time you have launched OpenOCD, the Windows Firewall may pop-up a window asking for access. Click on "*Allow Access*".
+
+.. image:: ../images/eval-aducm3029-openocd-firewall.png
+   :align: center
+
+-  If everything goes fine, in the Console window, you will see a report without
+   errors.
+
+   -  As a reference, the full text should be similar to:``Open On-Chip Debugger (OpenOCD) 0.9.0
+      Licensed under GNU GPL v2
+      Report bugs to <openocd-devel@lists.sourceforge.net>
+      0
+      Info : select transport "swd"
+      adapter speed: 1000 kHz
+      cortex_m reset_config sysresetreq
+      Info : CMSIS-DAP: SWD  Supported
+      Info : CMSIS-DAP: Interface Initialised (SWD)
+      Info : CMSIS-DAP: FW Version = 1.0
+      Info : SWCLK/TCK = 0 SWDIO/TMS = 1 TDI = 0 TDO = 0 nTRST = 0 nRESET = 1
+      Info : CMSIS-DAP: Interface ready
+      Info : clock speed 1000 kHz
+      Info : SWD IDCODE 0x2ba01477
+      Info : aducm3029.cpu: hardware has 2 breakpoints, 1 watchpoints
+      Info : CHIPID 0x0284
+      memory bus access delay set to 6 tck
+      adapter speed: 1000 kHz
+      Info : accepting 'gdb' connection on tcp/3333``
+
+-  Your program's execution is stopped automatically at the first breakpoint
+   which is at the beginning of main() loop. You can use the debug functions and
+   features of the CCES environment. (Such as stepping through, breakpoints,
+   register reads, variable values, etc.)
+
+.. image:: ../images/eval-aducm3029-debugging.png
+   :align: center
+
+-  To terminate a debug session, click on the red *Stop* button on the toolbar.
+
+.. image:: ../images/eval-aducm3029-debug-toolbar-stop.png
+   :align: center
+
+How to create an Intel Hex (.hex) file from an ADuCM3029 application
+--------------------------------------------------------------------
+
+-  Ensure that your program is built with semi-hosting disabled by visiting *Tools Settings \| Linker \| Libraries* and change *Semihosting support* to *nosys.specs* or *None*, depending on your application set-up.
+-  Rebuild your application.
+
+.. image:: ../images/eval-aducm3029-tools-semi-hosting.png
+   :align: center
+
+-  Convert your application into Intel Hex (.hex) format by visiting Tools Settings once more.
+-  Select the Build Steps tab.
+-  Add the following command to the *Post-build steps \| Command* entry box: ``arm-none-eabi-objcopy -O ihex ${ProjName} ${ProjName}.hex``
+-  Rebuild your application.
+
+.. image:: ../images/eval-aducm3029-tools-hex.png
+   :align: center
+
+*End of Document*

--- a/docs/solutions/reference-designs/eval-cog-ad3029lz/tools/cces_guide.rst
+++ b/docs/solutions/reference-designs/eval-cog-ad3029lz/tools/cces_guide.rst
@@ -371,4 +371,3 @@ How to create an Intel Hex (.hex) file from an ADuCM3029 application
 .. image:: ../images/eval-aducm3029-tools-hex.png
    :align: center
 
-*End of Document*

--- a/docs/solutions/reference-designs/eval-cog-ad3029lz/tools/hardware_usb.rst
+++ b/docs/solutions/reference-designs/eval-cog-ad3029lz/tools/hardware_usb.rst
@@ -13,8 +13,9 @@ which mode of operation the EV-COG-AD3029LZ emulator comes up.
    that the drivers are being installed in the task bar, open it up and wait
    till everything finished before progressing.
 
-| |image1|
-| |image2|
+|image1|
+
+|image2|
 
 DAPLINK Drive
 -------------
@@ -83,9 +84,6 @@ patches and updates to the firmware on the emulator.
 -  Unplug the micro USB cable from the USB port of the EV-COG-AD3029LZ, and then
    reconnect the USB cable to the USB port to “reboot” the board.
 
-*End of Document*
-
-`Back <https://wiki.analog.com/resources/eval/user-guides/ev-cog-ad3029lz>`_
 
 .. |image1| image:: ../images/device_drivers_install_notification.png
    :width: 400

--- a/docs/solutions/reference-designs/eval-cog-ad3029lz/tools/hardware_usb.rst
+++ b/docs/solutions/reference-designs/eval-cog-ad3029lz/tools/hardware_usb.rst
@@ -1,0 +1,93 @@
+Driver Installation for On-board Debugger (CMSIS DAP)
+=====================================================
+
+MCU Cog has an on-board debugger which supports the `ARM CMSIS DAP <https://developer.mbed.org/handbook/CMSIS-DAP>`_ interface. When connecting up the EV-COG-AD3029LZ to your computer or laptop, all the necessary drivers are automatically located and loaded up when using Windows operating systems.
+
+There are two sets of drivers that get installed on your computer depending on
+which mode of operation the EV-COG-AD3029LZ emulator comes up.
+
+.. important::
+
+   It is important to ensure that all drivers are installed, before trying to
+   use the EV-COG-AD3029LZ with the CrossCore Embedded Tools. So when you see
+   that the drivers are being installed in the task bar, open it up and wait
+   till everything finished before progressing.
+
+| |image1|
+| |image2|
+
+DAPLINK Drive
+-------------
+
+When the EV-COG-AD3029LZ emulator is connected to the ADuCM3029 and ready for
+program/debug mode, the "DAPLINK" drive is displayed on your computer.
+
+This mode allows users to drag and drop (or copy and paste) a .BIN or .HEX
+[Intel formatted] file directly into the DAPLINK drive, and that file will be
+flashed directly to the ADuCM3029. This means you don't have to use the tools or
+the debugger to program your board, making this very useful in production
+releases or updating applications already in the field.
+
+-  The PC will start searching for and install the following drivers:(if not
+   already complete)
+
+.. image:: ../images/device_drivers_install_complete.png
+   :align: center
+   :width: 400
+
+-  Then go to the **My Computer** view and search for the DAPLINK drive, if you see this then the drivers are complete and correct.
+
+.. image:: ../images/daplink_windows_explorer.png
+   :align: center
+   :width: 550
+
+-  After that simply drag and drop (or copy and paste) your .BIN or .HEX [Intel
+   formatted] file to the DAPLINK drive, and your EV-COG-AD3029LZ board will be
+   programmed.
+
+   -  Your Windows Explorer browser will close automatically
+
+-  You will need to press the RST button in order for the program to update
+
+   -  Alternatively you could unplug the micro USB cable from the USB port (P5)
+      of the EV-COG-AD3029LZ, and then reconnect it.
+
+Maintenance Drive
+-----------------
+
+When the EV-COG-AD3029LZ emulator is connected to the MK20DX128VFM5 (by holding
+down the "RST" button while connecting the USB port (P5) to the PC/laptop) the
+"Maintenance" drive is displayed on your computer. This mode allows a user to
+overwrite the ADuCM0329 interface file within the emulator. This allows for
+patches and updates to the firmware on the emulator.
+
+-  The PC will start searching for and install the following drivers:(if not
+   already complete)
+
+.. image:: ../images/device_drivers_install_maintenance.png
+   :align: center
+   :width: 400
+
+-  Then go to the **My Computer** view and search for the Maintenance drive, if you see this then the drivers are complete and correct.
+
+.. image:: ../images/maintenance_windows_explorer.png
+   :align: center
+   :width: 550
+
+-  After that simply drag and drop (or copy and paste) the latest interface file
+   to the Maintenance drive, and your EV-COG-AD3029LZ board will be updated with
+   the latest interface file.
+
+   -  Your Windows Explorer browser will close automatically
+
+-  Unplug the micro USB cable from the USB port of the EV-COG-AD3029LZ, and then
+   reconnect the USB cable to the USB port to “reboot” the board.
+
+*End of Document*
+
+`Back <https://wiki.analog.com/resources/eval/user-guides/ev-cog-ad3029lz>`_
+
+.. |image1| image:: ../images/device_drivers_install_notification.png
+   :width: 400
+.. |image2| image:: ../images/device_drivers_install.png
+   :width: 400

--- a/docs/solutions/reference-designs/eval-cog-ad3029lz/tools/other_ide.rst
+++ b/docs/solutions/reference-designs/eval-cog-ad3029lz/tools/other_ide.rst
@@ -64,6 +64,3 @@ following steps.
 -  Push the Green-Button – “Download and debug” – Another popup for C-SPY configuration opens up, just press “OK”
 -  That’s it – You are ready to go.
 
-*End of Document*
-
-`Back <https://wiki.analog.com/resources/eval/user-guides/ev-cog-ad3029lz>`_

--- a/docs/solutions/reference-designs/eval-cog-ad3029lz/tools/other_ide.rst
+++ b/docs/solutions/reference-designs/eval-cog-ad3029lz/tools/other_ide.rst
@@ -1,0 +1,69 @@
+Using Keil or IAR Tools with EV-COG-AD3029LZ
+============================================
+
+This will be a paragraph talk about why you might want to use Keil or IAR with
+the ADICUP3029. Perhaps you like the other tool chains and are familiar with
+them. Perhaps you have a full license and your company requires the work to be
+done using Keil or IAR. Please feel free to update and expand this paragraph.
+
+How to use EV-COG-AD3029LZ with Keil
+------------------------------------
+
+In order to use EV-COG-AD3029LZ board with IAR, you will need to replicate the
+following steps.
+
+-  Install mBed windows serial driver from
+
+   -  https://developer.mbed.org/handbook/Windows-serial-configuration
+
+-  Open any example-workspace and project from the ADuCM3029 BSP(board support package). I used the SysTick example in the below images
+-  In the Keil toolbar select **Project** → **Options** → **Debug**, and select the “CMSIS DAP” option
+
+.. image:: ../images/keildebug.png
+   :align: center
+   :width: 500
+
+-  Under the CMSIS DAP Settings, select the SW option
+
+.. image:: ../images/keilcmsisdap.png
+   :align: center
+   :width: 500
+
+-  Push Crtl+F5 or in the Keil toolbar select **Debug** → **Start/Stop Debug Session**
+-  That’s it – You are ready to go.
+
+How to use EV-COG-AD3029LZ with IAR
+-----------------------------------
+
+In order to use EV-COG-AD3029LZ board with IAR, you will need to replicate the
+following steps.
+
+-  Install mBed windows serial driver from
+
+   -  https://developer.mbed.org/handbook/Windows-serial-configuration
+
+-  Open any example-workspace and project from the ADuCM3029 BSP(board support package). I used the Timer example in the below images
+-  In the IAR toolbar select **Project** → **Options** → **Debugger**, and select the “CMSIS DAP” option
+
+.. image:: ../images/iar_options_cmsis-dap_debugger.png
+   :align: center
+   :width: 500
+
+-  Under the Debugger-CMSIS DAP tab, select the SWD option
+
+.. image:: ../images/iar_cmsis-dap_debugger_setup.png
+   :align: center
+   :width: 500
+
+-  Under the Debugger-CMSIS DAP tab, select Hardware for the reset type
+
+.. image:: ../images/reset.png
+   :align: center
+   :width: 500
+
+-  Push the Green-Button – “Download and debug” – Another popup for C-SPY configuration opens up, just press “OK”
+-  That’s it – You are ready to go.
+
+*End of Document*
+
+`Back <https://wiki.analog.com/resources/eval/user-guides/ev-cog-ad3029lz>`_

--- a/docs/solutions/reference-designs/eval-cog-ad3029lz/tools_driver.rst
+++ b/docs/solutions/reference-designs/eval-cog-ad3029lz/tools_driver.rst
@@ -1,0 +1,19 @@
+Development Tools & Drivers
+===========================
+
+This chapter provides all the necessary steps to download, install and setup the
+software environment from Analog Devices. There is also information on the
+different USB modes and drivers needed.
+
+It contains three main sections:
+
+-  :doc:`CrossCore Embedded Studio Download & Install </solutions/reference-designs/eval-cog-ad3029lz/tools/cces_download>` - Provides all the necessary instructions on how to download and install the CrossCore Embedded Studio software development environment.
+
+   -  :doc:`CrossCore Embedded Studio Quickstart Userguide </solutions/reference-designs/eval-cog-ad3029lz/tools/cces_guide>` - Provides information about using the CrossCore Embedded Studio IDE, in particular, the process of importing, building, debugging and creating user applications for the EV-COG-AD3029LZ.
+
+-  :doc:`Driver Installation for On-board Debugger (CMSIS DAP) </solutions/reference-designs/eval-cog-ad3029lz/tools/hardware_usb>` - Provides detailed information on how to load pre-compiled .HEX or .BIN files using the USB drive of the EV-COG-AD3029LZ board.
+-  :doc:`Using EV-COG-AD3029LZ with IAR & Keil IDEs </solutions/reference-designs/eval-cog-ad3029lz/tools/other_ide>` - Provides detailed information on how to use the EV-COG-AD3029LZ board with IAR Embedded Workbench and Keil µVision.
+
+| End Document
+
+`Back <https://wiki.analog.com/resources/eval/user-guides/ev-cog-ad3029lz>`_

--- a/docs/solutions/reference-designs/eval-cog-ad3029lz/tools_driver.rst
+++ b/docs/solutions/reference-designs/eval-cog-ad3029lz/tools_driver.rst
@@ -14,6 +14,3 @@ It contains three main sections:
 -  :doc:`Driver Installation for On-board Debugger (CMSIS DAP) </solutions/reference-designs/eval-cog-ad3029lz/tools/hardware_usb>` - Provides detailed information on how to load pre-compiled .HEX or .BIN files using the USB drive of the EV-COG-AD3029LZ board.
 -  :doc:`Using EV-COG-AD3029LZ with IAR & Keil IDEs </solutions/reference-designs/eval-cog-ad3029lz/tools/other_ide>` - Provides detailed information on how to use the EV-COG-AD3029LZ board with IAR Embedded Workbench and Keil µVision.
 
-| End Document
-
-`Back <https://wiki.analog.com/resources/eval/user-guides/ev-cog-ad3029lz>`_


### PR DESCRIPTION
## Summary
- Move eval-cog-ad3029lz wiki documentation to `solutions/reference-designs/eval-cog-ad3029lz/`
- 15 RST files with 47 localized images
- Generated stub `index.rst` with toctree

## Test plan
- [ ] Sphinx build passes without errors
- [ ] All toctree entries resolve correctly
- [ ] Images render properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)