### PR TITLE
reference-designs/ev-cog-ad3029lz: Add ev-cog-ad3029lz documentation

### DIFF
--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/cog_hw_userguide.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/cog_hw_userguide.rst
@@ -1,0 +1,219 @@
+EV-COG-AD3029LZ MCU Cog
+=======================
+
+The EV-COG-AD3029LZ is an *MCU Cog* board for the :adi:`ADuCM3029 MCU <en/products/processors-dsp/microcontrollers/precision-microcontrollers/aducm3029.html>`.
+
+Main Features
+-------------
+
+-  :adi:`ADuCM3029` (LFCSP package) - Ultra Low Power ARM Cortex-M3 MCU
+-  Compact form factor (3.5 cm X 7.5 cm) - Easy to deploy.
+-  On board debugger capability (CMSIS DAP compatible)
+-  Multiple power options and current monitoring test-points.
+-  On-board sensors: Accelerometer (ADXL362) and Temperature Sensor (ADT7420)
+-  Optional expansion capability - Using application specific add-on cards (*Gears*)
+-  Optional connectivity options - Using RF modules (*Connectivity Cogs*)
+
+Board
+-----
+
+Front-Side
+~~~~~~~~~~
+
+.. image:: images/25072017-tile-revb-front.png
+   :alt: 25072017-tile-revb-front.png
+
+Back-Side
+~~~~~~~~~
+
+.. image:: images/25072017-tile-revb-back.png
+   :alt: 25072017-tile-revb-back.png
+
+Power
+-----
+
+The MCU Cog board offers flexibility in terms of power supply and power muxing
+options. This is achieved with the use of jumpers on the board. The Cog board
+also offers multiple test points for monitoring current consumption.
+
+Power Supply Options
+~~~~~~~~~~~~~~~~~~~~
+
+The MCU Cog offers the following power supply options:
+
+::
+
+   -5V USB power (USB microB connector)
+   -3V CR2032 Coin cell (Cell holder - BT1)
+   -3V - 6V Rechargeable Li-Ion Battery (JST Connector - P6)
+   -3V - 6V External Supply from an MCU Cog Add-on card (via Connector C1)
+
+Power Muxing Options
+~~~~~~~~~~~~~~~~~~~~
+
+For details of the power muxing scheme, refer to the figure below.
+
+|image1|
+
+.. danger::
+
+   Do not insert shunt b/w positions 5 & 6 of JH4 when using USB supply. Doing
+   so can permanently damage this board.
+
+.. tip::
+
+   Refer to the *Jumper Settings* section further below for details on power related jumpers on the board
+
+Power Regulator
+~~~~~~~~~~~~~~~
+
+The MCU Cog board uses an on-board switching regulator - the :adi:`ADP5300 <en/products/power-management/switching-power-converters/switching-regulators/adp5300.html>`, which is a high efficiency, ultra-low power step down regulator. The MCU has complete control over the switching modes of the regulator via GPIO. The pin-mapping is shown in the table below.
+
+|direct|
+
+Current Measurement Options
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The MCU Cog enables IOT developers to measure and profile current consumption at
+different places on the board to enable isolation of current consumption
+hotspots. The current measure test points shown in the table below can be used
+along with a digital multimeter to profile current consumption.
+
+.. image:: images/24072017-tile-revb-current-test-points.png
+   :alt: 24072017-tile-revb-current-test-points.png
+
+Programming & Debug Options
+---------------------------
+
+The MCU Cog offers the following debug options:
+
+::
+
+   -On-board CMSIS-DAP debugger (USB microB connector)
+   -JLINK-9 Connector for access to SWD interface (P26)
+   -Access to SW interface to an MCU Cog Add-on card (via Connector C2)
+
+Wireless Connectivity Options
+-----------------------------
+
+The MCU Cog board offers support for ADI RF daughter-cards such as the EV-ADF70301-915AZ via the "EV-COG-BLEINTP1" connectivity Cog board that can be attached at Connector P2. This connectivity Cog board also has on-board BTLE circuit enabling the MCU Cog board to use BTLE communication as well. More details regarding wireless connectivity options are available on the `EV-COG-BLEINTP1 Wiki page <https://wiki.analog.com/resources/eval/user-guides/ev-cog-bleintp1z>`_.
+
+Buttons/LED(s)
+--------------
+
+The MCU Cog offers 2 buttons and 2 LED(s) that can be used by the Application.
+The default GPIO connections are shown in the tables below.
+
+.. image:: images/24072017-tile-revb-buttons-leds2.png
+   :alt: 24072017-tile-revb-buttons-leds2.png
+
+Expansion Connectors
+--------------------
+
+One of the USP of the MCU Cog is access to ALL GPIO via Expansion Connectors
+("C1" and "C2") for an Add-on card to utilize in its Application. This enables
+developers to confidently build final form factor hardware without having to
+worry about porting their firmware. The figures below capture the pin-mapping
+and jumpers that need to be changed to get external access (via the expansion
+connectors) to GPIO (as well as power/reset, etc).
+
+|image2|\ |image3|
+
+Jumper Settings
+---------------
+
+The MCU Cog offers flexibility in terms of power muxing options and the facility to route any GPIO externally via the expansion connectors "C1" and "C2". This is achieved with the use of jumpers. The MCU Cog has two types of jumpers - those labelled "JHx" and which are 2x2 1.27mm pitch headers and those labelled "JPx" and which are solder jumpers. The "JHx" jumpers are expected to be used more frequently than the "JPx" jumpers. The figures below capture the jumper settings. |image4| |image5|
+
+|image6|
+
+Jumper locations on board
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The following image of the bottom layer of the PCB highlights the jumper
+positions on the board:
+
+.. image:: images/cog_jumpers_annotated.png
+   :alt: Jumper Positions
+   :align: center
+
+Note that the jumpers JH6 and JP16 on the **top** layer of the board.
+
+Changing the jumper settings
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Shunt Jumpers (JHx)
+^^^^^^^^^^^^^^^^^^^
+
+As mentioned above, the shunt jumpers are 1.27mm headers, whose pins are shorted
+using a shunt. This shunt is inserted by default in the positions as mentioned
+in the table above.
+
+To change a jumper setting, carefully remove the shunt from its position, and
+re-insert the shunt in the correct position corresponding to the pin numbers to
+be shorted. The pin numbers are mentioned on the silkscreen of the PCB (usually
+both pin 1 & 2) and thus the default positions can be located.
+
+For example JH11 controls which signal is sent to the RTC1_SS2 SensorStrobe pin.
+By default the ADXL_362_INT2 signal is connected to the SensorStrobe pin. In
+order to connect the RF module, JH11 needs to be moved from "1 and 2" to "3 and
+4". The corresponding change is shown below:
+
+.. image:: images/shuntjumpersettingchange.png
+   :alt: Shunt Jumper Change
+   :align: center
+
+Solder Jumpers (JPx)
+^^^^^^^^^^^^^^^^^^^^
+
+Solder jumpers are shorted using a solder blob. There are 16 such jumpers on the
+board, out of which 15 are on the bottom side of the board while 1 (JP16) is on
+the top side of the board. Positions 1, 2 and 3 are usually indicated along the
+jumpers.
+
+To change a solder jumper, using a hot soldering iron, melt the blob of solder
+and move it into the desired position (1-2 or 3-2 or 4-2).
+
+For example, GPIO30 is connected to the on board ADT7420 temperature sensor by
+default. In order to bring it out to the expander JP3 needs to be shifted from
+1-2 to 2-3. After using a soldering iron to shift the jumpers, this is how it
+looks before and after:
+
+.. image:: images/solderjumpersettingchange.png
+   :alt: Solder Jumper Change
+   :align: center
+
+MCU Cog Design and Integration Files
+------------------------------------
+
+.. admonition:: Download
+   :class: download
+
+   `EV-COG-AD3029LZ MCU Cog RevB Schematics <resources/21052017-iot-devkit-tile-revb-schematics.pdf>`_
+
+   
+   `EV-COG-AD3029LZ MCU Cog RevB Layout and BOM <resources/ev-cog-ad3029lzboarddesigndatabase.zip>`_
+   
+
+Add-on Template
+~~~~~~~~~~~~~~~
+
+For developers designing a Cog add-on board, the template schematic/board files
+below might be a useful starting point. The board file has the placement of the
+expansion connectors as well as place-bound rules embedded.
+
+.. admonition:: Download
+   :class: download
+
+   `Gear Template Design Database <resources/geartemplatedesigndatabase.zip>`_
+
+| End Document
+
+:doc:`Back </solutions/reference-designs/ev-cog-ad3029lz/ev-cog-ad3029lz>`
+
+.. |image1| image:: images/23062017-tile-revb-power-mux-scheme.png
+.. |direct| image:: images/24072017-tile-revb-adp5300-gpio.png
+.. |image2| image:: images/c1-conn-mapping.png
+.. |image3| image:: images/c2-conn-mapping.png
+.. |image4| image:: images/3029_jumper_matrix.png
+.. |image5| image:: images/10082017-sensor-jumpers.png
+.. |image6| image:: images/10082017-debug-jumpers.png

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/cog_hw_userguide.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/cog_hw_userguide.rst
@@ -41,12 +41,10 @@ Power Supply Options
 
 The MCU Cog offers the following power supply options:
 
-::
-
-   -5V USB power (USB microB connector)
-   -3V CR2032 Coin cell (Cell holder - BT1)
-   -3V - 6V Rechargeable Li-Ion Battery (JST Connector - P6)
-   -3V - 6V External Supply from an MCU Cog Add-on card (via Connector C1)
+-  5V USB power (USB microB connector)
+-  3V CR2032 Coin cell (Cell holder - BT1)
+-  3V - 6V Rechargeable Li-Ion Battery (JST Connector - P6)
+-  3V - 6V External Supply from an MCU Cog Add-on card (via Connector C1)
 
 Power Muxing Options
 ~~~~~~~~~~~~~~~~~~~~
@@ -87,11 +85,9 @@ Programming & Debug Options
 
 The MCU Cog offers the following debug options:
 
-::
-
-   -On-board CMSIS-DAP debugger (USB microB connector)
-   -JLINK-9 Connector for access to SWD interface (P26)
-   -Access to SW interface to an MCU Cog Add-on card (via Connector C2)
+-  On-board CMSIS-DAP debugger (USB microB connector)
+-  JLINK-9 Connector for access to SWD interface (P26)
+-  Access to SW interface to an MCU Cog Add-on card (via Connector C2)
 
 Wireless Connectivity Options
 -----------------------------
@@ -117,7 +113,7 @@ worry about porting their firmware. The figures below capture the pin-mapping
 and jumpers that need to be changed to get external access (via the expansion
 connectors) to GPIO (as well as power/reset, etc).
 
-|image2|\ |image3|
+|image2| |image3|
 
 Jumper Settings
 ---------------
@@ -190,9 +186,9 @@ MCU Cog Design and Integration Files
 
    `EV-COG-AD3029LZ MCU Cog RevB Schematics <resources/21052017-iot-devkit-tile-revb-schematics.pdf>`_
 
-   
+
    `EV-COG-AD3029LZ MCU Cog RevB Layout and BOM <resources/ev-cog-ad3029lzboarddesigndatabase.zip>`_
-   
+
 
 Add-on Template
 ~~~~~~~~~~~~~~~
@@ -206,9 +202,6 @@ expansion connectors as well as place-bound rules embedded.
 
    `Gear Template Design Database <resources/geartemplatedesigndatabase.zip>`_
 
-| End Document
-
-:doc:`Back </solutions/reference-designs/ev-cog-ad3029lz/ev-cog-ad3029lz>`
 
 .. |image1| image:: images/23062017-tile-revb-power-mux-scheme.png
 .. |direct| image:: images/24072017-tile-revb-adp5300-gpio.png

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/ev-cog-ad3029lz.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/ev-cog-ad3029lz.rst
@@ -1,0 +1,67 @@
+EV-COG-AD3029LZ Development Kit
+===============================
+
+| The :adi:`EV-COG-AD3029LZ <en/design-center/evaluation-hardware-and-software/evaluation-boards-kits/EV-COG-AD3029.html>` (referred also as MCU Cog) is a development platform based on the industry leading ultra low power :adi:`ADuCM3029`
+| 32-bit ARM Cortex™-M3 microcontroller. The platform is designed to be an advanced development and prototyping vehicle to get customer ideas from concept to production with lower risk and faster time to market. |image1| Add-on hardware modules (also called as GEARs), MCU drivers and software application examples form Cog ecosystem. This ecosystem helps customers realize the solution faster, and thus helping them in faster time to market products.
+
+Applications using EV-COG-AD3029LZ board can be developed using one of the
+following toolchains.
+
+-  CrossCore Embedded Studio 2.7.0 and above - an Eclipse based Analog Devices Interactive Development Environment.
+-  IAR Embedded Workbench for ARM 8.20 and above
+-  Keil uVision 4 and above
+-  ARM mbed compiler
+
+Make sure a valid license for the selected toolchain is installed before using
+EV-COG-AD3029LZ board.
+
+-  :doc:`Introduction </solutions/reference-designs/ev-cog-ad3029lz/introduction>`
+-  `Software Packs & Board Support Package <https://wiki.analog.com/resources/eval/user-guides/ev-cog-ad3029lz/packs_&_bsp>`_: EV-COG-AD3029LZ software architecture is categorized into 4 groups as below.
+
+|image2|
+
+   -  :doc:`Analog Devices ADuCM302x Device Support Pack </solutions/reference-designs/ev-cog-ad3029lz/software/aducm302x>`
+
+      -  :doc:`Analog Devices EV-COG-AD3029LZ Off-Chip Drivers and Examples </solutions/reference-designs/ev-cog-ad3029lz/software/ev-cog-ad3029lz>`
+      -  :doc:`Analog Devices Sensor Drivers and Examples </solutions/reference-designs/ev-cog-ad3029lz/software/sensor>`
+      -  :doc:`Analog Devices Bluetooth Low Energy Software </solutions/reference-designs/ev-cog-ad3029lz/software/connectivity>`
+
+-  :doc:`QuickStart Guide </solutions/reference-designs/ev-cog-ad3029lz/quickstart_1>`
+
+   -  `EV-COG-AD3029LZ with CrossCore Embedded Studio <https://wiki.analog.com/resources/eval/quickstart/ev-cog-ad3029lz/tools/cces_guide>`_
+
+      -  :doc:`EV-COG-AD3029LZ with IAR Embedded Workbench for ARM </solutions/reference-designs/ev-cog-ad3029lz/tools/iar_guide>`
+      -  :doc:`EV-COG-AD3029LZ Keil uVision IDE </solutions/reference-designs/ev-cog-ad3029lz/tools/other_ide>`
+
+For more details refer below links.
+
+-  :doc:`Hardware Details </solutions/reference-designs/ev-cog-ad3029lz/hardware_details>`
+
+   -  :doc:`EV-COG-AD3029LZ MCU COG </solutions/reference-designs/ev-cog-ad3029lz/cog_hw_userguide>`
+
+      -  `Power Measurement on EV-COG-AD3029LZ MCU COG <https://wiki.analog.com/resources/eval/user-guides/ev-cog-ad3029lz/_powermeasurement>`_
+      -  `EV-COG-BLEINTP1Z Connectivity COG <https://wiki.analog.com/resources/eval/user-guides/ev-cog-bleintp1z>`_
+      -  `EV-GEAR-EXPANDER1Z Expander Gear <https://wiki.analog.com/resources/eval/user-guides/ev-gear-expander1z>`_
+      -  `EV-COG-SMARTMESH1Z Connectivity COG <https://wiki.analog.com/resources/eval/user-guides/ev-cog-smartmesh1z>`_
+
+-  `Development Tools & Driver <https://wiki.analog.com/resources/eval/user-guides/ev-cog-ad3029lz/tools_&_driver>`_
+
+   -  :doc:`CCES - CrossCore Embedded Studio Download & Install </solutions/reference-designs/ev-cog-ad3029lz/tools/cces_download>`
+
+      -  :doc:`CrossCore Embedded Studio Quickstart Userguide for EV-COG-AD3029LZ </solutions/reference-designs/ev-cog-ad3029lz/tools/cces_guide>`
+      -  :doc:`CMSIS-DAP - Driver installation for on-board debugger </solutions/reference-designs/ev-cog-ad3029lz/tools/hardware_usb>`
+
+-  :doc:`Example Project </solutions/reference-designs/ev-cog-ad3029lz/example_project>`
+
+   -  `Wifi Example <https://wiki.analog.com/resources/eval/user-guides/ev-cog-ad3029lz/example_project/_wifi_example>`_
+
+      -  `SD Card Example <https://wiki.analog.com/resources/eval/user-guides/ev-cog-ad3029lz/example_project/_sd_card_example>`_
+
+         -  `SmartMesh Slave Mode Temperature Sensor Example <https://wiki.analog.com/resources/eval/user-guides/ev-cog-ad3029lz/example_project/_temp_sensor_smartmesh>`_
+
+-  `Help & Support <https://wiki.analog.com/resources/eval/user-guides/ev-cog-ad3029lz/help_&_support>`_
+
+.. |image1| image:: images/wiki-cog-3029.png
+   :width: 450
+
+.. |image2| image:: images/drawing1-copy.png

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/ev-cog-ad3029lz.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/ev-cog-ad3029lz.rst
@@ -1,8 +1,8 @@
 EV-COG-AD3029LZ Development Kit
 ===============================
 
-| The :adi:`EV-COG-AD3029LZ <en/design-center/evaluation-hardware-and-software/evaluation-boards-kits/EV-COG-AD3029.html>` (referred also as MCU Cog) is a development platform based on the industry leading ultra low power :adi:`ADuCM3029`
-| 32-bit ARM Cortex™-M3 microcontroller. The platform is designed to be an advanced development and prototyping vehicle to get customer ideas from concept to production with lower risk and faster time to market. |image1| Add-on hardware modules (also called as GEARs), MCU drivers and software application examples form Cog ecosystem. This ecosystem helps customers realize the solution faster, and thus helping them in faster time to market products.
+The :adi:`EV-COG-AD3029LZ <en/design-center/evaluation-hardware-and-software/evaluation-boards-kits/EV-COG-AD3029.html>` (referred also as MCU Cog) is a development platform based on the industry leading ultra low power :adi:`ADuCM3029`
+32-bit ARM Cortex™-M3 microcontroller. The platform is designed to be an advanced development and prototyping vehicle to get customer ideas from concept to production with lower risk and faster time to market. |image1| Add-on hardware modules (also called as GEARs), MCU drivers and software application examples form Cog ecosystem. This ecosystem helps customers realize the solution faster, and thus helping them in faster time to market products.
 
 Applications using EV-COG-AD3029LZ board can be developed using one of the
 following toolchains.
@@ -16,7 +16,7 @@ Make sure a valid license for the selected toolchain is installed before using
 EV-COG-AD3029LZ board.
 
 -  :doc:`Introduction </solutions/reference-designs/ev-cog-ad3029lz/introduction>`
--  `Software Packs & Board Support Package <https://wiki.analog.com/resources/eval/user-guides/ev-cog-ad3029lz/packs_&_bsp>`_: EV-COG-AD3029LZ software architecture is categorized into 4 groups as below.
+-  :doc:`Software Packs & Board Support Package </solutions/reference-designs/ev-cog-ad3029lz/packs_bsp>`: EV-COG-AD3029LZ software architecture is categorized into 4 groups as below.
 
 |image2|
 
@@ -28,7 +28,7 @@ EV-COG-AD3029LZ board.
 
 -  :doc:`QuickStart Guide </solutions/reference-designs/ev-cog-ad3029lz/quickstart_1>`
 
-   -  `EV-COG-AD3029LZ with CrossCore Embedded Studio <https://wiki.analog.com/resources/eval/quickstart/ev-cog-ad3029lz/tools/cces_guide>`_
+   -  :doc:`EV-COG-AD3029LZ with CrossCore Embedded Studio </solutions/reference-designs/ev-cog-ad3029lz/tools/cces_guide>`
 
       -  :doc:`EV-COG-AD3029LZ with IAR Embedded Workbench for ARM </solutions/reference-designs/ev-cog-ad3029lz/tools/iar_guide>`
       -  :doc:`EV-COG-AD3029LZ Keil uVision IDE </solutions/reference-designs/ev-cog-ad3029lz/tools/other_ide>`
@@ -39,12 +39,12 @@ For more details refer below links.
 
    -  :doc:`EV-COG-AD3029LZ MCU COG </solutions/reference-designs/ev-cog-ad3029lz/cog_hw_userguide>`
 
-      -  `Power Measurement on EV-COG-AD3029LZ MCU COG <https://wiki.analog.com/resources/eval/user-guides/ev-cog-ad3029lz/_powermeasurement>`_
+      -  :doc:`Power Measurement on EV-COG-AD3029LZ MCU COG </solutions/reference-designs/ev-cog-ad3029lz/powermeasurement>`
       -  `EV-COG-BLEINTP1Z Connectivity COG <https://wiki.analog.com/resources/eval/user-guides/ev-cog-bleintp1z>`_
       -  `EV-GEAR-EXPANDER1Z Expander Gear <https://wiki.analog.com/resources/eval/user-guides/ev-gear-expander1z>`_
       -  `EV-COG-SMARTMESH1Z Connectivity COG <https://wiki.analog.com/resources/eval/user-guides/ev-cog-smartmesh1z>`_
 
--  `Development Tools & Driver <https://wiki.analog.com/resources/eval/user-guides/ev-cog-ad3029lz/tools_&_driver>`_
+-  :doc:`Development Tools & Driver </solutions/reference-designs/ev-cog-ad3029lz/tools_driver>`
 
    -  :doc:`CCES - CrossCore Embedded Studio Download & Install </solutions/reference-designs/ev-cog-ad3029lz/tools/cces_download>`
 
@@ -53,13 +53,13 @@ For more details refer below links.
 
 -  :doc:`Example Project </solutions/reference-designs/ev-cog-ad3029lz/example_project>`
 
-   -  `Wifi Example <https://wiki.analog.com/resources/eval/user-guides/ev-cog-ad3029lz/example_project/_wifi_example>`_
+   -  :doc:`Wifi Example </solutions/reference-designs/ev-cog-ad3029lz/example_project/wifi_example>`
 
-      -  `SD Card Example <https://wiki.analog.com/resources/eval/user-guides/ev-cog-ad3029lz/example_project/_sd_card_example>`_
+      -  :doc:`SD Card Example </solutions/reference-designs/ev-cog-ad3029lz/example_project/sd_card_example>`
 
-         -  `SmartMesh Slave Mode Temperature Sensor Example <https://wiki.analog.com/resources/eval/user-guides/ev-cog-ad3029lz/example_project/_temp_sensor_smartmesh>`_
+         -  :doc:`SmartMesh Slave Mode Temperature Sensor Example </solutions/reference-designs/ev-cog-ad3029lz/example_project/temp_sensor_smartmesh>`
 
--  `Help & Support <https://wiki.analog.com/resources/eval/user-guides/ev-cog-ad3029lz/help_&_support>`_
+-  :doc:`Help & Support </solutions/reference-designs/ev-cog-ad3029lz/help_support>`
 
 .. |image1| image:: images/wiki-cog-3029.png
    :width: 450

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/example_project.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/example_project.rst
@@ -1,0 +1,12 @@
+Example Projects
+================
+
+Following application are available with EV-COG-AD3029LZ.
+
+-  `Wifi Example <https://wiki.analog.com/resources/eval/user-guides/ev-cog-ad3029lz/example_project/_wifi_example>`_: This WiFi Example project provides software support to enable WiFi functionality using ESP8266 WiFi module along with EV-Cog-AD3029LZ over UART Interface.
+-   `SD Card Example <https://wiki.analog.com/resources/eval/user-guides/ev-cog-ad3029lz/example_project/_sd_card_example>`_: This document explains about the hardware and software setup, which is required to interface the SDHC memory card to the EV-COG-AD3029LZ through SPI Interface.
+-   `SmartMesh Slave Mode Temperature Sensor Example <https://wiki.analog.com/resources/eval/user-guides/ev-cog-ad3029lz/example_project/_temp_sensor_smartmesh>`_:This document explains how temperature data can be sent via EV-COG-SMARTMESH1Z configured in the slave mode to the E-manager connected to the users PC. It also explains the software flow and how to view the expected output.
+
+:doc:`Back </solutions/reference-designs/ev-cog-ad3029lz/ev-cog-ad3029lz>`
+
+*End of Document*

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/example_project.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/example_project.rst
@@ -3,10 +3,7 @@ Example Projects
 
 Following application are available with EV-COG-AD3029LZ.
 
--  `Wifi Example <https://wiki.analog.com/resources/eval/user-guides/ev-cog-ad3029lz/example_project/_wifi_example>`_: This WiFi Example project provides software support to enable WiFi functionality using ESP8266 WiFi module along with EV-Cog-AD3029LZ over UART Interface.
--   `SD Card Example <https://wiki.analog.com/resources/eval/user-guides/ev-cog-ad3029lz/example_project/_sd_card_example>`_: This document explains about the hardware and software setup, which is required to interface the SDHC memory card to the EV-COG-AD3029LZ through SPI Interface.
--   `SmartMesh Slave Mode Temperature Sensor Example <https://wiki.analog.com/resources/eval/user-guides/ev-cog-ad3029lz/example_project/_temp_sensor_smartmesh>`_:This document explains how temperature data can be sent via EV-COG-SMARTMESH1Z configured in the slave mode to the E-manager connected to the users PC. It also explains the software flow and how to view the expected output.
+-  :doc:`Wifi Example </solutions/reference-designs/ev-cog-ad3029lz/example_project/wifi_example>`: This WiFi Example project provides software support to enable WiFi functionality using ESP8266 WiFi module along with EV-Cog-AD3029LZ over UART Interface.
+-  :doc:`SD Card Example </solutions/reference-designs/ev-cog-ad3029lz/example_project/sd_card_example>`: This document explains about the hardware and software setup, which is required to interface the SDHC memory card to the EV-COG-AD3029LZ through SPI Interface.
+-  :doc:`SmartMesh Slave Mode Temperature Sensor Example </solutions/reference-designs/ev-cog-ad3029lz/example_project/temp_sensor_smartmesh>`: This document explains how temperature data can be sent via EV-COG-SMARTMESH1Z configured in the slave mode to the E-manager connected to the users PC. It also explains the software flow and how to view the expected output.
 
-:doc:`Back </solutions/reference-designs/ev-cog-ad3029lz/ev-cog-ad3029lz>`
-
-*End of Document*

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/example_project/adf7030_example.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/example_project/adf7030_example.rst
@@ -1,0 +1,155 @@
+ADF7030 INTERFACE WITH EV-COG-AD3029LZ
+======================================
+
+Introduction
+------------
+
+This document explains about the hardware and software setup, which is required
+to interface a ADF7030 radio transceiver with the EV-COG-AD3029LZ using SPI
+protocol. The entire setup is made simple with the use of AD-GEAR-DISPLAY1Z,
+which contains the slots for the ADF7030 Daughter Card.
+
+.. image:: ../images/radio_gear.png
+   :width: 600
+
+The hardware details cover the COG jumper settings and also the pin mapping
+between the ADF7030-1 Daughter card and the EV-COG-AD3029LZ. The software
+details cover the software development kit required and the software
+architecture of the code base written to interface the ADF7030 Daughter card
+with the EV-COG-AD3029LZ.
+
+Boards and Accessories required
+-------------------------------
+
+.. image:: ../images/cog_gear_radio.png
+   :width: 800
+
+a.) EV-COG-AD3029LZ (left) b.) AD-GEAR-DISPLAY1Z (middle) c.) ADF7030 Daughter
+card (Right)
+
+- Two of each is required. One for the Transmitter setup and the other for the
+  Receiver setup.
+
+Hardware interface
+------------------
+
+This section contains hardware related information about AD-GEAR-DISPLAY1Z,
+EV-COG-AD3029-LZ and the ADF7030-1 Daughter card. Links are provided to the WiKi
+page of the target COG-AD3029-LZ, the Schematics, BOMs and technical
+documentations at the end of this page.
+
+Connection Diagram
+~~~~~~~~~~~~~~~~~~
+
+.. image:: ../images/cog_adf7030_connection.png
+   :width: 700
+
+- The AD-GEAR-DISPLAY1Z board is required as it acts as the interface between
+  EV-COG-AD3029LZ and ADF7030-1 Daughter Card.
+
+Board Interface
+~~~~~~~~~~~~~~~
+
+-  Connect the AD-GEAR-DISPLAY1Z via it’s Cog connectors to the
+   EV-COG-AD3029LZ’s expansion connectors.
+
+.. image:: ../images/cog_gear_connection.png
+   :width: 600
+
+-  Connect the ADF7030-1 Daughter card to the AD-GEAR-DISPLAY1Z via the
+   expansion's radio connectors.
+
+.. image:: ../images/gear_radio_connection.png
+   :width: 600
+
+Pin Connection
+~~~~~~~~~~~~~~
+
+==================== ============
+EV-COG-AD3029LZ pins ADF7030-1 DB
+==================== ============
+GPIO18 / SPI2_CLK    SCLK
+GPIO19 / SPI2_MOSI   MOSI
+GPIO20 / SPI2_MISO   MISO
+GPIO39 / SPI2_CS3    CS
+GPIO01 / INT_PIN0    GPIO3
+GPIO35 / INT_PIN1    GPIO4
+GPIO35 / TRG_PIN0    GPIO5
+GPIO35 / TRG_PIN1    GPIO0
+GPIO03 / RST_PIN     RST
+==================== ============
+
+Software Details
+----------------
+
+This section contains software related information about AD-GEAR-DISPLAY1Z and
+the EV-COG-AD3029-LZ and the application. Links are provided to the user guides,
+BSPs, software tool chains and the example project at the end of this page.
+
+Application files
+~~~~~~~~~~~~~~~~~
+
+A library consisting of ADF7030-1 specific drivers are provided for interfacing
+the radio module with the host controller.
+
+The example software provided consists of the following,
+
+-  Three example application projects:
+
+   -  OfflineCalibration
+
+      -  TxPacket
+      -  RxPacket
+
+-  ADF7030-1 specific driver source files.
+
+- The example application requires ADuCM302x-Rel2.0.0 BSP for IAR to be
+  installed.
+
+Software Architecture
+~~~~~~~~~~~~~~~~~~~~~
+
+The software architecture for the ADF7030-1 applications is depicted below
+
+|image1|
+
+- The system specific APIs like SPI, UART, GPIO etc and present in the
+  ADuCM302x-Rel2.0.0 BSP .
+
+- The Radio control APIs are found in the Driver files provided within the
+  project application folder.
+
+- The 3 different projects (OfflineCalibration, RX_packet and TX_packet) share
+  the same workspace but only one of them can be set as active at a time.
+
+IDE Setup and example application
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This section covers the various steps involved in getting the RX_packet and
+TX_packet application code to run on EV-COG-AD3029LZ after the hardware setup is
+done.
+
+Following are the steps involved,
+
+-  Download and install IAR Embedded Workbench 7.60.1 or higher.
+-  Download and Install TeraTerm or any equivalent Terminal emulator program
+-  The ADF7030-1 project is available on `Bitbucket <https://bitbucket.analog.com/projects/IOTTGAPPS/repos/adf7030-1-rf-support-for-3029/browse>`_.
+-  Import the source into IAR workspace .
+-  Set TX_packet as active project, build and flash it into the transmitter setup.
+-  Now, set RX_packet as active project, build and flash it into the receiver setup.
+-  open two instances of TeraTerm(Terminal emulator program) each for
+   transmitter and Receiver, press reset on both setups and see RSSI and data
+   being printed on the receiver terminal window.
+
+References and Links
+--------------------
+
+-  :adi:`ADuCM3029 Hardware Reference Manual <media/en/dsp-documentation/processor-manuals/ADuCM302x-mixed-signal-control-processor-hardware-reference.pdf>`
+-  :doc:`EV-COG-AD3029LZ User guide with the BSP </solutions/reference-designs/ev-cog-ad3029lz/ev-cog-ad3029lz>`
+-  Schematics of EV-COG-AD3029LZ and AD-GEAR-DISPLAY1Z are found in the Docs folder of the ADF7030-1 project.
+-  :adi:`ADF7030-1 Data sheet <media/en/technical-documentation/data-sheets/ADF7030-1.pdf>`
+-  :adi:`ADF7030-1 Software Reference Manual <media/en/technical-documentation/user-guides/ADF7030-1-UG-1002.pdf>`
+-  :adi:`ADF7030-1 Hardware Reference Manual <media/en/technical-documentation/user-guides/ADF7030-1-UG-957.pdf>`
+
+.. |image1| image:: ../images/adf7030_flow.png
+   :width: 800

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/example_project/joystick_example.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/example_project/joystick_example.rst
@@ -114,7 +114,7 @@ Following are the steps involved,
 
 -  Download and install IAR Embedded Workbench 7.60.1 or higher.
 -  Download the joystick_example project from `joystick_example.zip <../resources/joystick_example.zip>`_
--  The joystick_example project is also available on `Bitbucket <https://wiki.analog.com/link_to_bitbucket_has_to_be_put_here>`_.
+-  The joystick_example project is also available on `GitHub <https://github.com/analogdevicesinc/EV-COG-AD3029LZ>`_.
 -  Import the source into IAR workspace and run the application software to
    generate interrupts by joystick press.
 

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/example_project/joystick_example.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/example_project/joystick_example.rst
@@ -1,0 +1,128 @@
+JOYSTICK INTERFACE WITH EV-COG-AD3029LZ
+=======================================
+
+Introduction
+------------
+
+This document explains about the hardware and software setup, which is required
+to interface a joystick with the EV-COG-AD3029LZ using MCP23S17 as an
+interfacing I/O expander chip. The entire setup is made simple with the use of
+AD-GEAR-DISPLAY1Z, which contains the joystick and the expander IC.
+
+.. image:: ../images/cog_joystick.png
+   :width: 600
+
+The hardware details cover the COG jumper settings and also the pin mapping
+between the joystick, MCP23S17 expander and the EV-COG-AD3029LZ. The software
+details cover the software development kit required and the software
+architecture of the code base written to interface the joystick with the
+EV-COG-AD3029LZ.
+
+Boards and Accessories required
+-------------------------------
+
+.. image:: ../images/cog_gear.png
+   :width: 700
+
+a.) EV-COG-AD3029LZ (left) b.) AD-GEAR-DISPLAY1Z (right)
+
+Hardware interface
+------------------
+
+This section contains hardware related information about AD-GEAR-DISPLAY1Z and
+the EV-COG-AD3029-LZ. Links are provided to the WiKi page of the target
+COG-AD3029-LZ, the Schematics, BOMs and technical documentations at the end of
+this page.
+
+Connection Diagram
+~~~~~~~~~~~~~~~~~~
+
+.. image:: ../images/cog_joystick_pin.png
+   :width: 600
+
+- The joystick and the I/O expander-MCP23s17 are embedded on the
+  AD-GEAR-DISPLAY1Z.
+
+Board Interface
+~~~~~~~~~~~~~~~
+
+-  Connect the AD-GEAR-DISPLAY1Z via it’s Cog connectors to the
+   EV-COG-AD3029LZ’s expansion connectors.
+
+.. image:: ../images/cog_gear_connection.png
+   :width: 600
+
+Pin Connection
+~~~~~~~~~~~~~~
+
+==================== ============= ========
+EV-COG-AD3029LZ pins MCP23S17 pins Joystick
+==================== ============= ========
+GPIO22 / SPI1_CLK    SCL_SCK       -
+GPIO23 / SPI1_MOSI   SI            -
+GPIO24 / SPI1_MISO   SO            -
+GPIO34 / SPI1_CS2    CS_N          -
+GPIO15 / INT_WAKE0   INTA          -
+-                    GPA0          SW1
+-                    GPA1          SW2
+-                    GPA2          SW3
+-                    GPA3          SW4
+-                    GPA4          SW5
+==================== ============= ========
+
+- A0, A1 and A2 of the I/O expander are connected to the ground.
+
+- RESET_N of the I/O expander is connected to EXT_VDD_OUT of the COG board.
+
+Software Details
+----------------
+
+This section contains software related information about AD-GEAR-DISPLAY1Z and
+the EV-COG-AD3029-LZ and the application. Links are provided to the user guides,
+BSPs, software tool chains and the example project at the end of this page.
+
+Application files
+~~~~~~~~~~~~~~~~~
+
+The example project provided consists mainly of the following,
+
+-  mcp23s17_3.c
+-  mcp23s17.h
+-  SPI_PE.h
+-  adi_spi_pe.h
+-  IAR project files( \*.eww, \*.ewt, \*.ewt)
+-  The application uses the ADuCM302x-Rel 2.0.0 driver BSP for IAR.
+-  IAR Embedded Workbench 7.60.1 or higher is advised to be used.
+
+Application flow
+~~~~~~~~~~~~~~~~
+
+.. image:: ../images/joystick_flow.png
+   :width: 800
+
+- All the APIs for using the I/O expander is within the mcp23s17_3.c with
+  supporting definitions found in SPI_PE.h and adi_spi_pe.h. A separate driver
+  file to use the I/O expander is yet to be created.
+
+IDE Setup and example application
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This section covers the various steps involved in getting the joystick_example
+application code to run on EV-COG-AD3029LZ after the hardware setup is done.
+
+Following are the steps involved,
+
+-  Download and install IAR Embedded Workbench 7.60.1 or higher.
+-  Download the joystick_example project from `joystick_example.zip <../resources/joystick_example.zip>`_
+-  The joystick_example project is also available on `Bitbucket <https://wiki.analog.com/link_to_bitbucket_has_to_be_put_here>`_.
+-  Import the source into IAR workspace and run the application software to
+   generate interrupts by joystick press.
+
+References and Links
+--------------------
+
+-  :adi:`ADuCM3029 Hardware Reference Manual <media/en/dsp-documentation/processor-manuals/ADuCM302x-mixed-signal-control-processor-hardware-reference.pdf>`
+-  :doc:`EV-COG-AD3029LZ User guide with the BSP </solutions/reference-designs/ev-cog-ad3029lz/ev-cog-ad3029lz>`
+-  `MCP23s17 Datasheet <http://ww1.microchip.com/downloads/en/DeviceDoc/20001952C.pdf>`_
+-  Schematics of EV-COG-AD3029LZ and AD-GEAR-DISPLAY1Z are found in the Docs
+   folder of the joystick_example project.

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/example_project/lcd_example.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/example_project/lcd_example.rst
@@ -1,0 +1,127 @@
+LCD (EADOGM128x6) INTERFACE WITH EV-COG-AD3029LZ
+================================================
+
+Introduction
+------------
+
+This document explains about the hardware and software setup, which is required
+to interface a LCD (EADOGM128W6) with the EV-COG-AD3029LZ through SPI interface.
+
+.. image:: ../images/cog_gear_display.png
+   :width: 600
+
+The hardware details cover the COG jumper settings and also the pin mapping
+between the LCD (EADOGM128W6) and the EV-COG-AD3029LZ. The software details
+cover the software development kit required and the software architecture of the
+code base written to interface the LCD with the EV-COG-AD3029LZ.
+
+Boards and Accessories required
+-------------------------------
+
+.. image:: ../images/cog_gear.png
+   :width: 700
+
+a.) EV-COG-AD3029LZ (left) b.) AD-GEAR-DISPLAY1Z (right)
+
+Hardware interface
+------------------
+
+This section contains hardware related information about AD-GEAR-DISPLAY1Z and
+the EV-COG-AD3029-LZ. Links are provided to the WiKi page of the target
+COG-AD3029-LZ, the Schematics, BOMs and technical documentations at the end of
+this page.
+
+Connection Diagram
+~~~~~~~~~~~~~~~~~~
+
+.. image:: ../images/cog_lcd_connection.png
+   :width: 600
+
+The LCD backlight (if present) is controllable by the GPIO Expander. Please
+refer to the schematics of the LCD Gear expander in the Docs folder of the
+lcd_example project for more information.
+
+Board Interface
+~~~~~~~~~~~~~~~
+
+-  Connect the AD-GEAR-DISPLAY1Z via it’s Cog connectors to the
+   EV-COG-AD3029LZ’s expansion connectors.
+
+.. image:: ../images/cog_gear_connection.png
+   :width: 600
+
+Pin Connection
+~~~~~~~~~~~~~~
+
+==================== ======================
+EV-COG-AD3029LZ pins AD-GEAR-DISPLAY1Z pins
+==================== ======================
+GPIO22 / SPI1_CLK    SCL_SCK
+GPIO23 / SPI1_MOSI   SI
+GPIO08 / LCD_A0      A0
+GPIO25 / SPI1_CS0    CS_N
+GPIO28 / LCD_RST     RST_N
+==================== ======================
+
+LCD Backlight
+~~~~~~~~~~~~~
+
+The LCD has a corresponding backlight that can be purchased separately and
+soldered beneath the LCD. The gear does not come included with the components
+needed to support the LCD backlight by default and the components need to be
+added as per the schematic.
+
+Software Details
+----------------
+
+This section contains software related information about AD-GEAR-DISPLAY1Z and
+the EV-COG-AD3029-LZ. Links are provided to the user guides, BSPs, software tool
+chains and the example project at the end of this page.
+
+Application files
+~~~~~~~~~~~~~~~~~
+
+The example software provided consists mainly of the following
+
+-  LCD_test.c
+-  LCD_test.h
+-  CCES project files (\*.svc, \*.project, \*.cproject).
+-  The application uses the ADuCM302x-Rel 2.0.0 driver BSP for CCES.
+-  CrossCore Embedded Studio 2.6.0 or higher is advised to be used.
+
+Application flow
+~~~~~~~~~~~~~~~~
+
+.. image:: ../images/lcd_flow.png
+   :width: 600
+
+-  A BMP-LCD tool application is provided in the Docs folder of the lcd_example project to convert bitmap image to be displayed into an array of hex bytes that can be included in the source code and used to display an image.
+-  All the APIs for using the LCD is within the LCD_test.c file. In the next
+   release the APIs to interact with the LCD will be moved to a separate file.
+
+IDE Setup and example application
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This section covers the various steps involved in getting the LCD_example
+application code to run on EV-COG-AD3029LZ after the hardware setup is done.
+
+Following are the steps involved,
+
+-  Download and install CrossCore Embedded Studio 2.6.0 or higher.
+-  Download the lcd_example project from `lcd_example.zip <../resources/lcd_example.zip>`_
+-  The lcd_example project is also available on `Bitbucket <https://bitbucket.analog.com/projects/IOTTGAPPS/repos/lcd-ev-cog-aducm3029lz/browse>`_.
+-  Import the source into CCES workspace and run the application software and
+   see the results displayed on the LCD.
+
+Upon successfully flashing the project into the COG, it will lead to displaying
+the Analog Devices logo on the LCD screen followed by the messages "IoT Apps"
+and "LCD test Application".
+
+References and Links
+--------------------
+
+-  :adi:`ADuCM3029 Hardware Reference Manual <media/en/dsp-documentation/processor-manuals/ADuCM302x-mixed-signal-control-processor-hardware-reference.pdf>`
+-  :doc:`EV-COG-AD3029LZ User guide with the BSP </solutions/reference-designs/ev-cog-ad3029lz/ev-cog-ad3029lz>`
+-  `EA-DOGM128w6 (LCD) <http://www.lcd-module.com/eng/pdf/grafik/dogm128e.pdf>`_
+-  Schematics of EV-COG-AD3029LZ and AD-GEAR-DISPLAY1Z are found in the Docs
+   folder of the lcd_example project.

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/example_project/sd_card_example.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/example_project/sd_card_example.rst
@@ -1,0 +1,112 @@
+SDHC card Interfacing with EV-COG-AD3029LZ
+==========================================
+
+Introduction
+------------
+
+This document explains about the hardware and software setup, which is required
+to interface the SDHC memory card to the EV-COG-AD3029LZ through SPI Interface.
+
+.. image:: ../images/introductio_bgw.png
+   :width: 600
+
+The hardware details covers the pin mapping between the SDHC memory card and
+EV-COG-AD3029LZ along with useful links that provides more details for
+EV-COG-AD3029LZ and SDHC memory card . The software details covers the software
+development kit required to interface the SDHC memory card with EV-COG-AD3029LZ
+and the software architecture.
+
+Boards and Accessories required
+-------------------------------
+
+.. image:: ../images/things_needed_all.png
+
+a.) EV-GEAR-EXPANDER1Z (left) b.) EV-COG-AD3029LZ (middle) c.) SDHC card (right)
+
+Hardware interface
+------------------
+
+SPI interface
+~~~~~~~~~~~~~
+
+.. image:: ../images/block_diagram.png
+   :align: center
+
+Schematic of SDHC card slot (P2) in expander gear
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. image:: ../images/sdcardinterface.png
+
+Steps
+~~~~~
+
+1. Connect the EV-GEAR-EXPANDER1Z via it’s Cog connectors to the
+   EV-COG-AD3029LZ’s expansion connectors.
+
+|image1|
+
+2. Insert the SDHC card into the SDHC slot (P2) of the expander gear as shown in
+   the figure below.
+
+.. image:: ../images/capture4-bgw.png
+
+Software Details
+----------------
+
+A modular implementation of FatFs library called Elm-Chan FatFs library is
+provided for using SD card with Fat file system
+
+The example software provided consists of these packs
+
+-  Example application code.
+-  Elm-Chan’s FatFs C library- This pack is required for the implementation of
+   FAT file system on SD card.
+
+- The index of API’s provided by Elm-Chan’s FatFs C library and their description can be found in this `Link <http://elm-chan.org/fsw/ff/00index_e.html>`_
+
+- The driver version used is -> ADuCM302x-Rel1.0.6
+
+Software Architecture
+~~~~~~~~~~~~~~~~~~~~~
+
+The software architecture for the SDHC application along with the FATFS is
+depicted below.
+
+.. image:: ../images/software_flow_v1.png
+
+The Application level software handles file management tasks such as create,
+read /write ,edit files.
+
+The Files in the FSFAT folder provides the Elm-Chan FATFS API calls. The files
+under HAL folder provides the SPI interface port for the ADuCM3029 Controller.
+
+Raw I/O without FatFs
+~~~~~~~~~~~~~~~~~~~~~
+
+If raw read/write access to SD card at sector level is needed in the user
+application without the FATFS then the user can only use the files in HAL
+folder.
+
+To do the above, remove the static keyword from the declaration and definition
+of the functions that the user needs to use from the SD.C and SD.h files. After
+doing the changes user can add SD.h in their application code.
+
+.. important::
+
+   While using with FatFs library the user application should not call the low
+   level functions (in HAL).Doing so may crash the library and lead to errors.
+
+SD Card Example Application
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. admonition:: Download
+   :class: download
+
+   :git-EV-COG-AD3029LZ:`SD Card With EV-COG_AD3029LZ <SDCARD%20EXAMPLE%20PROJECT/SD_CARD_SPI_3029_V1.0>`
+
+:doc:`Back </solutions/reference-designs/ev-cog-ad3029lz/ev-cog-ad3029lz>`
+
+*End of Document*
+
+.. |image1| image:: https://wiki.analog.com/_media/_resources/eval/user-guides/ev-cog-ad3029lz/example_project/cog_expan_connector.png
+   :width: 800

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/example_project/sd_card_example.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/example_project/sd_card_example.rst
@@ -102,11 +102,8 @@ SD Card Example Application
 .. admonition:: Download
    :class: download
 
-   :git-EV-COG-AD3029LZ:`SD Card With EV-COG_AD3029LZ <SDCARD%20EXAMPLE%20PROJECT/SD_CARD_SPI_3029_V1.0>`
+   `SD Card With EV-COG_AD3029LZ <https://github.com/analogdevicesinc/EV-COG-AD3029LZ/tree/master/SDCARD%20EXAMPLE%20PROJECT/SD_CARD_SPI_3029_V1.0>`_
 
-:doc:`Back </solutions/reference-designs/ev-cog-ad3029lz/ev-cog-ad3029lz>`
 
-*End of Document*
-
-.. |image1| image:: https://wiki.analog.com/_media/_resources/eval/user-guides/ev-cog-ad3029lz/example_project/cog_expan_connector.png
+.. |image1| image:: ../images/cog_expan_connector.png
    :width: 800

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/example_project/temp_sensor_smartmesh.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/example_project/temp_sensor_smartmesh.rst
@@ -19,7 +19,7 @@ consists of these packs:-
 
 -  `SmartMesh C library <https://github.com/dustcloud/sm_clib>`_- This pack is required for the implementation of the serial APIs of the EV-COG-SMARTMESH1Z and nullifies the need for application software to deal low level processes.
 
-For details on the C-Library, follow this\ `link <https://dustcloud.atlassian.net/wiki/spaces/CLIB>`_
+For details on the C-Library, follow this `link <https://dustcloud.atlassian.net/wiki/spaces/CLIB>`_
 
 Software Overview
 -----------------
@@ -41,7 +41,7 @@ This section gives user a basic understanding on how the software is designed
 for handling both transmission and reception of packets between the
 EV-COG-SMARTMESH1Z and EV-COG-AD3029LZ.
 
-To download the software source from Analog Devices Git - click on :git-EV-COG-AD3029LZ:`"SmartMesh-Temperature-Sensor-Software" <SmartMesh_temp_slavemode_licensed_v2.0>`
+To download the software source from Analog Devices Git - click on `"SmartMesh-Temperature-Sensor-Software" <https://github.com/analogdevicesinc/EV-COG-AD3029LZ/tree/master/SmartMesh_temp_slavemode_licensed_v2.0>`_
 
 Transmission of Packets
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -153,13 +153,10 @@ Example project
 .. admonition:: Download
    :class: download
 
-   To download an example project to interface EV-COG-SMARTMESH1Z with EV-COG-AD3029LZ click on :git-EV-COG-AD3029LZ:`"SmartMesh-Temperature-Sensor-Software" <SmartMesh_temp_slavemode_licensed_v2.0>`
+   To download an example project to interface EV-COG-SMARTMESH1Z with EV-COG-AD3029LZ click on `"SmartMesh-Temperature-Sensor-Software" <https://github.com/analogdevicesinc/EV-COG-AD3029LZ/tree/master/SmartMesh_temp_slavemode_licensed_v2.0>`_
 
-   
+
    The example project sends temperature data or a dummy data to the manager
    which can be viewed on TempMonitor(GUI) or on the APIExplorer(GUI) of the
    manager.
 
-:doc:`Back </solutions/reference-designs/ev-cog-ad3029lz/ev-cog-ad3029lz>`
-
-*End of Document*

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/example_project/temp_sensor_smartmesh.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/example_project/temp_sensor_smartmesh.rst
@@ -1,0 +1,165 @@
+Software example using EV-COG-SMARTMESH1Z
+=========================================
+
+This document explains how temperature data can be sent via EV-COG-SMARTMESH1Z
+configured in the slave mode to the E-manager connected to the users PC. It also
+explains the software flow and how to view the expected output.
+
+Software Details
+----------------
+
+A modular software framework is provided for quick application prototyping.
+Based on the application use case, developers need to download the respective
+software packs.
+
+The EV-COG-SMARTMESH1Z interfaced EV-COG-AD3029LZ , software development kit
+consists of these packs:-
+
+#. :adi:`BSP - Board Support Package for EV-COG-AD3029LZ <en/design-center/evaluation-hardware-and-software/evaluation-boards-kits/eval-aducm3029-ezkit.html#eb-relatedsoftware>`- This pack along with the DFP is required to develop applications using the on-board drivers.
+
+-  `SmartMesh C library <https://github.com/dustcloud/sm_clib>`_- This pack is required for the implementation of the serial APIs of the EV-COG-SMARTMESH1Z and nullifies the need for application software to deal low level processes.
+
+For details on the C-Library, follow this\ `link <https://dustcloud.atlassian.net/wiki/spaces/CLIB>`_
+
+Software Overview
+-----------------
+
+.. image:: ../images/software_over.png
+   :align: center
+   :width: 300
+
+::
+
+   *Application software has provisions to handle sensor data collection or preprocessing of collected data and can draw implications on the collected data.
+   *BSP handles sending and receiving of packets over UART interface.
+   *C-LIB is a library for handling API calls, HDLC packetisation, etc.
+
+Software Architecture
+---------------------
+
+This section gives user a basic understanding on how the software is designed
+for handling both transmission and reception of packets between the
+EV-COG-SMARTMESH1Z and EV-COG-AD3029LZ.
+
+To download the software source from Analog Devices Git - click on :git-EV-COG-AD3029LZ:`"SmartMesh-Temperature-Sensor-Software" <SmartMesh_temp_slavemode_licensed_v2.0>`
+
+Transmission of Packets
+~~~~~~~~~~~~~~~~~~~~~~~
+
+.. image:: ../images/transmit.png
+   :align: center
+   :width: 300
+
+The Application level software handles tasks such as invoking API commands,
+handling API replies and performing user-application specific tasks. The C-Lib
+later performs HDLC packetization and other tasks there by making it easy for
+the user to send commands to the EV-COG-SMARTMESH1Z. In the BSP, APIs specific
+to UART communication aid in sending transmit packets over the UART lines.
+
+Reception of Packets
+~~~~~~~~~~~~~~~~~~~~
+
+When EV-COG-SMARTMESH1Z sends a packet to EV-COG-AD3029LZ, the received packet
+is written to a circular buffer using the UART specific APIs of the BSP. At the
+application level software , the circular buffer is continuously checked for
+data written. When a byte of data is written to the circular buffer, the
+application level software calls routines that handle the data written to the
+buffer. The C-Lib processes the received packet and sends a callback to the
+application level software with only the required field in the received packet.
+
+.. image:: ../images/receive.png
+   :align: center
+   :width: 305
+
+Software Flow:-
+---------------
+
+.. image:: ../images/iamge6.jpg
+   :align: center
+   :width: 600
+
+Interface Guide
+---------------
+
+This section covers the various steps involved in the interface of the
+EV-COG-SMARTMESH1Z with EV-COG-AD3029LZ and thereby run the C-library on the
+EV-COG-AD3029LZ and get it to talk to EV-COG-SMARTMESH1Z.
+
+Following are the steps involved :-
+
+- Connect the EV-COG-SMARTMESH1Z with EV-COG-AD3029LZ  as shown in the Board Interface section.
+- Download and Install the necessary soft wares for working with  the EV-COG-SMARTMESH1Z and EV-COG-AD3029LZ as mentioned in the Software Details section.
+- For setting up  the SmartMesh-IP-Manager  follow `this <http://cds.linear.com/docs/en/application-note/SmartMesh_IP_Easy_Start_Guide_for_the_Embedded_Manager.pdf>`_  link.
+- Download the  `Source code <https://bitbucket.analog.com/projects/IOTTGAPPS/repos/dust-ev-cog-ad3029lz/browse>`_.
+- Place the contents of the SmartMesh C-Library in the your project folder.
+- Here is a list of files of the SmartMesh C-Library you need to include in the project folder:-
+- dn_endianness.c
+- dn_hdlc.c
+- dn_ipmt.c
+- dn_lock.c
+- dn_serial_mt.c
+- Import the source into IAR and run the application software.
+
+Importing source file to IAR
+----------------------------
+
+:doc:`Here </solutions/reference-designs/ev-cog-ad3029lz/tools/iar_guide>` is the link for working with IAR Embedded Workbench for programming EV-COG-3029LZ which cover topics related to initial settings and project importing tasks and running the projects.
+
+Successful Interface of EV-COG-SMARTMESH1Z with EV-COG-AD3029LZ
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Steps to obtain output as shown in fig.1 :-
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. image:: ../images/image_7.png
+   :align: center
+
+::
+
+   *Open Tera Term.
+   *Click on Serial and select the Com port to which the manager is connected.
+   *Type “login user” .
+   *Type “sm” which is  a command for showing all the motes connected to the manager.
+
+Steps to obtain output as shown in fig.2 :-
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. image:: ../images/image_8.png
+   :align: center
+
+::
+
+   *Click on APIExplorer.exe.
+   *Select Manager and click on connect through “serialMux” or through specific Com port.
+   *In the command window select “subscribe”.
+   *To subscribe to all notifications  fill “FFFFFFFF” in the filter section and “00000000” in the unackFilter.
+   *In the “ notifications “ section, one can see the data and other notifications.
+
+Steps to obtain output as shown in fig.3 :-
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. image:: ../images/image_9.png
+   :align: center
+
+::
+
+   *Click on TempMonitor.exe.
+   *Press  “load” manager.
+   *In the mote list, the temperature data sent by the mote is visible.
+
+Example project
+---------------
+
+.. admonition:: Download
+   :class: download
+
+   To download an example project to interface EV-COG-SMARTMESH1Z with EV-COG-AD3029LZ click on :git-EV-COG-AD3029LZ:`"SmartMesh-Temperature-Sensor-Software" <SmartMesh_temp_slavemode_licensed_v2.0>`
+
+   
+   The example project sends temperature data or a dummy data to the manager
+   which can be viewed on TempMonitor(GUI) or on the APIExplorer(GUI) of the
+   manager.
+
+:doc:`Back </solutions/reference-designs/ev-cog-ad3029lz/ev-cog-ad3029lz>`
+
+*End of Document*

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/example_project/wifi_example.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/example_project/wifi_example.rst
@@ -1,0 +1,24 @@
+WiFi Example Project
+====================
+
+This WiFi Example project provides software support to enable WiFi functionality
+using ESP8266 WiFi module along with EV-Cog-AD3029LZ over UART Interface.
+
+The ESP8266 WiFi module is plugged into the P9 port of the EV-COG-BLEINTP1Z board ( Refer Hardware Details section 2,EV-COG-BLEINTP1Z Connectivity Cog - WiFi Module connector section `ev-cog-bleintp1z <https://wiki.analog.com/resources/eval/user-guides/ev-cog-bleintp1z>`_ ).EV-Cog-AD3029LZ communicates to ESP8266 WiFi module through AT commands over UART interface.
+
+WiFi Software Pack for CCES
+---------------------------
+
+The following document details what is in the WiFi Software Pack as well as how
+to install this pack in CCES and work with it. Additionally, it covers how to
+build and run the example Wi-Fi application project that accompany with this
+package
+
+.. admonition:: Download
+   :class: download
+
+   `wifi_software_users_guide.pdf <../resources/wifi_software_users_guide.pdf>`_
+
+:doc:`Back </solutions/reference-designs/ev-cog-ad3029lz/ev-cog-ad3029lz>`
+
+*End of Document*

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/example_project/wifi_example.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/example_project/wifi_example.rst
@@ -19,6 +19,3 @@ package
 
    `wifi_software_users_guide.pdf <../resources/wifi_software_users_guide.pdf>`_
 
-:doc:`Back </solutions/reference-designs/ev-cog-ad3029lz/ev-cog-ad3029lz>`
-
-*End of Document*

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/hardware_details.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/hardware_details.rst
@@ -1,0 +1,19 @@
+Hardware Details
+================
+
+This page contains hardware-related information about the EV-COG-AD3029LZ board
+and the various hardware add on modules which can be used with the board. Each
+sub-section contains a detailed description of the board, connectors, jumpers
+and buttons. It also provides links to the Schematics, Bill of materials, design
+projects, and Technical documentation. It also gives internal links to the
+provided example demo software projects.
+
+The following boards are currently available:
+
+-  :doc:`EV-COG-AD3029LZ MCU Cog </solutions/reference-designs/ev-cog-ad3029lz/cog_hw_userguide>`
+-  `EV-COG-BLEINTP1Z Connectivity Cog <https://wiki.analog.com/resources/eval/user-guides/ev-cog-bleintp1z>`_
+-  `EV-GEAR-EXPANDER1Z Expander Gear <https://wiki.analog.com/resources/eval/user-guides/ev-gear-expander1z>`_
+
+| End Document
+
+:doc:`Back </solutions/reference-designs/ev-cog-ad3029lz/ev-cog-ad3029lz>`

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/hardware_details.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/hardware_details.rst
@@ -14,6 +14,3 @@ The following boards are currently available:
 -  `EV-COG-BLEINTP1Z Connectivity Cog <https://wiki.analog.com/resources/eval/user-guides/ev-cog-bleintp1z>`_
 -  `EV-GEAR-EXPANDER1Z Expander Gear <https://wiki.analog.com/resources/eval/user-guides/ev-gear-expander1z>`_
 
-| End Document
-
-:doc:`Back </solutions/reference-designs/ev-cog-ad3029lz/ev-cog-ad3029lz>`

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/help_support.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/help_support.rst
@@ -1,0 +1,99 @@
+Help and Support
+================
+
+Do you need help or have general support questions, than I hope this page helps
+you resolve those.
+
+This page has a quickstart troubleshooting approach that goes over some very
+general questions and common pitfalls, but if you have a specific issue which
+requires more information or detail please contact us through EngineerZone or
+Email. (links can be found further down on the page where to direct specific
+questions)
+
+What to do When Things Go Wrong
+-------------------------------
+
+There are many things that can go wrong with an ecosystem this complex, but if
+you are having issues getting the board or software working, here are a few
+simple things you can try before contacting Analog Devices.
+
+-  Check the Power
+
+   -  Do you have the USB cable plugged in? if yes, then check switch (S7) in USB position
+   -  If you are using batteries, is the switch (S7) in the "BATT" position
+
+      -  Try replacing your batteries, and see if the board powers up.
+
+-  Program the EV-COG-AD3029LZ
+
+   -  Sometimes a flashed program doesn't run properly or can make it difficult to run the debugger.
+   -  The first thing to try in this case, is to :doc:`drag and drop </solutions/reference-designs/ev-cog-ad3029lz/tools/hardware_usb>` a known good .HEX or .BIN program into flash.(something with quick visible indicators works best)
+   -  If drag and drop is not working, it may be necessary to erase the flash.
+      To do so:
+
+      -  Download and install the CrossCore Serial Flash Programmer from here: :adi:`en/design-center/processors-and-dsp/evaluation-and-development-software/crosscore-serial-flash-programmer.html#dsp-overview`.
+      -  Make sure that the USB is connected and on UART header (P8) 1 & 2 and 7 & 8 are shorted.
+      -  Power cycle the EV-COG-AD3029LZ board while holding down the boot switch.
+      -  Select the mbed serial COM port in the CrossCore Serial Flash Programmer, and erase the flash.
+      -  Then try :doc:`drag and drop </solutions/reference-designs/ev-cog-ad3029lz/tools/hardware_usb>` a .HEX or .BIN file into flash
+
+   -  If the mass erase didn't work, and you are trying to drag and drop a large
+      .BIN file on EV-COG-AD3029LZ hardware, it's possible that the mbed
+      interface file needs to be updated to support your application.
+
+      -  Please visit the :doc:`Driver Installation for On-board Debugger (CMSIS DAP) </solutions/reference-designs/ev-cog-ad3029lz/tools/hardware_usb>`\ page in order to put the board in update mode.
+      -  Once you are in "maintenance mode" you should drag and drop the latest interface file onto your maintenance drive. That file can be downloaded at the bottom of :doc:`Driver Installation for On-board Debugger (CMSIS DAP) </solutions/reference-designs/ev-cog-ad3029lz/tools/hardware_usb>`.
+
+-  Not receiving/transmitting data to the UART
+
+   -  Make sure that the UART header (P8) is positioned in the correct destination to transmit/receive UART data.
+   -  JH6 is shorted.
+
+This is just a brief self-help guide to troubleshooting common issues. If you
+have other questions that need answering please direct those requests to the
+locations outlined below.
+
+Hardware, Software, and Documentation Questions
+-----------------------------------------------
+
+If you have any questions regarding the **EV-COG-AD3029LZ**, any of the **shields/pmods** or are experiencing any problems using the **software** or issues following any of the **documentation** feel free to ask us a question.
+
+-  :ez:`ADuCM3029 support community <community/analog-microcontrollers/aducm302x>` for questions about:
+
+   -  EV-COG-AD3029LZ hardware
+   -  ADuCM3029 silicon
+   -  EV-COG-AD3029LZ software
+   -  EV-COG-AD3029LZ documentation
+
+When asking a question please take the time to give a detailed description of
+your problem. If you are experiencing a problem please state the steps you have
+executed, the result you expected you would get and the result you actually got.
+By doing so you enable us to provide you precise and detailed answers in a
+timely manner.
+
+.. tip::
+
+   Before asking questions please take the time to check if somebody else
+   already asked the same question. You might just find your question already
+   answered.
+
+CrossCore Embedded Studio questions
+-----------------------------------
+
+If you have questions regarding the tools and tool chain that is used with the
+EV-COG-AD3029LZ, either post a question or send an email.
+
+-  :ez:`CrossCore Embedded Studio support community <community/dsp/software-and-development-tools/cces>` for questions about:
+
+   -  Download/Install issues
+   -  Build, debug, run, issues
+   -  Other tools related issues
+
+-  The CrossCore Embedded Studio team can also be emailed using the address
+   below:
+
+   -  `processor.tools.support@analog.com <https://wiki.analog.com/mailto/processor.tools.support@analog.com>`_
+
+*End of Document*
+
+:doc:`Back </solutions/reference-designs/ev-cog-ad3029lz/ev-cog-ad3029lz>`

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/help_support.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/help_support.rst
@@ -92,8 +92,5 @@ EV-COG-AD3029LZ, either post a question or send an email.
 -  The CrossCore Embedded Studio team can also be emailed using the address
    below:
 
-   -  `processor.tools.support@analog.com <https://wiki.analog.com/mailto/processor.tools.support@analog.com>`_
+   -  `processor.tools.support@analog.com <mailto:processor.tools.support@analog.com>`_
 
-*End of Document*
-
-:doc:`Back </solutions/reference-designs/ev-cog-ad3029lz/ev-cog-ad3029lz>`

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/images/1.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/images/1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:29513269e17730481e3e834265e4a5925c7816cb6f6454785da4ba28e7711bb8
+size 228102

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/images/10082017-debug-jumpers.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/images/10082017-debug-jumpers.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dbae1d16178c152fbc5431c8aad064d277400486f40b7b03f07a7aefb9eeb190
+size 10389

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/images/10082017-sensor-jumpers.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/images/10082017-sensor-jumpers.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8d2302f62503ee592158d4a23bd1c19cbf633731b6086c40e6e884ca062d1cea
+size 21046

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/images/11082017-mcu-cog-revb-horizontal-concept.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/images/11082017-mcu-cog-revb-horizontal-concept.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5c6f8de11f9d7de05e9211be244b932efa6cee5b68bfa439e61fe90d9ed06a87
+size 69006

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/images/11082017-mcu-cog-revb-stacking.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/images/11082017-mcu-cog-revb-stacking.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d1e4525fea1ac3e19d73caa4161c2aee350612ff7be3ad1cf2d82061941ebbb6
+size 17501

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/images/23062017-tile-revb-power-mux-scheme.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/images/23062017-tile-revb-power-mux-scheme.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b80c7beca0f4d29d7737d80ac1b89d16d46ea58a74939f7ebaab4e0a3db7a51b
+size 102911

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/images/24072017-tile-revb-adp5300-gpio.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/images/24072017-tile-revb-adp5300-gpio.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a34273b077c392ac21ca50141591e65bec0d1fe909298df1c622ba977c3619ac
+size 21068

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/images/24072017-tile-revb-buttons-leds2.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/images/24072017-tile-revb-buttons-leds2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f004d1923b6c8b1ee1a196dedcfd9bac5bce493351cb5b3a00d7652101b154d0
+size 3370

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/images/24072017-tile-revb-current-test-points.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/images/24072017-tile-revb-current-test-points.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:40f0061866348313528b6f085aca4e24b0c7ddbd5821c63437ddfeaa752fe9b1
+size 8460

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/images/25072017-tile-revb-back.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/images/25072017-tile-revb-back.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bb83767c617ca67d94f33a6bc70861493ed44e4ece607d778dcd6e3e54081542
+size 677643

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/images/25072017-tile-revb-front.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/images/25072017-tile-revb-front.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7c3928f7fe2526ee9e065cc681747149c161bcc126b4436bece693419e7a6e4d
+size 708749

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/images/3029_jumper_matrix.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/images/3029_jumper_matrix.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4ca4ea93eaaa6fdcd517847df72a1c5c7f9d3e4f792c4665e6c9808eac98124b
+size 20523

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/images/add_pack.jpg
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/images/add_pack.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2740d6898baf03dcfb1bc26f880ccd12ac12f0190fcfd3b8963f65376ee5edd2
+size 223050

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/images/adf7030_flow.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/images/adf7030_flow.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:52414c89cfc1561dbf4ba5b6984a63d535649202336d19a5fbf1680e9f74eaad
+size 149217

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/images/before_measurement.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/images/before_measurement.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8ff250f165caa3f9c983d2e92f7101646bf30668b259fe37cef23d10ea59bc04
+size 1464137

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/images/block_diagram.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/images/block_diagram.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7ab9819193946a274b88eacd2b5c602628f7258082abecdf08220d200dd6229e
+size 7731

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/images/build_icon.jpg
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/images/build_icon.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8bc2617a7cc8e159792ef9cf131dead944d45e53df3658c2fdd44f4e9e71c665
+size 8155

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/images/c1-conn-mapping.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/images/c1-conn-mapping.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fca315597a717e9c928dcb4105b80f871bbe91eb341920e9715ff035ed13ec60
+size 94457

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/images/c2-conn-mapping.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/images/c2-conn-mapping.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9e64cc196eaea73694bb0857c0f5a4f53d1f13efddcb7b2287a81689464ddaa0
+size 87392

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/images/c_persp.jpg
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/images/c_persp.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7741de2e28ce2865c4452b9b1158f7514738bf6766c21750d9c64a9689e45378
+size 8597

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/images/capture4-bgw.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/images/capture4-bgw.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ff4c97bc1139df05787e30d1adb89136b4c9ff7b2528b004d9429501b7fabfe3
+size 454629

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/images/cmsis_pack_install_1.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/images/cmsis_pack_install_1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5d4c2a56a8a3fc42ec94143c33ae5de9b23c04521aa46650e44efd60333d4241
+size 80905

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/images/cog_adf7030_connection.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/images/cog_adf7030_connection.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e47e9ae62890896a41b0ddd7a9b43273faa9e528f928c6b84feb58b96b287007
+size 27551

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/images/cog_expan_connector.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/images/cog_expan_connector.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5457046666407106c3656ff6c1e9aad4339f5df20ad94383b36b72d96fe3d40b
+size 326376

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/images/cog_gear.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/images/cog_gear.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:96d8705b7cb77302d83b0ae3bec0576de74569d6129df59829e7409f16fb386d
+size 1611769

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/images/cog_gear_connection.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/images/cog_gear_connection.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:18fabe07a61513dcccc26a0b6ac972fa941901afd2e5a737d1d5c9b93a23e99c
+size 689793

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/images/cog_gear_display.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/images/cog_gear_display.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5090ebdc6eba9ba54a53320073496b63b730e69bf34527d525e2f449d75a4a79
+size 1323215

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/images/cog_gear_radio.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/images/cog_gear_radio.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4eb6bbbb413545ec8ec6a5bd9fe2b40db5722c404a2ea74c301f9f0b60baf4ae
+size 1488432

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/images/cog_joystick.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/images/cog_joystick.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bf752e328ce80bc6ba9c3a46a7c7dd06dee42c6281aa48588fbc2a29096ab073
+size 869474

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/images/cog_joystick_pin.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/images/cog_joystick_pin.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b1340f0b08bc762308b2df6cb963c7bf03930dbe6ab5e8a8d88e71f31c3a1628
+size 27470

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/images/cog_jumpers_annotated.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/images/cog_jumpers_annotated.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a6d85a25cdec27591be9408de59585007cf7e0c7f4e06bc283b4512a86827179
+size 26407

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/images/cog_lcd_connection.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/images/cog_lcd_connection.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c978703ab2c1e18206693478b2c91f3e02420f809d2f797f596e55a33f6def44
+size 21635

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/images/coincell_overall.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/images/coincell_overall.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6df9183d296c375ebd7b36b3cb166d897fe49606cbda033612dad31d7fe310d6
+size 1294102

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/images/coincell_power.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/images/coincell_power.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3098e0ad9b242029246ae3a2d8fb125cacfc755f063005428100c8b126ec13d0
+size 913805

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/images/coincell_voltmon.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/images/coincell_voltmon.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:06cec5fe2a47b8a1d54e4ae9269eaa275e3b9d7f39d6b299b69806ab33c11c95
+size 1663888

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/images/create_new_project_1.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/images/create_new_project_1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7f679e8a601a27c6187707c3ff1dc07844c6b05fd7ca53c8fcaa00b1a4358f47
+size 40677

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/images/daplink_windows_explorer.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/images/daplink_windows_explorer.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a13d3272a9eddcdeb9298a7fa9bf9b7e3bfcb841f060244680fdc59cf9e23f0b
+size 77188

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/images/debug_config.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/images/debug_config.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5031720e037f5187186652c87dc5553dd96adeb881e7eca62d9cb9bd08d4f0ef
+size 70541

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/images/debug_debug_button.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/images/debug_debug_button.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ddca54c06fa6059fbd8dfe39b44f593e27eb269bfd8ebebf00a8c9ca893b7bc7
+size 474

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/images/debug_icon.jpg
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/images/debug_icon.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:797f55b2e8fa6c2f78f22167dbc72ce97214ff1a4efccf1aeb2431a8d41985ef
+size 8124

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/images/device_drivers_install.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/images/device_drivers_install.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c9ff0ca300a592c7b6b2fc4361e0e261787e01755cf476896c49bb58908c8809
+size 33050

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/images/device_drivers_install_complete.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/images/device_drivers_install_complete.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:202cf81daf2751868bdf138167454e5b11f7311a6961028d01d8204e5057ea28
+size 12993

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/images/device_drivers_install_maintenance.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/images/device_drivers_install_maintenance.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eabf9ad84490b4f8ce54635eb6372e4d16ae354b09d524a564904aca131476ba
+size 10079

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/images/device_drivers_install_notification.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/images/device_drivers_install_notification.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1b63f3b3775b481a5a7433a1003e31de7b579401087111319f94678e459a01ba
+size 7835

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/images/download_packs_online.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/images/download_packs_online.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5de34057fb6ababb2ce395ebfcca623b97a7df5262f85ad2be5e9a1ddae504f4
+size 49716

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/images/drawing1-copy.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/images/drawing1-copy.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e0c48ff580c93251035308cd358721bce118a0cb0b01aa3ce4714cd7ca47dae8
+size 39703

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/images/eval-aducm3029-clone.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/images/eval-aducm3029-clone.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e53886dc7e6e1924bd56c289280047594780d723fde9e72567a7aa1c78dc21a0
+size 170294

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/images/eval-aducm3029-cmsis-pack-example-200.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/images/eval-aducm3029-cmsis-pack-example-200.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:35f29d7c6b4d32de9ee0bf65fe99a1d87d8aefd28eaea28a95a79b879e3b4f15
+size 330884

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/images/eval-aducm3029-debug-configuration.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/images/eval-aducm3029-debug-configuration.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bd218c02bb5397edcdf92b023452bfdcdb28d85943732e7fc09aed2cf4a09d71
+size 124031

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/images/eval-aducm3029-debug-hw-limited.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/images/eval-aducm3029-debug-hw-limited.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9c794b7428d9862abcb95e59e4490db3ad2222afdadb506fc58d66b025ed481d
+size 41287

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/images/eval-aducm3029-debug-perspective.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/images/eval-aducm3029-debug-perspective.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bfe0880c4935ab801ad1a2d503058415bd5cc9221baab016a4c0d896ccf9c724
+size 25989

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/images/eval-aducm3029-debug-semi-hosting.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/images/eval-aducm3029-debug-semi-hosting.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e87e371cbf49fec96a1acd7fb77d0957201cde520a80c1d72fef7b51c963c914
+size 30524

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/images/eval-aducm3029-debug-toolbar-stop.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/images/eval-aducm3029-debug-toolbar-stop.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2d6aa2e80c2bb63c9656906c62096247c4684c2bb3de201e24a6c8721365ff77
+size 40213

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/images/eval-aducm3029-debug-toolbar.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/images/eval-aducm3029-debug-toolbar.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6ce6b3835db7ade67dab8f871df66644e69c959ed51598ee79081117a8c75581
+size 49404

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/images/eval-aducm3029-debugging.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/images/eval-aducm3029-debugging.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:36e56e411f8a59e4108a3b1b0d3416627850364a56d68f93cbccc67bb548ee35
+size 225060

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/images/eval-aducm3029-example-browser.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/images/eval-aducm3029-example-browser.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b6314518f795fa482806b5f11ab6e3fbcf355e14daab98541bb6a3d24dc78bcc
+size 199290

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/images/eval-aducm3029-file-import.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/images/eval-aducm3029-file-import.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:95cd976bceb614450a80254fe5a236fbf19a7a6f1c09e5c63123c5c866901d51
+size 207086

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/images/eval-aducm3029-openocd-firewall.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/images/eval-aducm3029-openocd-firewall.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8079ae6e5c36514ceda43fecd2e2d2cffcec76494105139d3533a6879267aa18
+size 71385

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/images/eval-aducm3029-project-build.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/images/eval-aducm3029-project-build.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eb3236b8637569c7b89308e20e3e3691831f02782be2167e7f781aa010046205
+size 34753

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/images/eval-aducm3029-project-configure.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/images/eval-aducm3029-project-configure.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4f86360da46e2cb5b9c2eaa1c39c4762d53c063a0450f1d3974fb94d90990389
+size 187292

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/images/eval-aducm3029-project-explorer.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/images/eval-aducm3029-project-explorer.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ad04a3051e986444815f6c3289f5cf2f59c91d7ac9d01a882a57f88aa5800880
+size 46663

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/images/eval-aducm3029-project-new.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/images/eval-aducm3029-project-new.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6c23575e84ec526c86fbd58a9388880acd94fe6cf081e7daaee4977ba7851dbc
+size 169798

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/images/eval-aducm3029-project-tools-settings.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/images/eval-aducm3029-project-tools-settings.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dcbc1397e0ca3e8fe28dbe9df05198d018209c35466be6ddddf15be778752956
+size 187110

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/images/eval-aducm3029-spec.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/images/eval-aducm3029-spec.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1c76642b62219704bc254cdea104d1ed6823ff62ddf4c5360638a82da1afff30
+size 117686

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/images/eval-aducm3029-tools-hex.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/images/eval-aducm3029-tools-hex.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eac983a8f7fba71a58c6ae86d4afb90c2266b54e2fc8d56d5864c21eaa3eee2e
+size 207567

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/images/eval-aducm3029-tools-semi-hosting.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/images/eval-aducm3029-tools-semi-hosting.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e06ec3d210aae8dfac0d815806298ca9568ee164fba2857aa115c72193b3d013
+size 132179

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/images/eval-aducm3029-workspace.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/images/eval-aducm3029-workspace.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:aadb15dce1a2bfacfb6e5dd94533f2a7ab331787370a5fed739fa9dc044e5f73
+size 33564

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/images/example_run_1.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/images/example_run_1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8de73fabba0682cadcbd2b27b0c4badb63d10847aa9427311a9b5e8e6856d958
+size 10194

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/images/external_supply1.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/images/external_supply1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:88e9921e99d51671aa93c1f8aa06165462fbd32ebd3e0255834abe2b08973526
+size 522779

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/images/external_vdd_expander.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/images/external_vdd_expander.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5826cafb612eb62d3933032aaf957287607f0b003b4813038bd2851a0c89791f
+size 1433227

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/images/external_vdd_main1.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/images/external_vdd_main1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:64ae81e05d6927e49d20322a5243e16ddd48eeb9696b1dff39f4c1d23bfa3123
+size 1306435

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/images/gear_radio_connection.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/images/gear_radio_connection.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:15da7f368e7d8c649d840c27181e2910e846922dfce4623315cac004247ed57b
+size 1288577

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/images/hw_breakpoint.jpg
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/images/hw_breakpoint.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5664ce80b0d2f2e7397411de30085cb81a61fb130ffa13591c47bc59c40ea54f
+size 48077

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/images/iamge6.jpg
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/images/iamge6.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8d39cad1f6da310db5cac2cfd1ca70388fe319d83c22d4dd70bf31cce0d620ea
+size 55852

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/images/iar-aducm3029-cmsis-example-buttonpress1.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/images/iar-aducm3029-cmsis-example-buttonpress1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:749c958d873cb54819d3811bc61d4a19faf1873723dd94674006597534deff7a
+size 40711

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/images/iar-aducm3029-cmsis-example-mcu-select1.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/images/iar-aducm3029-cmsis-example-mcu-select1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:76b5983b15a289e1fccd4020487e5d99b7d10c67126109740b09d80cbcafa8fc
+size 41482

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/images/image_7.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/images/image_7.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:25b16ee6373b7181d181549ef92a4c435f14969bb767f4e1e1c86776626dc778
+size 50897

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/images/image_8.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/images/image_8.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:68cb09cb017e552fd5bcdbb8c6cf9ab0f8e83a291fec2c125d44a21258c2d518
+size 88474

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/images/image_9.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/images/image_9.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:096f0370b1ff3bb133929fb7c4dd5d9aef364732d43a26bbde366222d99d8a3f
+size 79795

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/images/img_20171030_180904.jpg
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/images/img_20171030_180904.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e2477ab2e3fcda988d5e86c28f2c25a2be6f9612efef0453b4aa6178013d1b99
+size 2210521

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/images/img_2668.jpg
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/images/img_2668.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:547f9f4a3933d149621a4819726dc17126d2879de88a83821198a46b82b10457
+size 1139143

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/images/import_existing_packs_icon.jpg
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/images/import_existing_packs_icon.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5048d056fb8cc69f7445fb5cd3cac9e743cafc00a64a81bf6cbc7188cc38814b
+size 8041

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/images/install_packs_online_new.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/images/install_packs_online_new.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f3a735a1ee148521ee59d1ccac856cb44ee10b284aa86ba07abb008426dabe40
+size 134640

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/images/introductio_bgw.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/images/introductio_bgw.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c8493665eedbb1bb16b95c387f7ea47efd9cecb789512c5cac44c79c8522fe48
+size 208097

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/images/joystick_flow.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/images/joystick_flow.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:51324302d90405417f06a79a7b86bac01b65d9ad013943933efa3d5e0fdcc003
+size 30701

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/images/keilcmsisdap.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/images/keilcmsisdap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0795db43e4a6e2798af65f8283ae49b9f6257e2d1d87e60da80ba81fabe42ca6
+size 19028

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/images/keildebug.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/images/keildebug.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:53d8db73a47c75089f2397e67017181dca7cdeb8d8941ce3c713f4db35d6f627
+size 20163

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/images/lcd_flow.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/images/lcd_flow.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d189ce058762b54aed74188e10f356a2dcc30bb8c307e48455eada4eca83d0e7
+size 31068

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/images/maintenance_windows_explorer.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/images/maintenance_windows_explorer.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9fcb8c556cc5be629098434e9e2a107e4c1af30c6fce0c7b4f46b68072bc8638
+size 78668

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/images/mcu_sleep1.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/images/mcu_sleep1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:56e7f5ae86ac441fc44aff973d6aa5d4bd2d87494cded6cbe004b74b35cfe6e1
+size 1653155

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/images/overall_external_supply.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/images/overall_external_supply.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d0c800bc73000b7ff1cb7dad50002c0d8d55b10e510860ac479909184202ad14
+size 1757566

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/images/pack_manager.jpg
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/images/pack_manager.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cc3b017a49c9c568ee43b99fe1698b1fd46fb432fa88bf4c2b4b8e0e4cd36503
+size 9703

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/images/pack_manager_example.jpg
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/images/pack_manager_example.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ad8bf993cde7ab1d257808de48471701a198bf9e272a7846444fb50159ff4156
+size 304009

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/images/power_isolation.jpg
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/images/power_isolation.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b317ee6c5030805b130c38b4a0a32e9a000a1227ec1150e6354fede5ccaadebe
+size 154064

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/images/radio_gear.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/images/radio_gear.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d9e444a81beffb0c38e7ae9ba106c00a2802e52ba4cbfad57c7b19d7fcccd034
+size 1811989

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/images/receive.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/images/receive.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2867d2f335da9836a67df6296a8d3a85670647f49e15e50c3db02a578b2efbd9
+size 43273

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/images/run_button.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/images/run_button.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:563116d923b708a4060e25c6b34d5c27b0331cdb238f39ce416d3dffaad4bf81
+size 463

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/images/run_icon.jpg
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/images/run_icon.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a6c7308b0465defd157a4af040d46e5442c45be58e8cc0e042243752e1c46c84
+size 8002

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/images/sdcardinterface.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/images/sdcardinterface.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cbf545a63ce6d254bb6f3ffa727194f0e530adcf371deff32b8be6ec2a0e49dc
+size 15808

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/images/semihosting.jpg
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/images/semihosting.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9313a539505a91d82dc152b0385163dd6cde0b786d3ab00088c4212a69cb251b
+size 33489

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/images/shuntjumpersettingchange.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/images/shuntjumpersettingchange.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a8a7530b1ce3de804fc60ba77a749c486e70ee3aacd91c371d06947cac71bacb
+size 222755

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/images/sleep_spikes.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/images/sleep_spikes.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:50a100dafbdbfd62c8e08281b58b395193de7892fce9ea3c4ebdde085d10deac
+size 1178919

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/images/sleep_usb.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/images/sleep_usb.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:348047e3adf4fcbdb289444179e6cd90ebaa9813bae0a1158d71dd32aecf3fe9
+size 1035923

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/images/software_flow_v1.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/images/software_flow_v1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ba37148ef07f3e19cd6f77cc8a367857614996ff6a3930ad330bf11ab35e7118
+size 28860

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/images/software_over.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/images/software_over.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:22b89b1b568bd7dc28236b5bb58d94db2641be75fa3172bfba555f29ed2e299d
+size 34246

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/images/software_packs_aducm302x_device_block_diagram.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/images/software_packs_aducm302x_device_block_diagram.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:27c23ec69a45cd097c1ac6d92530783817e395b2cf11a25c9b0f4b151695ada3
+size 42913

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/images/solderjumpersettingchange.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/images/solderjumpersettingchange.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a1249fac3c590226aaf347e2734cfaa9d67aa5b60d84ac5c12e9f5ab1a134673
+size 347430

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/images/th1_current.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/images/th1_current.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:66fb37e9e4d473a8612be4a88933782de602f8d12646896a3681123ce8feae03
+size 2719543

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/images/th3_active_current.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/images/th3_active_current.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d5c2a5842ee543253c6b27fc0a212a6f409b399d5ab8dd1426cb5aea4c67339d
+size 1558996

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/images/things_needed_all.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/images/things_needed_all.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2b760e793d20d7bc9727ef5e5676d880ef11889b0518c700b1dfe85ee33fe27b
+size 307646

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/images/transmit.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/images/transmit.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2c271b2e37ea1cf8ade1bf969fdc36be6c6eaacf270d57bd95a71191b1b2f31f
+size 32749

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/images/wiki-cog-3029.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/images/wiki-cog-3029.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1ebd7da70bab79a6402d025edfe8a4b085e9f2d3faec931a466b09f8890b7d38
+size 2657467

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/index.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/index.rst
@@ -1,8 +1,27 @@
-EV-COG-AD3029LZ Development Kit
-===============================
+.. _ev_cog_ad3029lz eval:
+
+EV COG AD3029LZ
+===========================================================================================
+
+.. TODO: Add a picture of the chip/board
+
+Overview
+-------------------------------------------------------------------------------
+
+.. TODO: Describe in max 10 rows the main features and applications.
+
+Features:
+
+- feature 1
+- feature 2
+
+Applications:
+
+- application 1
+- application 2
 
 .. toctree::
-   :titlesonly:
+   :hidden:
 
    ev-cog-ad3029lz
    cog_hw_userguide
@@ -31,3 +50,22 @@ EV-COG-AD3029LZ Development Kit
    tools/iar_guide
    tools/other_ide
    tools_driver
+
+Recommendations
+-------------------------------------------------------------------------------
+
+People who follow the flow that is outlined, have a much better experience with
+things. However, like many things, documentation is never as complete as it
+should be. If you have any questions, feel free to ask on our
+:ref:`EngineerZone forums <help-and-support>`, but before that, please make
+sure you read our documentation thoroughly.
+
+Warning
+-------------------------------------------------------------------------------
+
+.. esd-warning::
+
+Help and support
+-------------------------------------------------------------------------------
+
+Please go to :ref:`Help and Support <help-and-support>` page.

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/index.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/index.rst
@@ -1,0 +1,33 @@
+EV-COG-AD3029LZ Development Kit
+===============================
+
+.. toctree::
+   :titlesonly:
+
+   ev-cog-ad3029lz
+   cog_hw_userguide
+   example_project
+   example_project/adf7030_example
+   example_project/joystick_example
+   example_project/lcd_example
+   example_project/sd_card_example
+   example_project/temp_sensor_smartmesh
+   example_project/wifi_example
+   hardware_details
+   help_support
+   introduction
+   packs_bsp
+   packs_bsp/iar_support
+   powermeasurement
+   quickstart
+   quickstart_1
+   software/aducm302x
+   software/connectivity
+   software/ev-cog-ad3029lz
+   software/sensor
+   tools/cces_download
+   tools/cces_guide
+   tools/hardware_usb
+   tools/iar_guide
+   tools/other_ide
+   tools_driver

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/introduction.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/introduction.rst
@@ -1,0 +1,20 @@
+Introduction
+============
+
+The :adi:`EV-COG-AD3029` is a modular Internet of Things (IOT) development platform based on the :adi:`ADUCM3029` ultra low power microcontroller (MCU) with integrated power management for processing, control, and connectivity. The MCU system is based on the ARM Cortex-M3 processor, a collection of digital peripherals, embedded SRAM and flash memory, and an analog subsystem which provides clocking, reset, and power management capability in addition to an analog-to-digital converter (ADC) subsystem. The :adi:`ADUCM3029` has industry leading ultra low power which makes it ideal for developing battery powered and self powered wireless sensor nodes. The *Cog* platform uses CrossCore Embedded Studio, an open source Eclipse based Interactive Development Environment (IDE), which can be downloaded free of charge. The platform contains many hardware and software example projects to make it easier for customers to prototype and create connected systems and solutions for Internet of Things (IoT) applications.
+
+.. image:: images/11082017-mcu-cog-revb-horizontal-concept.png
+
+The *Cog* IOT development platform is modular in nature and comprises of:
+
+-  An MCU *Cog* (such as the :doc:`EV-COG-AD3029LZ </solutions/reference-designs/ev-cog-ad3029lz/cog_hw_userguide>`) which has an on-board debugger and test-points for monitoring energy consumption.
+-  An optional connectivity *Cog* (such as the `EV-COG-BLEINTP1Z <https://wiki.analog.com/resources/eval/user-guides/ev-cog-bleintp1z>`_) which offers BTLE, LPWAN or WiFi connectivity options.
+-  An optional application specific add-on board (*Gear*) which might have an optimized sensor signal chain, specific to the use-case. For example - an add-on board targeted at smart agriculture use-cases might have Light, Temperature and Humidity Sensors. For initial prototyping, a specialized Gear is available which provides access to Arduino and PMOD connectors in addition to debug connectors - see `EV-GEAR-EXPANDER1Z <https://wiki.analog.com/resources/eval/user-guides/ev-gear-expander1z>`_.
+
+This modular nature is depicted in the concept sketches below.
+
+.. image:: images/11082017-mcu-cog-revb-stacking.png
+
+| End Document
+
+:doc:`Back </solutions/reference-designs/ev-cog-ad3029lz/ev-cog-ad3029lz>`

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/introduction.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/introduction.rst
@@ -15,6 +15,3 @@ This modular nature is depicted in the concept sketches below.
 
 .. image:: images/11082017-mcu-cog-revb-stacking.png
 
-| End Document
-
-:doc:`Back </solutions/reference-designs/ev-cog-ad3029lz/ev-cog-ad3029lz>`

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/packs_bsp.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/packs_bsp.rst
@@ -10,11 +10,9 @@ software packs.
    Please make sure you install either of the below toolchain before installing
    any of the below packs
 
-   
+
    -  IAR Embedded Workbench for ARM 8.20.1 or higher
    -  CrossCore Embedded Studio 2.7.0 ® or higher
-   
-   packs
 
 The Cog software development kit consists of these packs
 
@@ -32,7 +30,7 @@ The Cog software development kit consists of these packs
 
    -  *Version History*
 
-      -  **Version 3.1.0** - Extended support for IAR Embedded Workbench.\ **[Latest]**
+      -  **Version 3.1.0** - Extended support for IAR Embedded Workbench. **[Latest]**
 
          -  Version: 1.0.0 - Initial Release
 
@@ -50,6 +48,3 @@ The Cog software development kit consists of these packs
 
       -  **Version: 1.0.0** - Initial Release **[Latest]**
 
-:doc:`Back </solutions/reference-designs/ev-cog-ad3029lz/ev-cog-ad3029lz>`
-
-*End of Document*

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/packs_bsp.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/packs_bsp.rst
@@ -1,0 +1,55 @@
+Software Packs & Board Support Package
+======================================
+
+A modular software framework is provided for quick application prototyping.
+Based on the application use case, developers need to download the respective
+software packs.
+
+.. important::
+
+   Please make sure you install either of the below toolchain before installing
+   any of the below packs
+
+   
+   -  IAR Embedded Workbench for ARM 8.20.1 or higher
+   -  CrossCore Embedded Studio 2.7.0 ® or higher
+   
+   packs
+
+The Cog software development kit consists of these packs
+
+-  :doc:`Analog Devices ADuCM302x Device Support Packs </solutions/reference-designs/ev-cog-ad3029lz/software/aducm302x>` - This is a bare minimum pack required to enable working with ADuCM3029 and develop simple applications using the on-chip drivers.
+
+   -  *Version History*
+
+      -  **Version: 3.1.0** - Extended support for IAR Embedded Workbench and Keil uVision. **[Latest]**
+
+         -  Version: 2.0.0 - API Changes to suit IoT applications
+         -  Version: 1.0.6 - Support Release
+         -  Version: 1.0.5 - Enables ECC during flash programming
+
+-  :doc:`Analog Devices EV-COG-AD3029LZ Off-Chip Drivers and Examples </solutions/reference-designs/ev-cog-ad3029lz/software/ev-cog-ad3029lz>` - This pack along with the DFP is required to develop applications using the on-board drivers.
+
+   -  *Version History*
+
+      -  **Version 3.1.0** - Extended support for IAR Embedded Workbench.\ **[Latest]**
+
+         -  Version: 1.0.0 - Initial Release
+
+-  :doc:`Analog Devices Sensor Drivers and Examples </solutions/reference-designs/ev-cog-ad3029lz/software/sensor>` - This pack is required only to develop applications using the GEARs.
+
+   -  *Version History*
+
+      -  **Version: 1.1.0** - Move example projects to respective board support packages. **[Latest]**
+
+         -  Version: 1.0.0 - Initial Release
+
+-  :doc:`Analog Devices Bluetooth Low Energy Software </solutions/reference-designs/ev-cog-ad3029lz/software/connectivity>` - This pack is required to enable BLE connectivity using EV-COG-BLEINTP1Z connectivity Cog.
+
+   -  *Version History*
+
+      -  **Version: 1.0.0** - Initial Release **[Latest]**
+
+:doc:`Back </solutions/reference-designs/ev-cog-ad3029lz/ev-cog-ad3029lz>`
+
+*End of Document*

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/packs_bsp/iar_support.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/packs_bsp/iar_support.rst
@@ -1,0 +1,86 @@
+IAR Board Support Package
+=========================
+
+A modular software framework is provided for quick application prototyping.
+
+.. important::
+
+   Please make sure you install IAR Embedded Workbench before installing the
+   pack
+
+The Cog software development kit
+
+-  `BSP - Board Support Package for EZ-KIT-ADuCM3029 <http://download.analog.com/tools/EZBoards/CM302x/Releases/Release_2.0.0/ADuCM3029_Software-Rel2.0.0.exe>`_ - This is a bare minimum pack required to enable working with ADuCM3029 on IAR. This helps to develop,
+
+   -  simple applications using the on-chip drivers.
+
+      -  simple applications using the on-board drivers.
+
+.. important::
+
+   The application examples found in the pack are developed for
+   EVAL-ADuCM3029-Ez-Kit and will require small changes to make it work for
+   EV-COG-AD3029LZ
+
+**As an example "LED_button_callback" is considered and the changes required is briefly explained.**
+
+**Here, the changes are made only with respect to the GPIOs and only on the application source file.**
+
+-  Install the IAR BSP from the above link.
+-  Open the "LED_button_callback.c" source code in the editor of your choice and
+   make the below changes:
+
+::
+
+     * PATH: C:\Analog Devices\ADuCM302x\ADuCM302x_EZ_Kit\examples\gpio\LED_button_callback\LED_button_callback.c
+       * Macro definition changes under "defined(__ADUCM302x__)":
+         * #define PB1_PORT_NUM        ADI_GPIO_PORT1
+         * #define PB1_PIN_NUM         ADI_GPIO_PIN_0
+          *
+     * #define PB2_PORT_NUM        ADI_GPIO_PORT0
+     * #define PB2_PIN_NUM         ADI_GPIO_PIN_9
+          *
+     * #define LED1_PORT_NUM       ADI_GPIO_PORT2
+     * #define LED1_PIN_NUM        ADI_GPIO_PIN_2
+          *
+     * #define LED2_PORT_NUM       ADI_GPIO_PORT2
+       * #define LED2_PIN_NUM        ADI_GPIO_PIN_10
+
+::
+
+         * Application code changes:
+         * Before changes:
+         * /* set GPIO output LED 4 and 5 */
+         * if(ADI_GPIO_SUCCESS != (eResult = adi_gpio_OutputEnable(ADI_GPIO_PORT1, (ADI_GPIO_PIN_12 | ADI_GPIO_PIN_13), true)))
+         * {
+         * DEBUG_MESSAGE("adi_gpio_SetDirection failed\n");
+         * break;
+         * }
+         * ...........
+         * After changes:
+         * /* set GPIO output LED 4 and 5 */
+         * if(ADI_GPIO_SUCCESS != (eResult = adi_gpio_OutputEnable(LED1_PORT_NUM , LED1_PIN_NUM, true)))
+         * {
+         * DEBUG_MESSAGE("adi_gpio_SetDirection failed\n");
+         * break;
+         * }
+         * if(ADI_GPIO_SUCCESS != (eResult = adi_gpio_OutputEnable(LED2_PORT_NUM, LED2_PIN_NUM , true)))
+         * {
+         * DEBUG_MESSAGE("adi_gpio_SetDirection failed\n");
+         * break;
+         * }
+         * ...........
+         * save the changes and close the source file.
+
+-  Now open the application in IAR embedded workbench.
+
+PATH:C:\\AnalogDevices\\ADuCM302x\\ADuCM302x_EZ_Kit\\examples\\gpio\\LED_button_callback\\ADuCM302x\\iar\\LED_button_callback.eww
+
+-  Press Alt+F7 to open the project options.
+-  Under category select Debugger.
+-  In setup, under Driver select CMSIS DAP.
+-  In Download, uncheck the verify download option.
+-  Under category select CMSIS DAP.
+-  In Interface, under Interface select SWD.
+-  Press "OK" to save and close the options window.
+-  Press Cltr+D to initiate download and debug.

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/powermeasurement.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/powermeasurement.rst
@@ -5,8 +5,8 @@ The MCU Cog boards **EV-COG-AD3029LZ** , **EV-COG-AD4050LZ**, and **EV-COG-AD405
 
 .. note::
 
-   \*\* The power measurement procedure is same for EV-COG-AD3029LZ,
-   EV-COG-AD4050LZ, EV-COG-AD4050WZ, and EV-COG-AD4050WZ.*\*
+   The power measurement procedure is same for EV-COG-AD3029LZ,
+   EV-COG-AD4050LZ, EV-COG-AD4050WZ, and EV-COG-AD4050WZ.
 
 Current measurement test points on COG
 --------------------------------------
@@ -157,7 +157,6 @@ rail. To power up COG from an external source,
    regulator. Connecting a source with voltage level more than 3.6V would damage
    the on board components.
 
-*End of Document*
 
 .. |image1| image:: images/power_isolation.jpg
    :width: 600

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/powermeasurement.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/powermeasurement.rst
@@ -1,0 +1,196 @@
+Power Measurement on COG Platform
+=================================
+
+The MCU Cog boards **EV-COG-AD3029LZ** , **EV-COG-AD4050LZ**, and **EV-COG-AD4050WZ** offer flexibility in terms of power supply and power isolation options for the circuits present on board.It allows the user to power optimize the board for a specific application by isolating or disconnecting some of the circuits which are not used otherwise. True MCU current and EEMBC ulpbench score can be reproduced with proper circuit isolation on the MCU cog board and multiple test points are provided for monitoring current consumption at various points. This wiki page describes the procedure to measure current consumption of the cog boards and to power optimize various applications.
+
+.. note::
+
+   \*\* The power measurement procedure is same for EV-COG-AD3029LZ,
+   EV-COG-AD4050LZ, EV-COG-AD4050WZ, and EV-COG-AD4050WZ.*\*
+
+Current measurement test points on COG
+--------------------------------------
+
++--------------------+--------------------------------------------------------------------+---------------------------------------------------------------+-----------------------------------------------------+
+| Current Test point | Description                                                        | Purpose                                                       | How to do current measurement                       |
++====================+====================================================================+===============================================================+=====================================================+
+| TH1                | Current test point between external supply VIN and regulator       | To supply/measure the overall board current                   | Connect an ammeter across the test point            |
++--------------------+--------------------------------------------------------------------+---------------------------------------------------------------+-----------------------------------------------------+
+| TH2                | Current test point between cog board supply (VDD_MAIN) and VDD_MCU | To supply/measure the current consumed by the MCU alone       | Connect an ammeter across the test point            |
++--------------------+--------------------------------------------------------------------+---------------------------------------------------------------+-----------------------------------------------------+
+| TH3                | Supply test point                                                  | To monitor VDD_MAIN                                           |                                                     |
++--------------------+--------------------------------------------------------------------+---------------------------------------------------------------+-----------------------------------------------------+
+| TH4                | Current test point between cog board supply (VDD_MAIN) and VDD_RF  | To supply/measure the current consumed by the RF module alone | Connect an ammeter across the test point            |
++--------------------+--------------------------------------------------------------------+---------------------------------------------------------------+-----------------------------------------------------+
+| TH5                | Current test point between MCU's GPIO and VDD_MCU_B                | Supplies the I2C pullups present on board                     | If needed, connect an ammeter across the test point |
++--------------------+--------------------------------------------------------------------+---------------------------------------------------------------+-----------------------------------------------------+
+
+.. important::
+
+   Removing the jumper on these test points except TH3 cut downs the supply to
+   the respective block, unless an ammeter is connected across these test point
+   during current measurement
+
+Power isolation jumpers
+-----------------------
+
+The following figure shows jumpers which connect the on board components to the VDD_MAIN supply rail. |image1| To do current profiling for any application, connect the ammeter as shown in overall board current measurement and remove some of the following jumpers if applicable.
+
++----------------+--------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| Jumper         | Action | Description                                                                                                                                                                                               |
++================+========+===========================================================================================================================================================================================================+
+| JH5            | Remove | powers up MBED. If UART is not used to print the messages in the application after downloading the firmware, disconnecting the MBED circuit would save ~10-12mA.                                          |
++----------------+--------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| JH6 (top side) | Remove | Connects reset from MBED to MCU's reset circuit. If not removed while isolating MBED circuit, leakage current of ~1uA is expected                                                                         |
++----------------+--------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| P8 (top side)  | Remove | If MCU UART lines are connected to RF UART lines or External UART lines, this is not required. If not, while disconnecting the MBED remove the jumpers on this header to avoid leakage through UART lines |
++----------------+--------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| JH3            | Remove | If debug LEDs are not used, disconnecting these LEDS would save ~2mA                                                                                                                                      |
++----------------+--------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| JH7            | Remove | Disconnects ADXL362 from VDD_MAIN (do only if necessary)                                                                                                                                                  |
++----------------+--------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| JH8            | Remove | Disconnects ADT7420 from VDD_MAIN (do only if necessary)                                                                                                                                                  |
++----------------+--------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+
+Measuring overall board current
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This section briefs about the jumper settings and wire connections to measure the overall board current. The default jumper settings on the COG board before the measurement is shown in the following figure. |image2| The following figure shows the connection to measure the overall board current. Remove the jumper on TH1 and connect an ammeter across the test points.
+
+|image3|
+
+Measuring MCU current
+~~~~~~~~~~~~~~~~~~~~~
+
+Measuring MCU active mode current
+---------------------------------
+
+To measure the MCU current, remove the jumper present on TH2 and connect an
+ammeter across TH2 as shown in the following figure (left). Other jumper can be
+left in default position. The measured MCU (ADuCM3029) active current is shown
+in the figure on the left.
+
+|image4|
+
+Measuring MCU sleep mode current
+--------------------------------
+
+To measure proper MCU sleep current, it is recommended to isolate some of the on
+board circuits such as debug LEDs and MBED (refer to power isolation jumpers
+section).
+
+-  Remove JH5 and JH6 to disconnect MBED
+-  Remove JH3 to disconnect Debug LEDs
+
+The following figure shows the front and back side of the board with the above mentioned jumpers removed and an ammeter is connected across TH3 to measure MCU sleep current. |image5| The overall MCU sleep current measurement setup is shown in the following figure. The measurement for MCU sleep mode is shown as an example. Note that the reading shown in the figure is an averaged value. |image6| By default, the board supply is fed from the on board step down regulator ADP5300 operating in Hysteresis mode. If the measured sleep current readings are not averaged, then observing spikes in the current profile at regular intervals is expected as shown in the following figure. |image7| This is because, the regulator switches between active and standby mode to save power. When the output voltage is just above the upper hysteresis threshold voltage, the regulator enters standby mode by disabling majority of the circuitry. The regulator then wakes up and charges the load capacitor when the output voltage decreases below the lower hysteresis threshold. Due to this switching, current spikes are expected to be seen in the output.The frequency of switching is not fixed in hysteresis mode and it depends on the load. As the load increases, the switching frequency also increases. But in PWM mode, the regulator always operates at a switching frequency of 2 MHz.
+
+Bypassing the regulator and powering COG with a coincell
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+In case of powering the COG board by using a CR2032 3V coin cell with minimal
+circuits, the on board regulator can be bypassed. Bypassing the regulator allows
+the 3V coin cell to directly supply the board. By do so, the ripples seen in the
+regulated output can be avoided and MCU current without any spikes can be
+observed. The following figure shows the jumper configuration for JH4 to bypass
+ADP5300. Insert the shunt on 5 & 6 positions of JH4.
+
+.. note::
+
+   In the figure, MBED circuit and debug LEDs were also disconnected to reduce
+   the load on 3V coincell. Otherwise the output voltage from the coin cell
+   would drop considerably
+
+|image8| The power switch position and overall jumper configurations are shown in the following figure. To monitor the battery voltage, a voltmeter is connected across TH3 (refer to Current measurement test points section). |image9| The overall current measurement setup measuring MCU hibernate current with full SRAM retention is shown below. |image10|
+
+Bypassing the regulator and powering COG with an external power supply on VDD_MAIN
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The COG boards can be powered up by an external power supply other than the USB
+and coin cell. The external supply can be connected to VDD_MAIN directly
+bypassing ADP5300.
+
+.. important::
+
+   external supply must be below 3.6V, if it is directly connected to VDD_MAIN
+
+The shunt on JH4 must be removed to directly connect the source meter to
+VDD_MAIN as shown below. Other jumpers can be left in default position.
+
+|image11|
+
+The source meter must be connected to TH3.
+
+-  connect positive lead to pin 1 of TH3
+-  connect negative lead to pin 2 of TH3
+
+The following figure shows the overall current measurement setup. In addition to
+source meter, an ammeter is connected across TH2 to measure MCU current.
+
+|image12|
+
+Powering the COG from an external supply (VDD_MAIN) through EV-GEAR-EXPANDER1Z
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+One of the power up options for COG is through an external supply on VDD_MAIN
+rail. To power up COG from an external source,
+
+-  change the switch position to 1 in S7 (this avoids the conflict in the power supply in case USB is connected).
+-  Insert the shunt in 3 & 4 positions on JH4 as shown in the following figure.
+   Other jumpers can be default positions.
+
+.. image:: images/external_vdd_main1.png
+   :align: center
+   :width: 700
+
+-  Connect the MCU COG board to EV-GEAR-EXPANDER1Z board via C1 & C2 connectors
+-  Connect the power supply to EV-GEAR-EXPANDER1Z as shown in the following
+   figure
+
+.. image:: images/external_vdd_expander.png
+   :align: center
+   :width: 500
+
+.. important::
+
+   The voltage source must be between 1.8V and 3.6V. In this setup, the VDD_MAIN
+   rail is directly sourced from an external power source bypassing the on board
+   regulator. Connecting a source with voltage level more than 3.6V would damage
+   the on board components.
+
+*End of Document*
+
+.. |image1| image:: images/power_isolation.jpg
+   :width: 600
+
+.. |image2| image:: images/before_measurement.png
+   :width: 600
+
+.. |image3| image:: images/th1_current.png
+   :width: 600
+
+.. |image4| image:: images/th3_active_current.png
+   :width: 600
+
+.. |image5| image:: images/mcu_sleep1.png
+   :width: 600
+
+.. |image6| image:: images/sleep_usb.png
+   :width: 300
+
+.. |image7| image:: images/sleep_spikes.png
+   :width: 400
+
+.. |image8| image:: images/coincell_power.png
+   :width: 400
+
+.. |image9| image:: images/coincell_voltmon.png
+   :width: 500
+
+.. |image10| image:: images/coincell_overall.png
+   :width: 300
+
+.. |image11| image:: images/external_supply1.png
+   :width: 500
+
+.. |image12| image:: images/overall_external_supply.png
+   :width: 700

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/quickstart.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/quickstart.rst
@@ -1,0 +1,107 @@
+MCU Cog Quick Start Guide [using CCES]
+======================================
+
+Setting up EV-COG-AD3029LZ is a three step process.
+
+-  IDE Setup
+-  Software Packs & Drivers Setup
+-  Running an Example Project
+
+IDE Setup
+---------
+
+-  Install Cross Core Embedded Studio
+
+   -  `CrossCore Embedded Studio 2.6.0 for Windows <http://download.analog.com/tools/CrossCoreEmbeddedStudio/Releases/Release_2.6.0/ADI_CrossCoreEmbeddedStudio-Rel2.6.0.exe>`_
+   -  `CrossCore Embedded Studio 2.6.0 for Ubuntu Linux 14.04 x86 <http://download.analog.com/tools/CrossCoreEmbeddedStudio/Releases/Release_2.6.0/adi-CrossCoreEmbeddedStudio-linux-x86-2.6.0.deb>`_
+
+-  License Installation
+
+   -  Start CCES and navigate to Help -> Manage Licenses.
+   -  Click New and enter the license key provided with the EV-COG-AD3029LZ box.
+   -  Follow the on-screen instructions to register and activate the license.
+
+Software Packs and Driver Setup
+-------------------------------
+
+-  Download the following packs for EV-COG-AD3029LZ
+
+   -  `ARM CMSIS Pack <https://keilpack.azureedge.net/pack/ARM.CMSIS.5.1.1.pack>`_
+   -  `Analog Devices ADuCM302x Device Support Pack <http://download.analog.com/tools/EZBoards/CM302x/Releases/AnalogDevices.ADuCM302x_DFP.2.0.0.pack>`_
+   -  `Analog Devices EV-COG-AD3029LZ Off-Chip Drivers and Examples <http://download.analog.com/tools/EZBoards/COG_AD3029/Releases/AnalogDevices.EV-COG-AD3029LZ_BSP.1.0.0.pack>`_
+
+-  Start CrossCore Embedded Studio.
+-  Go to CMSIS Pack Manager by navigating to Windows ->Perspective ->Open Perspective ->Others -> CMSIS Pack Manager.
+-  Click Import Existing Packs icon |image1|.\ :doc:`Refer for more details </solutions/reference-designs/ev-cog-ad3029lz/tools/cces_guide>`.
+-  Select all the packs and import. This will install the packs. Ignore the warnings seen on the console window. In order to remove these warnings, additional packs needs to be installed which are available in the last section of this page.
+-  Please refer to this `link <https://os.mbed.com/handbook/Windows-serial-configuration>`_ to download and install mbed serial driver on PC.
+
+Running an Example Project
+--------------------------
+
+-  Power the MCU Cog using a USB (micro-B) Cable. You should see a red LED and a
+   yellow LED turn on by default.
+
+.. image:: images/img_2668.jpg
+   :align: center
+   :width: 200
+
+-  In CCES IDE, click CMSIS Pack Manager icon |image2|.
+-  Select EV-COG-AD3029LZ from the Boards tab on the Left panel. (see below image)
+-  Copy button_press example from the Examples tab on the Right panel.
+
+.. image:: images/pack_manager_example.jpg
+   :align: center
+
+-  Click C/C++ perspective icon
+
+.. image:: images/c_persp.jpg
+
+-  Under Project Explorer select button_press example, click build icon |image3|.
+-  Click on Debug icon |image4| once build is complete. Below are the Debug Configuration settings.
+
+.. image:: images/debug_config.png
+   :align: center
+   :width: 700
+
+-  Click ok on Hardware Breakpoint Limited and Semihosting Enabled window.\
+
+|image5|
+
+.. image:: images/hw_breakpoint.jpg
+   :width: 400
+
+-  Click run |image6| on the Debug perspective.
+-  Now press BTN1 or BTN2 on EV-COG-AD3029LZ and inspect corresponding LED.
+
+You are all set!
+
+Additional Packs
+================
+
+For Sensor based application with BLE connectivity please download and install
+below packages.
+
+- Download below packs
+  - ` Analog Devices Sensor Drivers and Examples <http://download.analog.com/tools/Sensor_Software/Releases/AnalogDevices.ADI-SensorSoftware.1.1.0.pack>`_ - :doc:`Refer for more details </solutions/reference-designs/ev-cog-ad3029lz/software/sensor>`
+  - `Analog Devices Bluetooth Low Energy Software <http://download.analog.com/tools/BLE_Software/Releases/AnalogDevices.ADI-BleSoftware.1.0.0.pack>`_ - :doc:`Refer for more details </solutions/reference-designs/ev-cog-ad3029lz/software/connectivity>`
+   * Start CrossCore Embedded Studio.
+   * Go to CMSIS Pack Manager by navigating to Windows ->Perspective ->Open Perspective ->Others -> CMSIS Pack Manager.
+   * Install above downloaded packs by clicking Import Existing Packs icon  |resources-eval-user-guides-ev-cog-ad3029lz-import_existing_packs_icon.jpg|.
+   * Refer "Running Example Project" section as mentioned above to copy existing
+     sensor or BLE based application to workspace.
+
+| End Document
+
+:doc:`Back </solutions/reference-designs/ev-cog-ad3029lz/ev-cog-ad3029lz>`
+
+.. |image1| image:: images/import_existing_packs_icon.jpg
+.. |image2| image:: images/pack_manager.jpg
+.. |image3| image:: images/build_icon.jpg
+.. |image4| image:: images/debug_icon.jpg
+.. |image5| image:: images/semihosting.jpg
+   :width: 400
+
+.. |image6| image:: images/run_icon.jpg
+
+.. |resources-eval-user-guides-ev-cog-ad3029lz-import_existing_packs_icon.jpg| image:: images/import_existing_packs_icon.jpg

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/quickstart.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/quickstart.rst
@@ -64,7 +64,7 @@ Running an Example Project
    :align: center
    :width: 700
 
--  Click ok on Hardware Breakpoint Limited and Semihosting Enabled window.\
+-  Click ok on Hardware Breakpoint Limited and Semihosting Enabled window.
 
 |image5|
 
@@ -77,23 +77,22 @@ Running an Example Project
 You are all set!
 
 Additional Packs
-================
+----------------
 
 For Sensor based application with BLE connectivity please download and install
 below packages.
 
 - Download below packs
-  - ` Analog Devices Sensor Drivers and Examples <http://download.analog.com/tools/Sensor_Software/Releases/AnalogDevices.ADI-SensorSoftware.1.1.0.pack>`_ - :doc:`Refer for more details </solutions/reference-designs/ev-cog-ad3029lz/software/sensor>`
+
+  - `Analog Devices Sensor Drivers and Examples <http://download.analog.com/tools/Sensor_Software/Releases/AnalogDevices.ADI-SensorSoftware.1.1.0.pack>`_ - :doc:`Refer for more details </solutions/reference-designs/ev-cog-ad3029lz/software/sensor>`
   - `Analog Devices Bluetooth Low Energy Software <http://download.analog.com/tools/BLE_Software/Releases/AnalogDevices.ADI-BleSoftware.1.0.0.pack>`_ - :doc:`Refer for more details </solutions/reference-designs/ev-cog-ad3029lz/software/connectivity>`
-   * Start CrossCore Embedded Studio.
-   * Go to CMSIS Pack Manager by navigating to Windows ->Perspective ->Open Perspective ->Others -> CMSIS Pack Manager.
-   * Install above downloaded packs by clicking Import Existing Packs icon  |resources-eval-user-guides-ev-cog-ad3029lz-import_existing_packs_icon.jpg|.
-   * Refer "Running Example Project" section as mentioned above to copy existing
-     sensor or BLE based application to workspace.
 
-| End Document
+- Start CrossCore Embedded Studio.
+- Go to CMSIS Pack Manager by navigating to Windows ->Perspective ->Open Perspective ->Others -> CMSIS Pack Manager.
+- Install above downloaded packs by clicking Import Existing Packs icon |resources-eval-user-guides-ev-cog-ad3029lz-import_existing_packs_icon.jpg|.
+- Refer "Running Example Project" section as mentioned above to copy existing
+  sensor or BLE based application to workspace.
 
-:doc:`Back </solutions/reference-designs/ev-cog-ad3029lz/ev-cog-ad3029lz>`
 
 .. |image1| image:: images/import_existing_packs_icon.jpg
 .. |image2| image:: images/pack_manager.jpg

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/quickstart_1.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/quickstart_1.rst
@@ -1,0 +1,29 @@
+MCU Cog Quick Start Guide
+=========================
+
+Setting up EV-COG-AD3029LZ is a three step process.
+
+-  IDE Setup
+-  Software Packs & Drivers Setup
+-  Running an Example Project
+
+EV-COG-AD4050LZ can be used with following Toolchains. Please see below links
+for the quickstart guide with respect to different IDEs.
+
+CrossCore Embedded Studio
+-------------------------
+
+Click below link to go to CrossCore Embedded Studio userguide.
+
+`EV-COG-AD3029LZ with CrossCore Embedded Studio <https://wiki.analog.com/resources/eval/quickstart/ev-cog-ad3029lz/tools/cces_guide>`_
+
+IAR Embedded Workbench for ARM
+------------------------------
+
+Click below link to go to CrossCore Embedded Studio userguide.
+
+:doc:`EV-COG-AD3029LZ with IAR Embedded Workbench for ARM </solutions/reference-designs/ev-cog-ad3029lz/tools/iar_guide>`
+
+:doc:`Back </solutions/reference-designs/ev-cog-ad3029lz/ev-cog-ad3029lz>`
+
+| End Document

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/quickstart_1.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/quickstart_1.rst
@@ -15,7 +15,7 @@ CrossCore Embedded Studio
 
 Click below link to go to CrossCore Embedded Studio userguide.
 
-`EV-COG-AD3029LZ with CrossCore Embedded Studio <https://wiki.analog.com/resources/eval/quickstart/ev-cog-ad3029lz/tools/cces_guide>`_
+:doc:`EV-COG-AD3029LZ with CrossCore Embedded Studio </solutions/reference-designs/ev-cog-ad3029lz/tools/cces_guide>`
 
 IAR Embedded Workbench for ARM
 ------------------------------
@@ -24,6 +24,3 @@ Click below link to go to CrossCore Embedded Studio userguide.
 
 :doc:`EV-COG-AD3029LZ with IAR Embedded Workbench for ARM </solutions/reference-designs/ev-cog-ad3029lz/tools/iar_guide>`
 
-:doc:`Back </solutions/reference-designs/ev-cog-ad3029lz/ev-cog-ad3029lz>`
-
-| End Document

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/resources/21052017-iot-devkit-tile-revb-schematics.pdf
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/resources/21052017-iot-devkit-tile-revb-schematics.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2e375b26e89e62595d71f8e478aa96f49784acac08c37f91174308dc9c1c3c25
+size 205772

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/resources/ev-cog-ad3029lzboarddesigndatabase.zip
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/resources/ev-cog-ad3029lzboarddesigndatabase.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:72d142d06aad96320b5e1b64c0406ad7b0cf96bd921f4dc52438bc29f97f2472
+size 7377968

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/resources/ev_cog_ad3029lz_mbed.zip
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/resources/ev_cog_ad3029lz_mbed.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:52fbe3488bfaa2e15bcea5651956abc42d70fb8076501a6a90330fd9b758e252
+size 99555

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/resources/geartemplatedesigndatabase.zip
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/resources/geartemplatedesigndatabase.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:58d8879d58e551ed79b1d2bfa98dd5cc907a819853bc0daa0cd8ebd009d4d69a
+size 323517

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/resources/joystick_example.zip
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/resources/joystick_example.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1b60d4fad1d5030ac7d96ae04c7653587785fa5338dba7428522809c2ef7b560
+size 4301989

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/resources/lcd_example.zip
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/resources/lcd_example.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eac76cecc006df9ba3cc082815aa2c92c3fb1bf7528e83825e95cd0d297dbc5b
+size 2130696

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/resources/wifi_software_users_guide.pdf
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/resources/wifi_software_users_guide.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f01a6d10621d51a23a2be14fd6b189691c1f186de4810efbe6a10ade5798eba8
+size 1046194

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/software/aducm302x.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/software/aducm302x.rst
@@ -1,0 +1,76 @@
+Analog Devices ADuCM302x Device Support Pack
+============================================
+
+General Description/Overview
+----------------------------
+
+The ADuCM302x Device Family Pack (DFP) provides access to all the necessary on-chip peripheral drivers for both the :adi:`ADuCM3029` and the :adi:`ADuCM3027` devices. This software layer is the foundation layer needed when writing applications using this microprocessor family. When combined with the EV-COG-AD3029LZ software pack as well as the Sensors software pack, there are many great Internet of Things(IoT) applications and demos that can be replicated using the EV-COG-AD3029LZ development platform.
+
+The following on-chip drivers are provided as part of the ADuCM302x Device
+Family Pack:
+
+-  spi
+
+.. image:: ../images/software_packs_aducm302x_device_block_diagram.png
+   :align: right
+   :width: 600
+
+-  i2c
+-  uart
+-  sport
+-  beep
+-  wdt
+-  gpio
+-  rtc
+-  dma
+-  cryto
+-  adc
+-  tmr
+
+For detailed information regarding the ADuCM302x DFP, please see our complete
+ADuCM302x software user guide.
+
+.. hint::
+
+   
+   -  `ADuCM302x DFP 3.1.0 Release Notes <http://download.analog.com/tools/EZBoards/CM302x/Releases/Release_3.1.0/ADuCM302x_DFP_3.1.0_Release_Notes.pdf>`_
+   -  `ADuCM302x DFP 2.0.0 Release Notes <http://download.analog.com/tools/EZBoards/CM302x/Releases/Release_2.0.0/ADuCM302x_DFP_2.0.0_Release_Notes.pdf>`_
+   
+
+.. important::
+
+   
+   You MUST have this software package installed on your laptop or PC in order
+   to compile, debug, and run the applications for the EV-COG-AD3029LZ platform.
+   
+
+Downloading the ADuCM302x Software Pack
+---------------------------------------
+
+The software pack can be installed directly by the tool chain's CMSIS pack
+manager. Optionally, you may download and then use the CMSIS pack manager's
+manual installation to install the pack.
+
+-  Downloaded via the tool chain's CMSIS pack manager
+
+   -  It is **recommended** to download the ADuCM302x software pack through from the tool chain's CMSIS pack manager. That way, all the files, directories structure, and project structure for the various applications is properly saved and accessed. For a detailed description on how to download the ADuCM302x software pack through CrossCore Embedded Studio please see our :doc:`Cross Core Embedded Studio Quickstart User Guide </solutions/reference-designs/ev-cog-ad3029lz/tools/cces_guide>`.
+
+-  Downloaded to local directory
+
+   -  However if you do decide to download the ADuCM302x software pack to your
+      PC/laptop directly, please use the link below to download the pack file
+      from Keil's website. You will then need to "import" the pack file using
+      your tool chain's CMSIS pack manager's import feature. Note that all
+      software packs can be downloaded from Keil's website.
+
+.. admonition:: Download
+   :class: download
+
+   
+   -  `ADuCM302x DFP 3.1.0 (Latest) <http://download.analog.com/tools/EZBoards/CM302x/Releases/AnalogDevices.ADuCM302x_DFP.3.1.0.pack>`_
+   -  `ADuCM302x DFP 2.0.0 <http://download.analog.com/tools/EZBoards/CM302x/Releases/AnalogDevices.ADuCM302x_DFP.2.0.0.pack>`_
+   
+
+*End of Document*
+
+:doc:`Back </solutions/reference-designs/ev-cog-ad3029lz/ev-cog-ad3029lz>`

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/software/aducm302x.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/software/aducm302x.rst
@@ -32,17 +32,17 @@ ADuCM302x software user guide.
 
 .. hint::
 
-   
+
    -  `ADuCM302x DFP 3.1.0 Release Notes <http://download.analog.com/tools/EZBoards/CM302x/Releases/Release_3.1.0/ADuCM302x_DFP_3.1.0_Release_Notes.pdf>`_
    -  `ADuCM302x DFP 2.0.0 Release Notes <http://download.analog.com/tools/EZBoards/CM302x/Releases/Release_2.0.0/ADuCM302x_DFP_2.0.0_Release_Notes.pdf>`_
-   
+
 
 .. important::
 
-   
+
    You MUST have this software package installed on your laptop or PC in order
    to compile, debug, and run the applications for the EV-COG-AD3029LZ platform.
-   
+
 
 Downloading the ADuCM302x Software Pack
 ---------------------------------------
@@ -66,11 +66,8 @@ manual installation to install the pack.
 .. admonition:: Download
    :class: download
 
-   
+
    -  `ADuCM302x DFP 3.1.0 (Latest) <http://download.analog.com/tools/EZBoards/CM302x/Releases/AnalogDevices.ADuCM302x_DFP.3.1.0.pack>`_
    -  `ADuCM302x DFP 2.0.0 <http://download.analog.com/tools/EZBoards/CM302x/Releases/AnalogDevices.ADuCM302x_DFP.2.0.0.pack>`_
-   
 
-*End of Document*
 
-:doc:`Back </solutions/reference-designs/ev-cog-ad3029lz/ev-cog-ad3029lz>`

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/software/connectivity.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/software/connectivity.rst
@@ -1,7 +1,9 @@
 Analog Devices Bluetooth Low Energy Software
 ============================================
 
-<note > **There are no seperate toolchain,On-Board Peripheral Drivers & Software for EV-COG-AD3029WZ, the toolchain,On-Board Peripheral Drivers & Software for EV-COG-AD3029LZ works with EV-COG-AD3029WZ.The user needs to change only the pin muxing based on the application.For help regarding pinmapping refer to the Hardware Details section.** 
+.. note::
+
+   There are no separate toolchain, On-Board Peripheral Drivers & Software for EV-COG-AD3029WZ. The toolchain, On-Board Peripheral Drivers & Software for EV-COG-AD3029LZ works with EV-COG-AD3029WZ. The user needs to change only the pin muxing based on the application. For help regarding pinmapping refer to the Hardware Details section.
 
 General Description/Overview
 ----------------------------
@@ -26,7 +28,7 @@ Notes.
 
    `BLE Connectivity Pack <http://download.analog.com/tools/BLE_Software/Releases/Release_1.0.0/ADI-BleSoftware_1.0.0_Release_Notes.pdf>`_
 
-   
+
 
 Downloading the Sensor Software Pack
 ------------------------------------
@@ -35,17 +37,14 @@ The software pack can be downloaded in following way.
 
 -  Downloaded via the tools program
 
-   -  It is **recommended** to download the Connectivity software pack through from the tools program you are using. That way, all the files, directories structure, and project structure for the various applications is properly saved and accessed. For a detailed description on how to download the Connectivity software pack through CrossCore Embedded Studio please see our `Cross Core Embedded Studio Quickstart User Guide <https://wiki.analog.com/resources/eval/user-guides/eval-cog-ad3029lz/tools/cces_guide>`_.
+   -  It is **recommended** to download the Connectivity software pack through from the tools program you are using. That way, all the files, directories structure, and project structure for the various applications is properly saved and accessed. For a detailed description on how to download the Connectivity software pack through CrossCore Embedded Studio please see our :doc:`Cross Core Embedded Studio Quickstart User Guide </solutions/reference-designs/ev-cog-ad3029lz/tools/cces_guide>`.
 
 .. admonition:: Download
    :class: download
 
    Download the Connectivity Software Pack.
 
-   
+
    `ADI-BLESoftware pack 1.0.0 <http://download.analog.com/tools/BLE_Software/Releases/AnalogDevices.ADI-BleSoftware.1.0.0.pack>`_
-   
 
-| End Document
 
-:doc:`Back </solutions/reference-designs/ev-cog-ad3029lz/ev-cog-ad3029lz>`

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/software/connectivity.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/software/connectivity.rst
@@ -1,0 +1,51 @@
+Analog Devices Bluetooth Low Energy Software
+============================================
+
+<note > **There are no seperate toolchain,On-Board Peripheral Drivers & Software for EV-COG-AD3029WZ, the toolchain,On-Board Peripheral Drivers & Software for EV-COG-AD3029LZ works with EV-COG-AD3029WZ.The user needs to change only the pin muxing based on the application.For help regarding pinmapping refer to the Hardware Details section.** 
+
+General Description/Overview
+----------------------------
+
+Connectivity pack includes Bluetooth Low Energy (BLE) drivers for
+EV-COG-AD3029LZ. Following are the requirements to use BLE drives available in
+the pack.
+
+-  :doc:`EV-COG-AD3029LZ MCU Cog </solutions/reference-designs/ev-cog-ad3029lz/cog_hw_userguide>`
+-  `EV-COG-BLEINTP1Z Connectivity Cog <https://wiki.analog.com/resources/eval/user-guides/ev-cog-bleintp1z>`_
+
+Connectivity Pack for BLE contains the following examples
+
+-  FindMe Target
+-  Proximity Reporter
+-  Data Exchange (Hello World)
+
+For detailed information regarding the BLE Connectivity Pack, please see Release
+Notes.
+
+.. hint::
+
+   `BLE Connectivity Pack <http://download.analog.com/tools/BLE_Software/Releases/Release_1.0.0/ADI-BleSoftware_1.0.0_Release_Notes.pdf>`_
+
+   
+
+Downloading the Sensor Software Pack
+------------------------------------
+
+The software pack can be downloaded in following way.
+
+-  Downloaded via the tools program
+
+   -  It is **recommended** to download the Connectivity software pack through from the tools program you are using. That way, all the files, directories structure, and project structure for the various applications is properly saved and accessed. For a detailed description on how to download the Connectivity software pack through CrossCore Embedded Studio please see our `Cross Core Embedded Studio Quickstart User Guide <https://wiki.analog.com/resources/eval/user-guides/eval-cog-ad3029lz/tools/cces_guide>`_.
+
+.. admonition:: Download
+   :class: download
+
+   Download the Connectivity Software Pack.
+
+   
+   `ADI-BLESoftware pack 1.0.0 <http://download.analog.com/tools/BLE_Software/Releases/AnalogDevices.ADI-BleSoftware.1.0.0.pack>`_
+   
+
+| End Document
+
+:doc:`Back </solutions/reference-designs/ev-cog-ad3029lz/ev-cog-ad3029lz>`

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/software/ev-cog-ad3029lz.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/software/ev-cog-ad3029lz.rst
@@ -15,9 +15,9 @@ EV-COG-AD3029LZ software pack contains the following components:
 -  On-Chip Driver Examples ( GPIO,RTC, SPI, Systick, TMR, UART, WDT)
 -  Bluetooth Profile Examples
 
-   -  \* FindMe Target
-   -  \* Proximity Reporter
-   -  \* Data Exchange (Hello World)
+   -  FindMe Target
+   -  Proximity Reporter
+   -  Data Exchange (Hello World)
 
 -  Android IoTNode application software
 -  Documentation
@@ -27,17 +27,17 @@ our complete EV-COG-AD3029LZ software user guide.
 
 .. hint::
 
-   
+
    -  `EV-COG-AD3029LZ BSP 3.1.0 Release Notes <http://download.analog.com/tools/EZBoards/COG_AD3029/Releases/Release_3.1.0/EV-COG-AD3029LZ_3.1.0_Release_Notes.pdf>`_
    -  `EV-COG-AD3029LZ BSP 2.0.0 Release Notes <http://download.analog.com/tools/EZBoards/COG_AD3029/Releases/Release_1.0.0/EV-COG-AD3029LZ_1.0.0_Release_Notes.pdf>`_
-   
+
 
 .. important::
 
-   
+
    You MUST have this software package installed on your laptop or PC in order
    to compile, debug, and run the applications for the EV-COG-AD3029LZ platform.
-   
+
 
 Downloading the EV-COG-AD3029LZ Software Pack
 ---------------------------------------------
@@ -58,11 +58,8 @@ The software pack can be downloaded in several ways.
 .. admonition:: Download
    :class: download
 
-   
+
    -  `EV-COG-AD3029LZ BSP 3.1.0 (Latest) <http://download.analog.com/tools/EZBoards/COG_AD3029/Releases/AnalogDevices.EV-COG-AD3029LZ_BSP.3.1.0.pack>`_
    -  `EV-COG-AD3029LZ BSP 1.0.0 <http://download.analog.com/tools/EZBoards/COG_AD3029/Releases/AnalogDevices.EV-COG-AD3029LZ_BSP.1.0.0.pack>`_
-   
 
-*End of Document*
 
-:doc:`Back </solutions/reference-designs/ev-cog-ad3029lz/ev-cog-ad3029lz>`

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/software/ev-cog-ad3029lz.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/software/ev-cog-ad3029lz.rst
@@ -1,0 +1,68 @@
+Analog Devices EV-COG-AD3029LZ Off-Chip Drivers and Examples
+============================================================
+
+General Description/Overview
+----------------------------
+
+The EV-COG-AD3029LZ software pack provides access to all the necessary on-board peripheral drivers for the :adi:`EV-COG-AD3029LZ` development platform. This software layer is the secondary layer needed when writing applications using this development platform. The **EV-COG-AD3029LZ** software pack builds on top of what the ADuCm302x software pack provides. The **EV-COG-AD3029LZ** software pack makes it easier to use the on-board peripherals so creating your application layer is will be easier. Combined with the ADuCM302x and Sensors software pack, there are many great **Internet of Things(IoT)** applications and demos that can be replicated using the **EV-COG-AD3029LZ** development platform.
+
+The drivers and examples in the BSP are designed to work with CrossCore Embedded
+Studio 2.6.0 ® and the ADuCM302x Device Family Pack 2.0.0.
+
+EV-COG-AD3029LZ software pack contains the following components:
+
+-  Bluetooth Companion Module
+-  On-Chip Driver Examples ( GPIO,RTC, SPI, Systick, TMR, UART, WDT)
+-  Bluetooth Profile Examples
+
+   -  \* FindMe Target
+   -  \* Proximity Reporter
+   -  \* Data Exchange (Hello World)
+
+-  Android IoTNode application software
+-  Documentation
+
+For detailed information regarding the EV-COG-AD3029LZ software pack, please see
+our complete EV-COG-AD3029LZ software user guide.
+
+.. hint::
+
+   
+   -  `EV-COG-AD3029LZ BSP 3.1.0 Release Notes <http://download.analog.com/tools/EZBoards/COG_AD3029/Releases/Release_3.1.0/EV-COG-AD3029LZ_3.1.0_Release_Notes.pdf>`_
+   -  `EV-COG-AD3029LZ BSP 2.0.0 Release Notes <http://download.analog.com/tools/EZBoards/COG_AD3029/Releases/Release_1.0.0/EV-COG-AD3029LZ_1.0.0_Release_Notes.pdf>`_
+   
+
+.. important::
+
+   
+   You MUST have this software package installed on your laptop or PC in order
+   to compile, debug, and run the applications for the EV-COG-AD3029LZ platform.
+   
+
+Downloading the EV-COG-AD3029LZ Software Pack
+---------------------------------------------
+
+The software pack can be downloaded in several ways.
+
+-  Downloaded via the tools program
+
+   -  It is **recommended** to download the EV-COG-AD3029LZ software pack through from the tools program you are using. That way, all the files, directories structure, and project structure for the various applications is properly saved and accessed. For a detailed description on how to download the EV-COG-AD3029LZ software pack through CrossCore Embedded Studio please see our :doc:`CrossCore Embedded Studio Quickstart Userguide </solutions/reference-designs/ev-cog-ad3029lz/tools/cces_guide>`.
+
+-  Downloaded to local directory
+
+   -  However if you do decide to download the EV-COG-AD3029LZ software pack to
+      your PC/laptop directly, please use the link below, and make sure you save
+      the software pack to the correct local directory for your
+      applications/projects.
+
+.. admonition:: Download
+   :class: download
+
+   
+   -  `EV-COG-AD3029LZ BSP 3.1.0 (Latest) <http://download.analog.com/tools/EZBoards/COG_AD3029/Releases/AnalogDevices.EV-COG-AD3029LZ_BSP.3.1.0.pack>`_
+   -  `EV-COG-AD3029LZ BSP 1.0.0 <http://download.analog.com/tools/EZBoards/COG_AD3029/Releases/AnalogDevices.EV-COG-AD3029LZ_BSP.1.0.0.pack>`_
+   
+
+*End of Document*
+
+:doc:`Back </solutions/reference-designs/ev-cog-ad3029lz/ev-cog-ad3029lz>`

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/software/sensor.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/software/sensor.rst
@@ -1,0 +1,67 @@
+Analog Devices Sensor Drivers and Examples
+==========================================
+
+<note > **There are no seperate toolchain,On-Board Peripheral Drivers & Software for EV-COG-AD3029WZ, the toolchain,On-Board Peripheral Drivers & Software for EV-COG-AD3029LZ works with EV-COG-AD3029WZ.The user needs to change only the pin muxing based on the application.For help regarding pinmapping refer to the Hardware Details section.** 
+
+General Description/Overview
+----------------------------
+
+Sensor software pack contains sensor software components. Sensor components are based on the sensor classes which abstract the functionality across sensor types. The Sensors software pack provides access to all the necessary add-on module digital drivers that attach to the :adi:`EV-COG-AD3029LZ` development platform. This software layer is the highest layer of abstraction from the microprocessor, and because of this can be useful to jump start code development for your application using any microprocessor. For example, if you are using the ADXL362, the Sensor software pack contains drivers and code snippets on the application level, so that can be transported to other microprocessor, with confidence that Analog Devices provided the application framework pieces. When combined with the :adi:`ADuCM3029` and :adi:`EV-COG-AD3029LZ` software packs there are many great Internet of Things(IoT) applications.
+
+ADI Sensor Software requires CrossCore Embedded Studio 2.6.0 ® , ADuCM3029
+Device Family Pack 2.0.0 and EV-COG-AD3029LZ Board Support Package 1.0.0.
+
+The following application examples and sensor drivers are provided as part of
+the Sensor software pack:
+
+-  Accelerometer Demo
+-  Temperature Sensor Demo
+
+For detailed information regarding the Sensor software pack, please see our
+complete Sensor software user guide.
+
+.. hint::
+
+   
+   `Sensor Software Pack Release Notes <http://download.analog.com/tools/Sensor_Software/Releases/Release_1.1.0/ADI-SensorSoftware_1.1.0_Release_Notes.pdf>`_
+   
+
+.. important::
+
+   
+   You MUST have this software package installed on your laptop or PC in order
+   to compile, debug, and run the applications for the EC-COG-AD3029LZ platform.
+   
+
+Downloading the Sensor Software Pack
+------------------------------------
+
+The software pack can be downloaded in following ways.
+
+-  Downloaded via the tools program
+
+   -  It is **recommended** to download the Sensor software pack through from the tools program you are using. That way, all the files, directories structure, and project structure for the various applications is properly saved and accessed. For a detailed description on how to download the Sensor software pack through CrossCore Embedded Studio please see our :doc:`CrossCore Embedded Studio Quickstart Userguide </solutions/reference-designs/ev-cog-ad3029lz/tools/cces_guide>`
+
+-  Downloaded to local directory
+
+   -  However if you do decide to download the Sensor software pack to your
+      PC/laptop directly, please use the link below, and make sure you save the
+      software pack to the correct local directory for your
+      applications/projects.
+
+.. admonition:: Download
+   :class: download
+
+   
+   Download the Sensor Software Pack.
+   
+   `Sensor Software Pack 1.1.0 <http://download.analog.com/tools/Sensor_Software/Releases/AnalogDevices.ADI-SensorSoftware.1.1.0.pack>`_
+   
+   Link to Github Repository for Cloning or Viewing.
+   
+   `EV-COG-AD3029LZ Github <https://github.com/analogdevicesinc/EV-COG-AD3029LZ>`_
+   
+
+*End of Document*
+
+:doc:`Back </solutions/reference-designs/ev-cog-ad3029lz/ev-cog-ad3029lz>`

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/software/sensor.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/software/sensor.rst
@@ -1,7 +1,9 @@
 Analog Devices Sensor Drivers and Examples
 ==========================================
 
-<note > **There are no seperate toolchain,On-Board Peripheral Drivers & Software for EV-COG-AD3029WZ, the toolchain,On-Board Peripheral Drivers & Software for EV-COG-AD3029LZ works with EV-COG-AD3029WZ.The user needs to change only the pin muxing based on the application.For help regarding pinmapping refer to the Hardware Details section.** 
+.. note::
+
+   There are no separate toolchain, On-Board Peripheral Drivers & Software for EV-COG-AD3029WZ. The toolchain, On-Board Peripheral Drivers & Software for EV-COG-AD3029LZ works with EV-COG-AD3029WZ. The user needs to change only the pin muxing based on the application. For help regarding pinmapping refer to the Hardware Details section.
 
 General Description/Overview
 ----------------------------
@@ -22,16 +24,16 @@ complete Sensor software user guide.
 
 .. hint::
 
-   
+
    `Sensor Software Pack Release Notes <http://download.analog.com/tools/Sensor_Software/Releases/Release_1.1.0/ADI-SensorSoftware_1.1.0_Release_Notes.pdf>`_
-   
+
 
 .. important::
 
-   
+
    You MUST have this software package installed on your laptop or PC in order
    to compile, debug, and run the applications for the EC-COG-AD3029LZ platform.
-   
+
 
 Downloading the Sensor Software Pack
 ------------------------------------
@@ -52,16 +54,13 @@ The software pack can be downloaded in following ways.
 .. admonition:: Download
    :class: download
 
-   
+
    Download the Sensor Software Pack.
-   
+
    `Sensor Software Pack 1.1.0 <http://download.analog.com/tools/Sensor_Software/Releases/AnalogDevices.ADI-SensorSoftware.1.1.0.pack>`_
-   
+
    Link to Github Repository for Cloning or Viewing.
-   
+
    `EV-COG-AD3029LZ Github <https://github.com/analogdevicesinc/EV-COG-AD3029LZ>`_
-   
 
-*End of Document*
 
-:doc:`Back </solutions/reference-designs/ev-cog-ad3029lz/ev-cog-ad3029lz>`

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/tools/cces_download.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/tools/cces_download.rst
@@ -1,0 +1,139 @@
+CrossCore Embedded Studio Download & Install
+============================================
+
+This page provides all the necessary steps to get CrossCore Embedded Studio
+(CCES) software environment up and running on Windows or Linux.
+
+The CCES software development environment for EV-COG-AD3029LZ is based on open
+source tools, and is maintained by Analog Devices. CCES includes support for DSP
+(digital signal processing) and ARM Cortex M- and A- devices, and includes the
+following features and many more:
+
+-  Eclipse based IDE
+-  GNU ARM Embedded Toolchain for Cortex-M core based parts (5-2016-q2-update release)
+-  OpenOCD with support for ADuCM302x and ADuCM4x50 microcontroller (open source SWD)
+-  CMSIS Pack files
+-  Mbed CMSIS-DAP
+-  J-Link Lite
+
+.. important::
+
+   CrossCore Embedded Studio is based on Eclipse, but because the MBED platform
+   provides a CMSIS-DAP interface to connect to the board, the EV-COG-AD3029LZ
+   can be used without problems with IAR Embedded Workbench IDE or Keil µVision
+   IDE as well.
+
+Pre-Requisites and Requirements List
+====================================
+
+There are a few things that you will need for the tools and software to work
+properly.
+
+-  PC or laptop computer
+-  EV-COG-AD3029LZ hardware
+-  Micro USB to USB cables
+
+.. important::
+
+   USB cable needs to have ALL data lines connected, can't use a charging only
+   micro USB cable.
+
+-  Terminal Program to interface your PC with the EV-COG-AD3029LZ
+
+   -  `Putty <http://www.chiark.greenend.org.uk/~sgtatham/putty/download.html>`_
+
+      -  `Tera Term <https://en.osdn.jp/projects/ttssh2/releases/>`_
+      -  Or other favorite Terminal program
+
+CrossCore Embedded Studio Download Packages
+===========================================
+
+.. admonition:: Download
+   :class: download
+
+   
+   The EV-COG-AD3029LZ **requires** the use of Crosscore Embedded Studios version **2.6.0 or higher**. Do not attempt to use earlier versions of the CrossCore tools, due to compatibility issues that will **damage** the EV-COG-AD3029LZ.
+   
+   `CrossCore Embedded Studio 2.7.0 Windows Installer(Executable) <http://download.analog.com/tools/CrossCoreEmbeddedStudio/Releases/Release_2.7.0/ADI_CrossCoreEmbeddedStudio-Rel2.7.0.exe>`_
+   
+   `CrossCore Embedded Studio 2.7.0 Ubuntu Linux Installer(Debian) <http://download.analog.com/tools/CrossCoreEmbeddedStudio/Releases/Release_2.7.0/adi-CrossCoreEmbeddedStudio-linux-x86-2.7.0.deb>`_
+   
+   `CrossCore Embedded Studio 2.6.0 Windows Installer(Executable) <http://download.analog.com/tools/CrossCoreEmbeddedStudio/Releases/Release_2.6.0/ADI_CrossCoreEmbeddedStudio-Rel2.6.0.exe>`_
+   
+   `CrossCore Embedded Studio 2.6.0 Ubuntu Linux Installer(Debian) <http://download.analog.com/tools/CrossCoreEmbeddedStudio/Releases/Release_2.6.0/adi-CrossCoreEmbeddedStudio-linux-x86-2.6.0.deb>`_
+   
+
+The following features are available and supported
+--------------------------------------------------
+
+-  Compilation using the GNU ARM Embedded toolchain for the ADuCM302x and ADuCM4x50 ARM Cortex-M cores.
+-  Debugging ADuCM302x and ADuCM4x50 via the IDE with GDB/OpenOCD.
+-  Development and debugging of bare-metal applications on the ADuCM302x and
+   ADuCM4x50 ARM Cortex-M core.
+
+The following features are only supported via the Windows version
+-----------------------------------------------------------------
+
+-  Use of CrossCore Embedded Studio Add-Ins other than the Linux Add-In
+-  Debugging an Application using the CrossCore Debugger (TPSDK)
+
+CrossCore Embedded Studio Installer Instructions
+================================================
+
+It is best that you save all the files/folders to the default directories
+recommended by the CrossCore Embedded Studios installer. This way all the
+instructions and support provided will be easier.
+
+Installing CrossCore Embedded Studio on Windows
+-----------------------------------------------
+
+-  To install CrossCore Embedded Studio, double-click ADI_CrossCoreEmbeddedStudio-Rel2.6.0.exe
+-  The CrossCore Embedded Studio installer will install the mBed windows serial
+   driver.
+
+   -  It is available separately, if required
+
+      -  https://developer.mbed.org/handbook/Windows-serial-configuration
+
+The executable installs all necessary components to the Analog Devices local
+directory structure which can be found below.
+
+-  CrossCore Embedded Studio installs to **C:\\Analog Devices\\CrossCore Embedded Studio 2.6.0**
+-  Eclipse IDE installs to **C:\\Analog Devices\\CrossCore Embedded Studio 2.6.0\\Eclipse**
+-  GNU ARM Embedded Toolchain for Cortex-M installs to **C:\\Analog Devices\\CrossCore Embedded Studio 2.6.0\\ARM\\gcc-arm-embedded**
+-  OpenOCD installs to **C:\\Analog Devices\\CrossCore Embedded Studio 2.6.0\\ARM\\openocd\\bin**
+-  CMSIS Pack files are installed to **C:\\Analog Devices\\CrossCore Embedded Studio 2.5.1\\ARM\\packs**
+
+Installing CrossCore Embedded Studio on Linux
+---------------------------------------------
+
+-  To install CrossCore Embedded Studio, run the command:
+
+   -  sudo dpkg -i adi-CrossCoreEmbeddedStudio-linux-x86-2.6.0.deb
+
+The Ubuntu Linux Installer(Debian) installs all necessary components to the
+Analog Devices local directory structure which can be found below.
+
+-  CrossCore Embedded Studio installs to **/opt/analog/cces/2.6.0**
+-  Eclipse IDE installs to **/opt/analog/cces/2.6.0/Eclipse**
+-  GNU ARM Embedded Toolchain for Cortex-M installs to **/opt/analog/cces/2.6.0/ARM/gcc-arm-embedded**
+-  OpenOCD installs to **/opt/analog/cces/2.6.0/ARM/openocd/bin**
+-  CMSIS Pack files are installed to **/opt/analog/cces/2.6.0/ARM/packs**
+
+Activating CrossCore Embedded Studio
+====================================
+
+The first time you launch CrossCore Embedded Studio, you will be prompted to input a serial number, name, and email address. The serial number for **ALL** EV-COG-AD3029LZ boards is:
+
+Once the serial number has been activated, the CrossCore development tools will
+allow you full and unlimited access to all the features of the tool when using
+the Analog Devices family of ARM Cortex Processor.
+
+CrossCore Embedded Studio Support
+=================================
+
+For more details on CrossCore Embedded Studio, updated versions of the tools, release notes, tools documentation, or other support. Please visit the CrossCore :adi:`webpage <cces>`, or email the CrossCore support team at `processor.tools.support@analog.com <https://wiki.analog.com/mailto/processor.tools.support@analog.com>`_
+
+*End of Document*
+
+:doc:`Back </solutions/reference-designs/ev-cog-ad3029lz/ev-cog-ad3029lz>`

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/tools/cces_download.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/tools/cces_download.rst
@@ -24,7 +24,7 @@ following features and many more:
    IDE as well.
 
 Pre-Requisites and Requirements List
-====================================
+-------------------------------------
 
 There are a few things that you will need for the tools and software to work
 properly.
@@ -46,22 +46,22 @@ properly.
       -  Or other favorite Terminal program
 
 CrossCore Embedded Studio Download Packages
-===========================================
+--------------------------------------------
 
 .. admonition:: Download
    :class: download
 
-   
+
    The EV-COG-AD3029LZ **requires** the use of Crosscore Embedded Studios version **2.6.0 or higher**. Do not attempt to use earlier versions of the CrossCore tools, due to compatibility issues that will **damage** the EV-COG-AD3029LZ.
-   
+
    `CrossCore Embedded Studio 2.7.0 Windows Installer(Executable) <http://download.analog.com/tools/CrossCoreEmbeddedStudio/Releases/Release_2.7.0/ADI_CrossCoreEmbeddedStudio-Rel2.7.0.exe>`_
-   
+
    `CrossCore Embedded Studio 2.7.0 Ubuntu Linux Installer(Debian) <http://download.analog.com/tools/CrossCoreEmbeddedStudio/Releases/Release_2.7.0/adi-CrossCoreEmbeddedStudio-linux-x86-2.7.0.deb>`_
-   
+
    `CrossCore Embedded Studio 2.6.0 Windows Installer(Executable) <http://download.analog.com/tools/CrossCoreEmbeddedStudio/Releases/Release_2.6.0/ADI_CrossCoreEmbeddedStudio-Rel2.6.0.exe>`_
-   
+
    `CrossCore Embedded Studio 2.6.0 Ubuntu Linux Installer(Debian) <http://download.analog.com/tools/CrossCoreEmbeddedStudio/Releases/Release_2.6.0/adi-CrossCoreEmbeddedStudio-linux-x86-2.6.0.deb>`_
-   
+
 
 The following features are available and supported
 --------------------------------------------------
@@ -78,7 +78,7 @@ The following features are only supported via the Windows version
 -  Debugging an Application using the CrossCore Debugger (TPSDK)
 
 CrossCore Embedded Studio Installer Instructions
-================================================
+-------------------------------------------------
 
 It is best that you save all the files/folders to the default directories
 recommended by the CrossCore Embedded Studios installer. This way all the
@@ -121,7 +121,7 @@ Analog Devices local directory structure which can be found below.
 -  CMSIS Pack files are installed to **/opt/analog/cces/2.6.0/ARM/packs**
 
 Activating CrossCore Embedded Studio
-====================================
+-------------------------------------
 
 The first time you launch CrossCore Embedded Studio, you will be prompted to input a serial number, name, and email address. The serial number for **ALL** EV-COG-AD3029LZ boards is:
 
@@ -130,10 +130,7 @@ allow you full and unlimited access to all the features of the tool when using
 the Analog Devices family of ARM Cortex Processor.
 
 CrossCore Embedded Studio Support
-=================================
+----------------------------------
 
-For more details on CrossCore Embedded Studio, updated versions of the tools, release notes, tools documentation, or other support. Please visit the CrossCore :adi:`webpage <cces>`, or email the CrossCore support team at `processor.tools.support@analog.com <https://wiki.analog.com/mailto/processor.tools.support@analog.com>`_
+For more details on CrossCore Embedded Studio, updated versions of the tools, release notes, tools documentation, or other support. Please visit the CrossCore :adi:`webpage <cces>`, or email the CrossCore support team at `processor.tools.support@analog.com <mailto:processor.tools.support@analog.com>`_
 
-*End of Document*
-
-:doc:`Back </solutions/reference-designs/ev-cog-ad3029lz/ev-cog-ad3029lz>`

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/tools/cces_guide.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/tools/cces_guide.rst
@@ -190,8 +190,8 @@ There are three(3) methods for importing existing projects:
 How to Import Existing Projects Saved to a Local Drive
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
--  Select *File \| Import...* from the CCES menu.
--  A dialog will pop-up with several importing options, choose the *General \| Existing Projects into Workspace* option, and click Next
+-  Select *File | Import...* from the CCES menu.
+-  A dialog will pop-up with several importing options, choose the *General | Existing Projects into Workspace* option, and click Next
 -  Select *Browse* in the dialog window and search for the saved project which is on your local drive.
 -  (Optional) If the *Copy projects into workspace* option is checked, the project will be copied to your workspace folder and the newly copied project will be opened and used. This preserves the original version of the project.
 -  Click *Finish*
@@ -289,7 +289,7 @@ You will need to create a launch configuration to debug your ADuCM3029 program.
    :align: center
 
 Hardware breakpoints are limited in your ADuCM3029 application
-==============================================================
+--------------------------------------------------------------
 
 -  When you click Debug or Apply, you will be prompted with a dialog informing your the Hardware Breakpoints are limited. Click *Yes*. You can opt to not show this dialog again.
 
@@ -336,25 +336,27 @@ How to start and stop debugging an ADuCM3029 application
 -  If everything goes fine, in the Console window, you will see a report without
    errors.
 
-   -  As a reference, the full text should be similar to:``Open On-Chip Debugger (OpenOCD) 0.9.0
-      Licensed under GNU GPL v2
-      Report bugs to <openocd-devel@lists.sourceforge.net>
-      0
-      Info : select transport "swd"
-      adapter speed: 1000 kHz
-      cortex_m reset_config sysresetreq
-      Info : CMSIS-DAP: SWD  Supported
-      Info : CMSIS-DAP: Interface Initialised (SWD)
-      Info : CMSIS-DAP: FW Version = 1.0
-      Info : SWCLK/TCK = 0 SWDIO/TMS = 1 TDI = 0 TDO = 0 nTRST = 0 nRESET = 1
-      Info : CMSIS-DAP: Interface ready
-      Info : clock speed 1000 kHz
-      Info : SWD IDCODE 0x2ba01477
-      Info : aducm3029.cpu: hardware has 2 breakpoints, 1 watchpoints
-      Info : CHIPID 0x0284
-      memory bus access delay set to 6 tck
-      adapter speed: 1000 kHz
-      Info : accepting 'gdb' connection on tcp/3333``
+   -  As a reference, the full text should be similar to::
+
+         Open On-Chip Debugger (OpenOCD) 0.9.0
+         Licensed under GNU GPL v2
+         Report bugs to <openocd-devel@lists.sourceforge.net>
+         0
+         Info : select transport "swd"
+         adapter speed: 1000 kHz
+         cortex_m reset_config sysresetreq
+         Info : CMSIS-DAP: SWD  Supported
+         Info : CMSIS-DAP: Interface Initialised (SWD)
+         Info : CMSIS-DAP: FW Version = 1.0
+         Info : SWCLK/TCK = 0 SWDIO/TMS = 1 TDI = 0 TDO = 0 nTRST = 0 nRESET = 1
+         Info : CMSIS-DAP: Interface ready
+         Info : clock speed 1000 kHz
+         Info : SWD IDCODE 0x2ba01477
+         Info : aducm3029.cpu: hardware has 2 breakpoints, 1 watchpoints
+         Info : CHIPID 0x0284
+         memory bus access delay set to 6 tck
+         adapter speed: 1000 kHz
+         Info : accepting 'gdb' connection on tcp/3333
 
 -  Your program's execution is stopped automatically at the first breakpoint
    which is at the beginning of main() loop. You can use the debug functions and
@@ -386,8 +388,5 @@ How to create an Intel Hex (.hex) file from an ADuCM3029 application
 .. image:: ../images/eval-aducm3029-tools-hex.png
    :align: center
 
-*End of Document*
-
-:doc:`Back </solutions/reference-designs/ev-cog-ad3029lz/ev-cog-ad3029lz>`
 
 .. |image1| image:: ../images/install_packs_online_new.png

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/tools/cces_guide.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/tools/cces_guide.rst
@@ -1,0 +1,393 @@
+Cross Core Embedded Studio Quickstart User Guide for EV-COG-AD3029WZ
+====================================================================
+
+.. note::
+
+   There is no separate tool chain or software packs for EV-COG-AD3029WZ, the
+   tool chain and software packs for EV-COG-AD3029LZ is compatible with
+   EV-COG-AD3029WZ, except some pin map changes
+
+This page describes how to use the ADuCM302x Device Family Pack (DFP) with
+CrossCore Embedded Studio (CCES) to create, import, build and debug applications
+for the ADuCM302x processor. The ADuCM302x MCU integrates an ARM Cortex-M3
+processor with various on-chip peripherals within a single package.
+
+.. note::
+
+   ADuCM302x family has two versions of the device, ADuCM3027 and ADuCM3029, the
+   DFP supports both these versions
+
+This page describes how to install and work with the Analog Devices ADuCM302x
+DFP to start developing applications for the EV-COG-AD3029WZ.
+
+Additional help documentation can be found by opening CCES and selecting "Help
+Contents" from the CCES Help menu.
+
+This page covers:
+
+-  How to install Packs for CCES
+-  How to create a new project for the ADuCM3029
+-  How to add startup code and core components to a new project for the ADuCM3029
+-  How to import existing projects into your workspace
+-  How to build projects for programming the ADuCM3029
+-  How to configure the Tools Settings used by an ADuCM3029 project
+-  How to configure the debug session for an ADuCM3029 application
+-  How to start and stop debugging an ADuCM3029 application
+-  How to create an Intel Hex (.hex) file from an ADuCM3029 application
+
+Workspace and Projects
+======================
+
+A CCES workspace is a folder (e.g. c:\\Users\\anon\\cces\\2.6.0) that contains
+project resources and metadata. When projects are created or imported, details
+about that project are stored in the workspace. The workspace metadata also
+includes preferences set through the CCES Preferences dialog box and IDE window
+layouts. By default, CCES creates new projects within your workspace folder.
+
+Each time you start CCES, you will be prompted for a workspace location. You can
+opt to default to a workspace directory by choosing to use a workspace directory
+as your default. You will not be prompted the next time you open CCES.
+
+.. image:: ../images/eval-aducm3029-workspace.png
+   :align: center
+
+How to install Packs for CCES
+-----------------------------
+
+There are two ways to install packs for CCES as follows.
+
+-  Toolchain's CMSIS Pack Manger
+-  Download to Local Directory
+
+Toolchain's CMSIS Pack Manger
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Follow below instructions to install packs using the CMSIS Pack Manager.
+
+-  Go to Windows -> Perspective -> Open Perspective -> Other...
+-  Select CMSIS Pack Manager and click OK.
+
+.. image:: ../images/download_packs_online.png
+   :align: center
+
+-  On the left hand side of the window, under devices tab, expand **Analog Devices**.
+-  Expand **ADuCM302x Series**
+-  Select **ADuCM3029**
+-  On right hand side, under packs tab, click **Install** on respective packs to be installed.
+
+|image1| This will install the packs in CCES toolchain.
+
+Download to Local Directory
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Please download the following packs to your local directory.
+
+-  `ARM CMSIS Pack <https://keilpack.azureedge.net/pack/ARM.CMSIS.5.1.0.pack>`_
+-  :doc:`Analog Devices ADuCM302x Device Support Pack </solutions/reference-designs/ev-cog-ad3029lz/software/aducm302x>`
+-  :doc:`Analog Devices EV-COG-AD3029LZ Off-Chip Drivers and Examples </solutions/reference-designs/ev-cog-ad3029lz/software/ev-cog-ad3029lz>`
+-  :doc:`Analog Devices Sensor Drivers and Examples </solutions/reference-designs/ev-cog-ad3029lz/software/sensor>`
+-  :doc:`Analog Devices Bluetooth Low Energy Software </solutions/reference-designs/ev-cog-ad3029lz/software/connectivity>`
+
+After downloading the .pack files, select the Import Packs button in the CMSIS
+Pack Manager's View, choose the .pack file as shown in the screenshot below and
+click Open.
+
+You will be prompted to accept a license agreement and after agreeing to it,
+Pack file will be installed into CrossCore Embedded Studio's CMSIS-Pack
+installation directory (e.g. C:\\Analog Devices\\CrossCore Embedded Studio
+2.6.0\\ARM\\packs\\AnalogDevices).
+
+.. image:: ../images/add_pack.jpg
+   :align: center
+
+ADuCM3029 Board Support Packs (BSP)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+EV-COG-AD3029WZ/LZ Board Support Pack
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The EV-COG-AD3029LZ Board Support Pack (BSP) provides the drivers for off-chip
+peripherals which are on the EV-COG-AD3029LZ Evaluation Board and examples for
+peripherals on the ADcCM3029 processor. The drivers and examples in the BSP are
+designed to work with CrossCore Embedded Studio and the ADuCM302x Device Family
+Pack (DFP).
+
+For more information on the EV-COG-AD3029LZ BSP, please refer to the User's
+Guide in the Documents folder (e.g. C:\\Analog Devices\\CrossCore Embedded
+Studio
+2.6.0\\ARM\\packs\\AnalogDevices\\EV-COG-AD3029LZ_BSP\\1.0.0\\Documents\\EV-COG-AD3029LZ_Users_Guide.pdf)
+
+ADI Sensor Software Pack
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ADI Sensor Software pack contains various sensor software components and
+associated examples. The examples in the sensor pack are designed to work with
+EV-COG-AD3029WZ board and associated sensor shields. ADI Sensor Software
+requires CrossCore Embedded Studio (CCES), ADuCM302x Device Family Pack (DFP)
+and EV-COG-AD3029LZ Board Support Pack (BSP).
+
+For more information on the ADI Sensor Software Pack, please refer to the User's
+Guide in the Documents folder (e.g. C:\\Analog Devices\\CrossCore Embedded
+Studio
+2.6.0\\ARM\\packs\\AnalogDevices\\ADI-SensorSoftware\\1.0.0\\Documents\\SensorSoftware_Users_Guide.pdf)
+
+How to create a new project for the ADuCM3029
+---------------------------------------------
+
+A project for ADuCM3029 can be created using the New CrossCore Project Wizard.
+This wizard will guide you through the steps to create a new project.
+
+.. image:: ../images/eval-aducm3029-project-new.png
+   :align: center
+
+-  To create a new project, go to the menu bar and find *File -> New -> CrossCore Project*.
+-  Choose Processor family ARM and select Processor type ADuCM3029.
+-  Choose your Silicon revision (default is 1.0).
+
+   -  A *SILICON_REVISION* macro will be set in your project's Tools Settings, allowing you to conditionally check the silicon revision in your source code.
+
+-  Project configuration allows you to add additional Add-ins to your project, such as Pin Multiplexing and changing the template language for a generated main function etc.
+-  Finally, press *Finish* and the project will be created and you can begin writing your program.
+
+.. image:: ../images/eval-aducm3029-project-explorer.png
+   :align: center
+
+How to add startup code and core components to a new project for the ADuCM3029
+------------------------------------------------------------------------------
+
+An out-of-the-box ADuCM3029 project does not have startup code or a linker
+description file that maps code and data. It is necessary to add these
+components using the Run-time Environment (RTE) Configuration Editor.
+
+CrossCore Projects created for Analog Devices' Cortex-M based processors, such
+as ADuCM3029 include a system.rteconfig file. Opening this file within the IDE
+will open the RTE Configuration Editor. Components from the CMSIS-Pack, such as
+drivers and services, can be added to a project by selecting them in the editor
+and clicking Save.
+
+At minimum, a new ADuCM3029 project will require the Device::Startup,
+CMSIS::Core and Device::Global Configuration components to be added to the
+project.
+
+-  Double-click on the system.rteconfig to open the RTE Configuration Editor.
+-  Select Device::Startup, CMSIS::Core and Device::Global Configuration.
+-  Click Save (Ctrl+S)
+-  *You can also choose Device::Startup and click the Resolve button to add dependant components*
+
+.. image:: ../images/eval-aducm3029-project-configure.png
+   :align: center
+
+How to import existing projects into your workspace
+---------------------------------------------------
+
+There are three(3) methods for importing existing projects:
+
+-  Examples that you have saved to a local drive on your PC.
+-  Examples that come with the ADuCM3029 Device Family Pack (DFP).
+-  Examples which are in the EV-COG-AD3029LZ GIT repository (most up to date
+   content).
+
+How to Import Existing Projects Saved to a Local Drive
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+-  Select *File \| Import...* from the CCES menu.
+-  A dialog will pop-up with several importing options, choose the *General \| Existing Projects into Workspace* option, and click Next
+-  Select *Browse* in the dialog window and search for the saved project which is on your local drive.
+-  (Optional) If the *Copy projects into workspace* option is checked, the project will be copied to your workspace folder and the newly copied project will be opened and used. This preserves the original version of the project.
+-  Click *Finish*
+
+.. image:: ../images/eval-aducm3029-file-import.png
+   :align: center
+
+How to Import Examples that come with the ADuCM3029 Device Family Pack (DFP) or Board Support Packs (BSP)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Examples are provided with the ADuCM3029 DFP and BSPs and can be opened from the
+CMSIS Pack Manager Perspective Examples View.
+
+-  Open CMSIS Pack Manager perspective by clicking "Open Perspective" icon on tool bar and selecting "CMSIS Pack Manager" in the Open Perspective window (or choose CMSIS Pack Manager perspective if already open).
+-  From the Examples View, select the example that you would like to open.
+-  Click the *Copy* Action button.
+-  A dialog will pop-up showing the location where the example will be copied to. Click *Copy* to copy and open the example project.
+
+.. image:: ../images/eval-aducm3029-cmsis-pack-example-200.png
+   :align: center
+
+The CCES Examples Browser can also be used to open examples by Help \| Browse
+Examples.
+
+-  Select ADuCM302x_DFP[x.y.z] in Product drop-down list, select the example and
+   click Open example. Then the example will be copied to your workspace.
+
+.. image:: ../images/eval-aducm3029-example-browser.png
+   :align: center
+
+How to Import Existing Projects from the GIT Repository
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+( Note that at the time of writing, the EV-COG-AD3029LZ GIT repo. is work In
+Progress )
+
+-  Open the GIT perspective by clicking "Open Perspective" icon on tool bar and selecting "Git" in the Open Perspective window (or choose the GIT perspective if already open).
+-  Clone the Git repository which contains all the latest code and projects
+   associated with the ADuCM3029. Populate the URI field with the following
+   address.
+
+   -   **URL:** - `EV-COG-AD3029LZ <https://github.com/analogdevicesinc/EV-COG-AD3029LZ>`_
+   -  Click *Next*, *Next* and then *Finish*. There may be a pause while the branches are fetched.
+
+-  In the Git Repositories window, *Right Click* on the *Projects* folder and select *Import Projects...*
+-  Select *Import existing Eclipse projects*
+-  Click *Next* and then *Finish*
+
+.. image:: ../images/eval-aducm3029-clone.png
+   :align: center
+
+How to build projects for programming the ADuCM3029
+---------------------------------------------------
+
+-  Open the C perspective by clicking "Open Perspective" icon on tool bar and selecting C in the Open Perspective window (or choose the C perspective if already open).
+-  Right click on the project and select the *Build Project*.
+
+   -  Or click the *Hammer* icon from the toolbar.
+
+.. image:: ../images/eval-aducm3029-project-build.png
+   :align: center
+
+How to configure the Tools Settings used by an ADuCM3029 project
+----------------------------------------------------------------
+
+-  Select the project in the Project Explorer View.
+-  Select the *Cog* icon from the View's toolbar.
+
+   -  Or right-click on the project, select *Properties* and choose *C/C++ Build \| Settings*.
+
+-  After configuring your project, click Apply and/or OK.
+
+.. image:: ../images/eval-aducm3029-project-tools-settings.png
+   :align: center
+
+How to configure the debug session for an ADuCM3029 application
+---------------------------------------------------------------
+
+You will need to create a launch configuration to debug your ADuCM3029 program.
+
+-  If you have already built a project, select that project in the Project Explorer View.
+-  Right-click on the project and choose *Debug As* and *Application with GDB and OpenOCD (Emulator)*
+-  In the *Target* tab, choose *Target (processor)* and in the drop-down select **Analog Devices ADuCM3029**
+-  In the *Target* tab, choose *Interface* and in the drop-down select **ARM CMSIS-DAP compliant adapter**
+-  In the *Main* tab, ensure that your project is selected in the *Project* entry box.
+
+   -  If the correct project is not populated, click the *Browse...* button and choose the project. Note that this is optional and you only need to choose a project if you want the IDE to search a project for the built binaries (programs), otherwise you can leave this entry blank.
+
+-  In the *Main* tab, ensure your binary (program) is selected in the *Application* entry box.
+
+   -  If the correct binary (program) is not populated, click on *Search Project...* and choose the binary (program) from those available in the chosen project.
+   -  If your binary (program) is not populated and it was not built from a project in your workspace (i.e. you have a pre-built binary), then click the *Browse...* button and search for your pre-built binary (program). Click *Open* when you have found and selected the pre-built binary (program).
+
+.. image:: ../images/eval-aducm3029-debug-configuration.png
+   :align: center
+
+Hardware breakpoints are limited in your ADuCM3029 application
+==============================================================
+
+-  When you click Debug or Apply, you will be prompted with a dialog informing your the Hardware Breakpoints are limited. Click *Yes*. You can opt to not show this dialog again.
+
+.. image:: ../images/eval-aducm3029-debug-hw-limited.png
+   :align: center
+
+How to start and stop debugging an ADuCM3029 application
+--------------------------------------------------------
+
+-  Ensure that you have connected your EV-COG-AD3029LZ board to your computer via the **USB** port (the micro USB connected closest to the DC barrel jack).
+-  If you are already in the Debug Configurations dialog, then click *Debug*.
+-  If you are in the C Perspective, then you can launch the last Debug session by clicking the *Beetle* Debug button on the toolbar.
+
+.. image:: ../images/eval-aducm3029-debug-toolbar.png
+   :align: center
+
+-  You will be prompted to switch perspective to the Debug perspective. Click *Yes*. You can opt to not show this dialog again.
+
+.. image:: ../images/eval-aducm3029-debug-perspective.png
+   :align: center
+
+-  If your binary (program) was built with semi-hosting enabled, then CCES will
+   warn you that you need to re-build the program when you want to run the
+   program without a debugger attached.
+
+.. image:: ../images/eval-aducm3029-debug-semi-hosting.png
+   :align: center
+
+-  To disable semi-hosting in your program, visit your project Tools Settings.
+-  Change the *semi-hosting support* option under *Linker \| Libraries* to nosys.specs or None, depending on whether or not your program is currently using semi-hosting (e.g. printf).
+-  After configuring your project, click Apply and/or OK.
+-  Right click on the project and select the *Build Project*.
+
+   -  Or click the *Hammer* icon from the toolbar.
+
+.. image:: ../images/eval-aducm3029-spec.png
+   :align: right
+
+-  If this is the first time you have launched OpenOCD, the Windows Firewall may pop-up a window asking for access. Click on "*Allow Access*".
+
+.. image:: ../images/eval-aducm3029-openocd-firewall.png
+   :align: center
+
+-  If everything goes fine, in the Console window, you will see a report without
+   errors.
+
+   -  As a reference, the full text should be similar to:``Open On-Chip Debugger (OpenOCD) 0.9.0
+      Licensed under GNU GPL v2
+      Report bugs to <openocd-devel@lists.sourceforge.net>
+      0
+      Info : select transport "swd"
+      adapter speed: 1000 kHz
+      cortex_m reset_config sysresetreq
+      Info : CMSIS-DAP: SWD  Supported
+      Info : CMSIS-DAP: Interface Initialised (SWD)
+      Info : CMSIS-DAP: FW Version = 1.0
+      Info : SWCLK/TCK = 0 SWDIO/TMS = 1 TDI = 0 TDO = 0 nTRST = 0 nRESET = 1
+      Info : CMSIS-DAP: Interface ready
+      Info : clock speed 1000 kHz
+      Info : SWD IDCODE 0x2ba01477
+      Info : aducm3029.cpu: hardware has 2 breakpoints, 1 watchpoints
+      Info : CHIPID 0x0284
+      memory bus access delay set to 6 tck
+      adapter speed: 1000 kHz
+      Info : accepting 'gdb' connection on tcp/3333``
+
+-  Your program's execution is stopped automatically at the first breakpoint
+   which is at the beginning of main() loop. You can use the debug functions and
+   features of the CCES environment. (Such as stepping through, breakpoints,
+   register reads, variable values, etc.)
+
+.. image:: ../images/eval-aducm3029-debugging.png
+   :align: center
+
+-  To terminate a debug session, click on the red *Stop* button on the toolbar.
+
+.. image:: ../images/eval-aducm3029-debug-toolbar-stop.png
+   :align: center
+
+How to create an Intel Hex (.hex) file from an ADuCM3029 application
+--------------------------------------------------------------------
+
+-  Ensure that your program is built with semi-hosting disabled by visiting *Tools Settings \| Linker \| Libraries* and change *Semihosting support* to *nosys.specs* or *None*, depending on your application set-up.
+-  Rebuild your application.
+
+.. image:: ../images/eval-aducm3029-tools-semi-hosting.png
+   :align: center
+
+-  Convert your application into Intel Hex (.hex) format by visiting Tools Settings once more.
+-  Select the Build Steps tab.
+-  Add the following command to the *Post-build steps \| Command* entry box: ``arm-none-eabi-objcopy -O ihex ${ProjName} ${ProjName}.hex``
+-  Rebuild your application.
+
+.. image:: ../images/eval-aducm3029-tools-hex.png
+   :align: center
+
+*End of Document*
+
+:doc:`Back </solutions/reference-designs/ev-cog-ad3029lz/ev-cog-ad3029lz>`
+
+.. |image1| image:: ../images/install_packs_online_new.png

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/tools/hardware_usb.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/tools/hardware_usb.rst
@@ -1,0 +1,113 @@
+Driver Installation for On-board Debugger (CMSIS DAP)
+=====================================================
+
+.. note::
+
+   \ The following steps are valid for both EV-COG-AD3029WZ and EV-COG-AD3029LZ\
+
+MCU Cog has an on-board debugger which supports the `ARM CMSIS DAP <https://developer.mbed.org/handbook/CMSIS-DAP>`_ interface. When connecting up the EV-COG-AD3029LZ to your computer or laptop, all the necessary drivers are automatically located and loaded up when using Windows operating systems.
+
+There are two sets of drivers that get installed on your computer depending on
+which mode of operation the EV-COG-AD3029LZ emulator comes up.
+
+.. important::
+
+   It is important to ensure that all drivers are installed, before trying to
+   use the EV-COG-AD3029LZ with the CrossCore Embedded Tools. So when you see
+   that the drivers are being installed in the task bar, open it up and wait
+   till everything finished before progressing.
+
+| |image1|
+| |image2|
+
+DAPLINK Drive
+-------------
+
+When the EV-COG-AD3029LZ emulator is connected to the ADuCM3029 and ready for
+program/debug mode, the "DAPLINK" drive is displayed on your computer.
+
+This mode allows users to drag and drop (or copy and paste) a .BIN or .HEX
+[Intel formatted] file directly into the DAPLINK drive, and that file will be
+flashed directly to the ADuCM3029. This means you don't have to use the tools or
+the debugger to program your board, making this very useful in production
+releases or updating applications already in the field.
+
+-  The PC will start searching for and install the following drivers:(if not
+   already complete)
+
+.. image:: ../images/device_drivers_install_complete.png
+   :align: center
+   :width: 400
+
+-  Then go to the **My Computer** view and search for the DAPLINK drive, if you see this then the drivers are complete and correct.
+
+.. image:: ../images/daplink_windows_explorer.png
+   :align: center
+   :width: 550
+
+-  After that simply drag and drop (or copy and paste) your .BIN or .HEX [Intel
+   formatted] file to the DAPLINK drive, and your EV-COG-AD3029LZ board will be
+   programmed.
+
+   -  Your Windows Explorer browser will close automatically
+
+-  You will need to press the RST button in order for the program to update
+
+   -  Alternatively you could unplug the micro USB cable from the USB port (P5)
+      of the EV-COG-AD3029LZ, and then reconnect it.
+
+Maintenance Drive
+-----------------
+
+When the EV-COG-AD3029LZ emulator is connected to the MK20DX128VFM5 (by holding
+down the "RST" button while connecting the USB port (P5) to the PC/laptop) the
+"Maintenance" drive is displayed on your computer. This mode allows a user to
+overwrite the ADuCM0329 interface file within the emulator. This allows for
+patches and updates to the firmware on the emulator.
+
+-  The PC will start searching for and install the following drivers:(if not
+   already complete)
+
+.. image:: ../images/device_drivers_install_maintenance.png
+   :align: center
+   :width: 400
+
+-  Then go to the **My Computer** view and search for the Maintenance drive, if you see this then the drivers are complete and correct.
+
+.. image:: ../images/maintenance_windows_explorer.png
+   :align: center
+   :width: 550
+
+-  After that simply drag and drop (or copy and paste) the latest interface file
+   to the Maintenance drive, and your EV-COG-AD3029LZ board will be updated with
+   the latest interface file.
+
+   -  Your Windows Explorer browser will close automatically
+
+-  Unplug the micro USB cable from the USB port of the EV-COG-AD3029LZ, and then
+   reconnect the USB cable to the USB port to “reboot” the board.
+
+EV-COG-AD3029LZ Interface File Downloads
+----------------------------------------
+
+.. admonition:: Download
+   :class: download
+
+   The current EV-COG-AD3029LZ interface file can be downloaded here:
+
+   
+   `EV-COG-AD3029LZ Interface File <../resources/ev_cog_ad3029lz_mbed.zip>`_
+   
+   -  Initial version of mbed firmware for interfacing ADuCM3029 on
+      EV-COG-AD3029LZ.
+   
+
+*End of Document*
+
+:doc:`Back </solutions/reference-designs/ev-cog-ad3029lz/ev-cog-ad3029lz>`
+
+.. |image1| image:: ../images/device_drivers_install_notification.png
+   :width: 400
+
+.. |image2| image:: ../images/device_drivers_install.png
+   :width: 400

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/tools/hardware_usb.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/tools/hardware_usb.rst
@@ -3,7 +3,7 @@ Driver Installation for On-board Debugger (CMSIS DAP)
 
 .. note::
 
-   \ The following steps are valid for both EV-COG-AD3029WZ and EV-COG-AD3029LZ\
+   The following steps are valid for both EV-COG-AD3029WZ and EV-COG-AD3029LZ.
 
 MCU Cog has an on-board debugger which supports the `ARM CMSIS DAP <https://developer.mbed.org/handbook/CMSIS-DAP>`_ interface. When connecting up the EV-COG-AD3029LZ to your computer or laptop, all the necessary drivers are automatically located and loaded up when using Windows operating systems.
 
@@ -17,8 +17,9 @@ which mode of operation the EV-COG-AD3029LZ emulator comes up.
    that the drivers are being installed in the task bar, open it up and wait
    till everything finished before progressing.
 
-| |image1|
-| |image2|
+|image1|
+
+|image2|
 
 DAPLINK Drive
 -------------
@@ -95,16 +96,13 @@ EV-COG-AD3029LZ Interface File Downloads
 
    The current EV-COG-AD3029LZ interface file can be downloaded here:
 
-   
+
    `EV-COG-AD3029LZ Interface File <../resources/ev_cog_ad3029lz_mbed.zip>`_
-   
+
    -  Initial version of mbed firmware for interfacing ADuCM3029 on
       EV-COG-AD3029LZ.
-   
 
-*End of Document*
 
-:doc:`Back </solutions/reference-designs/ev-cog-ad3029lz/ev-cog-ad3029lz>`
 
 .. |image1| image:: ../images/device_drivers_install_notification.png
    :width: 400

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/tools/iar_guide.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/tools/iar_guide.rst
@@ -1,0 +1,79 @@
+EV-COG-AD3029LZ with IAR Embedded Workbench for ARM
+===================================================
+
+First, install mBed windows serial driver from https://developer.mbed.org/handbook/Windows-serial-configuration
+
+IDE Setup
+---------
+
+-   Install IAR Embedded Workbench for ARM
+
+   -  Please visit https://www.iar.com/ to download IAR Embedded Workbench for ARM (version 8.20.1 or above)
+
+-   License Installation
+
+   -  Make sure valid license is installed for the corresponding version.
+
+Software Packs and Driver Setup
+-------------------------------
+
+-  Start IAR Embedded Workbench for ARM.
+-  Go to Project-> CMSIS-Pack-> Pack Installer.
+
+.. image:: ../images/cmsis_pack_install_1.png
+   :align: center
+   :width: 750
+
+-  In **'CMSIS Pack Manager'** window, Click Search for updates.
+-  Expand Analog Devices, then expand **ADuCM302x_DFP**. Right click on the latest version (for ex. 3.2.0) and click install.
+
+.. image:: ../images/1.png
+   :align: center
+   :width: 600
+
+-  After successful installation of **ADuCM302x_DFP**, repeat step 4 for **EV-COG-AD3029LZ_BSP**.
+-  After successful installation of **EV-COG-AD3029LZ_BSP**, expand ARM -> CMSIS and install the latest version (for ex. 5.4.0 ) available for ARM CMSIS Pack.
+
+Running an Example Project
+--------------------------
+
+-  Power the MCU Cog using a USB (micro-B) Cable. You should see a red LED and a
+   yellow LED turn on by default.
+
+.. image:: ../images/img_20171030_180904.jpg
+   :align: center
+   :width: 200
+
+-  In IAR IDE, go to Project-> Create New Project...
+
+.. image:: ../images/create_new_project_1.png
+   :align: center
+
+-  In **'Create New Project'** window, Select **'CMSIS Pack Example'** and click 'OK'.
+
+.. image:: ../images/example_run_1.png
+   :align: center
+
+-  Expand Analog Devices, select **ADuCM3029** and click 'Next'.
+
+.. image:: ../images/iar-aducm3029-cmsis-example-mcu-select1.png
+   :align: center
+   :width: 700
+
+-  Select **button_press** example and click 'Finish'.
+
+.. image:: ../images/iar-aducm3029-cmsis-example-buttonpress1.png
+   :align: center
+   :width: 700
+
+-  Save the project to the desired location.
+-  Click on 'Debug and Download' icon |image1|\ on the menu bar. This will compile, build and download the project on EV-COG-AD3029LZ using CMSIS-DAP.
+-  Click on 'Run' icon |image2| to start the debug session.
+-  Now press BTN1 or BTN2 on EV-COG-AD3029LZ and inspect corresponding LED
+
+You are all set!
+
+:doc:`Back </solutions/reference-designs/ev-cog-ad3029lz/quickstart>`
+
+.. |image1| image:: ../images/debug_debug_button.png
+.. |image2| image:: ../images/run_button.png

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/tools/iar_guide.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/tools/iar_guide.rst
@@ -67,7 +67,7 @@ Running an Example Project
    :width: 700
 
 -  Save the project to the desired location.
--  Click on 'Debug and Download' icon |image1|\ on the menu bar. This will compile, build and download the project on EV-COG-AD3029LZ using CMSIS-DAP.
+-  Click on 'Debug and Download' icon |image1| on the menu bar. This will compile, build and download the project on EV-COG-AD3029LZ using CMSIS-DAP.
 -  Click on 'Run' icon |image2| to start the debug session.
 -  Now press BTN1 or BTN2 on EV-COG-AD3029LZ and inspect corresponding LED
 

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/tools/other_ide.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/tools/other_ide.rst
@@ -1,0 +1,35 @@
+Using Keil IDE with EV-COG-AD3029LZ
+===================================
+
+This will be a paragraph talk about why you might want to use Keil with the
+EV-COG-AD3029LZ.
+
+How to use EV-COG-AD3029LZ with Keil
+------------------------------------
+
+In order to use EV-COG-AD3029LZ board with IAR, you will need to replicate the
+following steps.
+
+-  Install mBed windows serial driver from
+
+   -  https://developer.mbed.org/handbook/Windows-serial-configuration
+
+-  Open any example-workspace and project from the ADuCM3029 BSP(board support package). I used the SysTick example in the below images
+-  In the Keil toolbar select **Project** → **Options** → **Debug**, and select the “CMSIS DAP” option
+
+.. image:: ../images/keildebug.png
+   :align: center
+   :width: 500
+
+-  Under the CMSIS DAP Settings, select the SW option
+
+.. image:: ../images/keilcmsisdap.png
+   :align: center
+   :width: 500
+
+-  Push Crtl+F5 or in the Keil toolbar select **Debug** → **Start/Stop Debug Session**
+-  That’s it – You are ready to go.
+
+*End of Document*
+
+:doc:`Back </solutions/reference-designs/ev-cog-ad3029lz/ev-cog-ad3029lz>`

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/tools/other_ide.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/tools/other_ide.rst
@@ -30,6 +30,3 @@ following steps.
 -  Push Crtl+F5 or in the Keil toolbar select **Debug** → **Start/Stop Debug Session**
 -  That’s it – You are ready to go.
 
-*End of Document*
-
-:doc:`Back </solutions/reference-designs/ev-cog-ad3029lz/ev-cog-ad3029lz>`

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/tools_driver.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/tools_driver.rst
@@ -13,6 +13,3 @@ It contains three main sections:
 
 -  :doc:`Driver Installation for On-board Debugger (CMSIS DAP) </solutions/reference-designs/ev-cog-ad3029lz/tools/hardware_usb>` - Provides detailed information on how to load pre-compiled .HEX or .BIN files using the USB drive of the EV-COG-AD3029LZ board.
 
-| End Document
-
-:doc:`Back </solutions/reference-designs/ev-cog-ad3029lz/ev-cog-ad3029lz>`

--- a/docs/solutions/reference-designs/ev-cog-ad3029lz/tools_driver.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad3029lz/tools_driver.rst
@@ -1,0 +1,18 @@
+Development Tools & Drivers
+===========================
+
+This chapter provides all the necessary steps to download, install and setup the
+software environment from Analog Devices. There is also information on the
+different USB modes and drivers needed.
+
+It contains three main sections:
+
+-  :doc:`CrossCore Embedded Studio Download & Install </solutions/reference-designs/ev-cog-ad3029lz/tools/cces_download>` - Provides all the necessary instructions on how to download and install the CrossCore Embedded Studio software development environment.
+
+   -  :doc:`CrossCore Embedded Studio Quickstart Userguide </solutions/reference-designs/ev-cog-ad3029lz/tools/cces_guide>` - Provides information about using the CrossCore Embedded Studio IDE, in particular, the process of importing, building, debugging and creating user applications for the EV-COG-AD3029LZ.
+
+-  :doc:`Driver Installation for On-board Debugger (CMSIS DAP) </solutions/reference-designs/ev-cog-ad3029lz/tools/hardware_usb>` - Provides detailed information on how to load pre-compiled .HEX or .BIN files using the USB drive of the EV-COG-AD3029LZ board.
+
+| End Document
+
+:doc:`Back </solutions/reference-designs/ev-cog-ad3029lz/ev-cog-ad3029lz>`


### PR DESCRIPTION
## Summary
- Move ev-cog-ad3029lz wiki documentation to `solutions/reference-designs/ev-cog-ad3029lz/`
- 28 RST files with 111 localized images
- Generated stub `index.rst` with toctree

## Test plan
- [ ] Sphinx build passes without errors
- [ ] All toctree entries resolve correctly
- [ ] Images render properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)