### PR TITLE
reference-designs/ev-cog-ad3029wz: Add ev-cog-ad3029wz documentation

### DIFF
--- a/docs/solutions/reference-designs/ev-cog-ad3029wz/cog_hw_userguide.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad3029wz/cog_hw_userguide.rst
@@ -43,12 +43,10 @@ Power Supply Options
 
 The MCU Cog offers the following power supply options:
 
-::
-
-   -5V USB power (USB microB connector)
-   -3V CR2032 Coin cell (Cell holder - BT1)
-   -3V - 6V Rechargeable Li-Ion Battery (JST Connector - P6)
-   -3V - 6V External Supply from an MCU Cog Add-on card (via Connector C1)
+-  5V USB power (USB microB connector)
+-  3V CR2032 Coin cell (Cell holder - BT1)
+-  3V - 6V Rechargeable Li-Ion Battery (JST Connector - P6)
+-  3V - 6V External Supply from an MCU Cog Add-on card (via Connector C1)
 
 Power Muxing Options
 ~~~~~~~~~~~~~~~~~~~~
@@ -89,11 +87,9 @@ Programming & Debug Options
 
 The MCU Cog offers the following debug options:
 
-::
-
-   -On-board CMSIS-DAP debugger (USB microB connector)
-   -JLINK-9 Connector for access to SWD interface (P26)
-   -Access to SW interface to an MCU Cog Add-on card (via Connector C2)
+-  On-board CMSIS-DAP debugger (USB microB connector)
+-  JLINK-9 Connector for access to SWD interface (P26)
+-  Access to SW interface to an MCU Cog Add-on card (via Connector C2)
 
 Wireless Connectivity Options
 -----------------------------
@@ -225,9 +221,6 @@ expansion connectors as well as place-bound rules embedded.
 
    `Gear Template Design Database <resources/geartemplatedesigndatabase.zip>`_
 
-| End Document
-
-:doc:`Back </solutions/reference-designs/ev-cog-ad3029wz/ev-cog-ad3029wz>`
 
 .. |25072017-tile-revb-front.png| image:: images/25072017-tile-revb-front.png
 .. |25072017-tile-revb-back.png| image:: images/25072017-tile-revb-back.png

--- a/docs/solutions/reference-designs/ev-cog-ad3029wz/cog_hw_userguide.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad3029wz/cog_hw_userguide.rst
@@ -1,0 +1,240 @@
+EV-COG-AD3029WZ MCU Cog
+=======================
+
+The EV-COG-AD3029WZ is an *MCU Cog* board for the :adi:`ADuCM3029 MCU <en/products/processors-dsp/microcontrollers/precision-microcontrollers/aducm3029.html>`.
+
+Main Features
+-------------
+
+-  :adi:`ADuCM3029` (WLCSP package) - Ultra Low Power ARM Cortex-M3 MCU
+-  Compact form factor (3.5 cm X 7.5 cm) - Easy to deploy.
+-  On board debugger capability (CMSIS DAP compatible)
+-  Multiple power options and current monitoring test-points.
+-  On-board sensors: Accelerometer (ADXL362) and Temperature Sensor (ADT7420)
+-  Optional expansion capability - Using application specific add-on cards (*Gears*)
+-  Optional connectivity options - Using RF modules (*Connectivity Cogs*)
+
+Board
+-----
+
+Front-Side
+~~~~~~~~~~
+
+**this image needs to be changed**
+
+|25072017-tile-revb-front.png|
+
+Back-Side
+~~~~~~~~~
+
+**this image needs to be changed**
+
+|25072017-tile-revb-back.png|
+
+Power
+-----
+
+The MCU Cog board offers flexibility in terms of power supply and power muxing
+options. This is achieved with the use of jumpers on the board. The Cog board
+also offers multiple test points for monitoring current consumption.
+
+Power Supply Options
+~~~~~~~~~~~~~~~~~~~~
+
+The MCU Cog offers the following power supply options:
+
+::
+
+   -5V USB power (USB microB connector)
+   -3V CR2032 Coin cell (Cell holder - BT1)
+   -3V - 6V Rechargeable Li-Ion Battery (JST Connector - P6)
+   -3V - 6V External Supply from an MCU Cog Add-on card (via Connector C1)
+
+Power Muxing Options
+~~~~~~~~~~~~~~~~~~~~
+
+For details of the power muxing scheme, refer to the figure below.
+
+|image1|
+
+.. danger::
+
+   Do not insert shunt b/w positions 5 & 6 of JH4 when using USB supply. Doing
+   so can permanently damage this board.
+
+.. tip::
+
+   Refer to the *Jumper Settings* section further below for details on power related jumpers on the board
+
+Power Regulator
+~~~~~~~~~~~~~~~
+
+The MCU Cog board uses an on-board switching regulator - the :adi:`ADP5300 <en/products/power-management/switching-power-converters/switching-regulators/adp5300.html>`, which is a high efficiency, ultra-low power step down regulator. The MCU has complete control over the switching modes of the regulator via GPIO. The pin-mapping is shown in the table below.
+
+|direct|
+
+Current Measurement Options
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The MCU Cog enables IOT developers to measure and profile current consumption at
+different places on the board to enable isolation of current consumption
+hotspots. The current measure test points shown in the table below can be used
+along with a digital multimeter to profile current consumption.
+
+.. image:: images/24072017-tile-revb-current-test-points.png
+   :alt: 24072017-tile-revb-current-test-points.png
+
+Programming & Debug Options
+---------------------------
+
+The MCU Cog offers the following debug options:
+
+::
+
+   -On-board CMSIS-DAP debugger (USB microB connector)
+   -JLINK-9 Connector for access to SWD interface (P26)
+   -Access to SW interface to an MCU Cog Add-on card (via Connector C2)
+
+Wireless Connectivity Options
+-----------------------------
+
+The MCU Cog board offers support for ADI RF daughter-cards such as the EV-ADF70301-915AZ via the "EV-COG-BLEINTP1" connectivity Cog board that can be attached at Connector P2. This connectivity Cog board also has on-board BTLE circuit enabling the MCU Cog board to use BTLE communication as well. More details regarding wireless connectivity options are available on the `EV-COG-BLEINTP1 Wiki page <https://wiki.analog.com/resources/eval/user-guides/ev-cog-bleintp1z>`_.
+
+Buttons/LED(s)
+--------------
+
+The MCU Cog offers 2 buttons and 2 LED(s) that can be used by the Application.
+The default GPIO connections are shown in the tables below.
+
+.. image:: images/button_led.png
+
+Expansion Connectors
+--------------------
+
+One of the USP of the MCU Cog is access to ALL GPIO via Expansion Connectors
+("C1" and "C2") for an Add-on card to utilize in its Application. This enables
+developers to confidently build final form factor hardware without having to
+worry about porting their firmware. The figures below capture the pin-mapping
+and jumpers that need to be changed to get external access (via the expansion
+connectors) to GPIO (as well as power/reset, etc).
+
+Expansion connector "C1"
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+|image2| |image3|
+
+Expansion connector "C2"
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+|image4| |image5|
+
+Jumper Settings
+---------------
+
+The MCU Cog offers flexibility in terms of power muxing options and the facility
+to route any GPIO externally via the expansion connectors "C1" and "C2". This is
+achieved with the use of jumpers. The MCU Cog has two types of jumpers - those
+labelled "JHx" and which are 2x2 1.27mm pitch headers and those labelled "JPx"
+and which are solder jumpers. The "JHx" jumpers are expected to be used more
+frequently than the "JPx" jumpers. The figures below capture the jumper
+settings.
+
+|image6|
+
+.. image:: images/jumper_settings_2.png
+
+.. image:: images/jumper_settings_3.png
+
+Jumper locations on board
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The following image of the bottom layer of the PCB highlights the jumper
+positions on the board:
+
+.. image:: images/cog_jumpers_annotated.png
+   :alt: Jumper Positions
+   :align: center
+
+Note that the jumpers JH6 and JP16 on the **top** layer of the board.
+
+Changing the jumper settings
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Shunt Jumpers (JHx)
+^^^^^^^^^^^^^^^^^^^
+
+As mentioned above, the shunt jumpers are 1.27mm headers, whose pins are shorted
+using a shunt. This shunt is inserted by default in the positions as mentioned
+in the table above.
+
+To change a jumper setting, carefully remove the shunt from its position, and
+re-insert the shunt in the correct position corresponding to the pin numbers to
+be shorted. The pin numbers are mentioned on the silkscreen of the PCB (usually
+both pin 1 & 2) and thus the default positions can be located.
+
+For example JH11 controls which signal is sent to the RTC1_SS2 SensorStrobe pin.
+By default the ADXL_362_INT2 signal is connected to the SensorStrobe pin. In
+order to connect the RF module, JH11 needs to be moved from "1 and 2" to "3 and
+4". The corresponding change is shown below:
+
+.. image:: images/shuntjumpersettingchange.png
+   :alt: Shunt Jumper Change
+   :align: center
+
+Solder Jumpers (JPx)
+^^^^^^^^^^^^^^^^^^^^
+
+Solder jumpers are shorted using a solder blob. There are 16 such jumpers on the
+board, out of which 15 are on the bottom side of the board while 1 (JP16) is on
+the top side of the board. Positions 1, 2 and 3 are usually indicated along the
+jumpers.
+
+To change a solder jumper, using a hot soldering iron, melt the blob of solder
+and move it into the desired position (1-2 or 3-2 or 4-2).
+
+For example, GPIO30 is connected to the on board ADT7420 temperature sensor by
+default. In order to bring it out to the expander JP3 needs to be shifted from
+1-2 to 2-3. After using a soldering iron to shift the jumpers, this is how it
+looks before and after:
+
+.. image:: images/solderjumpersettingchange.png
+   :alt: Solder Jumper Change
+   :align: center
+
+MCU Cog Design and Integration Files
+------------------------------------
+
+.. admonition:: Download
+   :class: download
+
+   `EV-COG-AD3029WZ MCU Cog Schematics <resources/02_049050a_top.pdf>`_
+
+   
+   `EV-COG-AD3029LZ MCU Cog RevB Layout and BOM <resources/20_049050a.zip>`_
+   
+
+Add-on Template
+~~~~~~~~~~~~~~~
+
+For developers designing a Cog add-on board, the template schematic/board files
+below might be a useful starting point. The board file has the placement of the
+expansion connectors as well as place-bound rules embedded.
+
+.. admonition:: Download
+   :class: download
+
+   `Gear Template Design Database <resources/geartemplatedesigndatabase.zip>`_
+
+| End Document
+
+:doc:`Back </solutions/reference-designs/ev-cog-ad3029wz/ev-cog-ad3029wz>`
+
+.. |25072017-tile-revb-front.png| image:: images/25072017-tile-revb-front.png
+.. |25072017-tile-revb-back.png| image:: images/25072017-tile-revb-back.png
+.. |image1| image:: images/23062017-tile-revb-power-mux-scheme.png
+.. |direct| image:: images/24072017-tile-revb-adp5300-gpio.png
+.. |image2| image:: images/c1-1.png
+.. |image3| image:: images/c1-2.png
+.. |image4| image:: images/c2-1.png
+.. |image5| image:: images/c2-2.png
+.. |image6| image:: images/jumper_settings_1.png

--- a/docs/solutions/reference-designs/ev-cog-ad3029wz/ev-cog-ad3029wz.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad3029wz/ev-cog-ad3029wz.rst
@@ -1,0 +1,51 @@
+EV-COG-AD3029WZ Development Kit
+===============================
+
+The :adi:`EV-COG-AD3029WZ <en/design-center/evaluation-hardware-and-software/evaluation-boards-kits/EV-COG-AD3029.html>` (referred also as MCU Cog) is a development platform based on the industry leading ultra low power :adi:`ADuCM3029` 32-bit ARM Cortex™-M4F microcontroller. The platform is designed to be a development and prototyping vehicle to get customer ideas from concept to production with a minimal risk and faster time to market. |image1| Applications using EV-COG-AD3029WZ board can be developed using one of the following toolchains.
+
+-  Crosscore Embedded Studio 2.7.0 and above - an Eclipse based Analog Devices Interactive Development Environment.
+-  IAR Embedded Workbench for ARM 8.20 and above
+-  Keil uVision 4 and above
+-  ARM mbed Compiler
+
+Make sure a valid license for the selected toolchain is installed before using
+EV-COG-AD3029WZ board. \*\* The software and power measurement is same for both
+EV-COG-AD3029WZ and EV-COG-AD3029LZ \*\*
+
+-  :doc:`Introduction </solutions/reference-designs/ev-cog-ad3029wz/introduction>`
+-  `Software Packs & Board Support Package <https://wiki.analog.com/resources/eval/user-guides/ev-cog-ad3029wz/packs_&_bsp>`_: EV-COG-AD3029WZ software architecture is categorized into 4 groups as below.
+
+|image2|
+
+   -  :doc:`Analog Devices ADuCM302x Device Support Pack </solutions/reference-designs/ev-cog-ad3029wz/software/aducm302x>`
+
+      -  :doc:`Analog Devices EV-COG-AD3029WZ Off-Chip Drivers and Examples </solutions/reference-designs/ev-cog-ad3029wz/software/ev-cog-ad3029wz>`
+      -  `Analog Devices Sensor Drivers and Examples <https://wiki.analog.com/resources/eval/user-guides/ev-cog-ad3029lz/software/sensor>`_
+      -  `Analog Devices Bluetooth Low Energy Software <https://wiki.analog.com/resources/eval/user-guides/ev-cog-ad3029lz/software/connectivity>`_
+
+-  :doc:`QuickStart Guide </solutions/reference-designs/ev-cog-ad3029wz/quickstart_1>`
+
+   -  `EV-COG-AD3029WZ with CrossCore Embedded Studio <https://wiki.analog.com/resources/eval/quickstart/ev-cog-ad3029wz/tools/cces_guide>`_
+
+      -  :doc:`EV-COG-AD3029WZ with IAR Embedded Workbench for ARM </solutions/reference-designs/ev-cog-ad3029wz/tools/iar_guide>`
+      -  :doc:`EV-COG-AD3029WZ Keil uVision IDE </solutions/reference-designs/ev-cog-ad3029wz/tools/other_ide>`
+
+-  :doc:`Hardware Details </solutions/reference-designs/ev-cog-ad3029wz/hw_details>`
+
+   -  :doc:`EV-COG-AD3029WZ MCU Cog </solutions/reference-designs/ev-cog-ad3029wz/cog_hw_userguide>`
+
+      -  `Power Measurement on EV-COG-AD3029WZ MCU COG <https://wiki.analog.com/resources/eval/user-guides/ev-cog-ad3029lz/_powermeasurement>`_
+
+-  :doc:`Development Tools & Driver </solutions/reference-designs/ev-cog-ad3029wz/tools_driver>`
+
+   -  :doc:`CrossCore Embedded Studio Download & Install </solutions/reference-designs/ev-cog-ad3029wz/tools/cces_download>`
+
+      -  `CrossCore Embedded Studio Quickstart Userguide <https://wiki.analog.com/resources/eval/user-guides/ev-cog-ad3029lz/tools/cces_guide>`_
+      -  `Driver installation for on-board debugger (CMSIS-DAP) <https://wiki.analog.com/resources/eval/user-guides/ev-cog-ad3029lz/tools/hardware_usb>`_
+
+-  `Example Project <https://wiki.analog.com/resources/eval/user-guides/ev-cog-ad4050w/example_project>`_
+-  `Help & Support <https://wiki.analog.com/resources/eval/user-guides/ev-cog-ad4050lz/help_support>`_
+
+.. |image1| image:: images/front_image_new.png
+   :width: 550
+.. |image2| image:: images/drawing1-copy.png

--- a/docs/solutions/reference-designs/ev-cog-ad3029wz/ev-cog-ad3029wz.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad3029wz/ev-cog-ad3029wz.rst
@@ -9,11 +9,11 @@ The :adi:`EV-COG-AD3029WZ <en/design-center/evaluation-hardware-and-software/eva
 -  ARM mbed Compiler
 
 Make sure a valid license for the selected toolchain is installed before using
-EV-COG-AD3029WZ board. \*\* The software and power measurement is same for both
-EV-COG-AD3029WZ and EV-COG-AD3029LZ \*\*
+EV-COG-AD3029WZ board. **The software and power measurement is same for both
+EV-COG-AD3029WZ and EV-COG-AD3029LZ**
 
 -  :doc:`Introduction </solutions/reference-designs/ev-cog-ad3029wz/introduction>`
--  `Software Packs & Board Support Package <https://wiki.analog.com/resources/eval/user-guides/ev-cog-ad3029wz/packs_&_bsp>`_: EV-COG-AD3029WZ software architecture is categorized into 4 groups as below.
+-  :doc:`Software Packs & Board Support Package <packs_bsp>`: EV-COG-AD3029WZ software architecture is categorized into 4 groups as below.
 
 |image2|
 

--- a/docs/solutions/reference-designs/ev-cog-ad3029wz/hw_details.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad3029wz/hw_details.rst
@@ -14,6 +14,3 @@ The following boards are currently available:
 -  `EV-COG-BLEINTP1Z Connectivity Cog <https://wiki.analog.com/resources/eval/user-guides/ev-cog-bleintp1z>`_
 -  `EV-GEAR-EXPANDER1Z Expander Gear <https://wiki.analog.com/resources/eval/user-guides/ev-gear-expander1z>`_
 
-| End Document
-
-:doc:`Back </solutions/reference-designs/ev-cog-ad3029wz/ev-cog-ad3029wz>`

--- a/docs/solutions/reference-designs/ev-cog-ad3029wz/hw_details.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad3029wz/hw_details.rst
@@ -1,0 +1,19 @@
+Hardware Details
+================
+
+This page contains hardware-related information about the EV-COG-AD3029WZ board
+and the various hardware add on modules which can be used with the board. Each
+sub-section contains a detailed description of the board, connectors, jumpers
+and buttons. It also provides links to the Schematics, Bill of materials, design
+projects, and Technical documentation. It also gives internal links to the
+provided example demo software projects.
+
+The following boards are currently available:
+
+-  :doc:`EV-COG-AD3029LZ MCU Cog </solutions/reference-designs/ev-cog-ad3029wz/cog_hw_userguide>`
+-  `EV-COG-BLEINTP1Z Connectivity Cog <https://wiki.analog.com/resources/eval/user-guides/ev-cog-bleintp1z>`_
+-  `EV-GEAR-EXPANDER1Z Expander Gear <https://wiki.analog.com/resources/eval/user-guides/ev-gear-expander1z>`_
+
+| End Document
+
+:doc:`Back </solutions/reference-designs/ev-cog-ad3029wz/ev-cog-ad3029wz>`

--- a/docs/solutions/reference-designs/ev-cog-ad3029wz/images/11082017-mcu-cog-revb-horizontal-concept.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029wz/images/11082017-mcu-cog-revb-horizontal-concept.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5c6f8de11f9d7de05e9211be244b932efa6cee5b68bfa439e61fe90d9ed06a87
+size 69006

--- a/docs/solutions/reference-designs/ev-cog-ad3029wz/images/11082017-mcu-cog-revb-stacking.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029wz/images/11082017-mcu-cog-revb-stacking.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d1e4525fea1ac3e19d73caa4161c2aee350612ff7be3ad1cf2d82061941ebbb6
+size 17501

--- a/docs/solutions/reference-designs/ev-cog-ad3029wz/images/23062017-tile-revb-power-mux-scheme.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029wz/images/23062017-tile-revb-power-mux-scheme.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b80c7beca0f4d29d7737d80ac1b89d16d46ea58a74939f7ebaab4e0a3db7a51b
+size 102911

--- a/docs/solutions/reference-designs/ev-cog-ad3029wz/images/24072017-tile-revb-adp5300-gpio.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029wz/images/24072017-tile-revb-adp5300-gpio.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a34273b077c392ac21ca50141591e65bec0d1fe909298df1c622ba977c3619ac
+size 21068

--- a/docs/solutions/reference-designs/ev-cog-ad3029wz/images/24072017-tile-revb-current-test-points.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029wz/images/24072017-tile-revb-current-test-points.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:40f0061866348313528b6f085aca4e24b0c7ddbd5821c63437ddfeaa752fe9b1
+size 8460

--- a/docs/solutions/reference-designs/ev-cog-ad3029wz/images/25072017-tile-revb-back.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029wz/images/25072017-tile-revb-back.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bb83767c617ca67d94f33a6bc70861493ed44e4ece607d778dcd6e3e54081542
+size 677643

--- a/docs/solutions/reference-designs/ev-cog-ad3029wz/images/25072017-tile-revb-front.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029wz/images/25072017-tile-revb-front.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7c3928f7fe2526ee9e065cc681747149c161bcc126b4436bece693419e7a6e4d
+size 708749

--- a/docs/solutions/reference-designs/ev-cog-ad3029wz/images/button_led.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029wz/images/button_led.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:95ee7bf97cd6cd9e6640733e1c195c29b91591094955c6249add4351ac5f2860
+size 2929

--- a/docs/solutions/reference-designs/ev-cog-ad3029wz/images/c1-1.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029wz/images/c1-1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2e25ecf5e3313c6649555371d154a460e63232ec703a75c3e4a389936e29e6db
+size 21772

--- a/docs/solutions/reference-designs/ev-cog-ad3029wz/images/c1-2.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029wz/images/c1-2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:82fa413226c9587b329b021854ce204769af16364f6c2d63e590ee14a9b65360
+size 24700

--- a/docs/solutions/reference-designs/ev-cog-ad3029wz/images/c2-1.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029wz/images/c2-1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:76eef967a56ebb82bfa0e89ba0f49bf44f0130bbf8b3dec266c74acac7ebf295
+size 23733

--- a/docs/solutions/reference-designs/ev-cog-ad3029wz/images/c2-2.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029wz/images/c2-2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:20b5e9932ca2fa1e38718dfb86884800c5d102685fa0fc4b5c24289d8cd0e478
+size 20451

--- a/docs/solutions/reference-designs/ev-cog-ad3029wz/images/cmsis_pack_install_1.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029wz/images/cmsis_pack_install_1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5d4c2a56a8a3fc42ec94143c33ae5de9b23c04521aa46650e44efd60333d4241
+size 80905

--- a/docs/solutions/reference-designs/ev-cog-ad3029wz/images/cmsis_pack_install_2.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029wz/images/cmsis_pack_install_2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bffadcc381f6552810302dba2328dfc92f85628d3f204304ea06a898e965096f
+size 16063

--- a/docs/solutions/reference-designs/ev-cog-ad3029wz/images/cog_jumpers_annotated.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029wz/images/cog_jumpers_annotated.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a6d85a25cdec27591be9408de59585007cf7e0c7f4e06bc283b4512a86827179
+size 26407

--- a/docs/solutions/reference-designs/ev-cog-ad3029wz/images/create_new_project_1.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029wz/images/create_new_project_1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7f679e8a601a27c6187707c3ff1dc07844c6b05fd7ca53c8fcaa00b1a4358f47
+size 40677

--- a/docs/solutions/reference-designs/ev-cog-ad3029wz/images/debug_debug_button.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029wz/images/debug_debug_button.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ddca54c06fa6059fbd8dfe39b44f593e27eb269bfd8ebebf00a8c9ca893b7bc7
+size 474

--- a/docs/solutions/reference-designs/ev-cog-ad3029wz/images/drawing1-copy.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029wz/images/drawing1-copy.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e0c48ff580c93251035308cd358721bce118a0cb0b01aa3ce4714cd7ca47dae8
+size 39703

--- a/docs/solutions/reference-designs/ev-cog-ad3029wz/images/example_run_1.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029wz/images/example_run_1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8de73fabba0682cadcbd2b27b0c4badb63d10847aa9427311a9b5e8e6856d958
+size 10194

--- a/docs/solutions/reference-designs/ev-cog-ad3029wz/images/front_image_new.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029wz/images/front_image_new.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8ac17c0546927fce7a102842da591251bffa79e579f0d3fc9d4ad16ebd788d63
+size 6551628

--- a/docs/solutions/reference-designs/ev-cog-ad3029wz/images/iar-aducm3029-cmsis-example-buttonpress1.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029wz/images/iar-aducm3029-cmsis-example-buttonpress1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:749c958d873cb54819d3811bc61d4a19faf1873723dd94674006597534deff7a
+size 40711

--- a/docs/solutions/reference-designs/ev-cog-ad3029wz/images/iar-aducm3029-cmsis-example-mcu-select1.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029wz/images/iar-aducm3029-cmsis-example-mcu-select1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:76b5983b15a289e1fccd4020487e5d99b7d10c67126109740b09d80cbcafa8fc
+size 41482

--- a/docs/solutions/reference-designs/ev-cog-ad3029wz/images/iar-aducm3029-cmsis-packs-snapshot2.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029wz/images/iar-aducm3029-cmsis-packs-snapshot2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a2233e62fe34413962e669d1d4c511659f353901dffafa17ecfcd4600c224df7
+size 45211

--- a/docs/solutions/reference-designs/ev-cog-ad3029wz/images/img_20171030_180904.jpg
+++ b/docs/solutions/reference-designs/ev-cog-ad3029wz/images/img_20171030_180904.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e2477ab2e3fcda988d5e86c28f2c25a2be6f9612efef0453b4aa6178013d1b99
+size 2210521

--- a/docs/solutions/reference-designs/ev-cog-ad3029wz/images/jumper_settings_1.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029wz/images/jumper_settings_1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b98b3f38f7ab52388c2a3bb05ec9be3e61dd3284597dce0e24bb837872e4d87a
+size 24053

--- a/docs/solutions/reference-designs/ev-cog-ad3029wz/images/jumper_settings_2.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029wz/images/jumper_settings_2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:44caa23ebd4104db175566109dd7440b8c2d361b6ba4fa2c7c1459e5a691e0e8
+size 4495

--- a/docs/solutions/reference-designs/ev-cog-ad3029wz/images/jumper_settings_3.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029wz/images/jumper_settings_3.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:035d4a479bf17b1d7cb6b515102b3856428bf496e8751df7cbbffb79a5fdc015
+size 1289

--- a/docs/solutions/reference-designs/ev-cog-ad3029wz/images/keilcmsisdap.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029wz/images/keilcmsisdap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0795db43e4a6e2798af65f8283ae49b9f6257e2d1d87e60da80ba81fabe42ca6
+size 19028

--- a/docs/solutions/reference-designs/ev-cog-ad3029wz/images/keildebug.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029wz/images/keildebug.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:53d8db73a47c75089f2397e67017181dca7cdeb8d8941ce3c713f4db35d6f627
+size 20163

--- a/docs/solutions/reference-designs/ev-cog-ad3029wz/images/run_button.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029wz/images/run_button.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:563116d923b708a4060e25c6b34d5c27b0331cdb238f39ce416d3dffaad4bf81
+size 463

--- a/docs/solutions/reference-designs/ev-cog-ad3029wz/images/shuntjumpersettingchange.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029wz/images/shuntjumpersettingchange.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a8a7530b1ce3de804fc60ba77a749c486e70ee3aacd91c371d06947cac71bacb
+size 222755

--- a/docs/solutions/reference-designs/ev-cog-ad3029wz/images/software_packs_aducm302x_device_block_diagram.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029wz/images/software_packs_aducm302x_device_block_diagram.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:27c23ec69a45cd097c1ac6d92530783817e395b2cf11a25c9b0f4b151695ada3
+size 42913

--- a/docs/solutions/reference-designs/ev-cog-ad3029wz/images/solderjumpersettingchange.png
+++ b/docs/solutions/reference-designs/ev-cog-ad3029wz/images/solderjumpersettingchange.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a1249fac3c590226aaf347e2734cfaa9d67aa5b60d84ac5c12e9f5ab1a134673
+size 347430

--- a/docs/solutions/reference-designs/ev-cog-ad3029wz/index.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad3029wz/index.rst
@@ -1,8 +1,27 @@
-EV-COG-AD3029WZ Development Kit
-===============================
+.. _ev_cog_ad3029wz eval:
+
+EV COG AD3029WZ
+===========================================================================================
+
+.. TODO: Add a picture of the chip/board
+
+Overview
+-------------------------------------------------------------------------------
+
+.. TODO: Describe in max 10 rows the main features and applications.
+
+Features:
+
+- feature 1
+- feature 2
+
+Applications:
+
+- application 1
+- application 2
 
 .. toctree::
-   :titlesonly:
+   :hidden:
 
    ev-cog-ad3029wz
    cog_hw_userguide
@@ -16,3 +35,22 @@ EV-COG-AD3029WZ Development Kit
    tools/iar_guide
    tools/other_ide
    tools_driver
+
+Recommendations
+-------------------------------------------------------------------------------
+
+People who follow the flow that is outlined, have a much better experience with
+things. However, like many things, documentation is never as complete as it
+should be. If you have any questions, feel free to ask on our
+:ref:`EngineerZone forums <help-and-support>`, but before that, please make
+sure you read our documentation thoroughly.
+
+Warning
+-------------------------------------------------------------------------------
+
+.. esd-warning::
+
+Help and support
+-------------------------------------------------------------------------------
+
+Please go to :ref:`Help and Support <help-and-support>` page.

--- a/docs/solutions/reference-designs/ev-cog-ad3029wz/index.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad3029wz/index.rst
@@ -1,0 +1,18 @@
+EV-COG-AD3029WZ Development Kit
+===============================
+
+.. toctree::
+   :titlesonly:
+
+   ev-cog-ad3029wz
+   cog_hw_userguide
+   hw_details
+   introduction
+   packs_bsp
+   quickstart_1
+   software/aducm302x
+   software/ev-cog-ad3029wz
+   tools/cces_download
+   tools/iar_guide
+   tools/other_ide
+   tools_driver

--- a/docs/solutions/reference-designs/ev-cog-ad3029wz/introduction.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad3029wz/introduction.rst
@@ -1,0 +1,20 @@
+Introduction
+============
+
+The :adi:`EV-COG-AD3029WZ` is a modular Internet of Things (IOT) development platform based on the :adi:`ADUCM3029` ultra low power microcontroller (MCU) with integrated power management for processing, control, and connectivity. The MCU system is based on the ARM Cortex-M4F processor, a collection of digital peripherals, embedded SRAM and flash memory, and an analog subsystem which provides clocking, reset, and power management capability in addition to an analog-to-digital converter (ADC) subsystem. The :adi:`ADUCM3029` has industry leading ultra low power which makes it ideal for developing battery powered and self powered wireless sensor nodes. The *Cog* platform uses CrossCore Embedded Studio, an open source Eclipse based Interactive Development Environment (IDE), which can be downloaded free of charge. The platform contains many hardware and software example projects to make it easier for customers to prototype and create connected systems and solutions for Internet of Things (IoT) applications.
+
+.. image:: images/11082017-mcu-cog-revb-horizontal-concept.png
+
+The *Cog* IOT development kit is modular in nature and comprises of:
+
+-  An MCU *Cog* (such as the :doc:`EV-COG-AD3029WZ </solutions/reference-designs/ev-cog-ad3029wz/cog_hw_userguide>`) which has an on-board debugger and test-points for monitoring energy consumption.
+-  An optional connectivity *Cog* (such as the `EV-COG-BLEINTP1Z <https://wiki.analog.com/resources/eval/user-guides/eval-cog-ad3029lz/ev-cog-interposer>`_) which offers BTLE, LPWAN or WiFi connectivity options.
+-  An optional application specific add-on board (*Gear*) which might have an optimized sensor signal chain, specific to the use-case. For example - an add-on board targeted at smart agriculture use-cases might have Light, Temperature and Humidity Sensors. For initial prototyping, a specialized Gear is available which provides access to Arduino and PMOD connectors in addition to debug connectors - see `EV-GEAR-EXPANDER1Z <https://wiki.analog.com/resources/eval/user-guides/eval-cog-ad3029lz/ev-gear-expander>`_.
+
+This modular nature is depicted in the concept sketches below.
+
+.. image:: images/11082017-mcu-cog-revb-stacking.png
+
+| End Document
+
+:doc:`Back </solutions/reference-designs/ev-cog-ad3029wz/ev-cog-ad3029wz>`

--- a/docs/solutions/reference-designs/ev-cog-ad3029wz/introduction.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad3029wz/introduction.rst
@@ -15,6 +15,3 @@ This modular nature is depicted in the concept sketches below.
 
 .. image:: images/11082017-mcu-cog-revb-stacking.png
 
-| End Document
-
-:doc:`Back </solutions/reference-designs/ev-cog-ad3029wz/ev-cog-ad3029wz>`

--- a/docs/solutions/reference-designs/ev-cog-ad3029wz/packs_bsp.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad3029wz/packs_bsp.rst
@@ -1,7 +1,9 @@
 Software Packs & Board Support Package
 ======================================
 
-<note > **There are no seperate toolchain,On-Board Peripheral Drivers & Software for EV-COG-AD3029WZ, the toolchain,On-Board Peripheral Drivers & Software for EV-COG-AD3029LZ works with EV-COG-AD3029WZ.The user needs to change only the pin muxing based on the application.For help regarding pinmapping refer to the Hardware Details section.** 
+.. note::
+
+   There are no separate toolchain, On-Board Peripheral Drivers & Software for EV-COG-AD3029WZ; the toolchain, On-Board Peripheral Drivers & Software for EV-COG-AD3029LZ works with EV-COG-AD3029WZ. The user needs to change only the pin muxing based on the application. For help regarding pin mapping refer to the Hardware Details section.
 
 A modular software framework is provided for quick application prototyping.
 Based on the application use case, developers need to download the respective
@@ -15,8 +17,6 @@ software packs.
    
    -  IAR Embedded Workbench for ARM 8.20.1 or higher
    -  CrossCore Embedded Studio 2.7.0 ® or higher
-   
-   packs
 
 The Cog software development kit consists of these packs
 
@@ -34,7 +34,7 @@ The Cog software development kit consists of these packs
 
    -  *Version History*
 
-      -  **Version 3.1.0** - Extended support for IAR Embedded Workbench.\ **[Latest]**
+      -  **Version 3.1.0** - Extended support for IAR Embedded Workbench. **[Latest]**
 
          -  Version: 1.0.0 - Initial Release
 
@@ -52,6 +52,3 @@ The Cog software development kit consists of these packs
 
       -  **Version: 1.0.0** - Initial Release **[Latest]**
 
-:doc:`Back </solutions/reference-designs/ev-cog-ad3029wz/ev-cog-ad3029wz>`
-
-*End of Document*

--- a/docs/solutions/reference-designs/ev-cog-ad3029wz/packs_bsp.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad3029wz/packs_bsp.rst
@@ -1,0 +1,57 @@
+Software Packs & Board Support Package
+======================================
+
+<note > **There are no seperate toolchain,On-Board Peripheral Drivers & Software for EV-COG-AD3029WZ, the toolchain,On-Board Peripheral Drivers & Software for EV-COG-AD3029LZ works with EV-COG-AD3029WZ.The user needs to change only the pin muxing based on the application.For help regarding pinmapping refer to the Hardware Details section.** 
+
+A modular software framework is provided for quick application prototyping.
+Based on the application use case, developers need to download the respective
+software packs.
+
+.. important::
+
+   Please make sure you install either of the below toolchain before installing
+   any of the below packs
+
+   
+   -  IAR Embedded Workbench for ARM 8.20.1 or higher
+   -  CrossCore Embedded Studio 2.7.0 ® or higher
+   
+   packs
+
+The Cog software development kit consists of these packs
+
+-  :doc:`Analog Devices ADuCM302x Device Support Packs </solutions/reference-designs/ev-cog-ad3029wz/software/aducm302x>` - This is a bare minimum pack required to enable working with ADuCM3029 and develop simple applications using the on-chip drivers.
+
+   -  *Version History*
+
+      -  **Version: 3.1.0** - Extended support for IAR Embedded Workbench and Keil uVision. **[Latest]**
+
+         -  Version: 2.0.0 - API Changes to suit IoT applications
+         -  Version: 1.0.6 - Support Release
+         -  Version: 1.0.5 - Enables ECC during flash programming
+
+-  :doc:`Analog Devices EV-COG-AD3029WZ Off-Chip Drivers and Examples </solutions/reference-designs/ev-cog-ad3029wz/software/ev-cog-ad3029wz>` - This pack along with the DFP is required to develop applications using the on-board drivers.
+
+   -  *Version History*
+
+      -  **Version 3.1.0** - Extended support for IAR Embedded Workbench.\ **[Latest]**
+
+         -  Version: 1.0.0 - Initial Release
+
+-  `Analog Devices Sensor Drivers and Examples <https://wiki.analog.com/resources/eval/user-guides/ev-cog-ad3029lz/software/sensor>`_ - This pack is required only to develop applications using the GEARs.
+
+   -  *Version History*
+
+      -  **Version: 1.1.0** - Move example projects to respective board support packages. **[Latest]**
+
+         -  Version: 1.0.0 - Initial Release
+
+-  `Analog Devices Bluetooth Low Energy Software <https://wiki.analog.com/resources/eval/user-guides/ev-cog-ad3029lz/software/connectivity>`_ - This pack is required to enable BLE connectivity using EV-COG-BLEINTP1Z connectivity Cog.
+
+   -  *Version History*
+
+      -  **Version: 1.0.0** - Initial Release **[Latest]**
+
+:doc:`Back </solutions/reference-designs/ev-cog-ad3029wz/ev-cog-ad3029wz>`
+
+*End of Document*

--- a/docs/solutions/reference-designs/ev-cog-ad3029wz/quickstart_1.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad3029wz/quickstart_1.rst
@@ -1,0 +1,38 @@
+MCU Cog Quick Start Guide
+=========================
+
+<note > **There are no seperate toolchain,On-Board Peripheral Drivers & Software for EV-COG-AD3029WZ, the toolchain,On-Board Peripheral Drivers & Software for EV-COG-AD3029LZ works with EV-COG-AD3029WZ.The user needs to change only the pin muxing based on the application.For help regarding pinmapping refer to the Hardware Details section.** 
+
+Setting up EV-COG-AD3029WZ is a three step process.
+
+-  IDE Setup
+-  Software Packs & Drivers Setup
+-  Running an Example Project
+
+EV-COG-AD4050LZ can be used with following Toolchains. Please see below links
+for the quickstart guide with respect to different IDEs.
+
+CrossCore Embedded Studio
+-------------------------
+
+Click below link to go to CrossCore Embedded Studio userguide.
+
+`EV-COG-AD3029WZ with CrossCore Embedded Studio <https://wiki.analog.com/resources/eval/quickstart/ev-cog-ad3029wz/tools/cces_guide>`_
+
+IAR Embedded Workbench for ARM
+------------------------------
+
+Click below link to go to CrossCore Embedded Studio userguide.
+
+:doc:`EV-COG-AD3029WZ with IAR Embedded Workbench for ARM </solutions/reference-designs/ev-cog-ad3029wz/tools/iar_guide>`
+
+Keil uVision IDE
+----------------
+
+Click below link to go to Keil uVision IDE userguide.
+
+:doc:`EV-COG-AD3029WZ Keil uVision IDE </solutions/reference-designs/ev-cog-ad3029wz/tools/other_ide>`
+
+:doc:`Back </solutions/reference-designs/ev-cog-ad3029wz/ev-cog-ad3029wz>`
+
+| End Document

--- a/docs/solutions/reference-designs/ev-cog-ad3029wz/quickstart_1.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad3029wz/quickstart_1.rst
@@ -1,7 +1,9 @@
 MCU Cog Quick Start Guide
 =========================
 
-<note > **There are no seperate toolchain,On-Board Peripheral Drivers & Software for EV-COG-AD3029WZ, the toolchain,On-Board Peripheral Drivers & Software for EV-COG-AD3029LZ works with EV-COG-AD3029WZ.The user needs to change only the pin muxing based on the application.For help regarding pinmapping refer to the Hardware Details section.** 
+.. note::
+
+   There are no separate toolchain, On-Board Peripheral Drivers & Software for EV-COG-AD3029WZ; the toolchain, On-Board Peripheral Drivers & Software for EV-COG-AD3029LZ works with EV-COG-AD3029WZ. The user needs to change only the pin muxing based on the application. For help regarding pin mapping refer to the Hardware Details section.
 
 Setting up EV-COG-AD3029WZ is a three step process.
 
@@ -33,6 +35,3 @@ Click below link to go to Keil uVision IDE userguide.
 
 :doc:`EV-COG-AD3029WZ Keil uVision IDE </solutions/reference-designs/ev-cog-ad3029wz/tools/other_ide>`
 
-:doc:`Back </solutions/reference-designs/ev-cog-ad3029wz/ev-cog-ad3029wz>`
-
-| End Document

--- a/docs/solutions/reference-designs/ev-cog-ad3029wz/resources/02_049050a_top.pdf
+++ b/docs/solutions/reference-designs/ev-cog-ad3029wz/resources/02_049050a_top.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:659617b4adcb8d4bae1f7b3b4bd8ec1ff1adb64dead9aaf23f542cac8a0156c0
+size 126396

--- a/docs/solutions/reference-designs/ev-cog-ad3029wz/resources/20_049050a.zip
+++ b/docs/solutions/reference-designs/ev-cog-ad3029wz/resources/20_049050a.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:64487f6be3cb806140af3eac5d90cd9bf37dd549210008a4504d7743f9f05ec9
+size 5540548

--- a/docs/solutions/reference-designs/ev-cog-ad3029wz/resources/geartemplatedesigndatabase.zip
+++ b/docs/solutions/reference-designs/ev-cog-ad3029wz/resources/geartemplatedesigndatabase.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:58d8879d58e551ed79b1d2bfa98dd5cc907a819853bc0daa0cd8ebd009d4d69a
+size 323517

--- a/docs/solutions/reference-designs/ev-cog-ad3029wz/software/aducm302x.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad3029wz/software/aducm302x.rst
@@ -1,0 +1,78 @@
+Analog Devices ADuCM302x Device Support Pack
+============================================
+
+<note > **There are no seperate toolchain,On-Board Peripheral Drivers & Software for EV-COG-AD3029WZ, the toolchain,On-Board Peripheral Drivers & Software for EV-COG-AD3029LZ works with EV-COG-AD3029WZ.The user needs to change only the pin muxing based on the application.For help regarding pinmapping refer to the Hardware Details section.** 
+
+General Description/Overview
+----------------------------
+
+The ADuCM302x Device Family Pack (DFP) provides access to all the necessary on-chip peripheral drivers for both the :adi:`ADuCM3029` and the :adi:`ADuCM3027` devices. This software layer is the foundation layer needed when writing applications using this microprocessor family. When combined with the EV-COG-AD3029LZ software pack as well as the Sensors software pack, there are many great Internet of Things(IoT) applications and demos that can be replicated using the EV-COG-AD3029LZ development platform.
+
+The following on-chip drivers are provided as part of the ADuCM302x Device
+Family Pack:
+
+-  spi
+
+.. image:: ../images/software_packs_aducm302x_device_block_diagram.png
+   :align: right
+   :width: 600
+
+-  i2c
+-  uart
+-  sport
+-  beep
+-  wdt
+-  gpio
+-  rtc
+-  dma
+-  cryto
+-  adc
+-  tmr
+
+For detailed information regarding the ADuCM302x DFP, please see our complete
+ADuCM302x software user guide.
+
+.. hint::
+
+   
+   -  `ADuCM302x DFP 3.1.0 Release Notes <http://download.analog.com/tools/EZBoards/CM302x/Releases/Release_3.1.0/ADuCM302x_DFP_3.1.0_Release_Notes.pdf>`_
+   -  `ADuCM302x DFP 2.0.0 Release Notes <http://download.analog.com/tools/EZBoards/CM302x/Releases/Release_2.0.0/ADuCM302x_DFP_2.0.0_Release_Notes.pdf>`_
+   
+
+.. important::
+
+   
+   You MUST have this software package installed on your laptop or PC in order
+   to compile, debug, and run the applications for the EV-COG-AD3029LZ platform.
+   
+
+Downloading the ADuCM302x Software Pack
+---------------------------------------
+
+The software pack can be installed directly by the tool chain's CMSIS pack
+manager. Optionally, you may download and then use the CMSIS pack manager's
+manual installation to install the pack.
+
+-  Downloaded via the tool chain's CMSIS pack manager
+
+   -  It is **recommended** to download the ADuCM302x software pack through from the tool chain's CMSIS pack manager. That way, all the files, directories structure, and project structure for the various applications is properly saved and accessed. For a detailed description on how to download the ADuCM302x software pack through CrossCore Embedded Studio please see our `Cross Core Embedded Studio Quickstart User Guide <https://wiki.analog.com/resources/eval/user-guides/ev-cog-ad3029lz/tools/cces_guide>`_.
+
+-  Downloaded to local directory
+
+   -  However if you do decide to download the ADuCM302x software pack to your
+      PC/laptop directly, please use the link below to download the pack file
+      from Keil's website. You will then need to "import" the pack file using
+      your tool chain's CMSIS pack manager's import feature. Note that all
+      software packs can be downloaded from Keil's website.
+
+.. admonition:: Download
+   :class: download
+
+   
+   -  `ADuCM302x DFP 3.1.0 (Latest) <http://download.analog.com/tools/EZBoards/CM302x/Releases/AnalogDevices.ADuCM302x_DFP.3.1.0.pack>`_
+   -  `ADuCM302x DFP 2.0.0 <http://download.analog.com/tools/EZBoards/CM302x/Releases/AnalogDevices.ADuCM302x_DFP.2.0.0.pack>`_
+   
+
+*End of Document*
+
+:doc:`Back </solutions/reference-designs/ev-cog-ad3029wz/ev-cog-ad3029wz>`

--- a/docs/solutions/reference-designs/ev-cog-ad3029wz/software/aducm302x.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad3029wz/software/aducm302x.rst
@@ -1,7 +1,9 @@
 Analog Devices ADuCM302x Device Support Pack
 ============================================
 
-<note > **There are no seperate toolchain,On-Board Peripheral Drivers & Software for EV-COG-AD3029WZ, the toolchain,On-Board Peripheral Drivers & Software for EV-COG-AD3029LZ works with EV-COG-AD3029WZ.The user needs to change only the pin muxing based on the application.For help regarding pinmapping refer to the Hardware Details section.** 
+.. note::
+
+   There are no separate toolchain, On-Board Peripheral Drivers & Software for EV-COG-AD3029WZ; the toolchain, On-Board Peripheral Drivers & Software for EV-COG-AD3029LZ works with EV-COG-AD3029WZ. The user needs to change only the pin muxing based on the application. For help regarding pin mapping refer to the Hardware Details section.
 
 General Description/Overview
 ----------------------------
@@ -73,6 +75,3 @@ manual installation to install the pack.
    -  `ADuCM302x DFP 2.0.0 <http://download.analog.com/tools/EZBoards/CM302x/Releases/AnalogDevices.ADuCM302x_DFP.2.0.0.pack>`_
    
 
-*End of Document*
-
-:doc:`Back </solutions/reference-designs/ev-cog-ad3029wz/ev-cog-ad3029wz>`

--- a/docs/solutions/reference-designs/ev-cog-ad3029wz/software/ev-cog-ad3029wz.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad3029wz/software/ev-cog-ad3029wz.rst
@@ -1,7 +1,9 @@
-Analog Devices EV-COG-AD3029LZ Off-Chip Drivers and Examples
+Analog Devices EV-COG-AD3029WZ Off-Chip Drivers and Examples
 ============================================================
 
-<note > **There are no seperate toolchain,On-Board Peripheral Drivers & Software for EV-COG-AD3029WZ, the toolchain,On-Board Peripheral Drivers & Software for EV-COG-AD3029LZ works with EV-COG-AD3029WZ.The user needs to change only the pin muxing based on the application.For help regarding pinmapping refer to the Hardware Details section.** 
+.. note::
+
+   There are no separate toolchain, On-Board Peripheral Drivers & Software for EV-COG-AD3029WZ; the toolchain, On-Board Peripheral Drivers & Software for EV-COG-AD3029LZ works with EV-COG-AD3029WZ. The user needs to change only the pin muxing based on the application. For help regarding pin mapping refer to the Hardware Details section.
 
 General Description/Overview
 ----------------------------
@@ -17,9 +19,9 @@ EV-COG-AD3029LZ software pack contains the following components:
 -  On-Chip Driver Examples ( GPIO,RTC, SPI, Systick, TMR, UART, WDT)
 -  Bluetooth Profile Examples
 
-   -  \* FindMe Target
-   -  \* Proximity Reporter
-   -  \* Data Exchange (Hello World)
+   -  FindMe Target
+   -  Proximity Reporter
+   -  Data Exchange (Hello World)
 
 -  Android IoTNode application software
 -  Documentation
@@ -65,6 +67,3 @@ The software pack can be downloaded in several ways.
    -  `EV-COG-AD3029LZ BSP 1.0.0 <http://download.analog.com/tools/EZBoards/COG_AD3029/Releases/AnalogDevices.EV-COG-AD3029LZ_BSP.1.0.0.pack>`_
    
 
-*End of Document*
-
-`Back <https://wiki.analog.com/resources/eval/user-guides/ev-cog-ad3029lz>`_

--- a/docs/solutions/reference-designs/ev-cog-ad3029wz/software/ev-cog-ad3029wz.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad3029wz/software/ev-cog-ad3029wz.rst
@@ -1,0 +1,70 @@
+Analog Devices EV-COG-AD3029LZ Off-Chip Drivers and Examples
+============================================================
+
+<note > **There are no seperate toolchain,On-Board Peripheral Drivers & Software for EV-COG-AD3029WZ, the toolchain,On-Board Peripheral Drivers & Software for EV-COG-AD3029LZ works with EV-COG-AD3029WZ.The user needs to change only the pin muxing based on the application.For help regarding pinmapping refer to the Hardware Details section.** 
+
+General Description/Overview
+----------------------------
+
+The EV-COG-AD3029LZ software pack provides access to all the necessary on-board peripheral drivers for the :adi:`EV-COG-AD3029LZ` development platform. This software layer is the secondary layer needed when writing applications using this development platform. The **EV-COG-AD3029LZ** software pack builds on top of what the ADuCm302x software pack provides. The **EV-COG-AD3029LZ** software pack makes it easier to use the on-board peripherals so creating your application layer is will be easier. Combined with the ADuCM302x and Sensors software pack, there are many great **Internet of Things(IoT)** applications and demos that can be replicated using the **EV-COG-AD3029LZ** development platform.
+
+The drivers and examples in the BSP are designed to work with CrossCore Embedded
+Studio 2.6.0 ® and the ADuCM302x Device Family Pack 2.0.0.
+
+EV-COG-AD3029LZ software pack contains the following components:
+
+-  Bluetooth Companion Module
+-  On-Chip Driver Examples ( GPIO,RTC, SPI, Systick, TMR, UART, WDT)
+-  Bluetooth Profile Examples
+
+   -  \* FindMe Target
+   -  \* Proximity Reporter
+   -  \* Data Exchange (Hello World)
+
+-  Android IoTNode application software
+-  Documentation
+
+For detailed information regarding the EV-COG-AD3029LZ software pack, please see
+our complete EV-COG-AD3029LZ software user guide.
+
+.. hint::
+
+   
+   -  `EV-COG-AD3029LZ BSP 3.1.0 Release Notes <http://download.analog.com/tools/EZBoards/COG_AD3029/Releases/Release_3.1.0/EV-COG-AD3029LZ_3.1.0_Release_Notes.pdf>`_
+   -  `EV-COG-AD3029LZ BSP 2.0.0 Release Notes <http://download.analog.com/tools/EZBoards/COG_AD3029/Releases/Release_1.0.0/EV-COG-AD3029LZ_1.0.0_Release_Notes.pdf>`_
+   
+
+.. important::
+
+   
+   You MUST have this software package installed on your laptop or PC in order
+   to compile, debug, and run the applications for the EV-COG-AD3029LZ platform.
+   
+
+Downloading the EV-COG-AD3029LZ Software Pack
+---------------------------------------------
+
+The software pack can be downloaded in several ways.
+
+-  Downloaded via the tools program
+
+   -  It is **recommended** to download the EV-COG-AD3029LZ software pack through from the tools program you are using. That way, all the files, directories structure, and project structure for the various applications is properly saved and accessed. For a detailed description on how to download the EV-COG-AD3029LZ software pack through CrossCore Embedded Studio please see our `CrossCore Embedded Studio Quickstart Userguide <https://wiki.analog.com/resources/eval/user-guides/ev-cog-ad3029lz/tools/cces_guide>`_.
+
+-  Downloaded to local directory
+
+   -  However if you do decide to download the EV-COG-AD3029LZ software pack to
+      your PC/laptop directly, please use the link below, and make sure you save
+      the software pack to the correct local directory for your
+      applications/projects.
+
+.. admonition:: Download
+   :class: download
+
+   
+   -  `EV-COG-AD3029LZ BSP 3.1.0 (Latest) <http://download.analog.com/tools/EZBoards/COG_AD3029/Releases/AnalogDevices.EV-COG-AD3029LZ_BSP.3.1.0.pack>`_
+   -  `EV-COG-AD3029LZ BSP 1.0.0 <http://download.analog.com/tools/EZBoards/COG_AD3029/Releases/AnalogDevices.EV-COG-AD3029LZ_BSP.1.0.0.pack>`_
+   
+
+*End of Document*
+
+`Back <https://wiki.analog.com/resources/eval/user-guides/ev-cog-ad3029lz>`_

--- a/docs/solutions/reference-designs/ev-cog-ad3029wz/tools/cces_download.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad3029wz/tools/cces_download.rst
@@ -1,11 +1,9 @@
 CrossCore Embedded Studio Download & Install
 ============================================
 
-<note >There are no seperate toolchain,On-Board Peripheral Drivers & Software
-for EV-COG-AD3029WZ, the toolchain,On-Board Peripheral Drivers & Software for
-EV-COG-AD3029LZ works with EV-COG-AD3029WZ.The user needs to change only the pin
-muxing based on the application.For help regarding pinmapping refer to the
-Hardware Details section.
+.. note::
+
+   There are no separate toolchain, On-Board Peripheral Drivers & Software for EV-COG-AD3029WZ; the toolchain, On-Board Peripheral Drivers & Software for EV-COG-AD3029LZ works with EV-COG-AD3029WZ. The user needs to change only the pin muxing based on the application. For help regarding pin mapping refer to the Hardware Details section.
 
 This page provides all the necessary steps to get CrossCore Embedded Studio
 (CCES) software environment up and running on Windows or Linux.
@@ -30,7 +28,7 @@ following features and many more:
    IDE as well.
 
 Pre-Requisites and Requirements List
-====================================
+------------------------------------
 
 There are a few things that you will need for the tools and software to work
 properly.
@@ -52,7 +50,7 @@ properly.
       -  Or other favorite Terminal program
 
 CrossCore Embedded Studio Download Packages
-===========================================
+-------------------------------------------
 
 .. admonition:: Download
    :class: download
@@ -84,7 +82,7 @@ The following features are only supported via the Windows version
 -  Debugging an Application using the CrossCore Debugger (TPSDK)
 
 CrossCore Embedded Studio Installer Instructions
-================================================
+------------------------------------------------
 
 It is best that you save all the files/folders to the default directories
 recommended by the CrossCore Embedded Studios installer. This way all the
@@ -127,7 +125,7 @@ Analog Devices local directory structure which can be found below.
 -  CMSIS Pack files are installed to **/opt/analog/cces/2.6.0/ARM/packs**
 
 Activating CrossCore Embedded Studio
-====================================
+------------------------------------
 
 The first time you launch CrossCore Embedded Studio, you will be prompted to input a serial number, name, and email address. The serial number for **ALL** EV-COG-AD3029WZ boards is:
 
@@ -136,10 +134,7 @@ allow you full and unlimited access to all the features of the tool when using
 the Analog Devices family of ARM Cortex Processor.
 
 CrossCore Embedded Studio Support
-=================================
+---------------------------------
 
-For more details on CrossCore Embedded Studio, updated versions of the tools, release notes, tools documentation, or other support. Please visit the CrossCore :adi:`webpage <cces>`, or email the CrossCore support team at `processor.tools.support@analog.com <https://wiki.analog.com/mailto/processor.tools.support@analog.com>`_
+For more details on CrossCore Embedded Studio, updated versions of the tools, release notes, tools documentation, or other support. Please visit the CrossCore :adi:`webpage <cces>`, or email the CrossCore support team at `processor.tools.support@analog.com <mailto:processor.tools.support@analog.com>`_
 
-*End of Document*
-
-:doc:`Back </solutions/reference-designs/ev-cog-ad3029wz/ev-cog-ad3029wz>`

--- a/docs/solutions/reference-designs/ev-cog-ad3029wz/tools/cces_download.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad3029wz/tools/cces_download.rst
@@ -1,0 +1,145 @@
+CrossCore Embedded Studio Download & Install
+============================================
+
+<note >There are no seperate toolchain,On-Board Peripheral Drivers & Software
+for EV-COG-AD3029WZ, the toolchain,On-Board Peripheral Drivers & Software for
+EV-COG-AD3029LZ works with EV-COG-AD3029WZ.The user needs to change only the pin
+muxing based on the application.For help regarding pinmapping refer to the
+Hardware Details section.
+
+This page provides all the necessary steps to get CrossCore Embedded Studio
+(CCES) software environment up and running on Windows or Linux.
+
+The CCES software development environment for EV-COG-AD3029WZ is based on open
+source tools, and is maintained by Analog Devices. CCES includes support for DSP
+(digital signal processing) and ARM Cortex M- and A- devices, and includes the
+following features and many more:
+
+-  Eclipse based IDE
+-  GNU ARM Embedded Toolchain for Cortex-M core based parts (5-2016-q2-update release)
+-  OpenOCD with support for ADuCM302x and ADuCM4x50 microcontroller (open source SWD)
+-  CMSIS Pack files
+-  Mbed CMSIS-DAP
+-  J-Link Lite
+
+.. important::
+
+   CrossCore Embedded Studio is based on Eclipse, but because the MBED platform
+   provides a CMSIS-DAP interface to connect to the board, the EV-COG-AD3029WZ
+   can be used without problems with IAR Embedded Workbench IDE or Keil µVision
+   IDE as well.
+
+Pre-Requisites and Requirements List
+====================================
+
+There are a few things that you will need for the tools and software to work
+properly.
+
+-  PC or laptop computer
+-  EV-COG-AD3029WZ hardware
+-  Micro USB to USB cables
+
+.. important::
+
+   USB cable needs to have ALL data lines connected, can't use a charging only
+   micro USB cable.
+
+-  Terminal Program to interface your PC with the EV-COG-AD3029WZ
+
+   -  `Putty <http://www.chiark.greenend.org.uk/~sgtatham/putty/download.html>`_
+
+      -  `Tera Term <https://en.osdn.jp/projects/ttssh2/releases/>`_
+      -  Or other favorite Terminal program
+
+CrossCore Embedded Studio Download Packages
+===========================================
+
+.. admonition:: Download
+   :class: download
+
+   
+   The EV-COG-AD3029WZ **requires** the use of Crosscore Embedded Studios version **2.6.0 or higher**. Do not attempt to use earlier versions of the CrossCore tools, due to compatibility issues that will **damage** the EV-COG-AD3029WZ.
+   
+   `CrossCore Embedded Studio 2.7.0 Windows Installer(Executable) <http://download.analog.com/tools/CrossCoreEmbeddedStudio/Releases/Release_2.7.0/ADI_CrossCoreEmbeddedStudio-Rel2.7.0.exe>`_
+   
+   `CrossCore Embedded Studio 2.7.0 Ubuntu Linux Installer(Debian) <http://download.analog.com/tools/CrossCoreEmbeddedStudio/Releases/Release_2.7.0/adi-CrossCoreEmbeddedStudio-linux-x86-2.7.0.deb>`_
+   
+   `CrossCore Embedded Studio 2.6.0 Windows Installer(Executable) <http://download.analog.com/tools/CrossCoreEmbeddedStudio/Releases/Release_2.6.0/ADI_CrossCoreEmbeddedStudio-Rel2.6.0.exe>`_
+   
+   `CrossCore Embedded Studio 2.6.0 Ubuntu Linux Installer(Debian) <http://download.analog.com/tools/CrossCoreEmbeddedStudio/Releases/Release_2.6.0/adi-CrossCoreEmbeddedStudio-linux-x86-2.6.0.deb>`_
+   
+
+The following features are available and supported
+--------------------------------------------------
+
+-  Compilation using the GNU ARM Embedded toolchain for the ADuCM302x and ADuCM4x50 ARM Cortex-M cores.
+-  Debugging ADuCM302x and ADuCM4x50 via the IDE with GDB/OpenOCD.
+-  Development and debugging of bare-metal applications on the ADuCM302x and
+   ADuCM4x50 ARM Cortex-M core.
+
+The following features are only supported via the Windows version
+-----------------------------------------------------------------
+
+-  Use of CrossCore Embedded Studio Add-Ins other than the Linux Add-In
+-  Debugging an Application using the CrossCore Debugger (TPSDK)
+
+CrossCore Embedded Studio Installer Instructions
+================================================
+
+It is best that you save all the files/folders to the default directories
+recommended by the CrossCore Embedded Studios installer. This way all the
+instructions and support provided will be easier.
+
+Installing CrossCore Embedded Studio on Windows
+-----------------------------------------------
+
+-  To install CrossCore Embedded Studio, double-click ADI_CrossCoreEmbeddedStudio-Rel2.6.0.exe
+-  The CrossCore Embedded Studio installer will install the mBed windows serial
+   driver.
+
+   -  It is available separately, if required
+
+      -  https://developer.mbed.org/handbook/Windows-serial-configuration
+
+The executable installs all necessary components to the Analog Devices local
+directory structure which can be found below.
+
+-  CrossCore Embedded Studio installs to **C:\\Analog Devices\\CrossCore Embedded Studio 2.6.0**
+-  Eclipse IDE installs to **C:\\Analog Devices\\CrossCore Embedded Studio 2.6.0\\Eclipse**
+-  GNU ARM Embedded Toolchain for Cortex-M installs to **C:\\Analog Devices\\CrossCore Embedded Studio 2.6.0\\ARM\\gcc-arm-embedded**
+-  OpenOCD installs to **C:\\Analog Devices\\CrossCore Embedded Studio 2.6.0\\ARM\\openocd\\bin**
+-  CMSIS Pack files are installed to **C:\\Analog Devices\\CrossCore Embedded Studio 2.5.1\\ARM\\packs**
+
+Installing CrossCore Embedded Studio on Linux
+---------------------------------------------
+
+-  To install CrossCore Embedded Studio, run the command:
+
+   -  sudo dpkg -i adi-CrossCoreEmbeddedStudio-linux-x86-2.6.0.deb
+
+The Ubuntu Linux Installer(Debian) installs all necessary components to the
+Analog Devices local directory structure which can be found below.
+
+-  CrossCore Embedded Studio installs to **/opt/analog/cces/2.6.0**
+-  Eclipse IDE installs to **/opt/analog/cces/2.6.0/Eclipse**
+-  GNU ARM Embedded Toolchain for Cortex-M installs to **/opt/analog/cces/2.6.0/ARM/gcc-arm-embedded**
+-  OpenOCD installs to **/opt/analog/cces/2.6.0/ARM/openocd/bin**
+-  CMSIS Pack files are installed to **/opt/analog/cces/2.6.0/ARM/packs**
+
+Activating CrossCore Embedded Studio
+====================================
+
+The first time you launch CrossCore Embedded Studio, you will be prompted to input a serial number, name, and email address. The serial number for **ALL** EV-COG-AD3029WZ boards is:
+
+Once the serial number has been activated, the CrossCore development tools will
+allow you full and unlimited access to all the features of the tool when using
+the Analog Devices family of ARM Cortex Processor.
+
+CrossCore Embedded Studio Support
+=================================
+
+For more details on CrossCore Embedded Studio, updated versions of the tools, release notes, tools documentation, or other support. Please visit the CrossCore :adi:`webpage <cces>`, or email the CrossCore support team at `processor.tools.support@analog.com <https://wiki.analog.com/mailto/processor.tools.support@analog.com>`_
+
+*End of Document*
+
+:doc:`Back </solutions/reference-designs/ev-cog-ad3029wz/ev-cog-ad3029wz>`

--- a/docs/solutions/reference-designs/ev-cog-ad3029wz/tools/iar_guide.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad3029wz/tools/iar_guide.rst
@@ -1,11 +1,9 @@
 EV-COG-AD3029WZ with IAR Embedded Workbench for ARM
 ===================================================
 
-<note >There are no seperate toolchain,On-Board Peripheral Drivers & Software
-for EV-COG-AD3029WZ, the toolchain,On-Board Peripheral Drivers & Software for
-EV-COG-AD3029LZ works with EV-COG-AD3029WZ.The user needs to change only the pin
-muxing based on the application.For help regarding pinmapping refer to the
-Hardware Details section.
+.. note::
+
+   There are no separate toolchain, On-Board Peripheral Drivers & Software for EV-COG-AD3029WZ; the toolchain, On-Board Peripheral Drivers & Software for EV-COG-AD3029LZ works with EV-COG-AD3029WZ. The user needs to change only the pin muxing based on the application. For help regarding pin mapping refer to the Hardware Details section.
 
 First, install mBed windows serial driver from https://developer.mbed.org/handbook/Windows-serial-configuration
 
@@ -23,13 +21,13 @@ IDE Setup
 Software Packs and Driver Setup
 -------------------------------
 
--  Download the following packs for EV-COG-AD3029LZ \*\* (The packs are same for
-   EV-COG-AD3029LZ and EV-COG-AD3029WZ) \*\*
+-  Download the following packs for EV-COG-AD3029LZ **(The packs are same for
+   EV-COG-AD3029LZ and EV-COG-AD3029WZ)**
 
    -  `ARM CMSIS Pack <https://keilpack.azureedge.net/pack/ARM.CMSIS.5.2.0.pack>`_
 
       -  `DFP - Device Family Pack for ADuCM302x <http://download.analog.com/tools/EZBoards/CM302x/Releases/AnalogDevices.ADuCM302x_DFP.3.1.0.pack>`_
-      -  `BSP - Board Support Pack for EV-COG-AD3029LZ <http://download.analog.com/tools/EZBoards/COG_AD3029/Releases/AnalogDevices.EV-COG-AD3029LZ_BSP.3.1.0.pack>`_
+   -  `BSP - Board Support Pack for EV-COG-AD3029LZ <http://download.analog.com/tools/EZBoards/COG_AD3029/Releases/AnalogDevices.EV-COG-AD3029LZ_BSP.3.1.0.pack>`_
 
 -  Start IAR Embedded Workbench for ARM.
 -  Go to Project-> CMSIS-Pack-> Pack Installer.
@@ -84,13 +82,11 @@ Running an Example Project
    :width: 700
 
 -  Save the project to the desired location.
--  Click on 'Debug and Download' icon |image1|\ on the menu bar. This will compile, build and download the project on EV-COG-AD3029WZ using CMSIS-DAP.
+-  Click on 'Debug and Download' icon |image1| on the menu bar. This will compile, build and download the project on EV-COG-AD3029WZ using CMSIS-DAP.
 -  Click on 'Run' icon |image2| to start the debug session.
 -  Now press BTN1 or BTN2 on EV-COG-AD3029WZ and inspect corresponding LED
 
 You are all set!
-
-:doc:`Back </solutions/reference-designs/ev-cog-ad3029wz/quickstart_1>`
 
 .. |image1| image:: ../images/debug_debug_button.png
 .. |image2| image:: ../images/run_button.png

--- a/docs/solutions/reference-designs/ev-cog-ad3029wz/tools/iar_guide.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad3029wz/tools/iar_guide.rst
@@ -1,0 +1,96 @@
+EV-COG-AD3029WZ with IAR Embedded Workbench for ARM
+===================================================
+
+<note >There are no seperate toolchain,On-Board Peripheral Drivers & Software
+for EV-COG-AD3029WZ, the toolchain,On-Board Peripheral Drivers & Software for
+EV-COG-AD3029LZ works with EV-COG-AD3029WZ.The user needs to change only the pin
+muxing based on the application.For help regarding pinmapping refer to the
+Hardware Details section.
+
+First, install mBed windows serial driver from https://developer.mbed.org/handbook/Windows-serial-configuration
+
+IDE Setup
+---------
+
+-   Install IAR Embedded Workbench for ARM
+
+   -  Please visit https://www.iar.com/ to download IAR Embedded Workbench for ARM (version 8.20.1 or above)
+
+-   License Installation
+
+   -  Make sure valid license is installed for the corresponding version.
+
+Software Packs and Driver Setup
+-------------------------------
+
+-  Download the following packs for EV-COG-AD3029LZ \*\* (The packs are same for
+   EV-COG-AD3029LZ and EV-COG-AD3029WZ) \*\*
+
+   -  `ARM CMSIS Pack <https://keilpack.azureedge.net/pack/ARM.CMSIS.5.2.0.pack>`_
+
+      -  `DFP - Device Family Pack for ADuCM302x <http://download.analog.com/tools/EZBoards/CM302x/Releases/AnalogDevices.ADuCM302x_DFP.3.1.0.pack>`_
+      -  `BSP - Board Support Pack for EV-COG-AD3029LZ <http://download.analog.com/tools/EZBoards/COG_AD3029/Releases/AnalogDevices.EV-COG-AD3029LZ_BSP.3.1.0.pack>`_
+
+-  Start IAR Embedded Workbench for ARM.
+-  Go to Project-> CMSIS-Pack-> Pack Installer.
+
+.. image:: ../images/cmsis_pack_install_1.png
+   :align: center
+   :width: 750
+
+-  In **'CMSIS Pack Manager'** window, click 'Install local pack file'.
+
+.. image:: ../images/cmsis_pack_install_2.png
+   :align: center
+   :width: 700
+
+-  In 'Pack file to install' window navigate to the downloaded pack (as already
+   done in step 1 of this section), select all the packs to install and click
+   Open.
+
+.. image:: ../images/iar-aducm3029-cmsis-packs-snapshot2.png
+   :align: center
+
+Running an Example Project
+--------------------------
+
+-  Power the MCU Cog using a USB (micro-B) Cable. You should see a red LED and a
+   yellow LED turn on by default.
+
+.. image:: ../images/img_20171030_180904.jpg
+   :align: center
+   :width: 200
+
+-  In IAR IDE, go to Project-> Create New Project...
+
+.. image:: ../images/create_new_project_1.png
+   :align: center
+
+-  In **'Create New Project'** window, Select **'CMSIS Pack Example'** and click 'OK'.
+
+.. image:: ../images/example_run_1.png
+   :align: center
+
+-  Expand Analog Devices, select **ADuCM3029** and click 'Next'.
+
+.. image:: ../images/iar-aducm3029-cmsis-example-mcu-select1.png
+   :align: center
+   :width: 700
+
+-  Select **button_press** example and click 'Finish'.
+
+.. image:: ../images/iar-aducm3029-cmsis-example-buttonpress1.png
+   :align: center
+   :width: 700
+
+-  Save the project to the desired location.
+-  Click on 'Debug and Download' icon |image1|\ on the menu bar. This will compile, build and download the project on EV-COG-AD3029WZ using CMSIS-DAP.
+-  Click on 'Run' icon |image2| to start the debug session.
+-  Now press BTN1 or BTN2 on EV-COG-AD3029WZ and inspect corresponding LED
+
+You are all set!
+
+:doc:`Back </solutions/reference-designs/ev-cog-ad3029wz/quickstart_1>`
+
+.. |image1| image:: ../images/debug_debug_button.png
+.. |image2| image:: ../images/run_button.png

--- a/docs/solutions/reference-designs/ev-cog-ad3029wz/tools/other_ide.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad3029wz/tools/other_ide.rst
@@ -1,7 +1,9 @@
 Using Keil IDE with EV-COG-AD3029WZ
 ===================================
 
-<note > **There are no seperate toolchain,On-Board Peripheral Drivers & Software for EV-COG-AD3029WZ, the toolchain,On-Board Peripheral Drivers & Software for EV-COG-AD3029LZ works with EV-COG-AD3029WZ.The user needs to change only the pin muxing based on the application.For help regarding pinmapping refer to the Hardware Details section.** 
+.. note::
+
+   There are no separate toolchain, On-Board Peripheral Drivers & Software for EV-COG-AD3029WZ; the toolchain, On-Board Peripheral Drivers & Software for EV-COG-AD3029LZ works with EV-COG-AD3029WZ. The user needs to change only the pin muxing based on the application. For help regarding pin mapping refer to the Hardware Details section.
 
 This will be a paragraph talk about why you might want to use Keil with the
 EV-COG-AD3029LZ.
@@ -32,6 +34,3 @@ following steps.
 -  Push Crtl+F5 or in the Keil toolbar select **Debug** → **Start/Stop Debug Session**
 -  That’s it – You are ready to go.
 
-*End of Document*
-
-:doc:`Back </solutions/reference-designs/ev-cog-ad3029wz/ev-cog-ad3029wz>`

--- a/docs/solutions/reference-designs/ev-cog-ad3029wz/tools/other_ide.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad3029wz/tools/other_ide.rst
@@ -1,0 +1,37 @@
+Using Keil IDE with EV-COG-AD3029WZ
+===================================
+
+<note > **There are no seperate toolchain,On-Board Peripheral Drivers & Software for EV-COG-AD3029WZ, the toolchain,On-Board Peripheral Drivers & Software for EV-COG-AD3029LZ works with EV-COG-AD3029WZ.The user needs to change only the pin muxing based on the application.For help regarding pinmapping refer to the Hardware Details section.** 
+
+This will be a paragraph talk about why you might want to use Keil with the
+EV-COG-AD3029LZ.
+
+How to use EV-COG-AD3029WZ with Keil
+------------------------------------
+
+In order to use EV-COG-AD3029WZ board with Keil, you will need to replicate the
+following steps.
+
+-  Install mBed windows serial driver from
+
+   -  https://developer.mbed.org/handbook/Windows-serial-configuration
+
+-  Open any example-workspace and project from the ADuCM3029 BSP(board support package). I used the SysTick example in the below images
+-  In the Keil toolbar select **Project** → **Options** → **Debug**, and select the “CMSIS DAP” option
+
+.. image:: ../images/keildebug.png
+   :align: center
+   :width: 500
+
+-  Under the CMSIS DAP Settings, select the SW option
+
+.. image:: ../images/keilcmsisdap.png
+   :align: center
+   :width: 500
+
+-  Push Crtl+F5 or in the Keil toolbar select **Debug** → **Start/Stop Debug Session**
+-  That’s it – You are ready to go.
+
+*End of Document*
+
+:doc:`Back </solutions/reference-designs/ev-cog-ad3029wz/ev-cog-ad3029wz>`

--- a/docs/solutions/reference-designs/ev-cog-ad3029wz/tools_driver.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad3029wz/tools_driver.rst
@@ -1,0 +1,24 @@
+Tools and Driver Details
+========================
+
+<note >There are no seperate toolchain,On-Board Peripheral Drivers & Software
+for EV-COG-AD3029WZ, the toolchain,On-Board Peripheral Drivers & Software for
+EV-COG-AD3029LZ works with EV-COG-AD3029WZ.The user needs to change only the pin
+muxing based on the application.For help regarding pinmapping refer to the
+Hardware Details section.
+
+This chapter provides all the necessary steps to download, install, and setup
+the software environment from Analog Devices. There is also information on the
+different USB modes and drivers needed.
+
+It contains two main sections:
+
+-  :doc:`CrossCore Embedded Studio Download & Install </solutions/reference-designs/ev-cog-ad3029wz/tools/cces_download>` - Provides all the necessary instructions on how to download and install the CrossCore Embedded Studios software development environment.
+
+   -  `CrossCore Embedded Studio Quickstart Userguide <https://wiki.analog.com/resources/eval/user-guides/ev-cog-ad3029lz/tools/cces_guide>`_ - Provides information about using the CrossCore Embedded Studios IDE, in particular, the process of importing, building, debugging, and creating user applications for the EV-COG-AD4050WZ.
+
+-  `Driver Installation for On-board Debugger (CMSIS DAP) <https://wiki.analog.com/resources/eval/user-guides/ev-cog-ad3029lz/tools/hardware_usb>`_ - Provides detailed information how to load pre-compiled .HEX or .BIN files using the USB drive of the EV-COG-AD3029WZ board.
+
+| End Document
+
+:doc:`Back </solutions/reference-designs/ev-cog-ad3029wz/ev-cog-ad3029wz>`

--- a/docs/solutions/reference-designs/ev-cog-ad3029wz/tools_driver.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad3029wz/tools_driver.rst
@@ -1,11 +1,9 @@
 Tools and Driver Details
 ========================
 
-<note >There are no seperate toolchain,On-Board Peripheral Drivers & Software
-for EV-COG-AD3029WZ, the toolchain,On-Board Peripheral Drivers & Software for
-EV-COG-AD3029LZ works with EV-COG-AD3029WZ.The user needs to change only the pin
-muxing based on the application.For help regarding pinmapping refer to the
-Hardware Details section.
+.. note::
+
+   There are no separate toolchain, On-Board Peripheral Drivers & Software for EV-COG-AD3029WZ; the toolchain, On-Board Peripheral Drivers & Software for EV-COG-AD3029LZ works with EV-COG-AD3029WZ. The user needs to change only the pin muxing based on the application. For help regarding pin mapping refer to the Hardware Details section.
 
 This chapter provides all the necessary steps to download, install, and setup
 the software environment from Analog Devices. There is also information on the
@@ -19,6 +17,3 @@ It contains two main sections:
 
 -  `Driver Installation for On-board Debugger (CMSIS DAP) <https://wiki.analog.com/resources/eval/user-guides/ev-cog-ad3029lz/tools/hardware_usb>`_ - Provides detailed information how to load pre-compiled .HEX or .BIN files using the USB drive of the EV-COG-AD3029WZ board.
 
-| End Document
-
-:doc:`Back </solutions/reference-designs/ev-cog-ad3029wz/ev-cog-ad3029wz>`


### PR DESCRIPTION
## Summary
- Move ev-cog-ad3029wz wiki documentation to `solutions/reference-designs/ev-cog-ad3029wz/`
- 13 RST files with 33 localized images
- Generated stub `index.rst` with toctree

## Test plan
- [ ] Sphinx build passes without errors
- [ ] All toctree entries resolve correctly
- [ ] Images render properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)