### PR TITLE
reference-designs/ev-cog-ad4050lz: Add ev-cog-ad4050lz documentation

### DIFF
--- a/docs/solutions/reference-designs/ev-cog-ad4050lz/cog_hw_userguide.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad4050lz/cog_hw_userguide.rst
@@ -41,12 +41,10 @@ Power Supply Options
 
 The MCU Cog offers the following power supply options:
 
-::
-
-   -5V USB power (USB microB connector)
-   -3V CR2032 Coin cell (Cell holder - BT1)
-   -3V - 6V Rechargeable Li-Ion Battery (JST Connector - P6)
-   -3V - 6V External Supply from an MCU Cog Add-on card (via Connector C1)
+-  5V USB power (USB microB connector)
+-  3V CR2032 Coin cell (Cell holder - BT1)
+-  3V - 6V Rechargeable Li-Ion Battery (JST Connector - P6)
+-  3V - 6V External Supply from an MCU Cog Add-on card (via Connector C1)
 
 Power Muxing Options
 ~~~~~~~~~~~~~~~~~~~~
@@ -87,11 +85,9 @@ Programming & Debug Options
 
 The MCU Cog offers the following debug options:
 
-::
-
-   -On-board CMSIS-DAP debugger (USB microB connector)
-   -JLINK-9 Connector for access to SWD interface (P26)
-   -Access to SW interface to an MCU Cog Add-on card (via Connector C2)
+-  On-board CMSIS-DAP debugger (USB microB connector)
+-  JLINK-9 Connector for access to SWD interface (P26)
+-  Access to SW interface to an MCU Cog Add-on card (via Connector C2)
 
 Wireless Connectivity Options
 -----------------------------
@@ -117,7 +113,7 @@ worry about porting their firmware. The figures below capture the pin-mapping
 and jumpers that need to be changed to get external access (via the expansion
 connectors) to GPIO (as well as power/reset, etc).
 
-|image2|\ |image3|
+|image2| |image3|
 
 Jumper Settings
 ---------------
@@ -205,10 +201,6 @@ expansion connectors as well as place-bound rules embedded.
    :class: download
 
    `Gear Template Design Database <resources/geartemplatedesigndatabase.zip>`_
-
-| End Document
-
-`Back <https://wiki.analog.com/resources/eval/user-guides/ev-cog-ad4050lz>`_
 
 .. |image1| image:: images/23062017-tile-revb-power-mux-scheme.png
 .. |direct| image:: images/24072017-tile-revb-adp5300-gpio.png

--- a/docs/solutions/reference-designs/ev-cog-ad4050lz/cog_hw_userguide.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad4050lz/cog_hw_userguide.rst
@@ -1,0 +1,219 @@
+EV-COG-AD4050LZ MCU Cog
+=======================
+
+The EV-COG-AD4050LZ is an *MCU Cog* board for the :adi:`ADuCM4050 MCU <en/products/processors-dsp/microcontrollers/ultra-low-power-microcontrollers/aducm4050.html>`.
+
+Main Features
+-------------
+
+-  :adi:`ADuCM4050` (LFCSP package) - Ultra Low Power ARM Cortex-M4F MCU
+-  Compact form factor (3.5 cm X 7.5 cm) - Easy to deploy.
+-  On board debugger capability (CMSIS DAP compatible)
+-  Multiple power options and current monitoring test-points.
+-  On-board sensors: Accelerometer (ADXL362) and Temperature Sensor (ADT7420)
+-  Optional expansion capability - Using application specific add-on cards (*Gears*)
+-  Optional connectivity options - Using RF modules (*Connectivity Cogs*)
+
+Board
+-----
+
+Front-Side
+~~~~~~~~~~
+
+.. image:: images/25072017-tile-revb-front.png
+   :alt: 25072017-tile-revb-front.png
+
+Back-Side
+~~~~~~~~~
+
+.. image:: images/25072017-tile-revb-back.png
+   :alt: 25072017-tile-revb-back.png
+
+Power
+-----
+
+The MCU Cog board offers flexibility in terms of power supply and power muxing
+options. This is achieved with the use of jumpers on the board. The Cog board
+also offers multiple test points for monitoring current consumption.
+
+Power Supply Options
+~~~~~~~~~~~~~~~~~~~~
+
+The MCU Cog offers the following power supply options:
+
+::
+
+   -5V USB power (USB microB connector)
+   -3V CR2032 Coin cell (Cell holder - BT1)
+   -3V - 6V Rechargeable Li-Ion Battery (JST Connector - P6)
+   -3V - 6V External Supply from an MCU Cog Add-on card (via Connector C1)
+
+Power Muxing Options
+~~~~~~~~~~~~~~~~~~~~
+
+For details of the power muxing scheme, refer to the figure below.
+
+|image1|
+
+.. danger::
+
+   Do not insert shunt b/w positions 5 & 6 of JH4 when using USB supply. Doing
+   so can permanently damage this board.
+
+.. tip::
+
+   Refer to the *Jumper Settings* section further below for details on power related jumpers on the board
+
+Power Regulator
+~~~~~~~~~~~~~~~
+
+The MCU Cog board uses an on-board switching regulator - the :adi:`ADP5300 <en/products/power-management/switching-power-converters/switching-regulators/adp5300.html>`, which is a high efficiency, ultra-low power step down regulator. The MCU has complete control over the switching modes of the regulator via GPIO. The pin-mapping is shown in the table below.
+
+|direct|
+
+Current Measurement Options
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The MCU Cog enables IOT developers to measure and profile current consumption at
+different places on the board to enable isolation of current consumption
+hotspots. The current measure test points shown in the table below can be used
+along with a digital multimeter to profile current consumption.
+
+.. image:: images/24072017-tile-revb-current-test-points.png
+   :alt: 24072017-tile-revb-current-test-points.png
+
+Programming & Debug Options
+---------------------------
+
+The MCU Cog offers the following debug options:
+
+::
+
+   -On-board CMSIS-DAP debugger (USB microB connector)
+   -JLINK-9 Connector for access to SWD interface (P26)
+   -Access to SW interface to an MCU Cog Add-on card (via Connector C2)
+
+Wireless Connectivity Options
+-----------------------------
+
+The MCU Cog board offers support for ADI RF daughter-cards such as the EV-ADF70301-915AZ via the "EV-COG-BLEINTP1" connectivity Cog board that can be attached at Connector P2. This connectivity Cog board also has on-board BTLE circuit enabling the MCU Cog board to use BTLE communication as well. More details regarding wireless connectivity options are available on the `EV-COG-BLEINTP1 Wiki page <https://wiki.analog.com/resources/eval/user-guides/ev-cog-bleintp1z>`_.
+
+Buttons/LED(s)
+--------------
+
+The MCU Cog offers 2 buttons and 2 LED(s) that can be used by the Application.
+The default GPIO connections are shown in the tables below.
+
+.. image:: images/24072017-tile-revb-buttons-leds2.png
+   :alt: 24072017-tile-revb-buttons-leds2.png
+
+Expansion Connectors
+--------------------
+
+One of the USP of the MCU Cog is access to ALL GPIO via Expansion Connectors
+("C1" and "C2") for an Add-on card to utilize in its Application. This enables
+developers to confidently build final form factor hardware without having to
+worry about porting their firmware. The figures below capture the pin-mapping
+and jumpers that need to be changed to get external access (via the expansion
+connectors) to GPIO (as well as power/reset, etc).
+
+|image2|\ |image3|
+
+Jumper Settings
+---------------
+
+The MCU Cog offers flexibility in terms of power muxing options and the facility to route any GPIO externally via the expansion connectors "C1" and "C2". This is achieved with the use of jumpers. The MCU Cog has two types of jumpers - those labelled "JHx" and which are 2x2 1.27mm pitch headers and those labelled "JPx" and which are solder jumpers. The "JHx" jumpers are expected to be used more frequently than the "JPx" jumpers. The figures below capture the jumper settings. |4050_power_jumper_matrix.png| |image4|
+
+|image5|
+
+Jumper locations on board
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The following image of the bottom layer of the PCB highlights the jumper
+positions on the board:
+
+.. image:: images/cog_jumpers_annotated.png
+   :alt: Jumper Position
+   :align: center
+
+Note that the jumpers JH6 and JP16 on the **top** layer of the board.
+
+Changing the jumper settings
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Shunt Jumpers (JHx)
+^^^^^^^^^^^^^^^^^^^
+
+As mentioned above, the shunt jumpers are 1.27mm headers, whose pins are shorted
+using a shunt. This shunt is inserted by default in the positions as mentioned
+in the table above.
+
+To change a jumper setting, carefully remove the shunt from its position, and
+re-insert the shunt in the correct position corresponding to the pin numbers to
+be shorted. The pin numbers are mentioned on the silkscreen of the PCB (usually
+both pin 1 & 2) and thus the default positions can be located.
+
+For example JH11 controls which signal is sent to the RTC1_SS2 SensorStrobe pin.
+By default the ADXL_362_INT2 signal is connected to the SensorStrobe pin. In
+order to connect the RF module, JH11 needs to be moved from "1 and 2" to "3 and
+4". The corresponding change is shown below:
+
+.. image:: images/shuntjumpersettingchange_1.png
+   :alt: Shunt Jumper Change
+   :align: center
+
+Solder Jumpers (JPx)
+^^^^^^^^^^^^^^^^^^^^
+
+Solder jumpers are shorted using a solder blob. There are 16 such jumpers on the
+board, out of which 15 are on the bottom side of the board while 1 (JP16) is on
+the top side of the board. Positions 1, 2 and 3 are usually indicated along the
+jumpers.
+
+To change a solder jumper, using a hot soldering iron, melt the blob of solder
+and move it into the desired position (1-2 or 3-2 or 4-2).
+
+For example, GPIO30 is connected to the on board ADT7420 temperature sensor by
+default. In order to bring it out to the expander JP3 needs to be shifted from
+1-2 to 2-3. Using a soldering iron to shift the jumpers, this is how it looks
+before and after:
+
+.. image:: images/solderjumpersettingchange_1.png
+   :alt: Solder Jumper Change
+   :align: center
+
+MCU Cog Design and Integration Files
+------------------------------------
+
+.. admonition:: Download
+   :class: download
+
+   `EV-COG-AD4050LZ MCU Cog revB Schematics <resources/aducm4050_cog_schematic.pdf>`_
+
+   
+   `EV-COG-AD4050LZ MCU Cog revB Layout Files & BOM <resources/ev-cog-ad4050lzboarddesigndatabase.zip>`_
+   
+
+Add-on Template
+~~~~~~~~~~~~~~~
+
+For developers designing a Cog add-on board, the template schematic/board files
+below might be a useful starting point. The board file has the placement of the
+expansion connectors as well as place-bound rules embedded.
+
+.. admonition:: Download
+   :class: download
+
+   `Gear Template Design Database <resources/geartemplatedesigndatabase.zip>`_
+
+| End Document
+
+`Back <https://wiki.analog.com/resources/eval/user-guides/ev-cog-ad4050lz>`_
+
+.. |image1| image:: images/23062017-tile-revb-power-mux-scheme.png
+.. |direct| image:: images/24072017-tile-revb-adp5300-gpio.png
+.. |image2| image:: images/c1-conn-mapping.png
+.. |image3| image:: images/c2-conn-mapping.png
+.. |4050_power_jumper_matrix.png| image:: images/4050_power_jumper_matrix.png
+.. |image4| image:: images/10082017-sensor-jumpers.png
+.. |image5| image:: images/10082017-debug-jumpers.png

--- a/docs/solutions/reference-designs/ev-cog-ad4050lz/example_project.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad4050lz/example_project.rst
@@ -1,0 +1,4 @@
+COMING SOON !!
+==============
+
+`Back <https://wiki.analog.com/resources/eval/user-guides/ev-cog-ad4050lz>`_

--- a/docs/solutions/reference-designs/ev-cog-ad4050lz/help_support.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad4050lz/help_support.rst
@@ -98,8 +98,4 @@ EVAL-ADICUP3029, either post a question or send an email.
 -  The CrossCore Embedded Studio team can also be emailed using the address
    below:
 
-   -  `processor.tools.support@analog.com <https://wiki.analog.com/mailto/processor.tools.support@analog.com>`_
-
-*End of Document*
-
-`Back <https://wiki.analog.com/resources/eval/user-guides/ev-cog-ad4050lz>`_
+   -  `processor.tools.support@analog.com <mailto:processor.tools.support@analog.com>`_

--- a/docs/solutions/reference-designs/ev-cog-ad4050lz/help_support.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad4050lz/help_support.rst
@@ -1,0 +1,105 @@
+Help and Support
+================
+
+<note >There are no seperate toolchain,On-Board Peripheral Drivers & Software
+for EV-COG-AD4050WZ, the toolchain,On-Board Peripheral Drivers & Software for
+EV-COG-AD4050LZ works with EV-COG-AD4050WZ.The user needs to change only the pin
+muxing based on the application.For help regarding pinmapping refer to the
+Hardware Details section.
+
+Do you need help or have general support questions, than I hope this page helps
+you resolve those.
+
+This page has a quickstart troubleshooting approach that goes over some very
+general questions and common pitfalls, but if you have a specific issue which
+requires more information or detail please contact us through EngineerZone or
+Email. (links can be found further down on the page where to direct specific
+questions)
+
+What to do When Things Go Wrong
+-------------------------------
+
+There are many things that can go wrong with an ecosystem this complex, but if
+you are having issues getting the board or software working, here are a few
+simple things you can try before contacting Analog Devices.
+
+-  Check the Power
+
+   -  Do you have the USB cable plugged in? if yes, then check switch (S7) in USB position
+   -  If you are using batteries, is the switch (S7) in the "BATT" position
+
+      -  Try replacing your batteries, and see if the board powers up.
+
+-  Program the EV-COG-AD4050LZ
+
+   -  Sometimes a flashed program doesn't run properly or can make it difficult to run the debugger.
+   -  The first thing to try in this case, is to :doc:`drag and drop </solutions/reference-designs/ev-cog-ad4050lz/tools/hardware_usb>` a known good .HEX or .BIN program into flash.(something with quick visible indicators works best)
+   -  If drag and drop is not working, it may be necessary to erase the flash.
+      To do so:
+
+      -  Download and install the CrossCore Serial Flash Programmer from here: :adi:`en/design-center/processors-and-dsp/evaluation-and-development-software/crosscore-serial-flash-programmer.html#dsp-overview`.
+      -  Make sure that the USB is connected and on UART header (P8) 1 & 2 and 7 & 8 are shorted.
+      -  Power cycle the EV-COG-AD4050LZ board while holding down the boot switch.
+      -  Select the mbed serial COM port in the CrossCore Serial Flash Programmer, and erase the flash.
+      -  Then try :doc:`drag and drop </solutions/reference-designs/ev-cog-ad4050lz/tools/hardware_usb>` a .HEX or .BIN file into flash
+
+   -  If the mass erase didn't work, and you are trying to drag and drop a large
+      .BIN file on EV-COG-AD4050LZ hardware, it's possible that the mbed
+      interface file needs to be updated to support your application.
+
+      -  Please visit the :doc:`Driver Installation for On-board Debugger (CMSIS DAP) </solutions/reference-designs/ev-cog-ad4050lz/tools/hardware_usb>` page in order to put the board in update mode.
+      -  Once you are in "maintenance mode" you should drag and drop the latest interface file onto your maintenance drive. That file can be downloaded at the bottom of :doc:`Driver Installation for On-board Debugger (CMSIS DAP) </solutions/reference-designs/ev-cog-ad4050lz/tools/hardware_usb>`.
+
+-  Not receiving/transmitting data to the UART
+
+   -  Make sure that the UART header (P8) is positioned in the correct
+      destination to transmit/receive UART data.
+
+This is just a brief self-help guide to troubleshooting common issues. If you
+have other questions that need answering please direct those requests to the
+locations outlined below.
+
+Hardware, Software, and Documentation Questions
+-----------------------------------------------
+
+If you have any questions regarding the **EV-COG-AD4050LZ** or are experiencing any problems using the **software** or issues following any of the **documentation** feel free to ask us a question.
+
+-  :ez:`ADuCM4050 support community <community/analog-microcontrollers/aducm4x50>` for questions about:
+
+   -  EV-COG-AD4050LZ hardware
+   -  ADuCM4050 silicon
+   -  EV-COG-AD4050LZ software
+   -  EV-COG-AD4050LZ documentation
+
+When asking a question please take the time to give a detailed description of
+your problem. If you are experiencing a problem please state the steps you have
+executed, the result you expected you would get and the result you actually got.
+By doing so you enable us to provide you precise and detailed answers in a
+timely manner.
+
+.. tip::
+
+   Before asking questions please take the time to check if somebody else
+   already asked the same question. You might just find your question already
+   answered.
+
+CrossCore Embedded Studio questions
+-----------------------------------
+
+If you have questions regarding the tools and tool chain that is used with the
+EVAL-ADICUP3029, either post a question or send an email.
+
+-  :ez:`CrossCore Embedded Studio support community <community/dsp/software-and-development-tools/cces>` for questions about:
+
+   -  Download/Install issues
+   -  Build, debug, run, issues
+   -  Other tools related issues
+
+-  The CrossCore Embedded Studio team can also be emailed using the address
+   below:
+
+   -  `processor.tools.support@analog.com <https://wiki.analog.com/mailto/processor.tools.support@analog.com>`_
+
+*End of Document*
+
+`Back <https://wiki.analog.com/resources/eval/user-guides/ev-cog-ad4050lz>`_

--- a/docs/solutions/reference-designs/ev-cog-ad4050lz/hw_details.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad4050lz/hw_details.rst
@@ -1,0 +1,17 @@
+Hardware Details
+================
+
+This page contains hardware-related information about the EV-COG-AD3029LZ board
+and the various hardware add on modules which can be used with the board. Each
+sub-section contains a detailed description of the board, connectors, jumpers
+and buttons. It also provides links to the Schematics, Bill of materials, design
+projects, and Technical documentation. It also gives internal links to the
+provided example demo software projects.
+
+The following boards are currently available:
+
+-  :doc:`EV-COG-AD4050LZ MCU Cog </solutions/reference-designs/ev-cog-ad4050lz/cog_hw_userguide>`
+
+| End Document
+
+`Back <https://wiki.analog.com/resources/eval/user-guides/ev-cog-ad4050lz>`_

--- a/docs/solutions/reference-designs/ev-cog-ad4050lz/images/10082017-debug-jumpers.png
+++ b/docs/solutions/reference-designs/ev-cog-ad4050lz/images/10082017-debug-jumpers.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dbae1d16178c152fbc5431c8aad064d277400486f40b7b03f07a7aefb9eeb190
+size 10389

--- a/docs/solutions/reference-designs/ev-cog-ad4050lz/images/10082017-sensor-jumpers.png
+++ b/docs/solutions/reference-designs/ev-cog-ad4050lz/images/10082017-sensor-jumpers.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8d2302f62503ee592158d4a23bd1c19cbf633731b6086c40e6e884ca062d1cea
+size 21046

--- a/docs/solutions/reference-designs/ev-cog-ad4050lz/images/11082017-mcu-cog-revb-horizontal-concept.png
+++ b/docs/solutions/reference-designs/ev-cog-ad4050lz/images/11082017-mcu-cog-revb-horizontal-concept.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5c6f8de11f9d7de05e9211be244b932efa6cee5b68bfa439e61fe90d9ed06a87
+size 69006

--- a/docs/solutions/reference-designs/ev-cog-ad4050lz/images/11082017-mcu-cog-revb-stacking.png
+++ b/docs/solutions/reference-designs/ev-cog-ad4050lz/images/11082017-mcu-cog-revb-stacking.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d1e4525fea1ac3e19d73caa4161c2aee350612ff7be3ad1cf2d82061941ebbb6
+size 17501

--- a/docs/solutions/reference-designs/ev-cog-ad4050lz/images/23062017-tile-revb-power-mux-scheme.png
+++ b/docs/solutions/reference-designs/ev-cog-ad4050lz/images/23062017-tile-revb-power-mux-scheme.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b80c7beca0f4d29d7737d80ac1b89d16d46ea58a74939f7ebaab4e0a3db7a51b
+size 102911

--- a/docs/solutions/reference-designs/ev-cog-ad4050lz/images/24072017-tile-revb-adp5300-gpio.png
+++ b/docs/solutions/reference-designs/ev-cog-ad4050lz/images/24072017-tile-revb-adp5300-gpio.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a34273b077c392ac21ca50141591e65bec0d1fe909298df1c622ba977c3619ac
+size 21068

--- a/docs/solutions/reference-designs/ev-cog-ad4050lz/images/24072017-tile-revb-buttons-leds2.png
+++ b/docs/solutions/reference-designs/ev-cog-ad4050lz/images/24072017-tile-revb-buttons-leds2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f004d1923b6c8b1ee1a196dedcfd9bac5bce493351cb5b3a00d7652101b154d0
+size 3370

--- a/docs/solutions/reference-designs/ev-cog-ad4050lz/images/24072017-tile-revb-current-test-points.png
+++ b/docs/solutions/reference-designs/ev-cog-ad4050lz/images/24072017-tile-revb-current-test-points.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:40f0061866348313528b6f085aca4e24b0c7ddbd5821c63437ddfeaa752fe9b1
+size 8460

--- a/docs/solutions/reference-designs/ev-cog-ad4050lz/images/25072017-tile-revb-back.png
+++ b/docs/solutions/reference-designs/ev-cog-ad4050lz/images/25072017-tile-revb-back.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bb83767c617ca67d94f33a6bc70861493ed44e4ece607d778dcd6e3e54081542
+size 677643

--- a/docs/solutions/reference-designs/ev-cog-ad4050lz/images/25072017-tile-revb-front.png
+++ b/docs/solutions/reference-designs/ev-cog-ad4050lz/images/25072017-tile-revb-front.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7c3928f7fe2526ee9e065cc681747149c161bcc126b4436bece693419e7a6e4d
+size 708749

--- a/docs/solutions/reference-designs/ev-cog-ad4050lz/images/4050_power_jumper_matrix.png
+++ b/docs/solutions/reference-designs/ev-cog-ad4050lz/images/4050_power_jumper_matrix.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4ca4ea93eaaa6fdcd517847df72a1c5c7f9d3e4f792c4665e6c9808eac98124b
+size 20523

--- a/docs/solutions/reference-designs/ev-cog-ad4050lz/images/aducm4050-fbl.png
+++ b/docs/solutions/reference-designs/ev-cog-ad4050lz/images/aducm4050-fbl.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b5b079bd5b3f9b630abbb7c0c766b59ff59c4ec60c1f46ff03ea0b0741afe673
+size 95846

--- a/docs/solutions/reference-designs/ev-cog-ad4050lz/images/build_icon.jpg
+++ b/docs/solutions/reference-designs/ev-cog-ad4050lz/images/build_icon.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8bc2617a7cc8e159792ef9cf131dead944d45e53df3658c2fdd44f4e9e71c665
+size 8155

--- a/docs/solutions/reference-designs/ev-cog-ad4050lz/images/c1-conn-mapping.png
+++ b/docs/solutions/reference-designs/ev-cog-ad4050lz/images/c1-conn-mapping.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fca315597a717e9c928dcb4105b80f871bbe91eb341920e9715ff035ed13ec60
+size 94457

--- a/docs/solutions/reference-designs/ev-cog-ad4050lz/images/c2-conn-mapping.png
+++ b/docs/solutions/reference-designs/ev-cog-ad4050lz/images/c2-conn-mapping.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9e64cc196eaea73694bb0857c0f5a4f53d1f13efddcb7b2287a81689464ddaa0
+size 87392

--- a/docs/solutions/reference-designs/ev-cog-ad4050lz/images/c_persp.jpg
+++ b/docs/solutions/reference-designs/ev-cog-ad4050lz/images/c_persp.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7741de2e28ce2865c4452b9b1158f7514738bf6766c21750d9c64a9689e45378
+size 8597

--- a/docs/solutions/reference-designs/ev-cog-ad4050lz/images/cmsis_pack_install_1.png
+++ b/docs/solutions/reference-designs/ev-cog-ad4050lz/images/cmsis_pack_install_1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5d4c2a56a8a3fc42ec94143c33ae5de9b23c04521aa46650e44efd60333d4241
+size 80905

--- a/docs/solutions/reference-designs/ev-cog-ad4050lz/images/cmsis_pack_install_2.png
+++ b/docs/solutions/reference-designs/ev-cog-ad4050lz/images/cmsis_pack_install_2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bffadcc381f6552810302dba2328dfc92f85628d3f204304ea06a898e965096f
+size 16063

--- a/docs/solutions/reference-designs/ev-cog-ad4050lz/images/cmsis_pack_install_3.png
+++ b/docs/solutions/reference-designs/ev-cog-ad4050lz/images/cmsis_pack_install_3.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f371570e5e2b580fa2c133cf25791e0cb4819930fdfa086aaa9da68ad907c7b3
+size 42478

--- a/docs/solutions/reference-designs/ev-cog-ad4050lz/images/cmsis_pack_manager.jpg
+++ b/docs/solutions/reference-designs/ev-cog-ad4050lz/images/cmsis_pack_manager.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:922667d361c847dd3f04e157bfbcaf86e94f606652faa103ee294dbde0515f81
+size 274420

--- a/docs/solutions/reference-designs/ev-cog-ad4050lz/images/cog_jumpers_annotated.png
+++ b/docs/solutions/reference-designs/ev-cog-ad4050lz/images/cog_jumpers_annotated.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a6d85a25cdec27591be9408de59585007cf7e0c7f4e06bc283b4512a86827179
+size 26407

--- a/docs/solutions/reference-designs/ev-cog-ad4050lz/images/create_new_project_1.png
+++ b/docs/solutions/reference-designs/ev-cog-ad4050lz/images/create_new_project_1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7f679e8a601a27c6187707c3ff1dc07844c6b05fd7ca53c8fcaa00b1a4358f47
+size 40677

--- a/docs/solutions/reference-designs/ev-cog-ad4050lz/images/daplink_windows_explorer.png
+++ b/docs/solutions/reference-designs/ev-cog-ad4050lz/images/daplink_windows_explorer.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a13d3272a9eddcdeb9298a7fa9bf9b7e3bfcb841f060244680fdc59cf9e23f0b
+size 77188

--- a/docs/solutions/reference-designs/ev-cog-ad4050lz/images/debug.jpg
+++ b/docs/solutions/reference-designs/ev-cog-ad4050lz/images/debug.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a5c554276fd11eef699251605dbc9d530d705b9ba0d4871eecb0df00407b9b6c
+size 86442

--- a/docs/solutions/reference-designs/ev-cog-ad4050lz/images/debug_debug_button.png
+++ b/docs/solutions/reference-designs/ev-cog-ad4050lz/images/debug_debug_button.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ddca54c06fa6059fbd8dfe39b44f593e27eb269bfd8ebebf00a8c9ca893b7bc7
+size 474

--- a/docs/solutions/reference-designs/ev-cog-ad4050lz/images/debug_icon.jpg
+++ b/docs/solutions/reference-designs/ev-cog-ad4050lz/images/debug_icon.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:797f55b2e8fa6c2f78f22167dbc72ce97214ff1a4efccf1aeb2431a8d41985ef
+size 8124

--- a/docs/solutions/reference-designs/ev-cog-ad4050lz/images/device_drivers_install.png
+++ b/docs/solutions/reference-designs/ev-cog-ad4050lz/images/device_drivers_install.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c9ff0ca300a592c7b6b2fc4361e0e261787e01755cf476896c49bb58908c8809
+size 33050

--- a/docs/solutions/reference-designs/ev-cog-ad4050lz/images/device_drivers_install_complete.png
+++ b/docs/solutions/reference-designs/ev-cog-ad4050lz/images/device_drivers_install_complete.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:202cf81daf2751868bdf138167454e5b11f7311a6961028d01d8204e5057ea28
+size 12993

--- a/docs/solutions/reference-designs/ev-cog-ad4050lz/images/device_drivers_install_maintenance.png
+++ b/docs/solutions/reference-designs/ev-cog-ad4050lz/images/device_drivers_install_maintenance.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eabf9ad84490b4f8ce54635eb6372e4d16ae354b09d524a564904aca131476ba
+size 10079

--- a/docs/solutions/reference-designs/ev-cog-ad4050lz/images/device_drivers_install_notification.png
+++ b/docs/solutions/reference-designs/ev-cog-ad4050lz/images/device_drivers_install_notification.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1b63f3b3775b481a5a7433a1003e31de7b579401087111319f94678e459a01ba
+size 7835

--- a/docs/solutions/reference-designs/ev-cog-ad4050lz/images/example_run_1.png
+++ b/docs/solutions/reference-designs/ev-cog-ad4050lz/images/example_run_1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8de73fabba0682cadcbd2b27b0c4badb63d10847aa9427311a9b5e8e6856d958
+size 10194

--- a/docs/solutions/reference-designs/ev-cog-ad4050lz/images/example_run_2.png
+++ b/docs/solutions/reference-designs/ev-cog-ad4050lz/images/example_run_2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:844730371561d0f89ee2045b70aac5125ae827e5d910c0205c8e54e373c1f0fc
+size 25624

--- a/docs/solutions/reference-designs/ev-cog-ad4050lz/images/example_run_3.png
+++ b/docs/solutions/reference-designs/ev-cog-ad4050lz/images/example_run_3.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8b58e6b25c35f694556b127828b626206f3609d4bfe7c91400a274c4a8605877
+size 29098

--- a/docs/solutions/reference-designs/ev-cog-ad4050lz/images/img_20171030_180904.jpg
+++ b/docs/solutions/reference-designs/ev-cog-ad4050lz/images/img_20171030_180904.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e2477ab2e3fcda988d5e86c28f2c25a2be6f9612efef0453b4aa6178013d1b99
+size 2210521

--- a/docs/solutions/reference-designs/ev-cog-ad4050lz/images/import_existing_packs_icon.jpg
+++ b/docs/solutions/reference-designs/ev-cog-ad4050lz/images/import_existing_packs_icon.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5048d056fb8cc69f7445fb5cd3cac9e743cafc00a64a81bf6cbc7188cc38814b
+size 8041

--- a/docs/solutions/reference-designs/ev-cog-ad4050lz/images/maintenance_windows_explorer.png
+++ b/docs/solutions/reference-designs/ev-cog-ad4050lz/images/maintenance_windows_explorer.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9fcb8c556cc5be629098434e9e2a107e4c1af30c6fce0c7b4f46b68072bc8638
+size 78668

--- a/docs/solutions/reference-designs/ev-cog-ad4050lz/images/pack_manager.jpg
+++ b/docs/solutions/reference-designs/ev-cog-ad4050lz/images/pack_manager.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cc3b017a49c9c568ee43b99fe1698b1fd46fb432fa88bf4c2b4b8e0e4cd36503
+size 9703

--- a/docs/solutions/reference-designs/ev-cog-ad4050lz/images/perspective_switch.jpg
+++ b/docs/solutions/reference-designs/ev-cog-ad4050lz/images/perspective_switch.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bbf11264393dbca7494f6e3ddc1480d463badbdcf66fb893012df2cddfbc9709
+size 40520

--- a/docs/solutions/reference-designs/ev-cog-ad4050lz/images/run_button.png
+++ b/docs/solutions/reference-designs/ev-cog-ad4050lz/images/run_button.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:563116d923b708a4060e25c6b34d5c27b0331cdb238f39ce416d3dffaad4bf81
+size 463

--- a/docs/solutions/reference-designs/ev-cog-ad4050lz/images/run_icon.jpg
+++ b/docs/solutions/reference-designs/ev-cog-ad4050lz/images/run_icon.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a6c7308b0465defd157a4af040d46e5442c45be58e8cc0e042243752e1c46c84
+size 8002

--- a/docs/solutions/reference-designs/ev-cog-ad4050lz/images/semihosting.jpg
+++ b/docs/solutions/reference-designs/ev-cog-ad4050lz/images/semihosting.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e7d9e2dedb5fba021803446da155597fda3cf8e195f813e6c59777c300ee6f66
+size 33588

--- a/docs/solutions/reference-designs/ev-cog-ad4050lz/images/shuntjumpersettingchange_1.png
+++ b/docs/solutions/reference-designs/ev-cog-ad4050lz/images/shuntjumpersettingchange_1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a8a7530b1ce3de804fc60ba77a749c486e70ee3aacd91c371d06947cac71bacb
+size 222755

--- a/docs/solutions/reference-designs/ev-cog-ad4050lz/images/solderjumpersettingchange_1.png
+++ b/docs/solutions/reference-designs/ev-cog-ad4050lz/images/solderjumpersettingchange_1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a1249fac3c590226aaf347e2734cfaa9d67aa5b60d84ac5c12e9f5ab1a134673
+size 347430

--- a/docs/solutions/reference-designs/ev-cog-ad4050lz/index.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad4050lz/index.rst
@@ -1,8 +1,27 @@
-EV-COG-AD4050LZ
-===============
+.. _ev_cog_ad4050lz eval:
+
+EV COG AD4050LZ
+===========================================================================================
+
+.. TODO: Add a picture of the chip/board
+
+Overview
+-------------------------------------------------------------------------------
+
+.. TODO: Describe in max 10 rows the main features and applications.
+
+Features:
+
+- feature 1
+- feature 2
+
+Applications:
+
+- application 1
+- application 2
 
 .. toctree::
-   :titlesonly:
+   :hidden:
 
    cog_hw_userguide
    example_project
@@ -19,3 +38,22 @@ EV-COG-AD4050LZ
    tools/cces_download
    tools/hardware_usb
    tools_driver
+
+Recommendations
+-------------------------------------------------------------------------------
+
+People who follow the flow that is outlined, have a much better experience with
+things. However, like many things, documentation is never as complete as it
+should be. If you have any questions, feel free to ask on our
+:ref:`EngineerZone forums <help-and-support>`, but before that, please make
+sure you read our documentation thoroughly.
+
+Warning
+-------------------------------------------------------------------------------
+
+.. esd-warning::
+
+Help and support
+-------------------------------------------------------------------------------
+
+Please go to :ref:`Help and Support <help-and-support>` page.

--- a/docs/solutions/reference-designs/ev-cog-ad4050lz/index.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad4050lz/index.rst
@@ -1,0 +1,21 @@
+EV-COG-AD4050LZ
+===============
+
+.. toctree::
+   :titlesonly:
+
+   cog_hw_userguide
+   example_project
+   help_support
+   hw_details
+   introduction
+   packs_bsp
+   quickstart
+   quickstart_guide/cces
+   quickstart_guide/iar
+   software/aducm4x50
+   software/eval-cog-ad4050lz
+   software/sensors
+   tools/cces_download
+   tools/hardware_usb
+   tools_driver

--- a/docs/solutions/reference-designs/ev-cog-ad4050lz/introduction.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad4050lz/introduction.rst
@@ -1,0 +1,20 @@
+Introduction
+============
+
+The :adi:`EV-COG-AD4050LZ` is a modular Internet of Things (IOT) development platform based on the :adi:`ADUCM4050` ultra low power microcontroller (MCU) with integrated power management for processing, control, and connectivity. The MCU system is based on the ARM Cortex-M4F processor, a collection of digital peripherals, embedded SRAM and flash memory, and an analog subsystem which provides clocking, reset, and power management capability in addition to an analog-to-digital converter (ADC) subsystem. The :adi:`ADUCM4050` has industry leading ultra low power which makes it ideal for developing battery powered and self powered wireless sensor nodes. The *Cog* platform uses CrossCore Embedded Studio, an open source Eclipse based Interactive Development Environment (IDE), which can be downloaded free of charge. The platform contains many hardware and software example projects to make it easier for customers to prototype and create connected systems and solutions for Internet of Things (IoT) applications.
+
+.. image:: images/11082017-mcu-cog-revb-horizontal-concept.png
+
+The *Cog* IOT development kit is modular in nature and comprises of:
+
+-  An MCU *Cog* (such as the `EV-COG-AD4050LZ <https://wiki.analog.com/resources/eval/user-guides/eval-cog-ad4050lz/cog_hw_userguide>`_) which has an on-board debugger and test-points for monitoring energy consumption.
+-  An optional connectivity *Cog* (such as the `EV-COG-BLEINTP1Z <https://wiki.analog.com/resources/eval/user-guides/eval-cog-ad3029lz/ev-cog-interposer>`_) which offers BTLE, LPWAN or WiFi connectivity options.
+-  An optional application specific add-on board (*Gear*) which might have an optimized sensor signal chain, specific to the use-case. For example - an add-on board targeted at smart agriculture use-cases might have Light, Temperature and Humidity Sensors. For initial prototyping, a specialized Gear is available which provides access to Arduino and PMOD connectors in addition to debug connectors - see `EV-GEAR-EXPANDER1Z <https://wiki.analog.com/resources/eval/user-guides/eval-cog-ad3029lz/ev-gear-expander>`_.
+
+This modular nature is depicted in the concept sketches below.
+
+.. image:: images/11082017-mcu-cog-revb-stacking.png
+
+| End Document
+
+`Back <https://wiki.analog.com/resources/eval/user-guides/ev-cog-ad4050lz>`_

--- a/docs/solutions/reference-designs/ev-cog-ad4050lz/packs_bsp.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad4050lz/packs_bsp.rst
@@ -1,0 +1,34 @@
+Software Packs & Board Support Package
+======================================
+
+A modular software framework is provided for quick application prototyping.
+Based on the application use case, developers need to download the respective
+software packs.
+
+.. important::
+
+   Please make sure you install either of the below toolchain before installing
+   any of the below packs
+
+   
+   -  IAR Embedded Workbench for ARM 8.20.1 or higher
+   -  CrossCore Embedded Studio 2.7.0 ® or higher
+   
+
+The Cog software development kit consists of the following packs:-
+
+-  :doc:`Analog Devices ADuCM4x50 Device Support </solutions/reference-designs/ev-cog-ad4050lz/software/aducm4x50>` - This is a bare minimum pack required to enable working with ADuCM4050 and develop simple applications using the on-chip drivers.
+
+   -  *Version History*
+
+      -  **Version: 3.1.0** - Extended support for IAR Embedded Workbench and Keil uVision. **[Latest]**
+
+-  :doc:`Analog Devices EV-COG-AD4050 Off-Chip Drivers and Examples </solutions/reference-designs/ev-cog-ad4050lz/software/eval-cog-ad4050lz>` - This pack along with the DFP is required to develop applications using the on-board drivers.
+
+   -  *Version History*
+
+      -  **Version 3.1.0** - Extended support for IAR Embedded Workbench.\ **[Latest]**
+
+| End Document
+
+`Back <https://wiki.analog.com/resources/eval/user-guides/ev-cog-ad4050lz>`_

--- a/docs/solutions/reference-designs/ev-cog-ad4050lz/packs_bsp.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad4050lz/packs_bsp.rst
@@ -27,8 +27,4 @@ The Cog software development kit consists of the following packs:-
 
    -  *Version History*
 
-      -  **Version 3.1.0** - Extended support for IAR Embedded Workbench.\ **[Latest]**
-
-| End Document
-
-`Back <https://wiki.analog.com/resources/eval/user-guides/ev-cog-ad4050lz>`_
+      -  **Version 3.1.0** - Extended support for IAR Embedded Workbench. **[Latest]**

--- a/docs/solutions/reference-designs/ev-cog-ad4050lz/quickstart.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad4050lz/quickstart.rst
@@ -24,6 +24,3 @@ Click below link to go to CrossCore Embedded Studio userguide.
 
 :doc:`EV-COG-AD4050LZ with IAR Embedded Workbench for ARM </solutions/reference-designs/ev-cog-ad4050lz/quickstart_guide/iar>`
 
-`Back <https://wiki.analog.com/resources/eval/user-guides/ev-cog-ad4050lz>`_
-
-| End Document

--- a/docs/solutions/reference-designs/ev-cog-ad4050lz/quickstart.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad4050lz/quickstart.rst
@@ -1,0 +1,29 @@
+MCU Cog Quick Start Guide
+=========================
+
+Setting up EV-COG-AD4050LZ is a three step process.
+
+-  IDE Setup
+-  Software Packs & Drivers Setup
+-  Running an Example Project
+
+EV-COG-AD4050LZ can be used with following Toolchains. Please see below links
+for the quickstart guide with respect to different IDEs.
+
+CrossCore Embedded Studio
+-------------------------
+
+Click below link to go to CrossCore Embedded Studio userguide.
+
+:doc:`EV-COG-AD4050LZ with CrossCore Embedded Studio </solutions/reference-designs/ev-cog-ad4050lz/quickstart_guide/cces>`
+
+IAR Embedded Workbench for ARM
+------------------------------
+
+Click below link to go to CrossCore Embedded Studio userguide.
+
+:doc:`EV-COG-AD4050LZ with IAR Embedded Workbench for ARM </solutions/reference-designs/ev-cog-ad4050lz/quickstart_guide/iar>`
+
+`Back <https://wiki.analog.com/resources/eval/user-guides/ev-cog-ad4050lz>`_
+
+| End Document

--- a/docs/solutions/reference-designs/ev-cog-ad4050lz/quickstart_guide/cces.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad4050lz/quickstart_guide/cces.rst
@@ -1,0 +1,84 @@
+EV-COG-AD4050LZ with CrossCore Embedded Studio
+==============================================
+
+IDE Setup
+---------
+
+-  Install Cross Core Embedded Studio
+
+   -  `CrossCore Embedded Studio 2.7.0 for Windows <http://download.analog.com/tools/CrossCoreEmbeddedStudio/Releases/Release_2.7.0/ADI_CrossCoreEmbeddedStudio-Rel2.7.0.exe>`_
+   -  `CrossCore Embedded Studio 2.7.0 for Ubuntu Linux 14.04 x86 <http://download.analog.com/tools/CrossCoreEmbeddedStudio/Releases/Release_2.7.0/adi-CrossCoreEmbeddedStudio-linux-x86-2.7.0.deb>`_
+
+-  License Installation
+
+   -  Start CCES and navigate to Help -> Manage Licenses.
+   -  Click New and enter the license key provided with the EV-COG-AD4050LZ box.
+   -  Follow the on-screen instructions to register and activate the license.
+
+Software Packs and Driver Setup
+-------------------------------
+
+-  Download the following packs for EV-COG-AD4050LZ
+
+   -  `ARM CMSIS Pack <https://keilpack.azureedge.net/pack/ARM.CMSIS.5.1.1.pack>`_
+   -  `Analog Devices ADuCM4050_DFP Pack 3.2.0 (Latest) <http://download.analog.com/tools/EZBoards/ADuCM4050/Releases/AnalogDevices.ADuCM4x50_DFP.3.2.0.pack>`_
+   -  `Analog Devices EV-COG-AD4050 Off-Chip Drivers and Examples 3.1.0 (Latest) <http://download.analog.com/tools/EZBoards/COG_4050/Releases/AnalogDevices.EV-COG-AD4050LZ_BSP.3.1.0.pack>`_
+
+-  Start CrossCore Embedded Studio.
+-  Go to CMSIS Pack Manager by navigating to Windows ->Perspective ->Open Perspective ->Others -> CMSIS Pack Manager.
+-  Click Import Existing Packs icon |image1|.\ `Refer for more details <https://wiki.analog.com/resources/ev/user-guides/ev-cog-ad4050lz/tools/cces_guide>`_.
+-  Select all the packs and import. This will install the packs. Ignore the warnings seen on the console window. In order to remove these warnings, additional packs needs to be installed which are available in the last section of this page.
+-  Please refer to this `link <https://os.mbed.com/handbook/Windows-serial-configuration>`_ to download and install mbed serial driver on PC.
+
+Running an Example Project
+--------------------------
+
+-  Power the MCU Cog using a USB (micro-B) Cable. You should see a red LED and a
+   yellow LED turn on by default.
+
+.. image:: ../images/img_20171030_180904.jpg
+   :align: center
+   :width: 200
+
+-  In CCES IDE, click CMSIS Pack Manager icon |image2|.
+-  Select EV-COG-AD4050LZ from the Boards tab on the Left panel. (see below image)
+-  Copy button_press example from the Examples tab on the Right panel.
+
+.. image:: ../images/cmsis_pack_manager.jpg
+   :align: center
+
+-  Click C/C++ perspective icon
+
+.. image:: ../images/c_persp.jpg
+
+-  Under Project Explorer select button_press example, click build icon |image3|.
+-  Click on Debug icon |image4| once build is complete. Below are the Debug Configuration settings.
+
+.. image:: ../images/debug.jpg
+   :align: center
+   :width: 700
+
+-  Click "ok" on Perspective Switch and Semihosting Enabled window.
+
+|image5|
+
+.. image:: ../images/perspective_switch.jpg
+   :align: center
+   :width: 500
+
+-  Click run |image6| on the Debug perspective.
+-  Now press BTN1 or BTN2 on EV-COG-AD4050LZ and inspect corresponding LED.
+
+You are all set!
+
+:doc:`Back </solutions/reference-designs/ev-cog-ad4050lz/quickstart>`
+
+| End Document
+
+.. |image1| image:: ../images/import_existing_packs_icon.jpg
+.. |image2| image:: ../images/pack_manager.jpg
+.. |image3| image:: ../images/build_icon.jpg
+.. |image4| image:: ../images/debug_icon.jpg
+.. |image5| image:: ../images/semihosting.jpg
+   :width: 500
+.. |image6| image:: ../images/run_icon.jpg

--- a/docs/solutions/reference-designs/ev-cog-ad4050lz/quickstart_guide/cces.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad4050lz/quickstart_guide/cces.rst
@@ -26,7 +26,7 @@ Software Packs and Driver Setup
 
 -  Start CrossCore Embedded Studio.
 -  Go to CMSIS Pack Manager by navigating to Windows ->Perspective ->Open Perspective ->Others -> CMSIS Pack Manager.
--  Click Import Existing Packs icon |image1|.\ `Refer for more details <https://wiki.analog.com/resources/ev/user-guides/ev-cog-ad4050lz/tools/cces_guide>`_.
+-  Click Import Existing Packs icon |image1|. `Refer for more details <https://wiki.analog.com/resources/ev/user-guides/ev-cog-ad4050lz/tools/cces_guide>`_.
 -  Select all the packs and import. This will install the packs. Ignore the warnings seen on the console window. In order to remove these warnings, additional packs needs to be installed which are available in the last section of this page.
 -  Please refer to this `link <https://os.mbed.com/handbook/Windows-serial-configuration>`_ to download and install mbed serial driver on PC.
 
@@ -70,10 +70,6 @@ Running an Example Project
 -  Now press BTN1 or BTN2 on EV-COG-AD4050LZ and inspect corresponding LED.
 
 You are all set!
-
-:doc:`Back </solutions/reference-designs/ev-cog-ad4050lz/quickstart>`
-
-| End Document
 
 .. |image1| image:: ../images/import_existing_packs_icon.jpg
 .. |image2| image:: ../images/pack_manager.jpg

--- a/docs/solutions/reference-designs/ev-cog-ad4050lz/quickstart_guide/iar.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad4050lz/quickstart_guide/iar.rst
@@ -76,15 +76,11 @@ Running an Example Project
    :width: 700
 
 -  Save the project to the desired location.
--  Click on 'Debug and Download' icon |image1|\ on the menu bar. This will compile, build and download the project on EV-COG-AD4050LZ using CMSIS-DAP.
+-  Click on 'Debug and Download' icon |image1| on the menu bar. This will compile, build and download the project on EV-COG-AD4050LZ using CMSIS-DAP.
 -  Click on 'Run' icon |image2| to start the debug session.
 -  Now press BTN1 or BTN2 on EV-COG-AD4050LZ and inspect corresponding LED
 
 You are all set!
-
-:doc:`Back </solutions/reference-designs/ev-cog-ad4050lz/quickstart>`
-
-| End Document
 
 .. |image1| image:: ../images/debug_debug_button.png
 .. |image2| image:: ../images/run_button.png

--- a/docs/solutions/reference-designs/ev-cog-ad4050lz/quickstart_guide/iar.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad4050lz/quickstart_guide/iar.rst
@@ -1,0 +1,90 @@
+EV-COG-AD4050LZ with IAR Embedded Workbench for ARM
+===================================================
+
+IDE Setup
+---------
+
+-   Install IAR Embedded Workbench for ARM
+
+   -  Please visit https://www.iar.com/ to download IAR Embedded Workbench for ARM (version 8.20.1 or above).
+
+-   License Installation
+
+   -  Make sure valid license is installed for the corresponding version.
+
+Software Packs and Driver Setup
+-------------------------------
+
+-  Download the following packs for EV-COG-AD4050LZ
+
+   -  `ARM CMSIS Pack <https://keilpack.azureedge.net/pack/ARM.CMSIS.5.2.0.pack>`_
+
+      -  `Analog Devices ADuCM4050_DFP Pack 3.2.0 (Latest) <http://www.keil.com/dd2/pack>`_
+      -  `Analog Devices EV-COG-AD4050 Off-Chip Drivers and Examples 3.1.0 (Latest) <http://download.analog.com/tools/EZBoards/COG_4050/Releases/AnalogDevices.EV-COG-AD4050LZ_BSP.3.1.0.pack>`_
+
+-  Start IAR Embedded Workbench for ARM.
+-  Go to Project-> CMSIS-Pack-> Pack Installer.
+
+.. image:: ../images/cmsis_pack_install_1.png
+   :align: center
+   :width: 750
+
+-  In **'CMSIS Pack Manager'** window, click 'Install local pack file'.
+
+.. image:: ../images/cmsis_pack_install_2.png
+   :align: center
+   :width: 700
+
+-  In 'Pack file to install' window navigate to the downloaded pack (as already
+   done in step 1 of this section), select all the packs to install and click
+   Open.
+
+.. image:: ../images/cmsis_pack_install_3.png
+   :align: center
+   :width: 700
+
+Running an Example Project
+--------------------------
+
+-  Power the MCU Cog using a USB (micro-B) Cable. You should see a red LED and a
+   yellow LED turn on by default.
+
+.. image:: ../images/img_20171030_180904.jpg
+   :align: center
+   :width: 200
+
+-  In IAR IDE, go to Project-> Create New Project...
+
+.. image:: ../images/create_new_project_1.png
+   :align: center
+
+-  In **'Create New Project'** window, Select **'CMSIS Pack Example'** and click 'OK'.
+
+.. image:: ../images/example_run_1.png
+   :align: center
+
+-  Expand Analog Devices, select **ADuCM4050** and click 'Next'.
+
+.. image:: ../images/example_run_2.png
+   :align: center
+   :width: 700
+
+-  Select **button_press** example and click 'Finish'.
+
+.. image:: ../images/example_run_3.png
+   :align: center
+   :width: 700
+
+-  Save the project to the desired location.
+-  Click on 'Debug and Download' icon |image1|\ on the menu bar. This will compile, build and download the project on EV-COG-AD4050LZ using CMSIS-DAP.
+-  Click on 'Run' icon |image2| to start the debug session.
+-  Now press BTN1 or BTN2 on EV-COG-AD4050LZ and inspect corresponding LED
+
+You are all set!
+
+:doc:`Back </solutions/reference-designs/ev-cog-ad4050lz/quickstart>`
+
+| End Document
+
+.. |image1| image:: ../images/debug_debug_button.png
+.. |image2| image:: ../images/run_button.png

--- a/docs/solutions/reference-designs/ev-cog-ad4050lz/resources/aducm4050_cog_schematic.pdf
+++ b/docs/solutions/reference-designs/ev-cog-ad4050lz/resources/aducm4050_cog_schematic.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ff2a9c19f93994d10a9d00fdf8bd374f3a0e3dbae514b62a76ee20411fce549a
+size 550016

--- a/docs/solutions/reference-designs/ev-cog-ad4050lz/resources/analogdevices.aducm4x50_ez_kit_bsp.3.1.1.zip
+++ b/docs/solutions/reference-designs/ev-cog-ad4050lz/resources/analogdevices.aducm4x50_ez_kit_bsp.3.1.1.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:56f33ee10a62c6c1d7f3403bfa22e8509ad37d80393dd4a62a9910512bae9656
+size 12052742

--- a/docs/solutions/reference-designs/ev-cog-ad4050lz/resources/ev-cog-ad4050lz.zip
+++ b/docs/solutions/reference-designs/ev-cog-ad4050lz/resources/ev-cog-ad4050lz.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:834b8e16d9650dbcd647685552e132329a2bcb8ffdcaa81bdc0fa2482278259c
+size 65860

--- a/docs/solutions/reference-designs/ev-cog-ad4050lz/resources/ev-cog-ad4050lzboarddesigndatabase.zip
+++ b/docs/solutions/reference-designs/ev-cog-ad4050lz/resources/ev-cog-ad4050lzboarddesigndatabase.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6ae82cca6d4fd83848b8cd3540949fc1e265a1f9511db9bbd8343e2d8b8649c0
+size 7775753

--- a/docs/solutions/reference-designs/ev-cog-ad4050lz/resources/geartemplatedesigndatabase.zip
+++ b/docs/solutions/reference-designs/ev-cog-ad4050lz/resources/geartemplatedesigndatabase.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:58d8879d58e551ed79b1d2bfa98dd5cc907a819853bc0daa0cd8ebd009d4d69a
+size 323517

--- a/docs/solutions/reference-designs/ev-cog-ad4050lz/software/aducm4x50.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad4050lz/software/aducm4x50.rst
@@ -1,0 +1,80 @@
+ADuCM4x50 On-Chip Peripherals Drivers & Software
+================================================
+
+General Description/Overview
+----------------------------
+
+The ADuCM4x50 Device Family Pack (DFP) provides access to all the necessary on-chip peripheral drivers for :adi:`ADuCM4050` devices. This software layer is the foundation layer needed when writing applications using this microprocessor family. When combined with the **EV-COG-AD4050LZ** software pack as well as the Sensors software pack, there are many great **Internet of Things(IoT)** applications and demos that can be replicated using the **EV-COG-AD4050LZ** development platform.
+
+The following on-chip drivers are provided as part of the ADuCM4x50 Device
+Family Pack:
+
+-  spi
+
+.. image:: ../images/aducm4050-fbl.png
+   :align: right
+   :width: 600
+
+-  i2c
+-  uart
+-  sport
+-  beep
+-  wdt
+-  gpio
+-  rtc
+-  dma
+-  crypto
+-  adc
+-  tmr
+
+For detailed information regarding the ADuCM4x50 DFP, please see our complete
+ADuCM4x50 software user guide.
+
+.. hint::
+
+   
+   -  `ADuCM4050 DFP 3.2.0 Release Notes <http://download.analog.com/tools/EZBoards/ADuCM4050/Releases/DeviceFamilyPack/Release_3.2.0/ADuCM4x50_DFP_3.2.0_Release_Notes.pdf>`_
+   -  `ADuCM4050 DFP 3.1.2 Release Notes <http://download.analog.com/tools/EZBoards/ADuCM4050/Releases/DeviceFamilyPack/Release_3.1.2/ADuCM4x50_DFP_3.1.2_Release_Notes.pdf>`_
+   -  `ADuCM4050 DFP 3.1.0 Release Notes <http://download.analog.com/tools/EZBoards/ADuCM4050/Releases/DeviceFamilyPack/Release_3.1.0/ADuCM4x50_DFP_3.1.0_Release_Notes.pdf>`_
+   -  `ADuCM4050 DFP 1.0.0 Release Notes <http://download.analog.com/tools/EZBoards/ADuCM4050/Releases/DeviceFamilyPack/Release_1.0.0/ADuCM4x50_DFP_1.0.0_Release_Notes.pdf>`_
+   
+
+.. important::
+
+   
+   You MUST have this software package installed on your laptop or PC in order
+   to compile, debug, and run the applications for the EV-COG-AD4050LZ platform.
+   
+
+Downloading the ADuCM4x50 Software Pack
+---------------------------------------
+
+The software pack can be installed directly by the tool chain's CMSIS pack
+manager. Optionally, you may download and then use the CMSIS pack manager's
+manual installation to install the pack.
+
+-  Downloaded via the tool chain's CMSIS pack manager
+
+   -  It is **recommended** to download the ADuCM4x50 software pack through from the tool chain's CMSIS pack manager. That way, all the files, directories structure, and project structure for the various applications is properly saved and accessed. For a detailed description on how to download the ADuCM4x50 software pack through CrossCore Embedded Studio please see our `CrossCore Embedded Studio Quickstart Userguide <https://wiki.analog.com/resources/ev/user-guides/ev-cog-ad4050lz/tools/cces_guide>`_.
+
+-  Downloaded to local directory
+
+   -  However if you do decide to download the ADuCM4x50 software pack to your
+      PC/laptop directly, please use the link below to download the pack file
+      from Keil's website. You will then need to "import" the pack file using
+      your tool chain's CMSIS pack manager's import feature. Note that all
+      software packs can be downloaded from Keil's website.
+
+.. admonition:: Download
+   :class: download
+
+   
+   -  `ADuCM4050_DFP Pack 3.2.0 (Latest) <http://download.analog.com/tools/EZBoards/ADuCM4050/Releases/AnalogDevices.ADuCM4x50_DFP.3.2.0.pack>`_
+   -  `ADuCM4050_DFP Pack 3.1.2 <http://download.analog.com/tools/EZBoards/ADuCM4050/Releases/AnalogDevices.ADuCM4x50_DFP.3.1.2.pack>`_
+   -  `ADuCM4050_DFP Pack 3.1.0 <http://download.analog.com/tools/EZBoards/ADuCM4050/Releases/AnalogDevices.ADuCM4x50_DFP.3.1.0.pack>`_
+   -  `ADuCM4050_DFP Pack 1.0.0 <http://download.analog.com/tools/EZBoards/ADuCM4050/Releases/DeviceFamilyPack/Release_1.0.0/ADuCM4x50_Device_Family_Pack-Rel1.0.0.zip>`_
+   
+
+*End of Document*
+
+`Back <https://wiki.analog.com/resources/eval/user-guides/ev-cog-ad4050w>`_

--- a/docs/solutions/reference-designs/ev-cog-ad4050lz/software/aducm4x50.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad4050lz/software/aducm4x50.rst
@@ -75,6 +75,3 @@ manual installation to install the pack.
    -  `ADuCM4050_DFP Pack 1.0.0 <http://download.analog.com/tools/EZBoards/ADuCM4050/Releases/DeviceFamilyPack/Release_1.0.0/ADuCM4x50_Device_Family_Pack-Rel1.0.0.zip>`_
    
 
-*End of Document*
-
-`Back <https://wiki.analog.com/resources/eval/user-guides/ev-cog-ad4050w>`_

--- a/docs/solutions/reference-designs/ev-cog-ad4050lz/software/eval-cog-ad4050lz.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad4050lz/software/eval-cog-ad4050lz.rst
@@ -73,6 +73,3 @@ The software pack can be downloaded in following ways.
    -  `AnalogDevices.ADuCM4x50_EZ_KIT_BSP.3.1.1 <../resources/analogdevices.aducm4x50_ez_kit_bsp.3.1.1.zip>`_
    
 
-*End of Document*
-
-`Back <https://wiki.analog.com/resources/eval/user-guides/ev-cog-ad4050lz>`_

--- a/docs/solutions/reference-designs/ev-cog-ad4050lz/software/eval-cog-ad4050lz.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad4050lz/software/eval-cog-ad4050lz.rst
@@ -1,0 +1,78 @@
+EV-COG-AD4050LZ On-Board Peripheral Drivers & Software
+======================================================
+
+General Description/Overview
+----------------------------
+
+The **EV-COG-AD4050LZ** software pack provides access to all the necessary on-board peripheral drivers for the :adi:`EV-COG-AD4050LZ` development platform. This software layer is the secondary layer needed when writing applications using this development platform. The **EV-COG-AD4050LZ** software pack builds on top of what the ADuCM4x50 software pack provides. The **EV-COG-AD4050LZ** software pack makes it easier to use the on-board peripherals so creating your application layer is will be easier. Combined with the ADuCM4x50 and Sensors software pack, there are many great Internet of Things(IoT) applications and demos that can be replicated using the **EV-COG-AD4050LZ** development platform.
+
+The drivers and examples in the BSP are designed to work with CrossCore Embedded
+Studio 2.6.0 ® and the ADuCM4x50 Device Family Pack.
+
+EV-COG-AD4050LZ software pack contains the following components:
+
+-  On-Chip Driver Examples ( GPIO,RTC, SPI, Systick, TMR, UART, WDT)
+-  Documentation
+
+For detailed information regarding the EV-COG-AD4050LZ software pack, please see
+our complete EV-COG-AD4050LZ software user guide.
+
+.. hint::
+
+   
+   -  `EV-COG-AD4050LZ BSP 3.1.0 Release Notes <http://download.analog.com/tools/EZBoards/COG_4050/Releases/Release_3.1.0/EV-COG-AD4050LZ_3.1.0_Release_Notes.pdf>`_
+   -  `EV-COG-AD4050LZ BSP 1.0.0 Release Notes <http://download.analog.com/tools/EZBoards/COG_4050/Releases/Release_1.0.0/EV-COG-AD4050LZ_1.0.0_Release_Notes.pdf>`_
+   
+
+.. important::
+
+   
+   You MUST have this software package installed on your laptop or PC in order
+   to compile, debug, and run the applications for the EV-COG-AD4050LZ platform.
+   
+
+Downloading the EV-COG-AD4050LZ Software Pack
+---------------------------------------------
+
+The software pack can be downloaded in following ways.
+
+-  Downloaded via the tools program
+
+   -  It is **recommended** to download the EV-COG-AD4050LZ software pack through from the tools program you are using. That way, all the files, directories structure, and project structure for the various applications is properly saved and accessed. For a detailed description on how to download the EV-COG-AD4050LZ software pack through CrossCore Embedded Studio please see our `CrossCore Embedded Studio Quickstart Userguide <https://wiki.analog.com/resources/ev/user-guides/ev-cog-ad4050lz/tools/cces_guide>`_.
+
+-  Downloaded to local directory
+
+   -  However if you do decide to download the EV-COG-AD4050LZ software pack to
+      your PC/laptop directly, please use the link below, and make sure you save
+      the software pack to the correct local directory for your
+      applications/projects.
+
+.. admonition:: Download
+   :class: download
+
+   
+   Download EV-COG-AD4050LZ Board Support Pack.
+   
+   -  `EV-COG-AD4050LZ BSP 3.1.0 (Latest) <http://download.analog.com/tools/EZBoards/COG_4050/Releases/AnalogDevices.EV-COG-AD4050LZ_BSP.3.1.0.pack>`_
+   -  `EV-COG-AD4050LZ BSP 1.0.0 <http://download.analog.com/tools/EZBoards/COG_4050/Releases/AnalogDevices.EV-COG-AD4050LZ_BSP.1.0.0.pack>`_
+   
+
+-  If you are looking for additional **Application Example Codes**, you can download the ADuCM4x50 EZ KIT software pack.
+
+.. important::
+
+   This Board Support Pack is Deprecated already and basically not intended for
+   EV-COG-AD4050LZ but you may use it for reference only.
+
+.. admonition:: Download
+   :class: download
+
+   
+   Download ADuCM4x50 EZ KIT Board Support Pack.
+   
+   -  `AnalogDevices.ADuCM4x50_EZ_KIT_BSP.3.1.1 <../resources/analogdevices.aducm4x50_ez_kit_bsp.3.1.1.zip>`_
+   
+
+*End of Document*
+
+`Back <https://wiki.analog.com/resources/eval/user-guides/ev-cog-ad4050lz>`_

--- a/docs/solutions/reference-designs/ev-cog-ad4050lz/software/sensors.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad4050lz/software/sensors.rst
@@ -56,6 +56,3 @@ The software pack can be downloaded in following ways.
    `Sensor Software Pack 1.1.0 <http://download.analog.com/tools/Sensor_Software/Releases/AnalogDevices.ADI-SensorSoftware.1.1.0.pack>`_
    
 
-*End of Document*
-
-`Back <https://wiki.analog.com/resources/eval/user-guides/ev-cog-ad4050lz>`_

--- a/docs/solutions/reference-designs/ev-cog-ad4050lz/software/sensors.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad4050lz/software/sensors.rst
@@ -1,0 +1,61 @@
+Sensor Application Software Packs and Drivers
+=============================================
+
+General Description/Overview
+----------------------------
+
+Sensor software pack contains sensor software components. Sensor components are based on the sensor classes which abstract the functionality across sensor types. The Sensors software pack provides access to all the necessary add-on module digital drivers that attach to the :adi:`EV-COG-AD4050LZ` development platform. This software layer is the highest layer of abstraction from the microprocessor, and because of this can be useful to jump start code development for your application using any microprocessor. For example, if you are using the ADXL362, the Sensor software pack contains drivers and code snippets on the application level, so that can be transported to other microprocessor, with confidence that Analog Devices provided the application framework pieces. When combined with the :adi:`ADuCM4050` and :adi:`EV-COG-AD4050LZ` software packs there are many great Internet of Things(IoT) applications.
+
+ADI Sensor Software requires CrossCore Embedded Studio 2.6.0 ® , ADuCM4050
+Device Family Pack 2.0.0 and EV-COG-AD4050LZ Board Support Package 1.0.0.
+
+The following application examples and sensor drivers are provided as part of
+the Sensor software pack:
+
+-  Accelerometer Demo
+-  Temperature Sensor Demo
+
+For detailed information regarding the Sensor software pack, please see our
+complete Sensor software user guide.
+
+.. hint::
+
+   
+   ADD LINK HERE Sensor Software Pack Release Notes.
+   
+
+.. important::
+
+   
+   You MUST have this software package installed on your laptop or PC in order
+   to compile, debug, and run the applications for the EV-COG-AD4050LZ platform.
+   
+
+Downloading the Sensor Software Pack
+------------------------------------
+
+The software pack can be downloaded in following ways.
+
+-  Downloaded via the tools program
+
+   -  It is **recommended** to download the Sensor software pack through from the tools program you are using. That way, all the files, directories structure, and project structure for the various applications is properly saved and accessed. For a detailed description on how to download the Sensor software pack through CrossCore Embedded Studio please see our `CrossCore Embedded Studio Quickstart Userguide <https://wiki.analog.com/resources/ev/user-guides/ev-cog-ad4050lz/tools/cces_guide>`_.
+
+-  Downloaded to local directory
+
+   -  However if you do decide to download the Sensor software pack to your
+      PC/laptop directly, please use the link below, and make sure you save the
+      software pack to the correct local directory for your
+      applications/projects.
+
+.. admonition:: Download
+   :class: download
+
+   Download the Sensor Software Pack.
+
+   
+   `Sensor Software Pack 1.1.0 <http://download.analog.com/tools/Sensor_Software/Releases/AnalogDevices.ADI-SensorSoftware.1.1.0.pack>`_
+   
+
+*End of Document*
+
+`Back <https://wiki.analog.com/resources/eval/user-guides/ev-cog-ad4050lz>`_

--- a/docs/solutions/reference-designs/ev-cog-ad4050lz/tools/cces_download.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad4050lz/tools/cces_download.rst
@@ -1,0 +1,139 @@
+CrossCore Embedded Studio Download & Install
+============================================
+
+This page provides all the necessary steps to get CrossCore Embedded Studio
+(CCES) software environment up and running on Windows or Linux.
+
+The CCES software development environment for EV-COG-AD4050LZ is based on open
+source tools, and is maintained by Analog Devices. CCES includes support for DSP
+(digital signal processing) and ARM Cortex M- and A- devices, and includes the
+following features and many more:
+
+-  Eclipse based IDE
+-  GNU ARM Embedded Toolchain for Cortex-M core based parts (5-2016-q2-update release)
+-  OpenOCD with support for ADuCM302x and ADuCM4x50 microcontroller (open source SWD)
+-  CMSIS Pack files
+-  Mbed CMSIS-DAP
+-  J-Link Lite
+
+.. important::
+
+   CrossCore Embedded Studio is based on Eclipse, but because the MBED platform
+   provides a CMSIS-DAP interface to connect to the board, the EV-COG-AD4050LZ
+   can be used without problems with IAR Embedded Workbench IDE or Keil µVision
+   IDE as well.
+
+Pre-Requisites and Requirements List
+====================================
+
+There are a few things that you will need for the tools and software to work
+properly.
+
+-  PC or laptop computer
+-  EV-COG-AD4050LZ hardware
+-  Micro USB to USB cables
+
+.. important::
+
+   USB cable needs to have ALL data lines connected, can't use a charging only
+   micro USB cable.
+
+-  Terminal Program to interface your PC with the EV-COG-AD4050LZ
+
+   -  `Putty <http://www.chiark.greenend.org.uk/~sgtatham/putty/download.html>`_
+
+      -  `Tera Term <https://en.osdn.jp/projects/ttssh2/releases/>`_
+      -  Or other favorite Terminal program
+
+CrossCore Embedded Studio Download Packages
+===========================================
+
+.. admonition:: Download
+   :class: download
+
+   
+   The EV-COG-AD4050LZ **requires** the use of Crosscore Embedded Studios version **2.6.0 or higher**. Do not attempt to use earlier versions of the CrossCore tools, due to compatibility issues that will **damage** the EV-COG-AD3029LZ.
+   
+   `CrossCore Embedded Studio 2.7.0 Windows Installer(Executable) <http://download.analog.com/tools/CrossCoreEmbeddedStudio/Releases/Release_2.7.0/ADI_CrossCoreEmbeddedStudio-Rel2.7.0.exe>`_
+   
+   `CrossCore Embedded Studio 2.7.0 Ubuntu Linux Installer(Debian) <http://download.analog.com/tools/CrossCoreEmbeddedStudio/Releases/Release_2.7.0/adi-CrossCoreEmbeddedStudio-linux-x86-2.7.0.deb>`_
+   
+   `CrossCore Embedded Studio 2.6.0 Windows Installer(Executable) <http://download.analog.com/tools/CrossCoreEmbeddedStudio/Releases/Release_2.6.0/ADI_CrossCoreEmbeddedStudio-Rel2.6.0.exe>`_
+   
+   `CrossCore Embedded Studio 2.6.0 Ubuntu Linux Installer(Debian) <http://download.analog.com/tools/CrossCoreEmbeddedStudio/Releases/Release_2.6.0/adi-CrossCoreEmbeddedStudio-linux-x86-2.6.0.deb>`_
+   
+
+The following features are available and supported
+--------------------------------------------------
+
+-  Compilation using the GNU ARM Embedded toolchain for the ADuCM302x and ADuCM4x50 ARM Cortex-M cores.
+-  Debugging ADuCM302x and ADuCM4x50 via the IDE with GDB/OpenOCD.
+-  Development and debugging of bare-metal applications on the ADuCM302x and
+   ADuCM4x50 ARM Cortex-M core.
+
+The following features are only supported via the Windows version
+-----------------------------------------------------------------
+
+-  Use of CrossCore Embedded Studio Add-Ins other than the Linux Add-In
+-  Debugging an Application using the CrossCore Debugger (TPSDK)
+
+CrossCore Embedded Studio Installer Instructions
+================================================
+
+It is best that you save all the files/folders to the default directories
+recommended by the CrossCore Embedded Studios installer. This way all the
+instructions and support provided will be easier.
+
+Installing CrossCore Embedded Studio on Windows
+-----------------------------------------------
+
+-  To install CrossCore Embedded Studio, double-click ADI_CrossCoreEmbeddedStudio-Rel2.6.0.exe
+-  The CrossCore Embedded Studio installer will install the mBed windows serial
+   driver.
+
+   -  It is available separately, if required
+
+      -  https://developer.mbed.org/handbook/Windows-serial-configuration
+
+The executable installs all necessary components to the Analog Devices local
+directory structure which can be found below.
+
+-  CrossCore Embedded Studio installs to **C:\\Analog Devices\\CrossCore Embedded Studio 2.6.0**
+-  Eclipse IDE installs to **C:\\Analog Devices\\CrossCore Embedded Studio 2.6.0\\Eclipse**
+-  GNU ARM Embedded Toolchain for Cortex-M installs to **C:\\Analog Devices\\CrossCore Embedded Studio 2.6.0\\ARM\\gcc-arm-embedded**
+-  OpenOCD installs to **C:\\Analog Devices\\CrossCore Embedded Studio 2.6.0\\ARM\\openocd\\bin**
+-  CMSIS Pack files are installed to **C:\\Analog Devices\\CrossCore Embedded Studio 2.5.1\\ARM\\packs**
+
+Installing CrossCore Embedded Studio on Linux
+---------------------------------------------
+
+-  To install CrossCore Embedded Studio, run the command:
+
+   -  sudo dpkg -i adi-CrossCoreEmbeddedStudio-linux-x86-2.6.0.deb
+
+The Ubuntu Linux Installer(Debian) installs all necessary components to the
+Analog Devices local directory structure which can be found below.
+
+-  CrossCore Embedded Studio installs to **/opt/analog/cces/2.6.0**
+-  Eclipse IDE installs to **/opt/analog/cces/2.6.0/Eclipse**
+-  GNU ARM Embedded Toolchain for Cortex-M installs to **/opt/analog/cces/2.6.0/ARM/gcc-arm-embedded**
+-  OpenOCD installs to **/opt/analog/cces/2.6.0/ARM/openocd/bin**
+-  CMSIS Pack files are installed to **/opt/analog/cces/2.6.0/ARM/packs**
+
+Activating CrossCore Embedded Studio
+====================================
+
+The first time you launch CrossCore Embedded Studio, you will be prompted to input a serial number, name, and email address. The serial number for **ALL** EV-COG-AD4050LZ boards is:
+
+Once the serial number has been activated, the CrossCore development tools will
+allow you full and unlimited access to all the features of the tool when using
+the Analog Devices family of ARM Cortex Processor.
+
+CrossCore Embedded Studio Support
+=================================
+
+For more details on CrossCore Embedded Studio, updated versions of the tools, release notes, tools documentation, or other support. Please visit the CrossCore :adi:`webpage <cces>`, or email the CrossCore support team at `processor.tools.support@analog.com <https://wiki.analog.com/mailto/processor.tools.support@analog.com>`_
+
+*End of Document*
+
+`Back <https://wiki.analog.com/resources/eval/user-guides/ev-cog-ad4050lz>`_

--- a/docs/solutions/reference-designs/ev-cog-ad4050lz/tools/cces_download.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad4050lz/tools/cces_download.rst
@@ -24,7 +24,7 @@ following features and many more:
    IDE as well.
 
 Pre-Requisites and Requirements List
-====================================
+------------------------------------
 
 There are a few things that you will need for the tools and software to work
 properly.
@@ -46,13 +46,13 @@ properly.
       -  Or other favorite Terminal program
 
 CrossCore Embedded Studio Download Packages
-===========================================
+-------------------------------------------
 
 .. admonition:: Download
    :class: download
 
    
-   The EV-COG-AD4050LZ **requires** the use of Crosscore Embedded Studios version **2.6.0 or higher**. Do not attempt to use earlier versions of the CrossCore tools, due to compatibility issues that will **damage** the EV-COG-AD3029LZ.
+   The EV-COG-AD4050LZ **requires** the use of Crosscore Embedded Studios version **2.6.0 or higher**. Do not attempt to use earlier versions of the CrossCore tools, due to compatibility issues that will **damage** the EV-COG-AD4050LZ.
    
    `CrossCore Embedded Studio 2.7.0 Windows Installer(Executable) <http://download.analog.com/tools/CrossCoreEmbeddedStudio/Releases/Release_2.7.0/ADI_CrossCoreEmbeddedStudio-Rel2.7.0.exe>`_
    
@@ -78,7 +78,7 @@ The following features are only supported via the Windows version
 -  Debugging an Application using the CrossCore Debugger (TPSDK)
 
 CrossCore Embedded Studio Installer Instructions
-================================================
+------------------------------------------------
 
 It is best that you save all the files/folders to the default directories
 recommended by the CrossCore Embedded Studios installer. This way all the
@@ -102,7 +102,7 @@ directory structure which can be found below.
 -  Eclipse IDE installs to **C:\\Analog Devices\\CrossCore Embedded Studio 2.6.0\\Eclipse**
 -  GNU ARM Embedded Toolchain for Cortex-M installs to **C:\\Analog Devices\\CrossCore Embedded Studio 2.6.0\\ARM\\gcc-arm-embedded**
 -  OpenOCD installs to **C:\\Analog Devices\\CrossCore Embedded Studio 2.6.0\\ARM\\openocd\\bin**
--  CMSIS Pack files are installed to **C:\\Analog Devices\\CrossCore Embedded Studio 2.5.1\\ARM\\packs**
+-  CMSIS Pack files are installed to **C:\\Analog Devices\\CrossCore Embedded Studio 2.6.0\\ARM\\packs**
 
 Installing CrossCore Embedded Studio on Linux
 ---------------------------------------------
@@ -121,7 +121,7 @@ Analog Devices local directory structure which can be found below.
 -  CMSIS Pack files are installed to **/opt/analog/cces/2.6.0/ARM/packs**
 
 Activating CrossCore Embedded Studio
-====================================
+------------------------------------
 
 The first time you launch CrossCore Embedded Studio, you will be prompted to input a serial number, name, and email address. The serial number for **ALL** EV-COG-AD4050LZ boards is:
 
@@ -130,10 +130,6 @@ allow you full and unlimited access to all the features of the tool when using
 the Analog Devices family of ARM Cortex Processor.
 
 CrossCore Embedded Studio Support
-=================================
+---------------------------------
 
-For more details on CrossCore Embedded Studio, updated versions of the tools, release notes, tools documentation, or other support. Please visit the CrossCore :adi:`webpage <cces>`, or email the CrossCore support team at `processor.tools.support@analog.com <https://wiki.analog.com/mailto/processor.tools.support@analog.com>`_
-
-*End of Document*
-
-`Back <https://wiki.analog.com/resources/eval/user-guides/ev-cog-ad4050lz>`_
+For more details on CrossCore Embedded Studio, updated versions of the tools, release notes, tools documentation, or other support. Please visit the CrossCore :adi:`webpage <cces>`, or email the CrossCore support team at `processor.tools.support@analog.com <mailto:processor.tools.support@analog.com>`_

--- a/docs/solutions/reference-designs/ev-cog-ad4050lz/tools/hardware_usb.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad4050lz/tools/hardware_usb.rst
@@ -1,0 +1,111 @@
+Driver Installation for On-board Debugger (CMSIS DAP)
+=====================================================
+
+The MCU Cog has an on-board debugger which supports the `ARM CMSIS DAP <https://developer.mbed.org/handbook/CMSIS-DAP>`_ interface. When connecting up the EV-COG-AD4050LZ to your computer or laptop, all the necessary drivers are automatically located and loaded up when using Windows operating systems.
+
+There are two sets of drivers that get installed on your computer depending on
+which mode of operation the EV-COG-AD4050LZ emulator comes up.
+
+.. important::
+
+   It EXTREMELY important to ensure that all drivers are installed, before
+   trying to use the EV-COG-AD4050LZ with the CrossCore Embedded Tools. So when
+   you see that the drivers are being installed in the task bar, open it up and
+   wait till everything finished before progressing.
+
+| |image1|
+| |image2|
+
+Mass Storage Drives
+-------------------
+
+DAPLINK Drive
+~~~~~~~~~~~~~
+
+When the EV-COG-AD4050LZ emulator is connected to the ADuCM4050 and ready for
+program/debug mode, the "DAPLINK" drive is displayed on your computer.
+
+This mode allows users to drag and drop (or copy and paste) a .BIN or .HEX
+[Intel formatted] file directly into the DAPLINK drive, and that file will be
+flashed directly to the ADuCM4050. This means you don't have to use the tools or
+the debugger to program your board, making this very useful in production
+releases or updating applications already in the field.
+
+-  The PC will start searching for and install the following drivers:(if not
+   already complete)
+
+.. image:: ../images/device_drivers_install_complete.png
+   :align: center
+   :width: 400
+
+-  Then go to the **My Computer** view and search for the DAPLINK drive, if you see this then the drivers are complete and correct.
+
+.. image:: ../images/daplink_windows_explorer.png
+   :align: center
+   :width: 550
+
+-  After that simply drag and drop (or copy and paste) your .BIN or .HEX [Intel
+   formatted] file to the DAPLINK drive, and your EV-COG-AD4050LZ board will be
+   programmed.
+
+   -  Your Windows Explorer browser will close automatically
+
+-  You will need to press the RST button in order for the program to update
+
+   -  Alternatively you could unplug the micro USB cable from the USB port (P5)
+      of the EV-COG-AD4050LZ, and then reconnect it.
+
+Maintenance Drive
+~~~~~~~~~~~~~~~~~
+
+When the EV-COG-AD4050LZ emulator is connected to the MK20DX128VFM5 (by holding
+down the "RST" button while connecting the USB port (P5) to the PC/laptop) the
+"Maintenance" drive is displayed on your computer. This mode allows a user to
+overwrite the ADuCM4050 interface file within the emulator. This allows for
+patches and updates to the firmware on the emulator.
+
+-  The PC will start searching for and install the following drivers:(if not
+   already complete)
+
+.. image:: ../images/device_drivers_install_maintenance.png
+   :align: center
+   :width: 400
+
+-  Then go to the **My Computer** view and search for the Maintenance drive, if you see this then the drivers are complete and correct.
+
+.. image:: ../images/maintenance_windows_explorer.png
+   :align: center
+   :width: 550
+
+-  After that simply drag and drop (or copy and paste) the latest interface file
+   to the Maintenance drive, and your EV-COG-AD4050LZ board will be updated with
+   the latest interface file.
+
+   -  Your Windows Explorer browser will close automatically
+
+-  Unplug the micro USB cable from the USB port of the EV-COG-AD4050LZ, and then
+   reconnect the USB cable to the USB port to “reboot” the board.
+
+EV-COG-AD4050LZ Interface File Downloads
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. admonition:: Download
+   :class: download
+
+   The current EV-COG-AD4050LZ interface file can be downloaded here:
+
+   
+   `EV-COG-AD4050LZ Interface File <../resources/ev-cog-ad4050lz.zip>`_
+   
+   -  Initial version of mbed firmware for interfacing ADuCM4050 on
+      EV-COG-AD4050LZ.
+   
+
+*End of Document*
+
+`Back <https://wiki.analog.com/resources/eval/user-guides/ev-cog-ad4050lz>`_
+
+.. |image1| image:: ../images/device_drivers_install_notification.png
+   :width: 400
+.. |image2| image:: ../images/device_drivers_install.png
+   :width: 400

--- a/docs/solutions/reference-designs/ev-cog-ad4050lz/tools_driver.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad4050lz/tools_driver.rst
@@ -1,0 +1,24 @@
+Tools and Driver Details
+========================
+
+<note >There are no seperate toolchain,On-Board Peripheral Drivers & Software
+for EV-COG-AD4050WZ, the toolchain,On-Board Peripheral Drivers & Software for
+EV-COG-AD4050LZ works with EV-COG-AD4050WZ.The user needs to change only the pin
+muxing based on the application.For help regarding pinmapping refer to the
+Hardware Details section.
+
+This chapter provides all the necessary steps to download, install, and setup
+the software environment from Analog Devices. There is also information on the
+different USB modes and drivers needed.
+
+It contains two main sections:
+
+-  `CrossCore Embedded Studio Download & Install <https://wiki.analog.com/resources/eval/user-guides/ev-cog-ad4050wz/tools/cces_download>`_ - Provides all the necessary instructions on how to download and install the CrossCore Embedded Studios software development environment.
+
+   -  `CrossCore Embedded Studio Quickstart Userguide <https://wiki.analog.com/resources/ev/user-guides/ev-cog-ad4050wz/tools/cces_guide>`_ - Provides information about using the CrossCore Embedded Studios IDE, in particular, the process of importing, building, debugging, and creating user applications for the EV-COG-AD4050LZ.
+
+-  :doc:`Driver Installation for On-board Debugger (CMSIS DAP) </solutions/reference-designs/ev-cog-ad4050lz/tools/hardware_usb>` - Provides detailed information how to load pre-compiled .HEX or .BIN files using the USB drive of the EV-COG-AD4050LZ board.
+
+| End Document
+
+`Back <https://wiki.analog.com/resources/eval/user-guides/ev-cog-ad4050lz>`_


### PR DESCRIPTION
## Summary
- Move ev-cog-ad4050lz wiki documentation to `solutions/reference-designs/ev-cog-ad4050lz/`
- 16 RST files with 43 localized images
- Generated stub `index.rst` with toctree

## Test plan
- [ ] Sphinx build passes without errors
- [ ] All toctree entries resolve correctly
- [ ] Images render properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)