### PR TITLE
reference-designs/ev-cog-ad4050w: Add ev-cog-ad4050w documentation

### DIFF
--- a/docs/solutions/reference-designs/ev-cog-ad4050w/cog_hw_userguide.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad4050w/cog_hw_userguide.rst
@@ -1,0 +1,257 @@
+EV-COG-AD4050WZ MCU Cog
+=======================
+
+The EV-COG-AD4050WZ is an *MCU Cog* board for the :adi:`ADuCM4050 MCU <en/products/processors-dsp/microcontrollers/ultra-low-power-microcontrollers/aducm4050.html>`.
+
+Main Features
+-------------
+
+-  :adi:`ADuCM4050` (WLCSP package) - Ultra Low Power ARM Cortex-M4F MCU
+-  Compact form factor (3.5 cm X 7.5 cm) - Easy to deploy.
+-  On board debugger capability (CMSIS DAP compatible)
+-  Multiple power options and current monitoring test-points.
+-  On-board sensors: Accelerometer (ADXL362) and Temperature Sensor (ADT7420)
+-  Optional expansion capability - Using application specific add-on cards (*Gears*)
+-  Optional connectivity options - Using RF modules (*Connectivity Cogs*)
+
+Board
+-----
+
+Front-Side
+~~~~~~~~~~
+
+.. image:: images/wz_front_side_boldtext.png
+   :alt: wz_front_side_boldtext.png
+
+Back-Side
+~~~~~~~~~
+
+.. image:: images/wz_backside.png
+
+Power
+-----
+
+The MCU Cog board offers flexibility in terms of power supply and power muxing
+options. This is achieved with the use of jumpers on the board. The Cog board
+also offers multiple test points for monitoring current consumption.
+
+Power Supply Options
+~~~~~~~~~~~~~~~~~~~~
+
+The MCU Cog offers the following power supply options:
+
+::
+
+   -5V USB power (USB microB connector)
+   -3V CR2032 Coin cell (Cell holder - BT1)
+   -3V - 6V Rechargeable Li-Ion Battery (JST Connector - P6)
+   -3V - 6V External Supply from an MCU Cog Add-on card (via Connector C1)
+
+Power Muxing Options
+~~~~~~~~~~~~~~~~~~~~
+
+For details of the power muxing scheme, refer to the figure below.
+
+|image1|
+
+.. danger::
+
+   Do not insert shunt b/w positions 5 & 6 of JH4 when using USB supply. Doing
+   so can permanently damage this board.
+
+.. tip::
+
+   Refer to the *Jumper Settings* section further below for details on power related jumpers on the board
+
+Power Regulator
+~~~~~~~~~~~~~~~
+
+The MCU Cog board uses an on-board switching regulator - the :adi:`ADP5300 <en/products/power-management/switching-power-converters/switching-regulators/adp5300.html>`, which is a high efficiency, ultra-low power step down regulator. The MCU has complete control over the switching modes of the regulator via GPIO. The pin-mapping is shown in the table below.
+
+|direct|
+
+Current Measurement Options
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The MCU Cog enables IOT developers to measure and profile current consumption at
+different places on the board to enable isolation of current consumption
+hotspots. The current measure test points shown in the table below can be used
+along with a digital multimeter to profile current consumption.
+
+.. image:: images/24072017-tile-revb-current-test-points.png
+   :alt: 24072017-tile-revb-current-test-points.png
+
+Programming & Debug Options
+---------------------------
+
+The MCU Cog offers the following debug options:
+
+::
+
+   -On-board CMSIS-DAP debugger (USB microB connector)
+   -JLINK-9 Connector for access to SWD interface (P26)
+   -Access to SW interface to an MCU Cog Add-on card (via Connector C2)
+
+Wireless Connectivity Options
+-----------------------------
+
+The MCU Cog board offers support for ADI RF daughter-cards such as the EV-ADF70301-915AZ via the "EV-COG-BLEINTP1" connectivity Cog board that can be attached at Connector P2. This connectivity Cog board also has on-board BTLE circuit enabling the MCU Cog board to use BTLE communication as well. More details regarding wireless connectivity options are available on the `EV-COG-BLEINTP1 Wiki page <https://wiki.analog.com/resources/eval/user-guides/ev-cog-bleintp1z>`_.
+
+.. important::
+
+   UART1 is wired to RF Module. If an application wants to use UART1 for some
+   purpose other than RF module, then RF Module cannot be used.
+
+Differences between EV-COG-AD4050LZ and EV-COG-AD4050WZ
+-------------------------------------------------------
+
+::
+
+   -LFXTAL changed to a smaller footprint version
+   -Instead of UART0 being brought to the RF, UART1 is always wired to the RF module (32-pin Hirose connector).
+   -If an application needs to use UART1 as well, the RF module may not be used at the same time.
+   -As a larger number of GPIOs are attached to the expansion connector (as given in the spreadsheet), the ADF_GPIOs from the RF module connector and RF_RTC_OPC1 are not available on the expansion headers.
+   -LED2 is on GPIO47 instead of earlier GPIO42 (as GPIO42 is not available), where there was GPIO42 earlier on the expansion pin header, now there is GPIO47.
+
+Buttons/LED(s)
+--------------
+
+The MCU Cog offers 2 buttons and 2 LED(s) that can be used by the Application.
+The default GPIO connections are shown in the tables below.
+
+.. image:: images/led_button_gpio.png
+   :width: 150
+
+Expansion Connectors
+--------------------
+
+One of the USP of the MCU Cog is access to ALL GPIO via Expansion Connectors
+("C1" and "C2") for an Add-on card to utilize in its Application. This enables
+developers to confidently build final form factor hardware without having to
+worry about porting their firmware. The figures below capture the pin-mapping
+and jumpers that need to be changed to get external access (via the expansion
+connectors) to GPIO (as well as power/reset, etc).
+
+COG CONNECTORS C1 & C2
+~~~~~~~~~~~~~~~~~~~~~~
+
+.. image:: images/cog_connector.png
+
+C1 &C2 PINOUT
+^^^^^^^^^^^^^
+
+C1 & C2 from pins 1 to 28
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. image:: images/cog_upto29.png
+
+C1 & C2 from pins 29 to 60
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. image:: images/cog_upto60.png
+
+Expansion connectors pin out table
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+\*\* Differences between EV-COG-AD4050WZ and EV-COG-AD4050LZ include the differently coloured entries in the pinout table*\* |image2| |image3| |image4|
+
+|image5|
+
+Jumper Settings
+---------------
+
+The MCU Cog offers flexibility in terms of power muxing options and the facility
+to route any GPIO externally via the expansion connectors "C1" and "C2". This is
+achieved with the use of jumpers. The MCU Cog has two types of jumpers - those
+labelled "JHx" and which are 2x2 1.27mm pitch headers and those labelled "JPx"
+and which are solder jumpers. The "JHx" jumpers are expected to be used more
+frequently than the "JPx" jumpers.
+
+Jumper locations on board
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The following image of the bottom layer of the PCB highlights the jumper
+positions on the board:
+
+.. image:: images/cog_jumpers_annotated.png
+   :alt: Jumper Position
+   :align: center
+
+Note that the jumpers JH6 and JP16 on the **top** layer of the board.
+
+Changing the jumper settings
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Shunt Jumpers (JHx)
+^^^^^^^^^^^^^^^^^^^
+
+As mentioned above, the shunt jumpers are 1.27mm headers, whose pins are shorted
+using a shunt. This shunt is inserted by default in the positions as mentioned
+in the table above.
+
+To change a jumper setting, carefully remove the shunt from its position, and
+re-insert the shunt in the correct position corresponding to the pin numbers to
+be shorted. The pin numbers are mentioned on the silkscreen of the PCB (usually
+both pin 1 & 2) and thus the default positions can be located.
+
+For example JH11 controls which signal is sent to the RTC1_SS2 SensorStrobe pin.
+By default the ADXL_362_INT2 signal is connected to the SensorStrobe pin. In
+order to connect the RF module, JH11 needs to be moved from "1 and 2" to "3 and
+4". The corresponding change is shown below:
+
+.. image:: images/shuntjumpersettingchange_1.png
+   :alt: Shunt Jumper Change
+   :align: center
+
+Solder Jumpers (JPx)
+^^^^^^^^^^^^^^^^^^^^
+
+Solder jumpers are shorted using a solder blob. There are 16 such jumpers on the
+board, out of which 15 are on the bottom side of the board while 1 (JP16) is on
+the top side of the board. Positions 1, 2 and 3 are usually indicated along the
+jumpers.
+
+To change a solder jumper, using a hot soldering iron, melt the blob of solder
+and move it into the desired position (1-2 or 3-2 or 4-2).
+
+For example, GPIO30 is connected to the on board ADT7420 temperature sensor by
+default. In order to bring it out to the expander JP3 needs to be shifted from
+1-2 to 2-3. Using a soldering iron to shift the jumpers, this is how it looks
+before and after:
+
+.. image:: images/solderjumpersettingchange_1.png
+   :alt: Solder Jumper Change
+   :align: center
+
+MCU Cog Design and Integration Files
+------------------------------------
+
+.. admonition:: Download
+   :class: download
+
+   `EV-COG-AD4050WZ MCU Cog Schematics <resources/02_047385a_top.pdf>`_
+
+   
+   `EV-COG-AD4050WZ MCU Cog Layout Files & BOM <resources/20-047385-01a_3_.zip>`_
+   
+
+Add-on Template
+~~~~~~~~~~~~~~~
+
+For developers designing a Cog add-on board, the template schematic/board files
+below might be a useful starting point. The board file has the placement of the
+expansion connectors as well as place-bound rules embedded.
+
+.. admonition:: Download
+   :class: download
+
+   `Gear Template Design Database <resources/geartemplatedesigndatabase.zip>`_
+
+:doc:`Back </solutions/reference-designs/ev-cog-ad4050w/ev-cog-ad4050w>`
+
+.. |image1| image:: images/23062017-tile-revb-power-mux-scheme.png
+.. |direct| image:: images/24072017-tile-revb-adp5300-gpio.png
+.. |image2| image:: images/1_30.png
+.. |image3| image:: images/1_60.png
+.. |image4| image:: images/2_30.png
+.. |image5| image:: images/2_60.png

--- a/docs/solutions/reference-designs/ev-cog-ad4050w/cog_hw_userguide.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad4050w/cog_hw_userguide.rst
@@ -40,12 +40,10 @@ Power Supply Options
 
 The MCU Cog offers the following power supply options:
 
-::
-
-   -5V USB power (USB microB connector)
-   -3V CR2032 Coin cell (Cell holder - BT1)
-   -3V - 6V Rechargeable Li-Ion Battery (JST Connector - P6)
-   -3V - 6V External Supply from an MCU Cog Add-on card (via Connector C1)
+-  5V USB power (USB microB connector)
+-  3V CR2032 Coin cell (Cell holder - BT1)
+-  3V - 6V Rechargeable Li-Ion Battery (JST Connector - P6)
+-  3V - 6V External Supply from an MCU Cog Add-on card (via Connector C1)
 
 Power Muxing Options
 ~~~~~~~~~~~~~~~~~~~~
@@ -86,11 +84,9 @@ Programming & Debug Options
 
 The MCU Cog offers the following debug options:
 
-::
-
-   -On-board CMSIS-DAP debugger (USB microB connector)
-   -JLINK-9 Connector for access to SWD interface (P26)
-   -Access to SW interface to an MCU Cog Add-on card (via Connector C2)
+-  On-board CMSIS-DAP debugger (USB microB connector)
+-  JLINK-9 Connector for access to SWD interface (P26)
+-  Access to SW interface to an MCU Cog Add-on card (via Connector C2)
 
 Wireless Connectivity Options
 -----------------------------
@@ -105,13 +101,11 @@ The MCU Cog board offers support for ADI RF daughter-cards such as the EV-ADF703
 Differences between EV-COG-AD4050LZ and EV-COG-AD4050WZ
 -------------------------------------------------------
 
-::
-
-   -LFXTAL changed to a smaller footprint version
-   -Instead of UART0 being brought to the RF, UART1 is always wired to the RF module (32-pin Hirose connector).
-   -If an application needs to use UART1 as well, the RF module may not be used at the same time.
-   -As a larger number of GPIOs are attached to the expansion connector (as given in the spreadsheet), the ADF_GPIOs from the RF module connector and RF_RTC_OPC1 are not available on the expansion headers.
-   -LED2 is on GPIO47 instead of earlier GPIO42 (as GPIO42 is not available), where there was GPIO42 earlier on the expansion pin header, now there is GPIO47.
+-  LFXTAL changed to a smaller footprint version
+-  Instead of UART0 being brought to the RF, UART1 is always wired to the RF module (32-pin Hirose connector).
+-  If an application needs to use UART1 as well, the RF module may not be used at the same time.
+-  As a larger number of GPIOs are attached to the expansion connector (as given in the spreadsheet), the ADF_GPIOs from the RF module connector and RF_RTC_OPC1 are not available on the expansion headers.
+-  LED2 is on GPIO47 instead of earlier GPIO42 (as GPIO42 is not available), where there was GPIO42 earlier on the expansion pin header, now there is GPIO47.
 
 Buttons/LED(s)
 --------------
@@ -153,7 +147,7 @@ C1 & C2 from pins 29 to 60
 Expansion connectors pin out table
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-\*\* Differences between EV-COG-AD4050WZ and EV-COG-AD4050LZ include the differently coloured entries in the pinout table*\* |image2| |image3| |image4|
+**Differences between EV-COG-AD4050WZ and EV-COG-AD4050LZ include the differently coloured entries in the pinout table** |image2| |image3| |image4|
 
 |image5|
 
@@ -246,8 +240,6 @@ expansion connectors as well as place-bound rules embedded.
    :class: download
 
    `Gear Template Design Database <resources/geartemplatedesigndatabase.zip>`_
-
-:doc:`Back </solutions/reference-designs/ev-cog-ad4050w/ev-cog-ad4050w>`
 
 .. |image1| image:: images/23062017-tile-revb-power-mux-scheme.png
 .. |direct| image:: images/24072017-tile-revb-adp5300-gpio.png

--- a/docs/solutions/reference-designs/ev-cog-ad4050w/ev-cog-ad4050w.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad4050w/ev-cog-ad4050w.rst
@@ -11,11 +11,11 @@ The :adi:`EV-COG-AD4050WZ <en/design-center/evaluation-hardware-and-software/eva
 Make sure a valid license for the selected toolchain is installed before using
 EV-COG-AD4050WZ board.
 
-\*\* The software and power measurement is same for both EV-COG-AD4050WZ and
-EV-COG-AD4050LZ \*\*
+**The software and power measurement is same for both EV-COG-AD4050WZ and
+EV-COG-AD4050LZ**
 
 -  :doc:`Introduction </solutions/reference-designs/ev-cog-ad4050w/introduction>`
--  :doc:`Software Packs & Board Support Package </solutions/reference-designs/ev-cog-ad4050w/packs_bsp>`:EV-COG-AD4050WZ software architecture is categorized into 2 groups as below.
+-  :doc:`Software Packs & Board Support Package </solutions/reference-designs/ev-cog-ad4050w/packs_bsp>`: EV-COG-AD4050WZ software architecture is categorized into 2 groups as below.
 
 |image2|
 

--- a/docs/solutions/reference-designs/ev-cog-ad4050w/ev-cog-ad4050w.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad4050w/ev-cog-ad4050w.rst
@@ -1,0 +1,52 @@
+EV-COG-AD4050WZ Development Kit
+===============================
+
+The :adi:`EV-COG-AD4050WZ <en/design-center/evaluation-hardware-and-software/evaluation-boards-kits/EV-COG-AD4050.html>` (referred also as MCU Cog) is a development platform based on the industry leading ultra low power :adi:`ADuCM4050` 32-bit ARM Cortex™-M4F microcontroller. The platform is designed to be a development and prototyping vehicle to get customer ideas from concept to production with a minimal risk and faster time to market. |image1| Applications using EV-COG-AD4050WZ board can be developed using one of the following toolchains.
+
+-  Crosscore Embedded Studio 2.7.0 and above - an Eclipse based Analog Devices Interactive Development Environment.
+-  IAR Embedded Workbench for ARM 8.20 and above
+-  Keil uVision 4 and above
+-  ARM mbed Compiler
+
+Make sure a valid license for the selected toolchain is installed before using
+EV-COG-AD4050WZ board.
+
+\*\* The software and power measurement is same for both EV-COG-AD4050WZ and
+EV-COG-AD4050LZ \*\*
+
+-  :doc:`Introduction </solutions/reference-designs/ev-cog-ad4050w/introduction>`
+-  :doc:`Software Packs & Board Support Package </solutions/reference-designs/ev-cog-ad4050w/packs_bsp>`:EV-COG-AD4050WZ software architecture is categorized into 2 groups as below.
+
+|image2|
+
+   -  `Analog Devices ADuCM4x50 Device Support <https://wiki.analog.com/resources/eval/user-guides/ev-cog-ad4050lz/software/aducm4x50>`_
+
+      -  `Analog Devices EV-COG-AD4050 Off-Chip Drivers and Examples <https://wiki.analog.com/resources/eval/user-guides/ev-cog-ad4050w/software/eval-cog-ad4050wz>`_
+
+-  :doc:`QuickStart Guide </solutions/reference-designs/ev-cog-ad4050w/quickstart>`
+
+   -  `EV-COG-AD4050WZ with CrossCore Embedded Studio <https://wiki.analog.com/resources/eval/user-guides/ev-cog-ad4050wz/quickstart_guide/cces>`_
+
+      -  `EV-COG-AD4050WZ with IAR Embedded Workbench for ARM <https://wiki.analog.com/resources/eval/user-guides/ev-cog-ad4050wz/quickstart_guide/iar>`_
+
+-  :doc:`Hardware Details </solutions/reference-designs/ev-cog-ad4050w/hw_details>`
+
+   -  :doc:`EV-COG-AD4050WZ MCU Cog </solutions/reference-designs/ev-cog-ad4050w/cog_hw_userguide>`
+
+      -  `Power Measurement on EV-COG-AD4050WZ MCU COG <https://wiki.analog.com/resources/eval/user-guides/ev-cog-ad3029lz/_powermeasurement>`_
+
+-  :doc:`Development Tools & Driver </solutions/reference-designs/ev-cog-ad4050w/tools_driver>`
+
+   -  :doc:`CrossCore Embedded Studio Download & Install </solutions/reference-designs/ev-cog-ad4050w/tools/cces_download>`
+
+      -  `CrossCore Embedded Studio Quickstart Userguide <https://wiki.analog.com/resources/ev/user-guides/ev-cog-ad4050w/tools/cces_guide>`_
+      -  `Driver installation for on-board debugger (CMSIS-DAP) <https://wiki.analog.com/resources/eval/user-guides/ev-cog-ad4050lz/tools/hardware_usb>`_
+
+-  :doc:`Example Project </solutions/reference-designs/ev-cog-ad4050w/example_project>`
+-  `Help & Support <https://wiki.analog.com/resources/eval/user-guides/ev-cog-ad4050lz/help_support>`_
+
+.. |image1| image:: images/front_image_new.png
+   :width: 550
+
+.. |image2| image:: images/aducm4050.png
+   :width: 400

--- a/docs/solutions/reference-designs/ev-cog-ad4050w/example_project.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad4050w/example_project.rst
@@ -1,0 +1,4 @@
+Example Project
+===============
+
+**COMING SOON**

--- a/docs/solutions/reference-designs/ev-cog-ad4050w/hw_details.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad4050w/hw_details.rst
@@ -11,7 +11,3 @@ provided example demo software projects.
 The following boards are currently available:
 
 -  :doc:`EV-COG-AD4050WZ MCU Cog </solutions/reference-designs/ev-cog-ad4050w/cog_hw_userguide>`
-
-| End Document
-
-:doc:`Back </solutions/reference-designs/ev-cog-ad4050w/ev-cog-ad4050w>`

--- a/docs/solutions/reference-designs/ev-cog-ad4050w/hw_details.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad4050w/hw_details.rst
@@ -1,0 +1,17 @@
+Hardware Details
+================
+
+This page contains hardware-related information about the EV-COG-AD4050WZ board
+and the various hardware add on modules which can be used with the board. Each
+sub-section contains a detailed description of the board, connectors, jumpers
+and buttons. It also provides links to the Schematics, Bill of materials, design
+projects, and Technical documentation. It also gives internal links to the
+provided example demo software projects.
+
+The following boards are currently available:
+
+-  :doc:`EV-COG-AD4050WZ MCU Cog </solutions/reference-designs/ev-cog-ad4050w/cog_hw_userguide>`
+
+| End Document
+
+:doc:`Back </solutions/reference-designs/ev-cog-ad4050w/ev-cog-ad4050w>`

--- a/docs/solutions/reference-designs/ev-cog-ad4050w/images/11082017-mcu-cog-revb-horizontal-concept.png
+++ b/docs/solutions/reference-designs/ev-cog-ad4050w/images/11082017-mcu-cog-revb-horizontal-concept.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5c6f8de11f9d7de05e9211be244b932efa6cee5b68bfa439e61fe90d9ed06a87
+size 69006

--- a/docs/solutions/reference-designs/ev-cog-ad4050w/images/11082017-mcu-cog-revb-stacking.png
+++ b/docs/solutions/reference-designs/ev-cog-ad4050w/images/11082017-mcu-cog-revb-stacking.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d1e4525fea1ac3e19d73caa4161c2aee350612ff7be3ad1cf2d82061941ebbb6
+size 17501

--- a/docs/solutions/reference-designs/ev-cog-ad4050w/images/1_30.png
+++ b/docs/solutions/reference-designs/ev-cog-ad4050w/images/1_30.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0ce5055ac6b664879a0ab0d3a5d81862498e1d02914338d3df35eac7993c89e6
+size 21080

--- a/docs/solutions/reference-designs/ev-cog-ad4050w/images/1_60.png
+++ b/docs/solutions/reference-designs/ev-cog-ad4050w/images/1_60.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:27e97993a3ac3a756e7e671a0f8eef2e9a5d2b7c52b19d7448758e70e0b400af
+size 25427

--- a/docs/solutions/reference-designs/ev-cog-ad4050w/images/23062017-tile-revb-power-mux-scheme.png
+++ b/docs/solutions/reference-designs/ev-cog-ad4050w/images/23062017-tile-revb-power-mux-scheme.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b80c7beca0f4d29d7737d80ac1b89d16d46ea58a74939f7ebaab4e0a3db7a51b
+size 102911

--- a/docs/solutions/reference-designs/ev-cog-ad4050w/images/24072017-tile-revb-adp5300-gpio.png
+++ b/docs/solutions/reference-designs/ev-cog-ad4050w/images/24072017-tile-revb-adp5300-gpio.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a34273b077c392ac21ca50141591e65bec0d1fe909298df1c622ba977c3619ac
+size 21068

--- a/docs/solutions/reference-designs/ev-cog-ad4050w/images/24072017-tile-revb-current-test-points.png
+++ b/docs/solutions/reference-designs/ev-cog-ad4050w/images/24072017-tile-revb-current-test-points.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:40f0061866348313528b6f085aca4e24b0c7ddbd5821c63437ddfeaa752fe9b1
+size 8460

--- a/docs/solutions/reference-designs/ev-cog-ad4050w/images/2_30.png
+++ b/docs/solutions/reference-designs/ev-cog-ad4050w/images/2_30.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6673597b7480159f21d90ce3af34eb900bbe7ab68fa59e2945001132dc96576a
+size 21829

--- a/docs/solutions/reference-designs/ev-cog-ad4050w/images/2_60.png
+++ b/docs/solutions/reference-designs/ev-cog-ad4050w/images/2_60.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2c10b53be748246e16d2c07d954fbd0b0011e20f53989962878423a8bcbe2b20
+size 25883

--- a/docs/solutions/reference-designs/ev-cog-ad4050w/images/aducm4050.png
+++ b/docs/solutions/reference-designs/ev-cog-ad4050w/images/aducm4050.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:56e77d674a554cdcbaa9df61fd9eba3740a5b5467ac0df4a6883ca8b0c4217bd
+size 17899

--- a/docs/solutions/reference-designs/ev-cog-ad4050w/images/build_icon.jpg
+++ b/docs/solutions/reference-designs/ev-cog-ad4050w/images/build_icon.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8bc2617a7cc8e159792ef9cf131dead944d45e53df3658c2fdd44f4e9e71c665
+size 8155

--- a/docs/solutions/reference-designs/ev-cog-ad4050w/images/c_persp.jpg
+++ b/docs/solutions/reference-designs/ev-cog-ad4050w/images/c_persp.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7741de2e28ce2865c4452b9b1158f7514738bf6766c21750d9c64a9689e45378
+size 8597

--- a/docs/solutions/reference-designs/ev-cog-ad4050w/images/cmsis_pack_install_1.png
+++ b/docs/solutions/reference-designs/ev-cog-ad4050w/images/cmsis_pack_install_1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5d4c2a56a8a3fc42ec94143c33ae5de9b23c04521aa46650e44efd60333d4241
+size 80905

--- a/docs/solutions/reference-designs/ev-cog-ad4050w/images/cmsis_pack_install_2.png
+++ b/docs/solutions/reference-designs/ev-cog-ad4050w/images/cmsis_pack_install_2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bffadcc381f6552810302dba2328dfc92f85628d3f204304ea06a898e965096f
+size 16063

--- a/docs/solutions/reference-designs/ev-cog-ad4050w/images/cmsis_pack_install_3.png
+++ b/docs/solutions/reference-designs/ev-cog-ad4050w/images/cmsis_pack_install_3.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f371570e5e2b580fa2c133cf25791e0cb4819930fdfa086aaa9da68ad907c7b3
+size 42478

--- a/docs/solutions/reference-designs/ev-cog-ad4050w/images/cmsis_pack_manager.jpg
+++ b/docs/solutions/reference-designs/ev-cog-ad4050w/images/cmsis_pack_manager.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:922667d361c847dd3f04e157bfbcaf86e94f606652faa103ee294dbde0515f81
+size 274420

--- a/docs/solutions/reference-designs/ev-cog-ad4050w/images/cog_connector.png
+++ b/docs/solutions/reference-designs/ev-cog-ad4050w/images/cog_connector.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f6594114bdca079d50cb5ce9473aaf7076b4749e4b6ac0378274c40e06f8d5fa
+size 13550

--- a/docs/solutions/reference-designs/ev-cog-ad4050w/images/cog_jumpers_annotated.png
+++ b/docs/solutions/reference-designs/ev-cog-ad4050w/images/cog_jumpers_annotated.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a6d85a25cdec27591be9408de59585007cf7e0c7f4e06bc283b4512a86827179
+size 26407

--- a/docs/solutions/reference-designs/ev-cog-ad4050w/images/cog_upto29.png
+++ b/docs/solutions/reference-designs/ev-cog-ad4050w/images/cog_upto29.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5ec63255ad2066468047864bc6b77d229ad4728a9a4377ab63f309c240ee668e
+size 28210

--- a/docs/solutions/reference-designs/ev-cog-ad4050w/images/cog_upto60.png
+++ b/docs/solutions/reference-designs/ev-cog-ad4050w/images/cog_upto60.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:395c4b4c930f56a87398fdf27844be1cc998e6f46ee391d16ad871285d9b8f9e
+size 23393

--- a/docs/solutions/reference-designs/ev-cog-ad4050w/images/create_new_project_1.png
+++ b/docs/solutions/reference-designs/ev-cog-ad4050w/images/create_new_project_1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7f679e8a601a27c6187707c3ff1dc07844c6b05fd7ca53c8fcaa00b1a4358f47
+size 40677

--- a/docs/solutions/reference-designs/ev-cog-ad4050w/images/debug.jpg
+++ b/docs/solutions/reference-designs/ev-cog-ad4050w/images/debug.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a5c554276fd11eef699251605dbc9d530d705b9ba0d4871eecb0df00407b9b6c
+size 86442

--- a/docs/solutions/reference-designs/ev-cog-ad4050w/images/debug_debug_button.png
+++ b/docs/solutions/reference-designs/ev-cog-ad4050w/images/debug_debug_button.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ddca54c06fa6059fbd8dfe39b44f593e27eb269bfd8ebebf00a8c9ca893b7bc7
+size 474

--- a/docs/solutions/reference-designs/ev-cog-ad4050w/images/debug_icon.jpg
+++ b/docs/solutions/reference-designs/ev-cog-ad4050w/images/debug_icon.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:797f55b2e8fa6c2f78f22167dbc72ce97214ff1a4efccf1aeb2431a8d41985ef
+size 8124

--- a/docs/solutions/reference-designs/ev-cog-ad4050w/images/example_run_1.png
+++ b/docs/solutions/reference-designs/ev-cog-ad4050w/images/example_run_1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8de73fabba0682cadcbd2b27b0c4badb63d10847aa9427311a9b5e8e6856d958
+size 10194

--- a/docs/solutions/reference-designs/ev-cog-ad4050w/images/example_run_2.png
+++ b/docs/solutions/reference-designs/ev-cog-ad4050w/images/example_run_2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:844730371561d0f89ee2045b70aac5125ae827e5d910c0205c8e54e373c1f0fc
+size 25624

--- a/docs/solutions/reference-designs/ev-cog-ad4050w/images/example_run_3.png
+++ b/docs/solutions/reference-designs/ev-cog-ad4050w/images/example_run_3.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8b58e6b25c35f694556b127828b626206f3609d4bfe7c91400a274c4a8605877
+size 29098

--- a/docs/solutions/reference-designs/ev-cog-ad4050w/images/front_image_new.png
+++ b/docs/solutions/reference-designs/ev-cog-ad4050w/images/front_image_new.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8ac17c0546927fce7a102842da591251bffa79e579f0d3fc9d4ad16ebd788d63
+size 6551628

--- a/docs/solutions/reference-designs/ev-cog-ad4050w/images/img_20171030_180904.jpg
+++ b/docs/solutions/reference-designs/ev-cog-ad4050w/images/img_20171030_180904.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e2477ab2e3fcda988d5e86c28f2c25a2be6f9612efef0453b4aa6178013d1b99
+size 2210521

--- a/docs/solutions/reference-designs/ev-cog-ad4050w/images/import_existing_packs_icon.jpg
+++ b/docs/solutions/reference-designs/ev-cog-ad4050w/images/import_existing_packs_icon.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5048d056fb8cc69f7445fb5cd3cac9e743cafc00a64a81bf6cbc7188cc38814b
+size 8041

--- a/docs/solutions/reference-designs/ev-cog-ad4050w/images/led_button_gpio.png
+++ b/docs/solutions/reference-designs/ev-cog-ad4050w/images/led_button_gpio.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2353d6e0b8c78fda4000d59774c93f68b0aa3485d27cc9e3fbc60a74e9b77b4a
+size 2398

--- a/docs/solutions/reference-designs/ev-cog-ad4050w/images/pack_manager.jpg
+++ b/docs/solutions/reference-designs/ev-cog-ad4050w/images/pack_manager.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cc3b017a49c9c568ee43b99fe1698b1fd46fb432fa88bf4c2b4b8e0e4cd36503
+size 9703

--- a/docs/solutions/reference-designs/ev-cog-ad4050w/images/perspective_switch.jpg
+++ b/docs/solutions/reference-designs/ev-cog-ad4050w/images/perspective_switch.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bbf11264393dbca7494f6e3ddc1480d463badbdcf66fb893012df2cddfbc9709
+size 40520

--- a/docs/solutions/reference-designs/ev-cog-ad4050w/images/run_button.png
+++ b/docs/solutions/reference-designs/ev-cog-ad4050w/images/run_button.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:563116d923b708a4060e25c6b34d5c27b0331cdb238f39ce416d3dffaad4bf81
+size 463

--- a/docs/solutions/reference-designs/ev-cog-ad4050w/images/run_icon.jpg
+++ b/docs/solutions/reference-designs/ev-cog-ad4050w/images/run_icon.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a6c7308b0465defd157a4af040d46e5442c45be58e8cc0e042243752e1c46c84
+size 8002

--- a/docs/solutions/reference-designs/ev-cog-ad4050w/images/semihosting.jpg
+++ b/docs/solutions/reference-designs/ev-cog-ad4050w/images/semihosting.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e7d9e2dedb5fba021803446da155597fda3cf8e195f813e6c59777c300ee6f66
+size 33588

--- a/docs/solutions/reference-designs/ev-cog-ad4050w/images/shuntjumpersettingchange_1.png
+++ b/docs/solutions/reference-designs/ev-cog-ad4050w/images/shuntjumpersettingchange_1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a8a7530b1ce3de804fc60ba77a749c486e70ee3aacd91c371d06947cac71bacb
+size 222755

--- a/docs/solutions/reference-designs/ev-cog-ad4050w/images/solderjumpersettingchange_1.png
+++ b/docs/solutions/reference-designs/ev-cog-ad4050w/images/solderjumpersettingchange_1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a1249fac3c590226aaf347e2734cfaa9d67aa5b60d84ac5c12e9f5ab1a134673
+size 347430

--- a/docs/solutions/reference-designs/ev-cog-ad4050w/images/wz_backside.png
+++ b/docs/solutions/reference-designs/ev-cog-ad4050w/images/wz_backside.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1037ca20045b8d00b3ac987a98d6d75e7cd28bcb1e65b2a32daaaa3e5dc31427
+size 370198

--- a/docs/solutions/reference-designs/ev-cog-ad4050w/images/wz_front_side_boldtext.png
+++ b/docs/solutions/reference-designs/ev-cog-ad4050w/images/wz_front_side_boldtext.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4fc716fa2e81be7e3d6871df3a7b964928a3e4d7f441f71b47eb91bde5edb370
+size 400747

--- a/docs/solutions/reference-designs/ev-cog-ad4050w/index.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad4050w/index.rst
@@ -1,8 +1,27 @@
-EV-COG-AD4050WZ Development Kit
-===============================
+.. _ev_cog_ad4050w eval:
+
+EV COG AD4050W
+=====================================================================================
+
+.. TODO: Add a picture of the chip/board
+
+Overview
+-------------------------------------------------------------------------------
+
+.. TODO: Describe in max 10 rows the main features and applications.
+
+Features:
+
+- feature 1
+- feature 2
+
+Applications:
+
+- application 1
+- application 2
 
 .. toctree::
-   :titlesonly:
+   :hidden:
 
    ev-cog-ad4050w
    cog_hw_userguide
@@ -15,3 +34,22 @@ EV-COG-AD4050WZ Development Kit
    quickstart_guide/iar
    tools/cces_download
    tools_driver
+
+Recommendations
+-------------------------------------------------------------------------------
+
+People who follow the flow that is outlined, have a much better experience with
+things. However, like many things, documentation is never as complete as it
+should be. If you have any questions, feel free to ask on our
+:ref:`EngineerZone forums <help-and-support>`, but before that, please make
+sure you read our documentation thoroughly.
+
+Warning
+-------------------------------------------------------------------------------
+
+.. esd-warning::
+
+Help and support
+-------------------------------------------------------------------------------
+
+Please go to :ref:`Help and Support <help-and-support>` page.

--- a/docs/solutions/reference-designs/ev-cog-ad4050w/index.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad4050w/index.rst
@@ -1,0 +1,17 @@
+EV-COG-AD4050WZ Development Kit
+===============================
+
+.. toctree::
+   :titlesonly:
+
+   ev-cog-ad4050w
+   cog_hw_userguide
+   example_project
+   hw_details
+   introduction
+   packs_bsp
+   quickstart
+   quickstart_guide/cces
+   quickstart_guide/iar
+   tools/cces_download
+   tools_driver

--- a/docs/solutions/reference-designs/ev-cog-ad4050w/introduction.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad4050w/introduction.rst
@@ -15,6 +15,3 @@ This modular nature is depicted in the concept sketches below.
 
 .. image:: images/11082017-mcu-cog-revb-stacking.png
 
-| End Document
-
-:doc:`Back </solutions/reference-designs/ev-cog-ad4050w/ev-cog-ad4050w>`

--- a/docs/solutions/reference-designs/ev-cog-ad4050w/introduction.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad4050w/introduction.rst
@@ -1,0 +1,20 @@
+Introduction
+============
+
+The :adi:`EV-COG-AD4050WZ` is a modular Internet of Things (IOT) development platform based on the :adi:`ADUCM4050` ultra low power microcontroller (MCU) with integrated power management for processing, control, and connectivity. The MCU system is based on the ARM Cortex-M4F processor, a collection of digital peripherals, embedded SRAM and flash memory, and an analog subsystem which provides clocking, reset, and power management capability in addition to an analog-to-digital converter (ADC) subsystem. The :adi:`ADUCM4050` has industry leading ultra low power which makes it ideal for developing battery powered and self powered wireless sensor nodes. The *Cog* platform uses CrossCore Embedded Studio, an open source Eclipse based Interactive Development Environment (IDE), which can be downloaded free of charge. The platform contains many hardware and software example projects to make it easier for customers to prototype and create connected systems and solutions for Internet of Things (IoT) applications.
+
+.. image:: images/11082017-mcu-cog-revb-horizontal-concept.png
+
+The *Cog* IOT development kit is modular in nature and comprises of:
+
+-  An MCU *Cog* (such as the `EV-COG-AD4050WZ <https://wiki.analog.com/resources/eval/user-guides/eval-cog-ad4050wz/cog_hw_userguide>`_) which has an on-board debugger and test-points for monitoring energy consumption.
+-  An optional connectivity *Cog* (such as the `EV-COG-BLEINTP1Z <https://wiki.analog.com/resources/eval/user-guides/eval-cog-ad3029lz/ev-cog-interposer>`_) which offers BTLE, LPWAN or WiFi connectivity options.
+-  An optional application specific add-on board (*Gear*) which might have an optimized sensor signal chain, specific to the use-case. For example - an add-on board targeted at smart agriculture use-cases might have Light, Temperature and Humidity Sensors. For initial prototyping, a specialized Gear is available which provides access to Arduino and PMOD connectors in addition to debug connectors - see `EV-GEAR-EXPANDER1Z <https://wiki.analog.com/resources/eval/user-guides/eval-cog-ad3029lz/ev-gear-expander>`_.
+
+This modular nature is depicted in the concept sketches below.
+
+.. image:: images/11082017-mcu-cog-revb-stacking.png
+
+| End Document
+
+:doc:`Back </solutions/reference-designs/ev-cog-ad4050w/ev-cog-ad4050w>`

--- a/docs/solutions/reference-designs/ev-cog-ad4050w/packs_bsp.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad4050w/packs_bsp.rst
@@ -1,0 +1,40 @@
+Software Packs & Board Support Package
+======================================
+
+A modular software framework is provided for quick application prototyping.
+Based on the application use case, developers need to download the respective
+software packs.
+
+<note >There are no seperate toolchain,software packs and board support package
+for EV-COG-AD4050WZ, the toolchain,software packs and board support package for
+EV-COG-AD4050LZ works with EV-COG-AD4050WZ.The user needs to change only the pin
+muxing based on the application.For help regarding pinmapping refer to the
+Hardware Details section.
+
+.. important::
+
+   Please make sure you install either of the below toolchain before installing
+   any of the below packs
+
+   
+   -  IAR Embedded Workbench for ARM 8.20.1 or higher
+   -  CrossCore Embedded Studio 2.7.0 ® or higher
+   
+
+The Cog software development kit consists of the following packs:-
+
+-  `Analog Devices ADuCM4x50 Device Support <https://wiki.analog.com/resources/eval/user-guides/ev-cog-ad4050lz/software/aducm4x50>`_ - This is a bare minimum pack required to enable working with ADuCM4050 and develop simple applications using the on-chip drivers.
+
+   -  *Version History*
+
+      -  **Version: 3.1.0** - Extended support for IAR Embedded Workbench and Keil uVision. **[Latest]**
+
+-  `Analog Devices EV-COG-AD4050 Off-Chip Drivers and Examples <https://wiki.analog.com/resources/eval/user-guides/ev-cog-ad4050lz/software/eval-cog-ad4050lz>`_ - This pack along with the DFP is required to develop applications using the on-board drivers.
+
+   -  *Version History*
+
+      -  **Version 3.1.0** - Extended support for IAR Embedded Workbench.\ **[Latest]**
+
+| End Document
+
+:doc:`Back </solutions/reference-designs/ev-cog-ad4050w/ev-cog-ad4050w>`

--- a/docs/solutions/reference-designs/ev-cog-ad4050w/packs_bsp.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad4050w/packs_bsp.rst
@@ -5,11 +5,13 @@ A modular software framework is provided for quick application prototyping.
 Based on the application use case, developers need to download the respective
 software packs.
 
-<note >There are no seperate toolchain,software packs and board support package
-for EV-COG-AD4050WZ, the toolchain,software packs and board support package for
-EV-COG-AD4050LZ works with EV-COG-AD4050WZ.The user needs to change only the pin
-muxing based on the application.For help regarding pinmapping refer to the
-Hardware Details section.
+.. note::
+
+   There are no separate toolchain, software packs and board support package for
+   EV-COG-AD4050WZ; the toolchain, software packs and board support package for
+   EV-COG-AD4050LZ works with EV-COG-AD4050WZ. The user needs to change only
+   the pin muxing based on the application. For help regarding pin mapping refer
+   to the Hardware Details section.
 
 .. important::
 
@@ -33,8 +35,4 @@ The Cog software development kit consists of the following packs:-
 
    -  *Version History*
 
-      -  **Version 3.1.0** - Extended support for IAR Embedded Workbench.\ **[Latest]**
-
-| End Document
-
-:doc:`Back </solutions/reference-designs/ev-cog-ad4050w/ev-cog-ad4050w>`
+      -  **Version 3.1.0** - Extended support for IAR Embedded Workbench. **[Latest]**

--- a/docs/solutions/reference-designs/ev-cog-ad4050w/quickstart.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad4050w/quickstart.rst
@@ -1,11 +1,13 @@
 MCU Cog Quick Start Guide
 =========================
 
-<note >There are no seperate toolchain,On-Board Peripheral Drivers & Software
-for EV-COG-AD4050WZ, the toolchain,On-Board Peripheral Drivers & Software for
-EV-COG-AD4050LZ works with EV-COG-AD4050WZ.The user needs to change only the pin
-muxing based on the application.For help regarding pinmapping refer to the
-Hardware Details section.
+.. note::
+
+   There are no separate toolchain, On-Board Peripheral Drivers & Software for
+   EV-COG-AD4050WZ; the toolchain, On-Board Peripheral Drivers & Software for
+   EV-COG-AD4050LZ works with EV-COG-AD4050WZ. The user needs to change only
+   the pin muxing based on the application. For help regarding pin mapping refer
+   to the Hardware Details section.
 
 Setting up EV-COG-AD4050WZ is a three step process.
 
@@ -29,7 +31,3 @@ IAR Embedded Workbench for ARM
 Click below link to go to CrossCore Embedded Studio userguide.
 
 :doc:`EV-COG-AD4050WZ with IAR Embedded Workbench for ARM </solutions/reference-designs/ev-cog-ad4050w/quickstart_guide/iar>`
-
-:doc:`Back </solutions/reference-designs/ev-cog-ad4050w/ev-cog-ad4050w>`
-
-| End Document

--- a/docs/solutions/reference-designs/ev-cog-ad4050w/quickstart.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad4050w/quickstart.rst
@@ -1,0 +1,35 @@
+MCU Cog Quick Start Guide
+=========================
+
+<note >There are no seperate toolchain,On-Board Peripheral Drivers & Software
+for EV-COG-AD4050WZ, the toolchain,On-Board Peripheral Drivers & Software for
+EV-COG-AD4050LZ works with EV-COG-AD4050WZ.The user needs to change only the pin
+muxing based on the application.For help regarding pinmapping refer to the
+Hardware Details section.
+
+Setting up EV-COG-AD4050WZ is a three step process.
+
+-  IDE Setup
+-  Software Packs & Drivers Setup
+-  Running an Example Project
+
+EV-COG-AD4050WZ can be used with following Toolchains. Please see below links
+for the quickstart guide with respect to different IDEs.
+
+CrossCore Embedded Studio
+-------------------------
+
+Click below link to go to CrossCore Embedded Studio userguide.
+
+:doc:`EV-COG-AD4050WZ with CrossCore Embedded Studio </solutions/reference-designs/ev-cog-ad4050w/quickstart_guide/cces>`
+
+IAR Embedded Workbench for ARM
+------------------------------
+
+Click below link to go to CrossCore Embedded Studio userguide.
+
+:doc:`EV-COG-AD4050WZ with IAR Embedded Workbench for ARM </solutions/reference-designs/ev-cog-ad4050w/quickstart_guide/iar>`
+
+:doc:`Back </solutions/reference-designs/ev-cog-ad4050w/ev-cog-ad4050w>`
+
+| End Document

--- a/docs/solutions/reference-designs/ev-cog-ad4050w/quickstart_guide/cces.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad4050w/quickstart_guide/cces.rst
@@ -1,0 +1,91 @@
+EV-COG-AD4050WZ with CrossCore Embedded Studio
+==============================================
+
+<note >There are no seperate toolchain,On-Board Peripheral Drivers & Software
+for EV-COG-AD4050WZ, the toolchain,On-Board Peripheral Drivers & Software for
+EV-COG-AD4050LZ works with EV-COG-AD4050WZ.The user needs to change only the pin
+muxing based on the application.For help regarding pinmapping refer to the
+Hardware Details section.
+
+IDE Setup
+---------
+
+-  Install Cross Core Embedded Studio
+
+   -  `CrossCore Embedded Studio 2.7.0 for Windows <http://download.analog.com/tools/CrossCoreEmbeddedStudio/Releases/Release_2.7.0/ADI_CrossCoreEmbeddedStudio-Rel2.7.0.exe>`_
+   -  `CrossCore Embedded Studio 2..0 for Ubuntu Linux 14.04 x86 <http://download.analog.com/tools/CrossCoreEmbeddedStudio/Releases/Release_2.7.0/adi-CrossCoreEmbeddedStudio-linux-x86-2.7.0.deb>`_
+
+-  License Installation
+
+   -  Start CCES and navigate to Help -> Manage Licenses.
+   -  Click New and enter the license key provided with the EV-COG-AD4050LZ box.
+   -  Follow the on-screen instructions to register and activate the license.
+
+Software Packs and Driver Setup
+-------------------------------
+
+-  Download the following packs for EV-COG-AD4050LZ
+
+   -  `ARM CMSIS Pack <https://keilpack.azureedge.net/pack/ARM.CMSIS.5.1.1.pack>`_
+   -  `Analog Devices ADuCM4x50 Device Support 3.1.0 (Latest) <http://download.analog.com/tools/EZBoards/ADuCM4050/Releases/AnalogDevices.ADuCM4x50_DFP.3.1.0.pack>`_
+
+-  `Analog Devices EV-COG-AD4050 Off-Chip Drivers and Examples 3.1.0 (Latest) <http://download.analog.com/tools/EZBoards/COG_4050/Releases/AnalogDevices.EV-COG-AD4050LZ_BSP.3.1.0.pack>`_
+-  Start CrossCore Embedded Studio.
+-  Go to CMSIS Pack Manager by navigating to Windows ->Perspective ->Open Perspective ->Others -> CMSIS Pack Manager.
+-  Click Import Existing Packs icon |image1|.\ `Refer for more details <https://wiki.analog.com/resources/ev/user-guides/ev-cog-ad4050lz/tools/cces_guide>`_.
+-  Select all the packs and import. This will install the packs. Ignore the warnings seen on the console window. In order to remove these warnings, additional packs needs to be installed which are available in the last section of this page.
+-  Please refer to this `link <https://os.mbed.com/handbook/Windows-serial-configuration>`_ to download and install mbed serial driver on PC.
+
+Running an Example Project
+--------------------------
+
+-  Power the MCU Cog using a USB (micro-B) Cable. You should see a red LED and a
+   yellow LED turn on by default.
+
+.. image:: ../images/img_20171030_180904.jpg
+   :align: center
+   :width: 200
+
+-  In CCES IDE, click CMSIS Pack Manager icon |image2|.
+-  Select EV-COG-AD4050LZ from the Boards tab on the Left panel. (see below image)
+-  Copy button_press example from the Examples tab on the Right panel.
+
+.. image:: ../images/cmsis_pack_manager.jpg
+   :align: center
+
+-  Click C/C++ perspective icon
+
+.. image:: ../images/c_persp.jpg
+
+-  Under Project Explorer select button_press example, click build icon |image3|.
+-  Click on Debug icon |image4| once build is complete. Below are the Debug Configuration settings.
+
+.. image:: ../images/debug.jpg
+   :align: center
+   :width: 700
+
+-  Click "ok" on Perspective Switch and Semihosting Enabled window.
+
+|image5|
+
+.. image:: ../images/perspective_switch.jpg
+   :align: center
+   :width: 500
+
+-  Click run |image6| on the Debug perspective.
+-  Now press BTN1 or BTN2 on EV-COG-AD4050LZ and inspect corresponding LED.
+
+You are all set!
+
+:doc:`Back </solutions/reference-designs/ev-cog-ad4050w/quickstart>`
+
+| End Document
+
+.. |image1| image:: ../images/import_existing_packs_icon.jpg
+.. |image2| image:: ../images/pack_manager.jpg
+.. |image3| image:: ../images/build_icon.jpg
+.. |image4| image:: ../images/debug_icon.jpg
+.. |image5| image:: ../images/semihosting.jpg
+   :width: 500
+
+.. |image6| image:: ../images/run_icon.jpg

--- a/docs/solutions/reference-designs/ev-cog-ad4050w/quickstart_guide/cces.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad4050w/quickstart_guide/cces.rst
@@ -1,11 +1,13 @@
 EV-COG-AD4050WZ with CrossCore Embedded Studio
 ==============================================
 
-<note >There are no seperate toolchain,On-Board Peripheral Drivers & Software
-for EV-COG-AD4050WZ, the toolchain,On-Board Peripheral Drivers & Software for
-EV-COG-AD4050LZ works with EV-COG-AD4050WZ.The user needs to change only the pin
-muxing based on the application.For help regarding pinmapping refer to the
-Hardware Details section.
+.. note::
+
+   There are no separate toolchain, On-Board Peripheral Drivers & Software for
+   EV-COG-AD4050WZ; the toolchain, On-Board Peripheral Drivers & Software for
+   EV-COG-AD4050LZ works with EV-COG-AD4050WZ. The user needs to change only
+   the pin muxing based on the application. For help regarding pin mapping refer
+   to the Hardware Details section.
 
 IDE Setup
 ---------
@@ -32,7 +34,7 @@ Software Packs and Driver Setup
 -  `Analog Devices EV-COG-AD4050 Off-Chip Drivers and Examples 3.1.0 (Latest) <http://download.analog.com/tools/EZBoards/COG_4050/Releases/AnalogDevices.EV-COG-AD4050LZ_BSP.3.1.0.pack>`_
 -  Start CrossCore Embedded Studio.
 -  Go to CMSIS Pack Manager by navigating to Windows ->Perspective ->Open Perspective ->Others -> CMSIS Pack Manager.
--  Click Import Existing Packs icon |image1|.\ `Refer for more details <https://wiki.analog.com/resources/ev/user-guides/ev-cog-ad4050lz/tools/cces_guide>`_.
+-  Click Import Existing Packs icon |image1|. `Refer for more details <https://wiki.analog.com/resources/ev/user-guides/ev-cog-ad4050lz/tools/cces_guide>`_.
 -  Select all the packs and import. This will install the packs. Ignore the warnings seen on the console window. In order to remove these warnings, additional packs needs to be installed which are available in the last section of this page.
 -  Please refer to this `link <https://os.mbed.com/handbook/Windows-serial-configuration>`_ to download and install mbed serial driver on PC.
 
@@ -76,10 +78,6 @@ Running an Example Project
 -  Now press BTN1 or BTN2 on EV-COG-AD4050LZ and inspect corresponding LED.
 
 You are all set!
-
-:doc:`Back </solutions/reference-designs/ev-cog-ad4050w/quickstart>`
-
-| End Document
 
 .. |image1| image:: ../images/import_existing_packs_icon.jpg
 .. |image2| image:: ../images/pack_manager.jpg

--- a/docs/solutions/reference-designs/ev-cog-ad4050w/quickstart_guide/iar.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad4050w/quickstart_guide/iar.rst
@@ -1,0 +1,103 @@
+EV-COG-AD4050WZ with IAR Embedded Workbench for ARM
+===================================================
+
+<note >There are no seperate toolchain,On-Board Peripheral Drivers & Software
+for EV-COG-AD4050WZ, the toolchain,On-Board Peripheral Drivers & Software for
+EV-COG-AD4050LZ works with EV-COG-AD4050WZ.The user needs to change only the pin
+muxing based on the application.For help regarding pinmapping refer to the
+Hardware Details section.
+
+IDE Setup
+---------
+
+-   Install IAR Embedded Workbench for ARM
+
+   -  Please visit https://www.iar.com/ to download IAR Embedded Workbench for ARM (version 8.20.1 or above).
+
+-   License Installation
+
+   -  Make sure valid license is installed for the corresponding version.
+
+Software Packs and Driver Setup
+-------------------------------
+
+-  Download the following packs for EV-COG-AD4050LZ
+
+   -  `ARM CMSIS Pack <https://keilpack.azureedge.net/pack/ARM.CMSIS.5.2.0.pack>`_
+
+      -  `Analog Devices ADuCM4x50 Device Support 3.1.0 (Latest) <http://download.analog.com/tools/EZBoards/ADuCM4050/Releases/AnalogDevices.ADuCM4x50_DFP.3.1.0.pack>`_
+      -  `Analog Devices EV-COG-AD4050 Off-Chip Drivers and Examples 3.1.0 (Latest) <http://download.analog.com/tools/EZBoards/COG_4050/Releases/AnalogDevices.EV-COG-AD4050LZ_BSP.3.1.0.pack>`_
+
+-  Start IAR Embedded Workbench for ARM.
+-  Go to Project-> CMSIS-Pack-> Pack Installer.
+
+.. image:: ../images/cmsis_pack_install_1.png
+   :align: center
+   :width: 750
+
+-  In **'CMSIS Pack Manager'** window, click 'Install local pack file'.
+
+.. image:: ../images/cmsis_pack_install_2.png
+   :align: center
+   :width: 700
+
+-  In 'Pack file to install' window navigate to the downloaded pack (as already
+   done in step 1 of this section), select all the packs to install and click
+   Open.
+
+.. image:: ../images/cmsis_pack_install_3.png
+   :align: center
+   :width: 700
+
+Running an Example Project
+--------------------------
+
+.. important::
+
+   The pins for LEDs and BUTTONs are different in example project as they are
+   developed for LZ version of 4050.So before running the example in your WZ
+   board change the pinmuxing appropriately by looking at the hardware details
+   section.
+
+-  Power the MCU Cog using a USB (micro-B) Cable. You should see a red LED and a
+   yellow LED turn on by default.
+
+.. image:: ../images/img_20171030_180904.jpg
+   :align: center
+   :width: 200
+
+-  In IAR IDE, go to Project-> Create New Project...
+
+.. image:: ../images/create_new_project_1.png
+   :align: center
+
+-  In **'Create New Project'** window, Select **'CMSIS Pack Example'** and click 'OK'.
+
+.. image:: ../images/example_run_1.png
+   :align: center
+
+-  Expand Analog Devices, select **ADuCM4050** and click 'Next'.
+
+.. image:: ../images/example_run_2.png
+   :align: center
+   :width: 700
+
+-  Select **button_press** example and click 'Finish'.
+
+.. image:: ../images/example_run_3.png
+   :align: center
+   :width: 700
+
+-  Save the project to the desired location.
+-  Click on 'Debug and Download' icon |image1|\ on the menu bar. This will compile, build and download the project on EV-COG-AD4050LZ using CMSIS-DAP.
+-  Click on 'Run' icon |image2| to start the debug session.
+-  Now press BTN1 or BTN2 on EV-COG-AD4050LZ and inspect corresponding LED
+
+You are all set!
+
+:doc:`Back </solutions/reference-designs/ev-cog-ad4050w/quickstart>`
+
+| End Document
+
+.. |image1| image:: ../images/debug_debug_button.png
+.. |image2| image:: ../images/run_button.png

--- a/docs/solutions/reference-designs/ev-cog-ad4050w/quickstart_guide/iar.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad4050w/quickstart_guide/iar.rst
@@ -1,11 +1,13 @@
 EV-COG-AD4050WZ with IAR Embedded Workbench for ARM
 ===================================================
 
-<note >There are no seperate toolchain,On-Board Peripheral Drivers & Software
-for EV-COG-AD4050WZ, the toolchain,On-Board Peripheral Drivers & Software for
-EV-COG-AD4050LZ works with EV-COG-AD4050WZ.The user needs to change only the pin
-muxing based on the application.For help regarding pinmapping refer to the
-Hardware Details section.
+.. note::
+
+   There are no separate toolchain, On-Board Peripheral Drivers & Software for
+   EV-COG-AD4050WZ; the toolchain, On-Board Peripheral Drivers & Software for
+   EV-COG-AD4050LZ works with EV-COG-AD4050WZ. The user needs to change only
+   the pin muxing based on the application. For help regarding pin mapping refer
+   to the Hardware Details section.
 
 IDE Setup
 ---------
@@ -89,15 +91,11 @@ Running an Example Project
    :width: 700
 
 -  Save the project to the desired location.
--  Click on 'Debug and Download' icon |image1|\ on the menu bar. This will compile, build and download the project on EV-COG-AD4050LZ using CMSIS-DAP.
+-  Click on 'Debug and Download' icon |image1| on the menu bar. This will compile, build and download the project on EV-COG-AD4050LZ using CMSIS-DAP.
 -  Click on 'Run' icon |image2| to start the debug session.
 -  Now press BTN1 or BTN2 on EV-COG-AD4050LZ and inspect corresponding LED
 
 You are all set!
-
-:doc:`Back </solutions/reference-designs/ev-cog-ad4050w/quickstart>`
-
-| End Document
 
 .. |image1| image:: ../images/debug_debug_button.png
 .. |image2| image:: ../images/run_button.png

--- a/docs/solutions/reference-designs/ev-cog-ad4050w/resources/02_047385a_top.pdf
+++ b/docs/solutions/reference-designs/ev-cog-ad4050w/resources/02_047385a_top.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4e956a4b855e69240600e32d70cc4fcfdacefb031163f6c922dd27a1cb13f0ec
+size 582753

--- a/docs/solutions/reference-designs/ev-cog-ad4050w/resources/20-047385-01a_3_.zip
+++ b/docs/solutions/reference-designs/ev-cog-ad4050w/resources/20-047385-01a_3_.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7053474b11074a796d65a0361bc5901ae58ed55c9b6858fc9804ae65bb7175ff
+size 6999234

--- a/docs/solutions/reference-designs/ev-cog-ad4050w/resources/geartemplatedesigndatabase.zip
+++ b/docs/solutions/reference-designs/ev-cog-ad4050w/resources/geartemplatedesigndatabase.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:58d8879d58e551ed79b1d2bfa98dd5cc907a819853bc0daa0cd8ebd009d4d69a
+size 323517

--- a/docs/solutions/reference-designs/ev-cog-ad4050w/tools/cces_download.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad4050w/tools/cces_download.rst
@@ -1,11 +1,13 @@
 CrossCore Embedded Studio Download & Install
 ============================================
 
-<note >There are no seperate toolchain,On-Board Peripheral Drivers & Software
-for EV-COG-AD4050WZ, the toolchain,On-Board Peripheral Drivers & Software for
-EV-COG-AD4050LZ works with EV-COG-AD4050WZ.The user needs to change only the pin
-muxing based on the application.For help regarding pinmapping refer to the
-Hardware Details section.
+.. note::
+
+   There are no separate toolchain, On-Board Peripheral Drivers & Software for
+   EV-COG-AD4050WZ; the toolchain, On-Board Peripheral Drivers & Software for
+   EV-COG-AD4050LZ works with EV-COG-AD4050WZ. The user needs to change only
+   the pin muxing based on the application. For help regarding pin mapping refer
+   to the Hardware Details section.
 
 This page provides all the necessary steps to get CrossCore Embedded Studio
 (CCES) software environment up and running on Windows or Linux.
@@ -30,7 +32,7 @@ following features and many more:
    IDE as well.
 
 Pre-Requisites and Requirements List
-====================================
+------------------------------------
 
 There are a few things that you will need for the tools and software to work
 properly.
@@ -52,13 +54,13 @@ properly.
       -  Or other favorite Terminal program
 
 CrossCore Embedded Studio Download Packages
-===========================================
+-------------------------------------------
 
 .. admonition:: Download
    :class: download
 
    
-   The EV-COG-AD4050LZ **requires** the use of Crosscore Embedded Studios version **2.6.0 or higher**. Do not attempt to use earlier versions of the CrossCore tools, due to compatibility issues that will **damage** the EV-COG-AD3029LZ.
+   The EV-COG-AD4050WZ **requires** the use of Crosscore Embedded Studios version **2.6.0 or higher**. Do not attempt to use earlier versions of the CrossCore tools, due to compatibility issues that will **damage** the EV-COG-AD4050WZ.
    
    `CrossCore Embedded Studio 2.7.0 Windows Installer(Executable) <http://download.analog.com/tools/CrossCoreEmbeddedStudio/Releases/Release_2.7.0/ADI_CrossCoreEmbeddedStudio-Rel2.7.0.exe>`_
    
@@ -84,7 +86,7 @@ The following features are only supported via the Windows version
 -  Debugging an Application using the CrossCore Debugger (TPSDK)
 
 CrossCore Embedded Studio Installer Instructions
-================================================
+------------------------------------------------
 
 It is best that you save all the files/folders to the default directories
 recommended by the CrossCore Embedded Studios installer. This way all the
@@ -108,7 +110,7 @@ directory structure which can be found below.
 -  Eclipse IDE installs to **C:\\Analog Devices\\CrossCore Embedded Studio 2.6.0\\Eclipse**
 -  GNU ARM Embedded Toolchain for Cortex-M installs to **C:\\Analog Devices\\CrossCore Embedded Studio 2.6.0\\ARM\\gcc-arm-embedded**
 -  OpenOCD installs to **C:\\Analog Devices\\CrossCore Embedded Studio 2.6.0\\ARM\\openocd\\bin**
--  CMSIS Pack files are installed to **C:\\Analog Devices\\CrossCore Embedded Studio 2.5.1\\ARM\\packs**
+-  CMSIS Pack files are installed to **C:\\Analog Devices\\CrossCore Embedded Studio 2.6.0\\ARM\\packs**
 
 Installing CrossCore Embedded Studio on Linux
 ---------------------------------------------
@@ -127,7 +129,7 @@ Analog Devices local directory structure which can be found below.
 -  CMSIS Pack files are installed to **/opt/analog/cces/2.6.0/ARM/packs**
 
 Activating CrossCore Embedded Studio
-====================================
+------------------------------------
 
 The first time you launch CrossCore Embedded Studio, you will be prompted to input a serial number, name, and email address. The serial number for **ALL** EV-COG-AD4050LZ boards is:
 
@@ -136,10 +138,7 @@ allow you full and unlimited access to all the features of the tool when using
 the Analog Devices family of ARM Cortex Processor.
 
 CrossCore Embedded Studio Support
-=================================
+---------------------------------
 
-For more details on CrossCore Embedded Studio, updated versions of the tools, release notes, tools documentation, or other support. Please visit the CrossCore :adi:`webpage <cces>`, or email the CrossCore support team at `processor.tools.support@analog.com <https://wiki.analog.com/mailto/processor.tools.support@analog.com>`_
+For more details on CrossCore Embedded Studio, updated versions of the tools, release notes, tools documentation, or other support. Please visit the CrossCore :adi:`webpage <cces>`, or email the CrossCore support team at `processor.tools.support@analog.com <mailto:processor.tools.support@analog.com>`_
 
-*End of Document*
-
-:doc:`Back </solutions/reference-designs/ev-cog-ad4050w/ev-cog-ad4050w>`

--- a/docs/solutions/reference-designs/ev-cog-ad4050w/tools/cces_download.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad4050w/tools/cces_download.rst
@@ -1,0 +1,145 @@
+CrossCore Embedded Studio Download & Install
+============================================
+
+<note >There are no seperate toolchain,On-Board Peripheral Drivers & Software
+for EV-COG-AD4050WZ, the toolchain,On-Board Peripheral Drivers & Software for
+EV-COG-AD4050LZ works with EV-COG-AD4050WZ.The user needs to change only the pin
+muxing based on the application.For help regarding pinmapping refer to the
+Hardware Details section.
+
+This page provides all the necessary steps to get CrossCore Embedded Studio
+(CCES) software environment up and running on Windows or Linux.
+
+The CCES software development environment for EV-COG-AD4050LZ is based on open
+source tools, and is maintained by Analog Devices. CCES includes support for DSP
+(digital signal processing) and ARM Cortex M- and A- devices, and includes the
+following features and many more:
+
+-  Eclipse based IDE
+-  GNU ARM Embedded Toolchain for Cortex-M core based parts (5-2016-q2-update release)
+-  OpenOCD with support for ADuCM302x and ADuCM4x50 microcontroller (open source SWD)
+-  CMSIS Pack files
+-  Mbed CMSIS-DAP
+-  J-Link Lite
+
+.. important::
+
+   CrossCore Embedded Studio is based on Eclipse, but because the MBED platform
+   provides a CMSIS-DAP interface to connect to the board, the EV-COG-AD4050LZ
+   can be used without problems with IAR Embedded Workbench IDE or Keil µVision
+   IDE as well.
+
+Pre-Requisites and Requirements List
+====================================
+
+There are a few things that you will need for the tools and software to work
+properly.
+
+-  PC or laptop computer
+-  EV-COG-AD4050LZ hardware
+-  Micro USB to USB cables
+
+.. important::
+
+   USB cable needs to have ALL data lines connected, can't use a charging only
+   micro USB cable.
+
+-  Terminal Program to interface your PC with the EV-COG-AD4050LZ
+
+   -  `Putty <http://www.chiark.greenend.org.uk/~sgtatham/putty/download.html>`_
+
+      -  `Tera Term <https://en.osdn.jp/projects/ttssh2/releases/>`_
+      -  Or other favorite Terminal program
+
+CrossCore Embedded Studio Download Packages
+===========================================
+
+.. admonition:: Download
+   :class: download
+
+   
+   The EV-COG-AD4050LZ **requires** the use of Crosscore Embedded Studios version **2.6.0 or higher**. Do not attempt to use earlier versions of the CrossCore tools, due to compatibility issues that will **damage** the EV-COG-AD3029LZ.
+   
+   `CrossCore Embedded Studio 2.7.0 Windows Installer(Executable) <http://download.analog.com/tools/CrossCoreEmbeddedStudio/Releases/Release_2.7.0/ADI_CrossCoreEmbeddedStudio-Rel2.7.0.exe>`_
+   
+   `CrossCore Embedded Studio 2.7.0 Ubuntu Linux Installer(Debian) <http://download.analog.com/tools/CrossCoreEmbeddedStudio/Releases/Release_2.7.0/adi-CrossCoreEmbeddedStudio-linux-x86-2.7.0.deb>`_
+   
+   `CrossCore Embedded Studio 2.6.0 Windows Installer(Executable) <http://download.analog.com/tools/CrossCoreEmbeddedStudio/Releases/Release_2.6.0/ADI_CrossCoreEmbeddedStudio-Rel2.6.0.exe>`_
+   
+   `CrossCore Embedded Studio 2.6.0 Ubuntu Linux Installer(Debian) <http://download.analog.com/tools/CrossCoreEmbeddedStudio/Releases/Release_2.6.0/adi-CrossCoreEmbeddedStudio-linux-x86-2.6.0.deb>`_
+   
+
+The following features are available and supported
+--------------------------------------------------
+
+-  Compilation using the GNU ARM Embedded toolchain for the ADuCM302x and ADuCM4x50 ARM Cortex-M cores.
+-  Debugging ADuCM302x and ADuCM4x50 via the IDE with GDB/OpenOCD.
+-  Development and debugging of bare-metal applications on the ADuCM302x and
+   ADuCM4x50 ARM Cortex-M core.
+
+The following features are only supported via the Windows version
+-----------------------------------------------------------------
+
+-  Use of CrossCore Embedded Studio Add-Ins other than the Linux Add-In
+-  Debugging an Application using the CrossCore Debugger (TPSDK)
+
+CrossCore Embedded Studio Installer Instructions
+================================================
+
+It is best that you save all the files/folders to the default directories
+recommended by the CrossCore Embedded Studios installer. This way all the
+instructions and support provided will be easier.
+
+Installing CrossCore Embedded Studio on Windows
+-----------------------------------------------
+
+-  To install CrossCore Embedded Studio, double-click ADI_CrossCoreEmbeddedStudio-Rel2.6.0.exe
+-  The CrossCore Embedded Studio installer will install the mBed windows serial
+   driver.
+
+   -  It is available separately, if required
+
+      -  https://developer.mbed.org/handbook/Windows-serial-configuration
+
+The executable installs all necessary components to the Analog Devices local
+directory structure which can be found below.
+
+-  CrossCore Embedded Studio installs to **C:\\Analog Devices\\CrossCore Embedded Studio 2.6.0**
+-  Eclipse IDE installs to **C:\\Analog Devices\\CrossCore Embedded Studio 2.6.0\\Eclipse**
+-  GNU ARM Embedded Toolchain for Cortex-M installs to **C:\\Analog Devices\\CrossCore Embedded Studio 2.6.0\\ARM\\gcc-arm-embedded**
+-  OpenOCD installs to **C:\\Analog Devices\\CrossCore Embedded Studio 2.6.0\\ARM\\openocd\\bin**
+-  CMSIS Pack files are installed to **C:\\Analog Devices\\CrossCore Embedded Studio 2.5.1\\ARM\\packs**
+
+Installing CrossCore Embedded Studio on Linux
+---------------------------------------------
+
+-  To install CrossCore Embedded Studio, run the command:
+
+   -  sudo dpkg -i adi-CrossCoreEmbeddedStudio-linux-x86-2.6.0.deb
+
+The Ubuntu Linux Installer(Debian) installs all necessary components to the
+Analog Devices local directory structure which can be found below.
+
+-  CrossCore Embedded Studio installs to **/opt/analog/cces/2.6.0**
+-  Eclipse IDE installs to **/opt/analog/cces/2.6.0/Eclipse**
+-  GNU ARM Embedded Toolchain for Cortex-M installs to **/opt/analog/cces/2.6.0/ARM/gcc-arm-embedded**
+-  OpenOCD installs to **/opt/analog/cces/2.6.0/ARM/openocd/bin**
+-  CMSIS Pack files are installed to **/opt/analog/cces/2.6.0/ARM/packs**
+
+Activating CrossCore Embedded Studio
+====================================
+
+The first time you launch CrossCore Embedded Studio, you will be prompted to input a serial number, name, and email address. The serial number for **ALL** EV-COG-AD4050LZ boards is:
+
+Once the serial number has been activated, the CrossCore development tools will
+allow you full and unlimited access to all the features of the tool when using
+the Analog Devices family of ARM Cortex Processor.
+
+CrossCore Embedded Studio Support
+=================================
+
+For more details on CrossCore Embedded Studio, updated versions of the tools, release notes, tools documentation, or other support. Please visit the CrossCore :adi:`webpage <cces>`, or email the CrossCore support team at `processor.tools.support@analog.com <https://wiki.analog.com/mailto/processor.tools.support@analog.com>`_
+
+*End of Document*
+
+:doc:`Back </solutions/reference-designs/ev-cog-ad4050w/ev-cog-ad4050w>`

--- a/docs/solutions/reference-designs/ev-cog-ad4050w/tools_driver.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad4050w/tools_driver.rst
@@ -1,0 +1,24 @@
+Tools and Driver Details
+========================
+
+<note >There are no seperate toolchain,On-Board Peripheral Drivers & Software
+for EV-COG-AD4050WZ, the toolchain,On-Board Peripheral Drivers & Software for
+EV-COG-AD4050LZ works with EV-COG-AD4050WZ.The user needs to change only the pin
+muxing based on the application.For help regarding pinmapping refer to the
+Hardware Details section.
+
+This chapter provides all the necessary steps to download, install, and setup
+the software environment from Analog Devices. There is also information on the
+different USB modes and drivers needed.
+
+It contains two main sections:
+
+-  :doc:`CrossCore Embedded Studio Download & Install </solutions/reference-designs/ev-cog-ad4050w/tools/cces_download>` - Provides all the necessary instructions on how to download and install the CrossCore Embedded Studios software development environment.
+
+   -  `CrossCore Embedded Studio Quickstart Userguide <https://wiki.analog.com/resources/ev/user-guides/ev-cog-ad4050w/tools/cces_guide>`_ - Provides information about using the CrossCore Embedded Studios IDE, in particular, the process of importing, building, debugging, and creating user applications for the EV-COG-AD4050LZ.
+
+-  `Driver Installation for On-board Debugger (CMSIS DAP) <https://wiki.analog.com/resources/eval/user-guides/ev-cog-ad4050lz/tools/hardware_usb>`_ - Provides detailed information how to load pre-compiled .HEX or .BIN files using the USB drive of the EV-COG-AD4050LZ board.
+
+| End Document
+
+:doc:`Back </solutions/reference-designs/ev-cog-ad4050w/ev-cog-ad4050w>`

--- a/docs/solutions/reference-designs/ev-cog-ad4050w/tools_driver.rst
+++ b/docs/solutions/reference-designs/ev-cog-ad4050w/tools_driver.rst
@@ -1,11 +1,13 @@
 Tools and Driver Details
 ========================
 
-<note >There are no seperate toolchain,On-Board Peripheral Drivers & Software
-for EV-COG-AD4050WZ, the toolchain,On-Board Peripheral Drivers & Software for
-EV-COG-AD4050LZ works with EV-COG-AD4050WZ.The user needs to change only the pin
-muxing based on the application.For help regarding pinmapping refer to the
-Hardware Details section.
+.. note::
+
+   There are no separate toolchain, On-Board Peripheral Drivers & Software for
+   EV-COG-AD4050WZ; the toolchain, On-Board Peripheral Drivers & Software for
+   EV-COG-AD4050LZ works with EV-COG-AD4050WZ. The user needs to change only
+   the pin muxing based on the application. For help regarding pin mapping refer
+   to the Hardware Details section.
 
 This chapter provides all the necessary steps to download, install, and setup
 the software environment from Analog Devices. There is also information on the
@@ -19,6 +21,3 @@ It contains two main sections:
 
 -  `Driver Installation for On-board Debugger (CMSIS DAP) <https://wiki.analog.com/resources/eval/user-guides/ev-cog-ad4050lz/tools/hardware_usb>`_ - Provides detailed information how to load pre-compiled .HEX or .BIN files using the USB drive of the EV-COG-AD4050LZ board.
 
-| End Document
-
-:doc:`Back </solutions/reference-designs/ev-cog-ad4050w/ev-cog-ad4050w>`


### PR DESCRIPTION
## Summary
- Move ev-cog-ad4050w wiki documentation to `solutions/reference-designs/ev-cog-ad4050w/`
- 12 RST files with 40 localized images
- Generated stub `index.rst` with toctree

## Test plan
- [ ] Sphinx build passes without errors
- [ ] All toctree entries resolve correctly
- [ ] Images render properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)