### PR TITLE
reference-designs/rapidnet-ip: Add rapidnet-ip documentation

### DIFF
--- a/docs/solutions/reference-designs/rapidnet-ip/deviceserver-userguide.rst
+++ b/docs/solutions/reference-designs/rapidnet-ip/deviceserver-userguide.rst
@@ -1,0 +1,186 @@
+RapidNet IP DeviceServer Userguide
+==================================
+
+DeviceServer
+------------
+
+.. image:: images/gateway.png
+   :align: center
+   :width: 400
+
+::
+
+                          RapidNet IP gateway bloack diagram
+
+RapidNet IP allows gateway applications to communicate with the network through
+the deviceServer.
+
+Starting the deviceServer
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Required files - deviceServer executable and deviceServer_config.ini
+
+-  Windows- The required files can be found in \\RapidNet-IP-Rel1.1.2\\Tools\\RapidNet-IP-Demo_App\\config
+-  Linux (Raspberry Pi) - The required files can be found in
+   \\RapidNet-IP-Rel1.1.2\\Manager\\deviceServer\\RaspberryPi
+
+Steps-
+
+-  Create a folder named "config" in the same directory as the deviceServer executable
+-  Place deviceServer_config.ini in the "config" folder
+-  Run the deviceServer executable via command prompt/terminal
+
+.. note::
+
+   Instructions to run the deviceServer-
+
+   
+   Windows
+   
+   -  Open a command prompt in the same directory as deviceServer.exe
+   -  Type "deviceServer.exe" in the commandline and press the Enter key.
+   
+   Linux
+   
+   -  Open a terminal window in the same directory as deviceServer
+   -  Type the following commands and press the Enter key after each-
+   
+      -  sudo chmod 555 deviceServer
+   
+         -  sudo ./deviceServer –v
+   
+
+Configuring the deviceServer/LBR
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The deviceServer_config.ini file defines the runtime configuration for the
+deviceServer/LBR, such as-
+
+-  LBR communication parameters such as COM port, baud rate
+-  RapidNet network parameters such as PAN ID, ISM band, datarate
+-  Debug preferences
+
+Message queues
+~~~~~~~~~~~~~~
+
+The gateway application is required to send and receive packets via message queues provided by the host operating system. The message queue names used by the deviceServer are defined in deviceServer_config.ini –
+
+-  ds_rxq_name=/rfm_host_app_rxq #Message queue used by deviceServer to receive messages from app.
+-  ds_txq_name=/rfm_host_app_txq #Message queue used by deviceServer to transmit
+   messages to app.
+
+.. important::
+
+   Ensure that message queuing is enabled in the operating system being used
+
+   
+   -  It may be enabled by default for linux systems
+   -  It is disabled by default for windows systems. Please find instructions on
+      how to enable it on page 6 of the Sensor integration guide (available in
+      the path \\RapidNet-IP-Rel1.1.2\\Docs)
+   
+
+Gateway application
+-------------------
+
+Gateway application flow
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. image:: images/gw_app_flow.png
+   :align: center
+   :width: 400
+
+deviceServer APIs
+~~~~~~~~~~~~~~~~~
+
+The RapidNet API guide provides a list of APIs to be used by gateway
+applications by exchanging request/response packets with the deviceServer. Some
+important APIs are-
+
+-  DS_UPDATE_LN_DATA_REQ – send data to one or multiple nodes in the network.
+-  DS_ADD_LN_PREFERRED_PARENT_REQ – set the preferred parent node for one or more nodes in the network.
+-  DS_GET_REGISTERED_LN_LIST_REQ - get the list of registered Motes
+-  DS_LBR_NWK_READY_IND – indication given by the deviceServer when the network has been started successfully
+-  DS_LN_REG_IND – indication given by the deviceServer when a node registers with the network
+-  DS_LN_APP_DATA_IND – indication given by the deviceServer when application data is received from a node
+
+Packet format
+^^^^^^^^^^^^^
+
+|image1| Where,
+
+-  MID – request/confirmation message ID
+-  ML – message length in bytes (including ML and MID)
+-  Message data – message data based on MID
+
+The full list of APIs with details of MID, message data and expected response
+can be found in the RapidNet API guide.
+
+Example - Requesting current state of a node from the deviceServer
+""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+
+-  The DS_GET_LN_STATE_REQ API is used to request the current state of a node.
+-  Send a DS_GET_LN_STATE_REQ to the deviceServer by writing the packet from below figure into the RX message queue of the deviceServer (ds_rxq_name)
+-  After performing necessary operations, the deviceServer responds with a
+   DS_GET_LN_STATE_CONF which should be read from the TX message queue of the
+   deviceServer (ds_txq_name)
+
+.. image:: images/ds_example_pf_1.png
+   :align: center
+   :width: 400
+
+::
+
+                                               Example DS_GET_LN_STATE_REQ packet
+
+.. image:: images/ds_example_pf_2.png
+   :align: center
+   :width: 400
+
+::
+
+                                               Example DS_GET_LN_STATE_CONF packet
+
+Example applications
+~~~~~~~~~~~~~~~~~~~~
+
+Example applications are provided for the linux operating system in the RapidNet
+software package, they can be found in the path-
+\\RapidNet-IP-Rel1.1.2\\Manager\\application\\appsOnLinux\\
+
+Example1
+^^^^^^^^
+
+Example application uses the DS_ADD_LN_LIST_REQ, DS_ADD_AP_LIST_REQ and
+DS_ADD_LN_PREFERRED_PARENT_REQ commands to add a list of LNs, APs and set the
+preferred parents for the list of LNs. It then uses the DS_UPDATE_LN_DATA_REQ
+command to send data to the list of nodes periodically.
+
+Example2_OTA_FU
+^^^^^^^^^^^^^^^
+
+Example application uses the DS_OTA_FU_FOR_LN_REQ API to update the firmware for
+a hardcoded list of end nodes.
+
+Example3_actions_commands
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Example application provides code snippets to test various APIs such as-
+
+-  DS_SET_LBR_CHANNEL_HOPPING_MASK_REQ
+-  DS_OTA_SET_LN_PARAMS_REQ
+-  DS_SET_LBR_RTC_TIME_REQ
+-  DS_GET_LBR_RTC_TIME_REQ
+-  DS_GET_LBR_PARAMS_REQ
+-  DS_GET_REGISTERED_LN_LIST_REQ
+-  DS_SET_LBR_FACTORY_DEFAULT_REQ
+-  DS_RESET_LBR_REQ
+-  DS_GET_AP_LIST_REQ
+-  DS_OTA_GET_LN_PARAMS_REQ
+-  DS_OTA_RESET_LN_REQ
+-  DS_GET_LN_STATE_REQ
+-  DS_GET_LN_STATS_REQ
+-  DS_GET_LN_FW_VERSION_REQ
+
+.. |image1| image:: images/ds_packet_format.png
+   :width: 400

--- a/docs/solutions/reference-designs/rapidnet-ip/images/1.png
+++ b/docs/solutions/reference-designs/rapidnet-ip/images/1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6949e9a574e2d11cb73b1c53ac4445a963f1e16c6ef50d680b2aca2497624a17
+size 93034

--- a/docs/solutions/reference-designs/rapidnet-ip/images/2.png
+++ b/docs/solutions/reference-designs/rapidnet-ip/images/2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4daecd2da33918957b1b388f6517dfe81a7a679f5ffbc7b131dc096ba7891ae7
+size 59935

--- a/docs/solutions/reference-designs/rapidnet-ip/images/3.png
+++ b/docs/solutions/reference-designs/rapidnet-ip/images/3.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6471cfe602b18d8b6c9ca4992f4e5efdc03c7cedce6f8f9d73df6491e9aeef9a
+size 51687

--- a/docs/solutions/reference-designs/rapidnet-ip/images/4.png
+++ b/docs/solutions/reference-designs/rapidnet-ip/images/4.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:767a46ce61d4a6d82ae5e7fe188ad8d2950febb9eae3c75b19a660642c9db400
+size 172125

--- a/docs/solutions/reference-designs/rapidnet-ip/images/ap_app_flow.png
+++ b/docs/solutions/reference-designs/rapidnet-ip/images/ap_app_flow.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:58c1b4515c795ad8d0fb4e46b679c78ce8a20a6a92d9ac7e11ab8196b1dd7aaf
+size 55423

--- a/docs/solutions/reference-designs/rapidnet-ip/images/castellations-1.png
+++ b/docs/solutions/reference-designs/rapidnet-ip/images/castellations-1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f501fec4640f13840f1adaa746a296f2016a6b6984ec3c73dd99ed99a6d757bd
+size 10853

--- a/docs/solutions/reference-designs/rapidnet-ip/images/cmsis_pack_install_1.png
+++ b/docs/solutions/reference-designs/rapidnet-ip/images/cmsis_pack_install_1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5d4c2a56a8a3fc42ec94143c33ae5de9b23c04521aa46650e44efd60333d4241
+size 80905

--- a/docs/solutions/reference-designs/rapidnet-ip/images/debug_debug_button.png
+++ b/docs/solutions/reference-designs/rapidnet-ip/images/debug_debug_button.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ddca54c06fa6059fbd8dfe39b44f593e27eb269bfd8ebebf00a8c9ca893b7bc7
+size 474

--- a/docs/solutions/reference-designs/rapidnet-ip/images/ds_example_pf_1.png
+++ b/docs/solutions/reference-designs/rapidnet-ip/images/ds_example_pf_1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:32065275ce2c440749dc128469f33b6194b4a60e7b4796124bec5ea0ee8576a9
+size 26498

--- a/docs/solutions/reference-designs/rapidnet-ip/images/ds_example_pf_2.png
+++ b/docs/solutions/reference-designs/rapidnet-ip/images/ds_example_pf_2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2b31947c7b74559f155106400209f2b1782c8ec2b5309df0df8873a03940450c
+size 19752

--- a/docs/solutions/reference-designs/rapidnet-ip/images/ds_packet_format.png
+++ b/docs/solutions/reference-designs/rapidnet-ip/images/ds_packet_format.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8a1691f8ddfecdd6829e282195f3c89d46d92c5b49507e290ea6bdb45a5380b2
+size 16189

--- a/docs/solutions/reference-designs/rapidnet-ip/images/gateway.png
+++ b/docs/solutions/reference-designs/rapidnet-ip/images/gateway.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3ea183c765ab8fd753b4e1288315303956a61f99d59d556b22b59546d4ca13f8
+size 19482

--- a/docs/solutions/reference-designs/rapidnet-ip/images/gw_app_flow.png
+++ b/docs/solutions/reference-designs/rapidnet-ip/images/gw_app_flow.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4abee7001acb1129eacdf903f6139cd1481f07aef1c2e41515efb911428d623b
+size 68995

--- a/docs/solutions/reference-designs/rapidnet-ip/images/master_mode_block_diagram.png
+++ b/docs/solutions/reference-designs/rapidnet-ip/images/master_mode_block_diagram.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:41365f066e050f3aef2e201e09f10bb313fd3f15fe97490d88f6ad8d25b62155
+size 20954

--- a/docs/solutions/reference-designs/rapidnet-ip/images/rf_module_block_doagram.png
+++ b/docs/solutions/reference-designs/rapidnet-ip/images/rf_module_block_doagram.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1502edccef7c550881747022035afced1e5875524b375bf4989b12df227584cd
+size 28403

--- a/docs/solutions/reference-designs/rapidnet-ip/images/slave_mode_app_flow.png
+++ b/docs/solutions/reference-designs/rapidnet-ip/images/slave_mode_app_flow.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:571954462092c69954c5d322e2748e3317b720f7740b1a2a7bead46354c909a5
+size 60062

--- a/docs/solutions/reference-designs/rapidnet-ip/images/slave_mode_block_diagram.png
+++ b/docs/solutions/reference-designs/rapidnet-ip/images/slave_mode_block_diagram.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2095ffcd17417006a026906e352cd3f6231e0fb686f1bdb35b4a0a7911351931
+size 16192

--- a/docs/solutions/reference-designs/rapidnet-ip/images/slave_mode_sample_app_flow.png
+++ b/docs/solutions/reference-designs/rapidnet-ip/images/slave_mode_sample_app_flow.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:637bf8e4a939dfdd0693ff7cbba9ff32faade8ae4732e250770954c35d267802
+size 52647

--- a/docs/solutions/reference-designs/rapidnet-ip/images/sm_example_1.png
+++ b/docs/solutions/reference-designs/rapidnet-ip/images/sm_example_1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2e68dffc43bbc448f602a266fef72c8b9b37c0209a9c69a1b98803791da7a37f
+size 15875

--- a/docs/solutions/reference-designs/rapidnet-ip/images/sm_example_2.png
+++ b/docs/solutions/reference-designs/rapidnet-ip/images/sm_example_2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a7fb3333f933fb25f39037ad88aabab65b89a6ab7890407c3dbc696bcdb5338f
+size 13239

--- a/docs/solutions/reference-designs/rapidnet-ip/images/sm_packet_format.png
+++ b/docs/solutions/reference-designs/rapidnet-ip/images/sm_packet_format.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b2844651bc371634a00d774f26b0ee25e7b31289f1d3c6ec5333ebe9e7c068e4
+size 17392

--- a/docs/solutions/reference-designs/rapidnet-ip/index.rst
+++ b/docs/solutions/reference-designs/rapidnet-ip/index.rst
@@ -1,0 +1,11 @@
+RapidNet IP Wireless Networking Protocol Solution
+=================================================
+
+.. toctree::
+   :titlesonly:
+
+   rapidnet-ip
+   deviceserver-userguide
+   repeater-mode
+   slave-mode
+   sw

--- a/docs/solutions/reference-designs/rapidnet-ip/index.rst
+++ b/docs/solutions/reference-designs/rapidnet-ip/index.rst
@@ -1,11 +1,49 @@
-RapidNet IP Wireless Networking Protocol Solution
-=================================================
+.. _rapidnet_ip eval:
+
+RAPIDNET IP
+===================================================================
+
+.. TODO: Add a picture of the chip/board
+
+Overview
+-------------------------------------------------------------------------------
+
+.. TODO: Describe in max 10 rows the main features and applications.
+
+Features:
+
+- feature 1
+- feature 2
+
+Applications:
+
+- application 1
+- application 2
 
 .. toctree::
-   :titlesonly:
+   :hidden:
 
    rapidnet-ip
    deviceserver-userguide
    repeater-mode
    slave-mode
    sw
+
+Recommendations
+-------------------------------------------------------------------------------
+
+People who follow the flow that is outlined, have a much better experience with
+things. However, like many things, documentation is never as complete as it
+should be. If you have any questions, feel free to ask on our
+:ref:`EngineerZone forums <help-and-support>`, but before that, please make
+sure you read our documentation thoroughly.
+
+Warning
+-------------------------------------------------------------------------------
+
+.. esd-warning::
+
+Help and support
+-------------------------------------------------------------------------------
+
+Please go to :ref:`Help and Support <help-and-support>` page.

--- a/docs/solutions/reference-designs/rapidnet-ip/rapidnet-ip.rst
+++ b/docs/solutions/reference-designs/rapidnet-ip/rapidnet-ip.rst
@@ -1,0 +1,150 @@
+RapidNet IP Wireless Networking Protocol Solution
+=================================================
+
+:adi:`RapidNet-IP` protocol is a long range sub-GHz wireless networking solution that addresses industrial and commercial applications where reliability, robustness, scalability, and battery life are critical. Applications such as electronic shelf label (ESL), smart lock, and smart infrastructure can be realized by RapidNet IP.
+
+RapidNet IP is a complete point-to-multipoint wireless networking solution
+operating in sub-GHz worldwide regional bands. RapidNet IP protocol uses
+star-repeater network topology, enables longer range communication with faster
+message transmit times.
+
+RapidNet IP leverages the market proven :adi:`ADF7023` radio transceiver and lowest power ULP processors (:adi:`ADuCM3029` or :adi:`ADuCM4050`).
+
+.. image:: images/1.png
+   :alt: RapidNet IP Network Topology.
+   :align: center
+   :width: 600
+
+Features and Specification
+--------------------------
+
+-  Efficient low power network
+
+   -   Low power IEEE802.15.4g/e wireless network with time synchronized channel hopping (TSCH)—no collisions and no lengthy receive waits
+
+      -  Lowest power consumption per node with star and extended star network
+         topology configuration.
+
+         -  Reliable end-to-end communications with acknowledgements
+
+-  Long range
+
+   -  Typical range of 500 m (2 hop and confguration setting dependent)
+
+-  Data rate and frequency
+
+   -   High throughput (4 pks/sec at 1 kB per packet)
+
+      -   Fast network join time (for example, 256 motes in 47 sec)
+      -   Low latency—minimum of 5 sec network loop cycle
+      -   ISM frequency band support (433,868,915,920 MHz)
+      -   Multiple data rate support (37.5 kbps to 300 kbps)
+      -   On-demand bandwidth allocation (for example, up to 1 MB per node/1 hr)
+
+-  Supported modes:
+
+   -  Master mode (on-chip applications)
+
+      -  Slave mode (application coprocessor)
+
+-  Current consumption:
+
+   -  Active: <10 µA ave. (3 updates of 1 kB packets/day case)
+
+      -  Sleep: <1.5 µA
+
+-  FCC and ARIB STD T108 regulation test feature support integrated
+-  Supports OTA (over-the-air) update
+-  Reliable scheduling of alert messages from any or all motes
+-  Sample software available for Linux® or :adi:`ADuCM4050`-based gateways with various backhaul connectivity options
+
+Software Package
+----------------
+
+Below are the pre-requisites for RapidNet IP for Developing application or running in-build demo. Please follow procedure on how to install IAR and DFP packs on :doc:`Prerequisites for RapidNet IP </solutions/reference-designs/rapidnet-ip/sw>` wiki page.
+
+-  IAR 8.22.2
+-  ADuCM3029 DFP 3.2.0
+-  EV-COG-AD3029LZ BSP 3.1.0
+-  RapidNet IP Binary installer 1.1.0 - for running the in-built demo
+-  RapidNet IP Source installer 1.1.0 - for developing applications
+
+RapidNet IP offers below Software Package.
+
+Binary Installer
+~~~~~~~~~~~~~~~~
+
+-  This software pack contains only binary files, tools and document required to run the RapidNet IP application.
+-  :adi:`Click here <en/products/landing-pages/001/rapidnet-ip-protocol.html>` to download the binary installer.
+
+Source Installer
+~~~~~~~~~~~~~~~~
+
+-  This software pack contains source code to develop application on RapidNet IP Protocol.
+-  Follow these steps to download "RapidNet IP" source package
+
+   -  Click www.analog.com/SRF to go to Analog devices software request form, to request the source installer.
+   -  Fill required details.
+   -  Under 'Target Hardware', select 'Ultra Low Power Microcontroller'
+   -  Under 'Software requested' section, check 'RapidNet IP'.
+   -  Click 'SUBMIT' button available at the bottom of the page.
+   -  You will receive an e-mail notification with a download link.
+
+RapidNet IP Module
+------------------
+
+User can buy RapidNet IP modules from third party vendors. Contact ADI for more
+information about this.
+
+Module Connection diagram
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. image:: images/rf_module_block_doagram.png
+   :align: center
+   :width: 500
+
+Castellation leads pinout
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. image:: images/castellations-1.png
+   :align: center
+   :width: 500
+
+RapidNet IP Development Kits
+----------------------------
+
+Below are the different kits available for evaluating RapidNet IP Network
+Protocol.
+
+-  **EV-RAPID-ESL-900JZ** - RapidNet IP ESL Evaluation kit with TELEC Certification specific for Japan.
+-  **EV-RAPID-ESL-900Z** - RapidNet IP ESL Evaluation Kit for all the regions except Japan.
+-  **EV-RAPID-NODE-900Z** - Electronic Shelf Labelling (ESL) node which should be ordered only if more nodes are required during the evaluation of EV-RAPID-ESL-900JZ/EV-RAPID-ESL-900Z.
+-  **EV-RAPID-KIT-900Z** - RapidNet IP Sensor Application Kit
+
+Below are the kit contents. Please click on the individual link to know more
+about the particular board.
+
+-  **EV-RAPID-ESL-900JZ/EV-RAPID-ESL-900Z** - RapidNet IP Electronic Shelf Labelling (ESL) Kit
+
+   -  `EV-COG-AD3029LZ <https://wiki.analog.com/resources/eval/user-guides/ev-cog-ad3029lz>`_ - development platform for Analog Devices Ultra Low Power Microcontroller :adi:`ADuCM3029`
+   -  `EV-DNG-RFMOD-9001Z <https://wiki.analog.com/resources/eval/user-guides/ev-dng-rfmod-9001z>`_ - USB Dongle which acts as Border Router for RapidNet IP Network **(902-958MHz)**
+   -  `EV-COG-ADF7023-9Z <https://wiki.analog.com/resources/eval/user-guides/ev-cog-adf7023-9z>`_ - :adi:`ADF7023-J` Connectivity Cog **(902-958MHz)**
+   -  `EV-GEAR-EINK1Z <https://wiki.analog.com/resources/eval/user-guides/ev-gear-eink1z>`_ - Cog Ecosystem Gear with E-Paper Display from E-INK.
+
+-  **EV-RAPID-NODE-900Z** - RapidNet IP Electronic Shelf Labelling (ESL) Kit
+
+   -  `EV-COG-AD3029LZ <https://wiki.analog.com/resources/eval/user-guides/ev-cog-ad3029lz>`_ - development platform for Analog Devices Ultra Low Power Microcontroller :adi:`ADuCM3029`
+   -  `EV-COG-ADF7023-9Z <https://wiki.analog.com/resources/eval/user-guides/ev-cog-adf7023-9z>`_ - :adi:`ADF7023-J` Connectivity Cog **(902-958MHz)**
+   -  `EV-GEAR-EINK1Z <https://wiki.analog.com/resources/eval/user-guides/ev-gear-eink1z>`_ - Cog Ecosystem Gear with E-Paper Display from E-INK.
+
+-  **EV-RAPID-KIT-900Z** - RapidNet IP Sensor Application Kit
+
+   -  `EV-COG-AD3029LZ <https://wiki.analog.com/resources/eval/user-guides/ev-cog-ad3029lz>`_ - development platform for Analog Devices Ultra Low Power Microcontroller :adi:`ADuCM3029`
+   -  `EV-DNG-RFMOD-9001Z <https://wiki.analog.com/resources/eval/user-guides/ev-dng-rfmod-9001z>`_ - USB Dongle which acts as Border Router for RapidNet IP Network **(902-958MHz)**
+
+Additional Resources
+--------------------
+
+-  :doc:`RapidNet IP Slave Mode Userguide </solutions/reference-designs/rapidnet-ip/slave-mode>`
+-  :doc:`RapidNet IP Repeater Userguide </solutions/reference-designs/rapidnet-ip/repeater-mode>`
+-  :doc:`RapidNet IP DeviceServer Userguide </solutions/reference-designs/rapidnet-ip/deviceserver-userguide>`

--- a/docs/solutions/reference-designs/rapidnet-ip/repeater-mode.rst
+++ b/docs/solutions/reference-designs/rapidnet-ip/repeater-mode.rst
@@ -1,0 +1,64 @@
+RapidNet IP Repeater Userguide
+==============================
+
+.. image:: images/1.png
+   :width: 400
+
+RapidNet IP device types
+------------------------
+
+RapidNet modules can be configures as a-
+
+-  Host/6LoWPAN border router (6LBR) – device used by the gateway to start and manage RapidNet network.
+-  Mote/6LoWPAN node (6LN) – device acting as end nodes sending/receiving data to/from the gateway.
+-  Repeater/ Access point (6AP) - device used to improve the signal range and
+   strength of a RapidNet network.
+
+This guide describes the steps to configure and use a RapidNet module as a
+repeater.
+
+Configuration APIs
+------------------
+
+RF Module stack parameter configurations and stack initialization is a one-time
+configuration that needs to be performed via configuration APIs over UART. The
+basic configuration APIs are-
+
+-  RFMODULE_SET_PARAMS_REQ- used to set RF module parameters such as network PANID, TX power, datarate.
+-  RFMODULE_SET_KEY_REQ- used to set the network key for the node.
+-  RFMODULE_CONFIG_NETWORK_REQ- used to set the module configuration such as node type (6LBR/6LN/6AP), mode (master/slave), etc.
+-  RFMODULE_START_NETWORK_REQ- This command starts the network for RF modules
+   configured as 6AP and 6LN i.e the nodes will search for a gateway (6LBR) to
+   join.
+
+Repeater flow
+~~~~~~~~~~~~~
+
+.. image:: images/ap_app_flow.png
+   :align: center
+   :width: 400
+
+Packet format
+~~~~~~~~~~~~~
+
+.. image:: images/sm_packet_format.png
+
+deviceServer APIs
+-----------------
+
+Once a module has been configured as a repeater, it joins the RapidNet network
+and can be used by nodes outside the range of the gateway to join the network.
+The deviceServer provides gateway applications certain APIs relevant to access
+points-
+
+-  DS_ADD_LN_PREFERRED_PARENT_REQ – used to force a node to prefer a certain access point to join the network.
+-  DS_GET_AP_LIST_REQ - used to get the list of joined APs
+
+.. important::
+
+   
+   -  Note that DS_ADD_LN_PREFERRED_PARENT_REQ needs to be sent before a node joins the network.
+   -  Please see the :doc:`RapidNet IP DeviceServer Userguide </solutions/reference-designs/rapidnet-ip/deviceserver-userguide>` for more information on using the deviceServer and it's APIs.
+   -  The full list of configuration/deviceServer APIs with details of command
+      ID, data and expected response can be found in the RapidNet API guide.
+   

--- a/docs/solutions/reference-designs/rapidnet-ip/slave-mode.rst
+++ b/docs/solutions/reference-designs/rapidnet-ip/slave-mode.rst
@@ -1,0 +1,141 @@
+RapidNet IP Slave Mode Userguide
+================================
+
+RapidNet IP software protocol supports two modes- master mode and slave mode.
+
+Master mode
+-----------
+
+The RapidNet module is used as primary MCU for application purposes and also
+used to communicate using RapidNet IP.
+
+.. important::
+
+   Even though the module software is open to customers, the RapidNet IP
+   protocol stack is still a black box.
+
+.. image:: images/master_mode_block_diagram.png
+   :align: center
+   :width: 400
+
+Slave mode
+----------
+
+The RapidNet module is used as a comms pipe by a different MCU which is
+primarily uised for application purposes. The application's MCU (apps MCU) is
+expected to use certain APIs over UART in order to communicate over RapidNet IP.
+
+|image1|
+
+UART interface
+~~~~~~~~~~~~~~
+
+The rfmodule project provided with the RapidNet software package is the default
+firmware to be programmed to the RapidNet module. It provides several
+configurable UART parameters such as baudrate, parity, data, stop bits, etc.
+
+.. note::
+
+   By default, the rfmodule firmware supports a baudrate of 460800, data of 8
+   bits, 1 stop bit, and no parity
+
+Apps MCU program flow
+~~~~~~~~~~~~~~~~~~~~~
+
+.. image:: images/slave_mode_app_flow.png
+   :align: center
+   :width: 400
+
+Configuration APIs
+^^^^^^^^^^^^^^^^^^
+
+RF Module stack parameter configurations and stack initialization can be
+controlled from Apps MCU through RFM commands. Some basic configuration commands
+are-
+
+-  RFMODULE_SET_PARAMS_REQ- used to set RF module parameters such as network PANID, TX power, datarate.
+-  RFMODULE_SET_KEY_REQ- used to set the network key for the node.
+-  RFMODULE_CONFIG_NETWORK_REQ- used to set the network parameters such as node type (LBR/LN /AP), mode (master/slave), etc.
+-  RFMODULE_START_NETWORK_REQ- This command starts the network for RF modules
+   configured as 6AP and 6LN i.e the nodes will search for a gateway (LBR) to
+   join.
+
+.. important::
+
+   The RapidNet module needs to be reconfigured on reset when last used in slave
+   mode.
+
+Slave mode APIs
+^^^^^^^^^^^^^^^
+
+These APIs allow the RapidNet module to be used as a comms pipe by the Apps MCU.
+Some basic APIs are-
+
+-  RFMODULE_SEND_REQ- used to transmit data to the gateway
+-  RFMODULE_DATA_IND- used to indicate to apps MCU that data has been received from the gateway
+-  RFMODULE_GOTO_SLEEP_REQ- used to put the RF Module into sleep mode.
+-  RFMODULE_WAKEUP_CONF- used to indicate to the apps MCU that the module wakeup
+   was successful. Apps MCU wakes the module by providing an external interrupt
+   via SYS-WAKE3 on the RapidNet module.
+
+.. note::
+
+   Host MCU should put the RapidNet module to sleep whenever there are no
+   packets to be sent.
+
+Packet format
+^^^^^^^^^^^^^
+
+.. image:: images/sm_packet_format.png
+   :align: center
+
+.. note::
+
+   The full list of configuration/slave mode APIs with details of command ID,
+   data and expected response can be found in the RapidNet API guide.
+
+Example - CONFIGURING THE RF MODULE PARAMETERS
+""""""""""""""""""""""""""""""""""""""""""""""
+
+The device PAN ID, PHY data rate, and transmit power can be set using a single
+command as shown below
+
+-  PAN ID: 0x3344
+-  PHY data rate: 50 Kbps
+-  Transmit power: 12 dBm
+
+.. image:: images/sm_example_1.png
+   :align: center
+
+Example - SENDING DATA REQUEST COMMAND
+""""""""""""""""""""""""""""""""""""""
+
+The format and parameters to send data request command to the RF Module to start
+device as RapidNet IP node is shown below.
+
+|image2|
+
+Sample Slave mode application
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A sample slave mode application is provided in the RapidNet software package, it
+uses the ADuCM3029 as it’s Apps MCU and the source code can be found in the
+path- \\RapidNet-IP-Rel1.1.2\\Tools\\sample_host_apps\\
+
+Sample application flow
+^^^^^^^^^^^^^^^^^^^^^^^
+
+.. image:: images/slave_mode_sample_app_flow.png
+   :align: center
+
+Application summary
+^^^^^^^^^^^^^^^^^^^
+
+-  The sample application sets the network parameters of the connected RapidNet module, configures it to be a node (LN) in slave mode and starts network using commands mentioned in the configuration APIs section.
+-  It then puts the node to sleep and toggles the GPIO acting as external wakeup after a set interval.
+-  It transmits a packet of data (1KB) to the gateway and waits to receive an acknowledgement. If acknowledgement is not received within a set interval, the packet is retransmitted.
+-  Steps 2 and 3 repeat indefinetly
+
+.. |image1| image:: images/slave_mode_block_diagram.png
+   :width: 400
+.. |image2| image:: images/sm_example_2.png

--- a/docs/solutions/reference-designs/rapidnet-ip/sw.rst
+++ b/docs/solutions/reference-designs/rapidnet-ip/sw.rst
@@ -1,0 +1,93 @@
+Prerequisites for RapidNet IP
+=============================
+
+This document lists the steps required for successful installation of
+development environment, software packs and RapidNet IP source installer.
+
+IAR EWARM - Installation
+------------------------
+
+-   Install IAR Embedded Workbench for ARM
+
+   -  Please visit https://www.iar.com/ to download IAR Embedded Workbench for ARM (version 8.22.2 preferred)
+
+-   License Installation
+
+   -  Make sure valid license is installed for the corresponding version.
+
+Software Packs and Driver - Installation
+----------------------------------------
+
+-  Following packs for ADuCM3029 can be downloaded directly from ARM website
+   using IAR tool.
+
+   -  ARM CMSIS Pack
+
+      -  ADuCM302x_DFP (3.2.0) - Device Family Pack for ADuCM302x
+      -  EV-COG-AD3029LZ_BSP - Board Support Pack for EV-COG-AD3029LZ
+
+-  Start IAR Embedded Workbench for ARM.
+-  Go to Project-> CMSIS-Pack-> Pack Installer.
+
+.. image:: images/cmsis_pack_install_1.png
+   :align: center
+   :width: 750
+
+-  In **'CMSIS Pack Manager'** window, click 'Search for updates'.
+
+.. image:: images/2.png
+   :align: center
+   :width: 600
+
+-  After search is complete, expand 'ARM' and 'CMSIS' under ARM. Right click on the latest version and select install from drop down options.
+-  After successful installation of ARM CMSIS pack, expand 'AnalaogDevices', then expand 'ADuCM302x_DFP'. Right click on **'3.2.0'** and click install drop down options.
+-  After successful installation of ADuCM302x_DFP, expand 'AnalaogDevices', then expand EV-COG-AD3029LZ_BSP'. Right click on **'3.1.0'** and click install drop down options.
+-  Restart IAR after successful installation of all the packs.
+
+RapidNet IP Source Installer - Download and Installation
+--------------------------------------------------------
+
+Below steps will guide how to download the RapidNet IP Source Installer.
+
+-  Click www.analog.com/SRF to go to Analog devices software request form, to request the source installer.
+-  Fill required details.
+-  Under 'Target Hardware', select 'Ultra Low Power Microcontroller'
+-  Under 'Software requested' section, check 'RapidNet IP'.
+-  Click 'SUBMIT' button available at the bottom of the page.
+-  An e-mail notification with a download link will be sent.
+
+Import RapidNet IP Example Project
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+-  Power the using a USB (micro-B) Cable. You should see a red LED and a yellow LED turn on by default.
+-  Start IAR Embedded Workbench for ARM.
+-  Go to File-> Open Workspace...
+-  Navigate to the RapidNet IP installation directory in Open Workspace. By default it will be installed at C:\\Analog Devices\\RapidNet-IP-Rel1.1.0.
+-  In 'Open Workspace' window go to Mote->application->esl->IAR.
+-  Select 'esl_lib.eww' and click open.
+-  Once the workspace is open, make sure 'esl_app' is select in the 'Workspace'
+   tab (left side). If not, select it from the bottom of the 'Workspace' tab.
+
+.. image:: images/3.png
+   :align: center
+   :width: 200
+
+-  Right click on 'esl_app - Debug' on Workspace Tab and select 'Options...'.
+-  Go to Debugger->Setup and under 'Driver' drop down menu select 'CMSIS DAP'.
+
+.. image:: images/4.png
+   :align: center
+   :width: 600
+
+-  Click on 'Debug and Download' icon |image1|\ on the menu bar. This will compile, build and download the project on EV-COG-AD3029LZ using CMSIS-DAP.
+
+mBed windows serial driver - Installation
+-----------------------------------------
+
+Install mBed windows serial driver from https://developer.mbed.org/handbook/Windows-serial-configuration
+
+You are all set!
+
+:doc:`Back </solutions/reference-designs/rapidnet-ip/rapidnet-ip>`
+
+.. |image1| image:: images/debug_debug_button.png

--- a/docs/solutions/reference-designs/rapidnet-ip/sw.rst
+++ b/docs/solutions/reference-designs/rapidnet-ip/sw.rst
@@ -79,7 +79,7 @@ Import RapidNet IP Example Project
    :align: center
    :width: 600
 
--  Click on 'Debug and Download' icon |image1|\ on the menu bar. This will compile, build and download the project on EV-COG-AD3029LZ using CMSIS-DAP.
+-  Click on 'Debug and Download' icon |image1| on the menu bar. This will compile, build and download the project on EV-COG-AD3029LZ using CMSIS-DAP.
 
 mBed windows serial driver - Installation
 -----------------------------------------


### PR DESCRIPTION
## Summary
- Move rapidnet-ip wiki documentation to `solutions/reference-designs/rapidnet-ip/`
- 6 RST files with 21 localized images
- Generated stub `index.rst` with toctree

## Test plan
- [ ] Sphinx build passes without errors
- [ ] All toctree entries resolve correctly
- [ ] Images render properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)