### PR TITLE
reference-designs/targetting: Add targetting documentation

### DIFF
--- a/docs/solutions/reference-designs/xilinx-sdsoc-targeting/images/dds_out.png
+++ b/docs/solutions/reference-designs/xilinx-sdsoc-targeting/images/dds_out.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9116df7b49f85befa55abc2f7ac7a6205ddd85408bc053ba7eecd8aa1c47c509
+size 345441

--- a/docs/solutions/reference-designs/xilinx-sdsoc-targeting/images/sdsoc_logo.png
+++ b/docs/solutions/reference-designs/xilinx-sdsoc-targeting/images/sdsoc_logo.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:48ad615ce6c97ab7ee0fd45e697e85a7f9184f79b509fdbe522a1053b1d5326b
+size 8322

--- a/docs/solutions/reference-designs/xilinx-sdsoc-targeting/images/sdsoc_platform_folder.png
+++ b/docs/solutions/reference-designs/xilinx-sdsoc-targeting/images/sdsoc_platform_folder.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:077240679903c698fd5c924fa8c5e094931526e8cd442e4fe96a5a41649320b5
+size 46326

--- a/docs/solutions/reference-designs/xilinx-sdsoc-targeting/images/tcl_update_hdl.png
+++ b/docs/solutions/reference-designs/xilinx-sdsoc-targeting/images/tcl_update_hdl.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:51840b3bc9260e1310eb8529c536ea6261e2fb2747abdc4f21af3fb401b9ff21
+size 23219

--- a/docs/solutions/reference-designs/xilinx-sdsoc-targeting/index.rst
+++ b/docs/solutions/reference-designs/xilinx-sdsoc-targeting/index.rst
@@ -1,0 +1,103 @@
+Xilinx SDSoc Targeting Example
+==============================
+
+.. image:: images/sdsoc_logo.png
+   :width: 200
+
+The Xilinx SDSoC™ development environment is a member of the Xilinx SDx™ family
+that provides a greatly simplified ASSP-like C/C++ programming experience
+including an easy to use Eclipse IDE and a comprehensive design environment for
+heterogeneous Zynq® All Programmable SoC and MPSoC deployment. Complete with the
+industry’s first C/C++ full-system optimizing compiler, SDSoC delivers system
+level profiling, automated software acceleration in programmable logic,
+automated system connectivity generation, and libraries to speed programming.
+
+To access the capabilities of SDSoC, please visit http://www.xilinx.com/products/design-tools/software-zone/sdsoc.html
+
+Analog Devices is an SDSoC development environment-qualified Xilinx Alliance
+Member and offers FMC boards and reference designs that can be used together
+with the SDSoC environment. Each SDSoC design is based on a platform which
+defines the hardware and software components on which the SDSoC compiler and
+linker generate hardware functions and IP-based data motion networks for
+communication between hardware functions and the platform as well as software
+drivers and applications. Currently Analog Devices provides SDSoC platform
+support for the following FMCOMMSx SDR systems:
+
+-  :adi:`AD-FMComms2-EBZ`
+-  :adi:`AD-FMComms3-EBZ`
+
+The supported Xilinx Zynq based carriers are:
+
+-  `ZC702 <https://www.xilinx.com/ZC702>`_
+-  `ZC706 <https://www.xilinx.com/ZC706>`_
+
+FMCOMMSx SDSoC Platforms
+------------------------
+
+The FMCOMMSx SDSoC platforms are automatically generated from the Analog Devices
+HDL reference designs that accompany the FMCOMMSx boards. Platform generation is
+done by running a tcl script in the Vivado tcl console. This script creates the
+platform Vivado project from the HDL reference design, as well as the platform
+software files. The generated platforms support Linux OS.
+
+Platform generation steps:
+
+-  Download the Analog Devices HDL reference designs repository from github using the link provided in the *Downloads* section below
+-  Download the platform generation files using the link provided in the *Downloads* section below
+-  Copy the platform generation files to the location where you cloned the HDL repository into the target project folder, *eg: \\hdl\\projects\\fmcomms2\\zc702*
+
+.. image:: images/sdsoc_platform_folder.png
+   :align: center
+   :width: 500
+
+-  Open Vivado and in the tcl console *cd* to the target project sdsoc folder, *eg. \\hdl\\projects\\fmcomms2\\zc702*
+-  Update the HDL design to Vivado 2015.2 by running the *sdsoc_platform/update_hdl.tcl* script. This step needs to be ran only once after downloading the HDL reference design.
+-  Regenerate the IP libraries following the steps described here: http://wiki.analog.com/resources/fpga/docs/hdl. This step needs to be ran only once after downloading the HDL reference design, or every time the IP libraries are modified.
+-  Generate the SDSoC platform by running the *sdsoc_platform/sdsoc_platform.tcl* script. Before running the script you need to edit it and change line 26 "*set argv [list C:/Xilinx/SDSoC/2015.2/platforms]*" to point to your SDSoC platforms folder. At the end of the process the new platform will be placed in the SDSoC platforms folder and will be named *<board>\_<carrier>*, where *<board>* is the name of the FMCOMMSx board and *<carrier>* is the name of the Xilinx carrier, *eg. fmcomms2_zc702*
+
+.. image:: images/tcl_update_hdl.png
+   :align: center
+   :width: 500
+
+.. admonition:: Download
+   :class: download
+
+   
+   -  :git-hdl:`Analog Devices HDL reference design <tree/hdl_2015_r1>`
+   -  `FMCOMMS2 + ZC702 SDSoC platform generation files <resources/fmcomms2_zc702_sdsoc_platform.zip>`_
+   -  `FMCOMMS2 + ZC706 SDSoC platform generation files <resources/fmcomms2_zc706_sdsoc_platform.zip>`_
+   -  `FMCOMMS3 + ZC702 SDSoC platform generation files <resources/fmcomms3_zc702_sdsoc_platform.zip>`_
+   -  `FMCOMMS3 + ZC706 SDSoC platform generation files <resources/fmcomms3_zc706_sdsoc_platform.zip>`_
+   
+
+FMCOMMS2 SDSoC Example
+----------------------
+
+The platform is accompanied by an example SDSoC project which implements a DDS
+block that will generate a CW that can be sent/received using the Analog Devices
+FMCOMMS2 board and the Xilinx ZC702 carrier board. The received signal can be
+displayed in the Analog Devices Linux IIO Oscillscope application. These are the
+steps to recreate the DDS project.
+
+-  Download the SDSoC DDS project source code using the link in the *Downloads* section below
+-  Start the SDSoC terminal and *cd* to the location where the project source code was extracted
+-  In the SDSoC terminal type *make*. This will build the software, generate the DDS IP and insert it into the FMCOMMSx platform. It will also generate the Linux SD card image.
+-  Create a SD card with the ADI Linux image as instructed here: `kuiper-linux <https://wiki.analog.com/resources/tools-software/linux-software/kuiper-linux>`_
+-  On the newly created SD card copy the *boot.bin* generated by SDSoC in the *sd_card* folder
+-  Insert the SD card in the Xilinx ZC702 carrier board, connect antennas to the RF ports of the FMCOMMS2 or loopback cables between Rx and Tx, connect the FMCOMMS2 to the ZC702, connect the ZC702 to a HDMI monitor, connect a mouse and keyboard to the ZC702, connect an Ethernet cable to the ZC702, start the system
+-  After Linux boots the IIO Oscilloscope starts automatically. In the IIO Oscilloscope configure the Rx and Tx LO frequencies to be the same, eg. 2.4GHz
+-  In the IIO Oscilloscope configure the Transmit/DDS as shown below. Please make sure to select a file unde ‘DAC Buffer settings’, any file will do, and press the *Load* button. All the DAC Channels must be selected before pressing *Load*.
+-  Using a program like WinSCP copy from the project folder the *dds_script.sh* to the device’s */usr/local/bin folder*. The credentials for the SCP connection between the PC and the device are: user – analog, password – analog. In order to configure the SCP connection you need the IP of the device, to get that just type *ifconfig* in a terminal on the device.
+-  Run the *dds_script.sh* as shown below. This will initialize and activate the DDS IP.
+-  On the IIO Oscilloscope select the *voltage0* and *voltage1* channels and press the *Play* button. You should see the DDS waveforms displayed by the IIO Oscilloscope .
+
+.. image:: images/dds_out.png
+   :align: center
+   :width: 400
+
+.. admonition:: Download
+   :class: download
+
+   
+   -  `SDSoC DDS source code <resources/sdsoc_dds_src.zip>`_
+   

--- a/docs/solutions/reference-designs/xilinx-sdsoc-targeting/resources/fmcomms2_zc702_sdsoc_platform.zip
+++ b/docs/solutions/reference-designs/xilinx-sdsoc-targeting/resources/fmcomms2_zc702_sdsoc_platform.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c39e1117387bb6ae0e2452e84be15bb5bb7be06fd52a0c74549da1312d022f71
+size 4489561

--- a/docs/solutions/reference-designs/xilinx-sdsoc-targeting/resources/fmcomms2_zc706_sdsoc_platform.zip
+++ b/docs/solutions/reference-designs/xilinx-sdsoc-targeting/resources/fmcomms2_zc706_sdsoc_platform.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b6d28134072d473ea228e763708c177bf5902d9a81d47b15e65ce188525b61f9
+size 4489612

--- a/docs/solutions/reference-designs/xilinx-sdsoc-targeting/resources/fmcomms3_zc702_sdsoc_platform.zip
+++ b/docs/solutions/reference-designs/xilinx-sdsoc-targeting/resources/fmcomms3_zc702_sdsoc_platform.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:69e85c358f29b9ad1fb94c021d68fa4fb0f8410db861fdf2ee3bc06db67573e5
+size 4489561

--- a/docs/solutions/reference-designs/xilinx-sdsoc-targeting/resources/fmcomms3_zc706_sdsoc_platform.zip
+++ b/docs/solutions/reference-designs/xilinx-sdsoc-targeting/resources/fmcomms3_zc706_sdsoc_platform.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:998d06048061b852a0fd90cc5d0e1debf9d2a48a06349dca4c1199011c7ff6a9
+size 4489612

--- a/docs/solutions/reference-designs/xilinx-sdsoc-targeting/resources/sdsoc_dds_src.zip
+++ b/docs/solutions/reference-designs/xilinx-sdsoc-targeting/resources/sdsoc_dds_src.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0b3085ec88d8a6b3cdad1cd3c035fbc50e406b695c37c17a2403644b7835ec9a
+size 4452


### PR DESCRIPTION
## Summary
- Move targetting wiki documentation to `solutions/reference-designs/targetting/`
- 2 RST files with 4 localized images
- Generated stub `index.rst` with toctree

## Test plan
- [ ] Sphinx build passes without errors
- [ ] All toctree entries resolve correctly
- [ ] Images render properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)