### PR TITLE
reference-designs/cn0511: Add cn0511 documentation

### DIFF
--- a/docs/solutions/reference-designs/cn0511/cn0511.rst
+++ b/docs/solutions/reference-designs/cn0511/cn0511.rst
@@ -1,0 +1,379 @@
+.. _cn0511:
+
+Quickstart Guide
+================
+
+Overview
+--------
+
+Instruments that operate at RF range with features like low distortion, ultra
+low phase noise, and portable signal generator are difficult to provide at
+reasonable cost.
+
+The system shown below in Figure 1 is an entirely self-contained DC to 5.5 GHz
+signal generator. It only requires the Raspberry Pi (RPi) to operate. The RF
+digital-to-analog converter (DAC), controlled using a 100 MHz Serial Peripheral
+Interface (SPI) from the RPi, allows for single tone, phase coherent, and fast
+frequency hopping across the spectrum. All the clocking requirements are
+generated using an on-board crystal, so no external clock source is needed. All
+the necessary power rails are also converted from the RPi into various supply
+voltage requirements of the RF signal generator.
+
+The system is designed to simplify the input requirements, optimize signal
+paths, and reduce external cables and components. This circuit can act as a
+standalone laboratory equipment or can be incorporated as a module into
+automatic test equipment. Its small size makes it particularly attractive when
+multiple channels are required. This Raspberry Pi compatible solution makes high
+speed signal generation more accessible and economical.
+
+.. figure:: images/cn0511_angle_view.png
+   :align: center
+   :width: 400
+
+   EVAL-CN0511-RPIZ Evaluation Board
+
+Hardware Configuration
+----------------------
+
+Block Assignments
+~~~~~~~~~~~~~~~~~
+
+.. figure:: images/block_terminal_assignment_v2.png
+   :align: center
+   :width: 400
+
+   EVAL-CN0511-RPIZ Block Terminal Assignments
+
+-  Connector **P1** is the terminal block for optional external +5V input supply.
+-  Connector **P2** is the 40-pin connector for Raspberry Pi.
+-  Connector **P3** is the terminal block for optional external +3.3V input supply.
+-  Connector **P4** is the fan connector for the AD9166.
+-  Connector **J1** is the RF output from the EVAL-CN0511-RPIZ.
+-  Connector **J2** is the optional external clock reference RF input for the EVAL-CN0511-RPIZ.
+
+Onboard Clock Reference
+~~~~~~~~~~~~~~~~~~~~~~~
+
+The CN0511 reference design board is supplied with an ultra low phase noise
+CMOS, voltage-controlled crystal clock oscillator. The CN0511 has a solder
+jumper (JP1) which configures different settings for the clock source, as shown
+below. The default position of JP1 is set at A-COM, which is the onboard
+clocking option.
+
+.. figure:: images/clock_source.png
+   :align: center
+   :width: 800
+
+   EVAL-CN0511-RPIZ Clock Source Schematic Diagram
+
+External Clock Reference Option
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+An external clock reference can be used to generate external clock reference to
+improve system noise. If the performance requirements cannot be met, an external
+option is available, which is limited of up to 500 MHz clock source input. This
+external clock source can be connected through the on-board SMA port(J2).
+
+.. important::
+
+   To use an external single-ended reference input (REFIN) up to 500 MHz, connect a 
+   single-ended low noise source to REFIN. Set solder link JP1 to B–COM to switch 
+   the clock reference from the on-board OCXO to an external clock source.
+
+RF Output
+~~~~~~~~~
+
+A spectrum analyzer can be can be used to observe the generated RF output from
+J1 on the EVAL-CN0511-RPIZ.
+
+.. figure:: images/cn0511_sma_input_output_v2.jpg
+   :align: center
+   :width: 600
+
+   RF Output and Optional External Clock Input Connections
+
+Connecting the Fan
+~~~~~~~~~~~~~~~~~~
+
+The AD9166 is a high power device that can dissipate nearly 4W depending on the
+user application and configuration. The EVAL-CN0511-RPIZ has a high cooling
+requirement; therefore, the fan should always be on to regulate the temperature
+below 60 degrees Celsius.
+
+.. figure:: images/heat_sink_v2.jpg
+   :align: center
+   :width: 600
+
+   CN0511 Fan and Thermal Management
+
+Input Supply
+~~~~~~~~~~~~
+
+Power to the EVAL-CN0511-RPIZ comes directly from the Raspberry Pi +5V supply
+provided by the USB cable. There is an optional +5V external supply coming from
+the two-pole screw terminal (P1). Only one input power supply is required and the
+Raspberry Pi USB cable is the recommended method.
+
+.. figure:: images/cn0511_power_supply_options.png
+   :width: 600
+
+   CN0511 Input Power Supply Connection Options
+
+System Setup
+------------
+
+Equipment Required
+~~~~~~~~~~~~~~~~~~
+
+**Hardware**
+
+-  EVAL-CN0511-RPIZ Circuit Evaluation Board
+-  Raspberry Pi 3B or higher version
+-  5V, 2A power supply or higher with micro USB connector
+-  SMA Cable (`PE39423-12 <https://www.pasternack.com/images/ProductPDF/PE39423-12.pdf>`_ or with similar specification)
+-  16 GB or larger SD card
+-  USB keyboard and mouse
+-  HDMI to HDMI cable
+-  Monitor with HDMI port
+
+**Software**
+
+-  Analog Devices Kuiper Linux image
+
+**Documentation**
+
+-  :adi:`cn0511 Circuit Note <cn0511>`
+
+System Block Diagram
+~~~~~~~~~~~~~~~~~~~~
+
+.. figure:: images/eval-cn0511_test_block_diagram.jpg
+   :align: center
+   :width: 500
+
+   Functional System Block Diagram
+
+Running the System
+~~~~~~~~~~~~~~~~~~
+
+To set up the complete system, follow these steps:
+
+-  Connect the EVAL-CN0511-RPIZ to the Raspberry Pi through the 40-pin connector.
+
+   .. figure:: images/cn0511_rpi_v1.jpg
+      :width: 600
+
+      Hardware Connection of EVAL-CN0511-RPIZ and Raspberry Pi 3 Model B+
+
+-  Burn the SD card with the proper Analog Devices, Inc. Kuiper Linux image. Insert the burned SD card 
+   on the designated slot on the Raspberry Pi.
+-  Connect the system to a monitor using an HDMI cable through the mini HDMI connector on the Raspberry Pi.
+-  Connect a USB keyboard and mouse to the RPi through the USB ports.
+-  Connect the RF load/signal analyzer to the dedicated output connectors from the EVAL-CN0511-RPIZ.
+-  Power on the RPi by plugging in a 5 V power supply with micro-USB connector.
+-  Open the terminal and configure the device tree overlay file. See software
+   section for detailed instructions. Make sure to reboot the RPi after saving
+   the config.txt file.
+
+   .. figure:: images/sample_setup_v2.jpg
+      :align: center
+      :width: 600
+
+      CN0511 System Setup
+
+----
+
+Software Setup
+--------------
+
+For the device to run, the SD card should be loaded with Analog Devices Kuiper
+Linux, a distribution based on Raspbian from the Raspberry Pi Foundation. It
+incorporates Linux device drivers for ADI products as well as tools and other
+software products designed and created with ease of use in mind. The reasoning
+behind creating this distribution is to minimize the barriers to
+integrating ADI hardware devices into a Linux-based embedded system.
+
+Access to the embedded system can be through a remote PC connected either via
+LAN cable or Wi-Fi.
+
+Downloading and Flashing Kuiper Linux Image on SD Card
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+In order to control the **EVAL-CN0511-RPIZ** from the Raspberry Pi, you will need 
+to install ADI Kuiper Linux on an SD card. Complete instructions,
+including where to download the SD card image, how to write it to the SD card, 
+and how to configure the system are provided at 
+:dokuwiki:`Kuiper Images </resources/tools-software/linux-software/kuiper-linux>`. 
+Write the image and follow the system configuration procedure.
+
+.. image:: images/command_prompt.png
+   :align: center
+   :width: 400
+
+Configuring the SD Card for the CN0511
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+For the Linux kernel to identify the device connected to the expansion header, 
+update the device tree overlay. A **Device Tree Overlay** contains information 
+about additional connected hardware, the EVAL-CN0511-RPIZ for this case. 
+The overlay file is already included in the SD card and just needs to be matched to the EVAL-CN0511-RPIZ.
+
+Follow the Hardware Configuration procedure under **Preparing the Image: Raspberry Pi** 
+in the :dokuwiki:`Kuiper Images </resources/tools-software/linux-software/kuiper-linux>` page, 
+substituting the following lines in **config.txt**:
+
+This brings up the file in the terminal. Scroll down until the line that begins
+with "dtoverlay" is found; then, whatever it currently is, change it to:
+
+::
+
+   dtoverlay=rpi-cn0511
+
+Save the file by Ctrl + X command. Reboot the system by typing on the command
+prompt:
+
+::
+
+   analog@analog:~$ sudo reboot
+
+----
+
+Graphical User Interface (GUI) and Example Python Scripts
+---------------------------------------------------------
+
+There are two main tools which a user has the option to interact with the
+EVAL-CN0511-RPIZ.
+
+-  IIO Oscilloscope
+-  Python (via Pyadi-iio)
+
+Software Control and Diagnostics via IIO Oscilloscope
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The EVAL-CN0511-RPIZ can be evaluated using IIO Oscilloscope. Customers can use
+the CN0511 plug-in tab, debug tab, and the DMM tab. Various controls and
+diagnostics are available in these plug-ins.
+
+CN0511 IIO Oscilloscope Plug-in
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The CN0511 plug-in tab provides a simple user interface to control the
+EVAL-CN0511-RPIZ as a signal generator.
+
+.. figure:: images/iio_scope_v1.jpg
+   :width: 600
+
+   Graphical User Interface (GUI) window of ADI IIO Oscilloscope with CN0511 Plug-in Single Tone Mode
+
+-  **Frequency (MHz)**: Set the desired output signal frequency to be produced by the AD9166.
+-  **Amplitude (dB)**: Adjust the RF signal amplitude of the AD9166 output.
+-  **Enter**: Provides a calibrated RF signal output from the AD9166.
+
+**DAC Amplifier**
+
+-  **Enable**: Enable/disable the AD9166 RF signal output.
+
+Debug Tab
+^^^^^^^^^
+
+The debug tab provides direct access to IIO device and channel attributes, as
+well as the registers of the CN0511 components. The IIO attributes and registers
+can be read and written for advanced configuration and information.
+
+DMM Tab
+^^^^^^^
+
+The DMM tab provides temperature readings for ADF4372 and AD9166 using internal
+temperature sensors on both devices.
+
+DAC Data Manager
+^^^^^^^^^^^^^^^^
+
+The DAC Data Manager set the DAC output scale for AD5693R that sets the bias on
+the on-board crystal oscillator.
+
+
+----
+
+Pyadi-IIO
+~~~~~~~~~
+
+:dokuwiki:`PyADI-IIO </resources/tools-software/linux-software/pyadi-iio>` is a python abstraction module for 
+ADI hardware with IIO drivers to make them easier to use. This module provides device-specific APIs built on top 
+of the current libIIO python bindings. These interfaces try to match the driver naming 
+as much as possible without the need to understand the complexities of libIIO and IIO.
+
+.. tip::
+
+   See this :ref:`page <cn0511-software-req>` for instructions on how to install pyadi-iio and its dependencies.
+
+Running the Example
+^^^^^^^^^^^^^^^^^^^
+
+This demo uses a PyADI-IIO example script. This script will show the single-tone
+frequency with calibrated output power in dBm.
+
+-  Connect the :adi:`EVAL-CN0511-RPIZ` to the Raspberry Pi.
+-  Open command prompt or terminal and navigate through the examples folder inside the downloaded or cloned *pyadi-iio* directory.
+-  Run the example script using the command.
+
+::
+
+   .../pyadi-iio/examples $ python3 cn0511_example.py
+
+.. image:: images/cn0511_example_output.jpg
+   :align: center
+   :width: 600
+
+.. admonition:: Download
+   :class: download
+
+   Github link for the python sample script: :git-pyadi-iio:`CN0511 Python Example <examples/cn0511_example.py>`
+
+Schematic, PCB Layout, Bill of Materials
+----------------------------------------
+
+.. admonition:: Download
+   :class: download
+
+   :adi:`EVAL-CN0511-RPIZ Design & Integration Files <cn0511-DesignSupport>`
+
+   -  Schematics
+   -  PCB Layout
+   -  Bill of Materials
+   -  Allegro project
+   
+Reference Demos & Software
+--------------------------
+
+-  :ref:`pyADI-IIO <pyadi-iio>`
+-  `AD9166 IIO <https://github.com/analogdevicesinc/libad9166-iio>`__
+-  :ref:`IIO Oscilloscope Installation Guide <iio-oscilloscope>`
+-  :ref:`Kuiper Images <kuiper>`
+
+More Information and Useful Links
+---------------------------------
+
+-  :adi:`CN0511 Circuit Note Page <CN0511>`
+-  :adi:`CN0511 Design Support Package <cn0511-DesignSupport>`
+-  :adi:`ADF4372 Product Page <ADF4372>`
+-  :adi:`LTC2928 Product Page <LTC2928>`
+-  :adi:`LTM8045 Product Page <LTM8045>`
+-  :adi:`AD5693 Product Page <AD5693>`
+-  :adi:`ADP5073 Product Page <ADP5073>`
+-  :adi:`ADP7183 Product Page <ADP7183>`
+-  :adi:`ADM7150 Product Page <ADM7150>`
+-  :adi:`ADM7154 Product Page <ADM7154>`
+-  :adi:`ADP1761 Product Page <ADP1761>`
+-  :adi:`LT3090 Product Page <LT3090>`
+-  :adi:`LTM4622 Product Page <LTM4622>`
+
+Registration
+------------
+
+.. tip::
+
+   Receive software update notifications, documentation updates, view the latest videos, 
+   and more when you register your hardware. 
+   `Register <https://form.analog.com/Form_Pages/FeedBack/EVAL-CN0511-RPIZ?&v=RevD>`_ 
+   to receive all these great benefits and more!

--- a/docs/solutions/reference-designs/cn0511/images/block_terminal_assignment_v2.png
+++ b/docs/solutions/reference-designs/cn0511/images/block_terminal_assignment_v2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:78139b1fe6b126f7edc59b947d9b273d111a7ebdfce534e8d1a69aaa8a95e6c6
+size 1368079

--- a/docs/solutions/reference-designs/cn0511/images/clock_source.png
+++ b/docs/solutions/reference-designs/cn0511/images/clock_source.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6a17537ee387cbd663a4cb4f1e9c3fcb27398087873961db23d9058442ab459a
+size 112913

--- a/docs/solutions/reference-designs/cn0511/images/cn0511_angle_view.png
+++ b/docs/solutions/reference-designs/cn0511/images/cn0511_angle_view.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d160d4c3400c2ed3485cda73804b23ed1f339bd2a2839ef12a24bfa34eb9c8e1
+size 1010378

--- a/docs/solutions/reference-designs/cn0511/images/cn0511_example_output.jpg
+++ b/docs/solutions/reference-designs/cn0511/images/cn0511_example_output.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5a73e5209a385f2d11833415951491e99522f2b68ddc976529acc223acd6dc64
+size 27279

--- a/docs/solutions/reference-designs/cn0511/images/cn0511_power_supply_options.png
+++ b/docs/solutions/reference-designs/cn0511/images/cn0511_power_supply_options.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:875cf6bcfdf137a019ae45c181fb75ee93e7054ec8395a8691d9f32892c8b5d2
+size 662293

--- a/docs/solutions/reference-designs/cn0511/images/cn0511_rpi_v1.jpg
+++ b/docs/solutions/reference-designs/cn0511/images/cn0511_rpi_v1.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f9404415971a7111b2763a63bad32877d679c5473f1dcb3b7b5d0eb03b0c7b3c
+size 157739

--- a/docs/solutions/reference-designs/cn0511/images/cn0511_sma_input_output_v2.jpg
+++ b/docs/solutions/reference-designs/cn0511/images/cn0511_sma_input_output_v2.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c00b294bc37df2a6edbe228875fcccb9d8695df59fac87cb38fee5416e99ca67
+size 111886

--- a/docs/solutions/reference-designs/cn0511/images/command_prompt.png
+++ b/docs/solutions/reference-designs/cn0511/images/command_prompt.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eed46fd40be61709bf3d2272f201215992ef6264def6498c226dbb4f9db158c0
+size 71042

--- a/docs/solutions/reference-designs/cn0511/images/eval-cn0511_test_block_diagram.jpg
+++ b/docs/solutions/reference-designs/cn0511/images/eval-cn0511_test_block_diagram.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6ae3f5d6c86569915c7c5c13da67f05a518aa9f4c9b7802b25f48514eb43ca4a
+size 48618

--- a/docs/solutions/reference-designs/cn0511/images/heat_sink_v2.jpg
+++ b/docs/solutions/reference-designs/cn0511/images/heat_sink_v2.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:945fd17968ef086d1948e321177431ea20baa7db9811a2ec2b8a345c7a3519ba
+size 121364

--- a/docs/solutions/reference-designs/cn0511/images/iio_scope_v1.jpg
+++ b/docs/solutions/reference-designs/cn0511/images/iio_scope_v1.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:17e6a60ee7c733ae8bb41e82267350c50c0695ad59eeb60fdaaaa7d6517709f1
+size 32155

--- a/docs/solutions/reference-designs/cn0511/images/sample_setup_v2.jpg
+++ b/docs/solutions/reference-designs/cn0511/images/sample_setup_v2.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:560386c6c17093571b6ade242242e97c757490d30aa7be4bf61a548c101ae601
+size 149935

--- a/docs/solutions/reference-designs/cn0511/index.rst
+++ b/docs/solutions/reference-designs/cn0511/index.rst
@@ -1,0 +1,82 @@
+.. _eval-cn0511-rpiz:
+
+EVAL-CN0511-RPIZ
+================
+
+DC to 5.5 GHz Signal Generator with +/-0.5 dB Calibrated Output Power
+
+.. image:: images/cn0511_angle_view.png
+   :align: center
+   :width: 400
+
+Overview
+--------
+
+Instruments that operate at RF range with features like low distortion, ultra
+low phase noise, and portable signal generator are difficult to provide at
+reasonable cost.
+
+The system shown is an entirely self-contained DC to 5.5 GHz
+signal generator. It only requires the Raspberry Pi (RPi) to operate. The RF
+digital-to-analog converter (DAC), controlled using a 100 MHz Serial Peripheral
+Interface (SPI) from the RPi, allows for single tone, phase coherent, and fast
+frequency hopping across the spectrum. All the clocking requirements are
+generated using an on-board crystal, so no external clock source is needed. All
+the necessary power rails are also converted from the RPi into various supply
+voltage requirements of the RF signal generator.
+
+The system is designed to simplify the input requirements, optimize signal
+paths, and reduce external cables and components. This circuit can act as a
+standalone laboratory equipment or can be incorporated as a module into
+automatic test equipment. Its small size makes it particularly attractive when
+multiple channels are required. This Raspberry Pi compatible solution makes 
+high speed signal generation more accessible and economical.
+
+Features
+--------
+
+- DC to 5.5 GHz Single Tone Generator
+- +/- 0.5 dB Wideband Amplitude Calibration from 0 dBm to -40 dBm
+- 48-Bit Frequency Tuning Resolution (~43 µHz)
+- Onboard VCXO for Quick Bring Up
+- Compatible with Raspberry Pi 3B+, 4, Zero W, Zero 2W
+
+Applications
+------------
+
+- Signal generator applications
+
+.. admonition:: Getting Started
+
+   The :adi:`CN0511` can be used for a wide range of applications, 
+   and the following demos are meant to show examples of the flexibility of the board. 
+   To get started with setup, configuration, and example use cases, 
+   please proceed to the Quick Start Guide and follow the provided demo pages.
+
+   - :doc:`Quick Start Guide <cn0511>`
+   - :ref:`Software Requirements <cn0511-software-req>`
+
+Recommendations
+---------------
+   
+People who follow the flow that is outlined, have a much better experience with
+things. However, like many things, documentation is never as complete as it
+should be. If you have any questions, feel free to ask on our
+:ez:`EngineerZone forums <help-and-support>`, but before that, please make
+sure you read our documentation thoroughly.
+
+Warning
+-------
+
+.. esd-warning::
+
+Help and Support
+----------------
+
+Please go to :ez:`Help and Support <help-and-support>` page.
+
+.. toctree::
+   :hidden:
+
+   cn0511
+   software_update

--- a/docs/solutions/reference-designs/cn0511/software_update.rst
+++ b/docs/solutions/reference-designs/cn0511/software_update.rst
@@ -1,0 +1,104 @@
+.. _cn0511-software-req:
+
+Software Requirements
+=====================
+
+Following the instructions below will allow you to install the latest version of libIIO and other requirements needed to run the example for CN0511. 
+This is necessary because the latest version of libIIO contains the necessary support for AD9166, which is the main component of CN0511.
+
+.. important::
+
+   -  This set of instructions will soon go away when the next version of Kuiper Linux is released
+   -  Line script to be copied are those found after the '$' symbol
+   -  Enter the password "analog" whenever asked for it during the
+      installation process
+
+   ::
+
+      [sudo] password for analog: analog
+
+----
+
+Libad9166-iio Installation 
+--------------------------
+
+1. After the reboot, open command prompt or terminal again to clone the
+   libad9166-iio from GitHub.
+
+   ::
+
+       analog@analog:~$ git clone https://github.com/analogdevicesinc/libad9166-iio
+
+2. Go to the libad9166-iio directory.
+
+   ::
+
+      analog@analog:~$ cd libad9166-iio
+
+3. Install the libad9166-iio and its dependencies by running the following commands:
+
+   ::
+
+      analog@analog:~/libad9166-iio $ cmake ./CMakeLists.txt
+
+   ::
+
+      analog@analog:~/libad9166-iio $ make
+
+   ::
+
+      analog@analog:~/libad9166-iio $ sudo make install
+
+4. Go to the Python directory.
+
+   ::
+
+      analog@analog:~/libad9166-iio $ cd bindings/python
+
+5. Install the other requirements needed for CN0511 libad9166-iio example project by running the following commands:
+
+   ::
+
+      analog@analog:~/libad9166-iio/bindings/python $ sudo pip install -r requirements_dev.txt
+
+   ::
+
+      analog@analog:~/python $ sudo pip install -r requirements_dev.txt
+
+   ::
+
+      analog@analog:~/python $ cmake ./CMakeLists.txt
+
+   ::
+
+      analog@analog:~/python $ sudo make
+
+   ::
+
+      analog@analog:~/python $ sudo make install
+
+----
+
+Pyadi-iio Installation
+----------------------
+
+1. Enter the following commands to install pyadi-iio from GitHub:
+
+   ::
+
+      analog@analog:~ $ sudo python -m pip install git+https://github.com/analogdevicesinc/pyadi-iio/
+
+   ::
+
+      analog@analog:~$ git clone https://github.com/analogdevicesinc/pyadi-iio
+
+2. Install the libatlas-base-dev and linux packages by running the following command:
+
+   ::
+
+      analog@analog:~$ sudo apt-get install libatlas-base-dev linux packages
+
+3. Then, choose 'Y' if were asked to continue.
+
+After all these requirements has been loaded in the Raspberry Pi, the example
+found in ~/home/analog/pyadi-iio/examples for CN0511 can now be run.


### PR DESCRIPTION
## Summary
- Move cn0511 wiki documentation to `solutions/reference-designs/cn0511/`
- 4 RST files with 12 localized images
- Generated stub `index.rst` with toctree

## Test plan
- [ ] Sphinx build passes without errors
- [ ] All toctree entries resolve correctly
- [ ] Images render properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)