### PR TITLE
reference-designs/eval-adpd410x: Add eval-adpd410x documentation

### DIFF
--- a/docs/solutions/reference-designs/eval-adpd410x/EVAL-ADPD4100-ARDZ_ANGLE-evaluation-board.jpg
+++ b/docs/solutions/reference-designs/eval-adpd410x/EVAL-ADPD4100-ARDZ_ANGLE-evaluation-board.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2d60acecaf61ae32577a95cc3912de2969c78a541fb1297671fe2ca4b991a132
+size 6170141

--- a/docs/solutions/reference-designs/eval-adpd410x/eval-adpd410x.rst
+++ b/docs/solutions/reference-designs/eval-adpd410x/eval-adpd410x.rst
@@ -1,0 +1,828 @@
+Quick Start Guide
+==================
+
+The :adi:`EVAL-ADPD410x-ARDZ` is a simple, Arduino form-factor breakout
+board for developing :adi:`ADPD4100` and :adi:`ADPD4101` applications.
+The :adi:`ADPD4101`, interfaced through I2C, and the :adi:`ADPD4100`,
+interfaced through SPI, are highly versatile, multimodal sensor front
+ends, stimulating up to eight light emitting diodes (LEDs) and measuring
+the return signal on up to eight separate current inputs. There are a
+number of other evaluation platforms for these devices, including the
+:adi:`EVAL-ADPD4100Z-PPG`, optimized for photoplethysmograph
+applications, and the reference design :adi:`CN0503`, optimized for
+optical liquid analysis applications such as colorimetry, turbidity, and
+fluorescence. The :adi:`EVAL-ADPD410x-ARDZ` board come in handy for
+adapting these evaluation boards to meet specific application
+requirements, as well as for "ground up" development of new
+applications.
+
+|image1|
+
+Features
+--------
+
+-  8 LED excitation channels with high-voltage extension circuitry
+-  8 Photodiode inputs
+
+Device Driver and Support
+-------------------------
+
+A no-OS device driver and an example program are provided, targeting the
+:adi:`EVAL-ADICUP3029` platform. The ADICUP3029 example application uses
+the ADPD410x no-OS driver and emulates the Linux IIO framework through
+the tinyiiod daemon library. The application communicates with the host
+computer via the serial backend over a USB-UART physical connection.
+This facilitates rapid application development on a host computer,
+independent from embedded code development.
+
+Similarly, utility software (such as iio_info, IIO Oscilloscope,
+PyADI-IIO, etc.) typically associated with Linux systems can be used
+with this no-OS implementation.
+
+Materials Needed
+----------------
+
+-  :adi:`EVAL-ADICUP3029`
+-  :adi:`EVAL-ADPD410x-ARDZ`
+-  Micro USB to USB cable
+-  PC or laptop with a USB port
+
+Hardware Setup
+--------------
+
+Jumper Configuration
+~~~~~~~~~~~~~~~~~~~~
+
+There are two shunt-configurable jumpers and three types of solder
+jumpers on the :adi:`EVAL-ADPD410x-ARDZ` board.
+
+I/O Logic Voltage (IOSEL) Shunt Positions
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+====================== ==============
+Correct Shunt Position Layout Picture
+====================== ==============
+Shorted Pin 1 and 2    |image2|
+====================== ==============
+
+Onboard LED and Photodiode (P10) Shunt Positions
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The onboard LED and photodiode are by default connected to LED1A and
+PD1A, respectively. **When using external LEDs and sensors on this
+channel, make sure to remove this connection using jumper header P10.**
+
+=============================================================== ==============
+ Correct Shunt Position                                         Layout Picture                    
+=============================================================== ==============
+Shorted Pin 1 and 2, Shorted Pin 3 and 4, Shorted Pin 5 and 6   |image3|
+=============================================================== ==============
+
+LED Supply Voltage (JP1) Solder Positions
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+====================== ==============
+Correct Shunt Position Layout Picture
+====================== ==============
+Shorted Pin 2 and 3    |image5|
+
+====================== ==============
+
+LED Driver Connection P9, P11, P13, P15, P17, P19, P22, P24
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+====================== ==============
+Correct Shunt Position Layout Picture
+====================== ==============
+Shorted                |image6|
+====================== ==============
+
+SPI or I2C Interface
+^^^^^^^^^^^^^^^^^^^^
+
++--------------------------+-----------------------------------+
+| Board                    | Shorted Resistors                 |
++==========================+===================================+
+| EVAL-ADPD410x-ARDZ (SPI) | Shorted R8 and R9, Open R6 and R7 |
++--------------------------+-----------------------------------+
+
+Below is a photo of the :adi:`ADPD4100` (SPI) board with all the
+correct shunt and solder jumper connections.
+
+|image9|
+
++------------------------------------------------------+
+| Board                           | Shorted Resistors  |
++=================================+====================+
+| :adi:`ADPD4101` (I2C)           | Shorted R6 and R7, |
+|                                 | Open R8 and R9     |
++------------------------------------------------------+
+
+Below is a photo of the EVAL-ADPD4101-ARDZ (I2C) board with all the
+correct shunt and solder jumper connections.
+
+|image12|
+
+Prototyping Connectors
+~~~~~~~~~~~~~~~~~~~~~~
+
+The board has two parallel 18-pin, 100-mil pitch male connectors, which
+give access to the LED driver channels, the photodiode inputs, custom
+I/O pins from the AFE, and supply voltage for the LED. The user can use
+this along with the break-away protoboard to implement a custom circuit
+for testing. The pin assignment and functions are shown below.
+
+|image13| |image14|
+
+Pins labeled **XYC** (where X refers to LED 1, 2, 3, or 4, and Y refers
+to channel A or B) denote connections to the LED cathode which are
+voltage protected via transistors to the ADPD4100/1 LED inputs (denoted
+by **LXY**). It is recommended to connect LED cathodes to these pins
+instead of connecting directly to **LXY** pins. **PDXY** (X refers to
+photodiode 1, 2, 3, or 4 and Y refers to channel A or B) pins denote
+photodiode signal inputs to the AFE. **ACOM** and **BCOM** pins refer to
+the common cathode bias output for photodiode sensors. These should be
+connected to the cathodes of photodiodes in the matching channel (for
+example, photodiodes connected to PD1A, PD2A, PD3A, and PD4A should
+have their cathodes connected to ACOM).
+
+A simple circuit for testing LED driver outputs and photodiode current
+sensing using the break-away prototype board can easily be set up using
+optocouplers, as shown below.
+
+.. image:: images/testschematic.png
+   :width: 600
+
+General Connection
+~~~~~~~~~~~~~~~~~~
+
+-  Set the following EVAL-ADICUP3029 switches according to their
+   configuration on the table.
+
+      ========== =============
+      Switch     Configuration
+      ========== =============
+      UART (S2)  USB
+      POWER (S5) WALL/USB
+      ========== =============
+
+-  Connect the :adi:`EVAL-ADPD410x-ARDZ` to the
+   :adi:`EVAL-ADICUP3029` using the headers shown. See correct Jumper
+   Configuration for both evaluation boards 
+   :doc:`here </solutions/reference-designs/eval-adpd410x/eval-adpd410x>`.
+
+      .. image:: images/arduinoconnection.jpg
+         :width: 400 px
+
+Driver/Firmware Setup
+-----------------------
+
+There are two basic ways to program the :adi:`EVAL-ADICUP3029` with the
+software for both boards.
+
+Dragging and Dropping the Hex File to the Daplink Drive
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+-  Ensure that the :adi:`EVAL-ADICUP3029` board switches are set to the
+   correct configuration, as detailed in 
+   :doc:`General Connection </solutions/reference-designs/eval-adpd410x/eval-adpd410x>`.
+-  Connect the :adi:`EVAL-ADICUP3029` board to the PC or laptop using
+   the Micro USB to USB cable.
+-  Drag and Drop the appropriate .hex file from the list below to the
+   Daplink Drive.
+
+      .. image:: images/daplink_windows_explorer.png
+         :width: 550 px
+
+-  The drive will unmount once the .hex file is dropped and wait for it
+   to reappear. Once it does, press the reset button of the
+   :adi:`EVAL-ADICUP3029` to ensure that the microcontroller is
+   updated.
+
+.. admonition:: Download
+   :class: download
+
+   Pre-built HEX files can be found here:
+
+   -  `EVAL-ADPD4100-ARDZ HEX File
+      (ADuCM3029_demo_adpd410x_spi.hex)
+      <https://github.com/analogdevicesinc/EVAL-ADICUP3029/releases/
+      download/Latest/ADuCM3029_demo_adpd410x_spi.hex>`_
+   -  `EVAL-ADPD4101-ARDZ HEX File
+      (ADuCM3029_demo_adpd410x_i2c.hex)
+      <https://github.com/analogdevicesinc/EVAL-ADICUP3029/releases/
+      download/Latest/ADuCM3029_demo_adpd410x_i2c.hex>`_
+
+   The latest source code can be found here:
+
+   -  :git-EVAL-ADICUP3029:`EVAL-ADICUP3029/tree/master/projects/ADuCM3029_demo_adpd410x<projects/ADuCM3029_demo_adpd410x>`.
+
+Using CrossCore Embedded Studio
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+-  Acquire a copy of the project source files of the
+   :adi:`EVAL-ADPD410x-ARDZ` by downloading the source files directly
+   from the repository at :git-EVAL-ADICUP3029:`EVAL-ADICUP3029/tree/master/projects/ADuCM3029_demo_adpd410x<projects/ADuCM3029_demo_adpd410x>` 
+   or you can clone the entire `EVAL-ADICUP3029 repository
+   <https://github.com/analogdevicesinc/EVAL-ADICUP3029>`_ and check
+   the projects folder for ADuCM3029_demo_adpd410x.
+-  Open CrossCore Embedded Studio and import the project into your
+   workspace, as detailed in the `cces_user_guide
+   <https://wiki.analog.com/resources/eval/user-guides/eval-adicup3029/
+   tools/cces_user_guide>`_. This allows you to edit the software to
+   fit your requirements.
+
+.. important::
+
+   If this is your first time using CrossCore Embedded Studio, check the
+   `user guide
+   <https://wiki.analog.com/resources/eval/user-guides/eval-adicup3029/
+   tools/cces_user_guide>`_ to get started.
+
+-  Once ready, you can opt to generate your own .hex file and use the
+   first method to program the :adi:`EVAL-ADICUP3029` or you can use a
+   debug session by following the quickstart guide.
+
+CrossCore Project Header File Configuration
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+-  Select which board the project will support when built using
+   :git-EVAL-ADICUP3029:`projects/ADuCM3029_demo_adpd410x/src/app_config.h`.
+
+   -  For EVAL-ADPD4100-ARDZ
+
+       |image15|
+
+   -  For EVAL-ADPD4101-ARDZ
+
+       |image16|
+
+         You can configure the default timeslots and other settings of the
+         :adi:`ADPD4100` or :adi:`ADPD4101` using 
+         :git-EVAL-ADICUP3029:`projects/ADuCM3029_demo_adpd410x/src/adpd410x_app_config.h`.
+
+-  You can set the default number of active timeslots and output data
+   rate.
+
+   |image17|
+
+-  Initial timeslot settings are configured using the
+   **adpd410x_timeslot_init** data structure, as shown below:
+
+   |image18|
+
+-  **Enabling ADC channel 2**
+
+   Each timeslot can use the two ADC input channels of the ADPD4100/1.
+   By default, the timeslot only uses channel 1. Setting this to true
+   will enable channel 2.
+
+-  **Timeslot Inputs**
+
+   |image19|
+
+   Each timeslot input can be set to use a pair of input pins of the
+   ADPD4100/1. Below are possible pair options:
+
+   |image20|
+
+-  Each of the input pins can be disabled or routed to any or both of
+   the channels. Below are the possible configurations of the input
+   pins.
+
+   |image21|
+
+-  **Timeslot Input Preconditioning**
+
+   Timeslot inputs have programmable connections, which precondition the
+   sensor to set operating conditions before sampling. Below are the
+   possible options:
+
+   |image22|
+
+-  **TIA Reference Voltage**
+
+   The reference voltage of the Trans-Impedance Amplifier (TIA) is
+   configurable. Below are the possible values:
+
+   |image23|
+
+-  **TIA Gain Resistor**
+
+   The gain resistor used by the TIA is configurable for each input
+   channel. Below are the possible values:
+
+   |image24|
+
+-  **Multiple Pulses and Integrator Chopping**
+
+      The ADPD4100/1 is capable of improving SNR using multiple pulses per sample
+      and integrator chopping, which have configurable settings.
+
+   -  **4-Pulse Reverse Pattern**
+
+      Each pulse from the LED in a set of 4 can be configured to either
+      have an on-off or off-on integrator chopping sequence. This is a
+      4-bit value, 1 bit for each pulse. Setting a bit reverses the
+      integrator chopping sequence for that pulse.
+
+   -  **4-Pulse Subtract Pattern**
+
+      The mathematical operation performed on a digitized ADC sample can
+      be set to addition or subtraction for each pulse in a set of 4.
+      This is a 4-bit value, 1 bit for each pulse. Setting a bit negates
+      the operation for that pulse.
+
+-  **Byte Number**
+
+   This sets the number of data bytes used in the timeslot.
+
+-  **Decimation Factor**
+
+   The decimation factor sets the number of time slot values used in the
+   final sample.
+   ``output data rate = sample rate / (decimation factor - 1)``
+
+-  **LED Output**
+
+   The 4 LED outputs have configurable output current and can be set to
+   either channel A or channel B only. You can define the LED value
+   directly or through fields. The first 7 bits are for the output
+   current, which scale from 1.5 mA to 200 mA for 0x01 to 0x7F. The
+   last bit is for the output channel. Setting this bit selects channel
+   B while clearing selects channel A.
+
+   |image25|
+
+-  **ADC Cycles**
+
+   This sets the number of integration cycles per ADC conversion. This
+   value can range from 0x01 to 0xFF.
+
+-  **Number of Repeats**
+
+   This sets the number of repeat ADC conversions. This value can range
+   from 0x01 to 0xFF. ``total number of pulses = ADC cycles X Number
+   of Repeats``
+
+Here is an example timeslot setting used in the pre-built hex files:
+
+|image26|
+
+Software Setup
+--------------
+
+Installation
+~~~~~~~~~~~~
+
+To communicate with the device from the PC or laptop using IIO commands,
+install the Libiio package by following the guide in the repository:
+`libiio/releases <https://github.com/analogdevicesinc/libiio/releases>`_. 
+The method is different for Windows or Linux operating systems.
+
+Connection
+~~~~~~~~~~
+
+The device must be able to create a context. Context creation in the
+software depends on the backend used to connect the device. This guide
+covers the device communication using the currently supported platform,
+a serial backend through a USB-UART connection. A simple way of
+checking, if the device is connected, is through the `iio_info
+<https://wiki.analog.com/resources/tools-software/linux-software/
+libiio/iio_info>`_ command. Specifically, it reports all IIO attributes
+of a detected device and context. To do this, simply enter the below
+command to a terminal or command line.
+
+::
+
+   iio_info -u serial:<serial port>
+
+Examples:
+
+-  In a Windows machine, you can check the port of your ADICUP3029 via
+   Device Manager in the Ports (COM & LPT) section. If your device is
+   in COM4, use **serial:COM4** as your URI (e.g., *iio_info -u
+   serial:COM4*).
+-  In a Unix-based machine, you will see it under the /dev/ directory
+   in this format "ttyUSBn", where n is a number depending on how many
+   serial USB devices are attached. If you see that your device is
+   ttyUSB0, use **serial:/dev/ttyUSB0** as your URI. (e.g., *iio_info
+   -u serial:/dev/ttyUSB0*).
+
+An example output of this command should look like the one below:
+
+|image27|
+
+Reading and Configuring the Device from Command Line
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Using the `iio_attr
+<https://wiki.analog.com/resources/tools-software/linux-software/
+libiio/iio_attr>`_ command from the Libiio package, you can read and
+configure the device.
+
+Reading Raw Channel Outputs from the Device
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The -c option of the `iio_attr
+<https://wiki.analog.com/resources/tools-software/linux-software/
+libiio/iio_attr>`_ command allows reading of the individual raw channel
+outputs. Specifically, this reads the raw attribute of the specified
+channel of the specified device in the context of the specified URI. The
+command follows the format shown below.
+
+::
+
+   iio_attr -u <URI> -c <DEVICENAME> <CHANNELNAME> <ATTRIBUTE>
+   For example, for a Windows Machine
+   iio_attr -u serial:COM4  -c adpd410x voltage0 raw
+
+-  <URI> specifies the URI similar to the one used in :doc:`Connection
+   </solutions/reference-designs/eval-adpd410x/eval-adpd410x>`.
+-  <DEVICENAME> specifies the device name, which is **adpd410x**.
+-  <CHANNELNAME> specifies the channel name, which are formatted as
+   voltageX where X can be from 0 to 7.
+-  <ATTRIBUTE> specifies the name of the channel attribute, which is
+   raw. This is a read-only attribute.
+
+An example output of this command should look like the one below:
+
+|image28|
+
+Reading and Writing Device Attributes
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The -d option of the `iio_attr
+<https://wiki.analog.com/resources/tools-software/linux-software/
+libiio/iio_attr>`_ command allows reading or writing (only for specific
+items) of device attributes. For example, the *sampling_frequency*
+attribute is readable and writeable. The command to read and write to
+this attribute is shown below:
+
+::
+
+   For reading, use iio_attr -u <URI> -d <DEVICENAME> <ATTRIBUTE>
+   For writing, use iio_attr -u <URI> -d <DEVICENAME> <ATTRIBUTE>
+   <VALUE>
+   for example, for a Windows Machine
+   iio_attr -u serial:COM4 -d adpd410x sampling_frequency 40
+
+-  <URI> specifies the URI similar to the one used in :doc:`Connection
+   </solutions/reference-designs/eval-adpd410x/eval-adpd410x>`.
+-  <DEVICENAME> specifies the device name which is **adpd410x**.
+-  <ATTRIBUTE> specifies the name of the device attribute which is
+   **sampling_frequency**.
+
+An example output of this command should look like the one below:
+
+|image29|
+
+IIO Oscilloscope
+~~~~~~~~~~~~~~~~
+
+.. important::
+
+   Make sure to download/update to the latest version of IIO-Oscilloscope
+   found on this `link
+   <https://github.com/analogdevicesinc/iio-oscilloscope/releases>`_.
+
+-  Install and start IIO-Oscilloscope. There are two options you can
+   use to select IIO contexts. First, you can use the Serial option and
+   input the correct port settings of the board from the Device Manager.
+   Another way is by manually entering the URI used in 
+   :doc:`Connection</solutions/reference-designs/eval-adpd410x/eval-adpd410x>`.
+
+   |image30|
+
+.. image:: images/iio-oscilloscopemanualcontext.png
+   :width: 400
+
+-  Press Refresh to display available IIO Devices, and once adpd410x is
+   detected, press Connect. It may take several presses to Connect
+   before the software proceeds and opens the Debug Panel and Waveform
+   Panel.
+
+.. image:: images/iio-oscilloscopedetecteddevice.png
+   :width: 400
+
+Debug Panel
+^^^^^^^^^^^
+
+In the Debug Panel, you can directly access the device/channel
+attributes and even the device registers. Remember to select first the
+adpd410x in the Device Selection section.
+
+|image31|
+
+Waveform Panel
+^^^^^^^^^^^^^^
+
+The Waveform panel, also known as the Capture window, displays the
+real-time waveform of selected photodiode channels of the ADPD410x.
+Select the desired channels to display in the upper left section. You
+can also edit the plot settings in the left section.
+
+.. important::
+
+   You cannot use the Debug Panel and the Waveform Panel simultaneously.
+   Using the Waveform Panel will freeze the Debug Panel.
+
+   |image32| |image33|
+
+.. important::
+
+   For best device operation and waveform captured, it is recommended to
+   use a time domain plot with 20 samples.
+
+Python and PyADI-IIO
+~~~~~~~~~~~~~~~~~~~~
+
+`PyADI-IIO <https://wiki.analog.com/resources/tools-software/linux-
+software/pyadi-iio>`_ is a python abstraction module for ADI hardware
+with IIO drivers to make them easier to use. This module provides
+device-specific APIs built on top of the current libIIO python bindings.
+These interfaces try to match the driver naming as much as possible
+without the need to understand the complexities of libIIO and IIO.
+
+Installing the Packages
+^^^^^^^^^^^^^^^^^^^^^^^
+
+.. important::
+
+   PyADI-IIO requires a Python installed on your computer. It is
+   recommended to install Python 3.7 or higher.
+
+Install PyADI-IIO using one of the methods in `PyADI-IIO
+<https://wiki.analog.com/resources/tools-software/linux-software/
+pyadi-iio>`_.
+
+There are two example scripts found in the examples folder in `PyADI-IIO
+<https://wiki.analog.com/resources/tools-software/linux-software/
+pyadi-iio>`_. To run both examples, the following packages are required:
+`pyqtgraph <https://www.pyqtgraph.org>`_, `scipy <https://scipy.org>`_,
+`PyQt5 <https://www.riverbankcomputing.com/software/pyqt>`_,
+`matplotlib <https://matplotlib.org>`_.
+
+If you are using `pip <https://pip.pypa.io/en/stable>`_, you can
+install all of the PyADI-IIO, as well as the example script
+dependencies, by following these steps:
+
+-  Clone or download the pyadi-iio repository `pyadi-iio/
+   <https://github.com/analogdevicesinc/pyadi-iio/>`_
+-  Open command prompt or terminal and navigate to the *pyadi-iio*
+   directory.
+-  Enter the following commands: ``...\pyadi-iio\>pip install -r
+   requirements.txt`` and ``...\pyadi-iio\>pip install -r
+   examples/requirements_adiplot.txt`` and
+   ``...\pyadi-iio\>python setup.py install``
+
+.. important::
+
+   One of the packages in *requirements_adiplot.txt* is the PyQt5. If you
+   already have a pre-installed PyQt5 prior to the installation of the
+   packages, it is suggested that you uninstall the said package in the
+   virtual environment. Duplicate installations may sometimes cause
+   errors that inhibit the system from displaying the real-time plot.
+   This can easily be done by inputting the command: *pip uninstall
+   PyQt5* while the virtual environment is active.
+
+Running the Examples
+^^^^^^^^^^^^^^^^^^^^
+
+There are three example scripts for the ADPD410x found in `pyadi-iio/
+<https://github.com/analogdevicesinc/pyadi-iio/>`_. The first simply
+reads from the photodiode channels, the second plots specified
+photodiode channels, and the third tests the board separately, with its
+onboard LED and photodiode and with a test setup built from the simple
+example circuit from 
+:doc:`Prototyping Connectors</solutions/reference-designs/eval-adpd410x/eval-adpd410x>`. For
+example 1, follow these steps:
+
+-  Connect the :adi:`EVAL-ADPD410x-ARDZ` to the
+   :adi:`EVAL-ADICUP3029`.
+-  Connect the :adi:`EVAL-ADICUP3029` to the PC using the micro-USB
+   cable and note the serial port from the Device Manager as in
+   :doc:`Connection </solutions/reference-designs/eval-adpd410x/eval-adpd410x>`.
+-  Open command prompt or terminal and navigate to the examples folder
+   inside the downloaded or cloned *pyadi-iio* directory.
+-  Run the example using the command: ``...\pyadi-iio\examples>python
+   adpd410x_example.py``
+-  Input the noted serial port and press *Connect*.
+   |image34|
+-  Once connected, press *Read*.
+   |image35|
+
+For example 2, follow these steps:
+
+-  Connect the :adi:`EVAL-ADPD410x-ARDZ` to the
+   :adi:`EVAL-ADICUP3029`.
+-  Connect the :adi:`EVAL-ADICUP3029` to the PC using the micro USB
+   cable and note the serial port from the Device Manager as in
+   :doc:`Connection </solutions/reference-designs/eval-adpd410x/eval-adpd410x>`.
+-  Open command prompt or terminal and navigate to the examples folder
+   inside the downloaded or cloned *pyadi-iio* directory.
+-  Run the example script using the command: ``...\pyadi-iio\examples>
+   python adpd410x_plot.py``
+-  The script will ask for a serial port. Input the noted serial port
+   and press Enter. In cases when the board is not found, press the
+   reset button (S1) on the :adi:`EVAL-ADPD410x-ARDZ` and input the
+   noted serial port again.
+
+   |image36|
+
+-  When the board is detected, you will be asked to specify the number
+   of channels (1 to 8) you want to read. Then, you need to specify the
+   desired channel numbers (1 to 8).
+
+   |image37|
+
+-  A plot will appear showing the specified channels. You have the
+   option to save a copy of the displayed waveform at any point in time
+   using the matplotlib controls at the top.
+
+   |image38|
+
+For example 3, follow these steps:
+
+-  Connect the :adi:`EVAL-ADPD410x-ARDZ` to the EVAL-ADICUP3029.
+-  Connect the :adi:`EVAL-ADICUP3029` to the pc using the micro-USB
+   cable and note the serial port from the Device Manager as in
+   :doc:`Connection </solutions/reference-designs/eval-adpd410x/eval-adpd410x>`.
+-  Open command prompt or terminal and navigate to the examples folder
+   inside the downloaded or cloned *pyadi-iio* directory.
+-  Run the example script using the command: ``...\pyadi-iio\examples>
+   python adpd410x_test.py``
+-  A GUI window will appear, as shown below. There are four buttons at
+   the top right for each test namely, open onboard LED test, covered
+   onboard LED test, no load test, and mounted jig test. **Before
+   pressing a button to start the test, select the noted COM port on the
+   dropdown list at the top left.**
+
+   |image39|
+
+-  **Open Onboard LED Test**
+
+   The test samples raw ADC values from the onboard photodiode and
+   checks whether it is consistent with the standard. Make sure that
+   all shunts on jumper header P10 are present and connected. A sample
+   passing result is shown below
+
+   |image40|
+
+-  **Covered Onboard LED Test**
+
+   Place your finger above the onboard photodiode and LED.
+
+   |image41|
+
+   This test checks if the sampled raw ADC value has significantly
+   increased from the standard uncovered value. A sample passing result
+   is shown below.
+
+   |image42|
+
+-  **No Load Test**
+   Remove all shunts on jumper header P10. This test checks the
+   photodiode input when no external sensor is connected. A sample
+   passing result is shown below.
+
+   |image43|.
+
+-  **Mounted Jig Test**
+
+   Using the simple test schematic shown in :doc:`Connection
+   </solutions/reference-designs/eval-adpd410x/eval-adpd410x>`, a test
+   board was fabricated using `MOC207M
+   <https://www.onsemi.com/pdf/datasheet/moc217m-d.pdf>`_ optocouplers.
+   Remove all shunts on jumper header P10 and connect the test jig to
+   the :adi:`EVAL-ADPD410x-ARDZ`, as shown below. **(The test jig shown
+   below was fabricated with female headers for easy mounting)**
+
+   |image44|
+
+   A sample passing result is shown below.
+
+   |image45|
+
+Schematic, PCB Layout, Bill of Materials
+----------------------------------------
+
+.. admonition:: Download
+   :class: download
+
+   :adi:`EVAL-ADPD410x-ARDZ Design & Integration Files<media/en/evaluation-documentation/evaluation-design-files/eval-adpd410x-ardz-designsupport.zip>`
+
+   -  Schematic
+   -  PCB Layout
+   -  Bill of Materials
+   -  Allegro Project
+
+Additional Information and Useful Links
+---------------------------------------
+
+-  :adi:`ADPD4100 Product Page <ADPD4100>`
+-  :adi:`ADPD4101 Product Page <ADPD4101>`
+-  :doc:`Fluorescence Measurement Demo </solutions/reference-designs/eval-adpd410x/fluorescence>`
+
+Registration
+------------
+
+.. tip::
+
+   Receive software update notifications, documentation updates, view
+   the latest videos, and more when you register your hardware.
+   `Register <https://form.analog.com/Form_Pages/FeedBack/EVAL-ADPD410X-
+   ARDZ?&v=RevD>`_ to receive all these great benefits and more!
+
+*End of Document*
+
+.. |image1| image:: images/20220105_094532.jpg
+   :width: 600
+.. |image2| image:: images/iosel_shunt.png
+   :width: 200
+.. |image3| image:: images/p10_shunt.png
+   :width: 100
+.. |image4| image:: images/p10_shunt.png
+   :width: 100
+.. |image5| image:: images/jp1_5v.png
+   :width: 100
+.. |image6| image:: images/p9_p13_p17_p22_p11_p15_p19_p24.png
+   :width: 400
+.. |image7| image:: images/adpd4100_r8_r9.png
+   :width: 100
+.. |image8| image:: images/adpd4100_r8_r9.png
+   :width: 100
+.. |image9| image:: images/spi.jpg
+   :width: 600
+.. |image10| image:: images/adpd4101_r6_r7.png
+   :width: 100
+.. |image11| image:: images/adpd4101_r6_r7.png
+   :width: 100
+.. |image12| image:: images/i2c.jpg
+   :width: 600
+.. |image13| image:: images/pinassignment.jpg
+   :width: 400
+.. |image14| image:: images/pinassignmentdiagram.png
+   :width: 400
+.. |image15| image:: images/adpd4100_support.png
+   :width: 400
+.. |image16| image:: images/adpd4101_support.png
+   :width: 400
+.. |image17| image:: images/activetimeslots_odr.png
+   :width: 400
+.. |image18| image:: images/timeslot_datastructure.png
+   :width: 400
+.. |image19| image:: images/timeslot_inputs.png
+   :width: 400
+.. |image20| image:: images/timeslot_pairoptions.png
+   :width: 400
+.. |image21| image:: images/timeslot_inputoptions.png
+   :width: 400
+.. |image22| image:: images/timeslot_precond.png
+   :width: 400
+.. |image23| image:: images/timeslot_tiavref.png
+   :width: 400
+.. |image24| image:: images/timeslot_tiares.png
+   :width: 400
+.. |image25| image:: images/timeslot_led.png
+   :width: 400
+.. |image26| image:: images/timeslot_example.png
+   :width: 400
+.. |image27| image:: images/iio_info_-_output.png
+   :width: 600
+.. |image28| image:: images/rawchanneliio.png
+   :width: 600
+.. |image29| image:: images/sampling_frequency_iio.png
+   :width: 600
+.. |image30| image:: images/iio-oscilloscopeserialcontext.png
+   :width: 400
+.. |image31| image:: images/iio-oscilloscopedebugwindow.png
+   :width: 400
+.. |image32| image:: images/iio-oscilloscopeplotinstructions.png
+   :width: 400
+.. |image33| image:: images/iio-oscilloscopeplot.png
+   :width: 400
+.. |image34| image:: images/pyadiiio_example1_comport.png
+   :width: 400
+.. |image35| image:: images/pyadiiio_example1_read.png
+   :width: 400
+.. |image36| image:: images/pyadiiio_example2_comport.png
+   :width: 400
+.. |image37| image:: images/pyadiiio_example2_inputchannels.png
+   :width: 400
+.. |image38| image:: images/pyadiiio_example2_plot.png
+   :width: 400
+.. |image39| image:: images/softwarewindow.png
+   :width: 600
+.. |image40| image:: images/openledresult.png
+   :width: 600
+.. |image41| image:: images/coveredled.jpg
+   :width: 400
+.. |image42| image:: images/coveredledresult.png
+   :width: 600
+.. |image43| image:: images/noloadtestresult.png
+   :width: 600
+.. |image44| image:: images/testjig_connection.jpg
+   :width: 600
+.. |image45| image:: images/mountedjigtestresult.png
+   :width: 600

--- a/docs/solutions/reference-designs/eval-adpd410x/fluorescence.rst
+++ b/docs/solutions/reference-designs/eval-adpd410x/fluorescence.rst
@@ -1,0 +1,199 @@
+.. _eval_adpd410x fluorescence_demo:
+
+Fluorescence Measurement Demo
+==============================
+
+The :adi:`EVAL-ADPD410x-ARDZ` allows users to take advantage 
+of the flexibility of the :adi:`ADPD4100` and :adi:`ADPD4101` as multimodal sensor front ends 
+to a wide range of applications. One example of a specialized application is the :adi:`CN0503`, 
+a reference design for optical water quality measurement. This demonstration shows how to perform 
+fluorescence measurement using the :adi:`EVAL-ADPD410x-ARDZ`, 
+similarly to the :ref:`CN0503 Fluorescence Measurement Demo <fluorescence-measurement>`.
+
+.. important::
+
+   This demo uses a lot of the optical, mechanical, and photodiode 
+   and LED components from the :adi:`CN0503` kit. This demo is especially 
+   prepared to show the ability of the :adi:`EVAL-ADPD410x-ARDZ` board to 
+   perform the same measurements as the :adi:`CN0503`. For a less complex 
+   demo setup, refer to the Turbidity Demo.
+
+General Description/Overview
+----------------------------
+
+One method of measuring the amount of substance in a sample is by using
+fluorescent light. In this setup, a light is passed from a monochromatic source
+through the sample, and then the fluorescence in the substance is measured using
+a detector tuned to its wavelength. The intensity of the fluorescent light
+compared to the intensity of the incident light will be proportional to the
+amount of the fluorescent substance in the sample. An effective way of
+performing this is by using the setup shown below.
+
+Light is emitted from an LED at 365 nm wavelength. It then passes through a beam-splitter, 
+which directs some of the incident light to a reference photodiode detector for sampling. 
+Quinine in the sample fluoresces due to the 365 nm light and emits ~450 nm light. 
+Another photodiode detector, sensitive to blue light frequencies, is positioned at 90 degrees 
+from the light path to measure the intensity. This placement decreases the effects of the 
+light emitted from the source LED. Additionally, a monochromatic filter is placed 
+in front of the detector to further isolate the measurement.
+
+|image1|
+
+Demo Requirements
+-----------------
+
+The following is a list of items needed to replicate this demo.
+
+-  :adi:`EVAL-ADPD410x-ARDZ`
+-  :adi:`EVAL-ADICUP3029` with firmware (see Firmware Setup)
+-  Host computer with PyADI-IIO and relevant dependencies installed (See :doc:`EVAL-ADPD410X-ARDZ Python Example </solutions/reference-designs/eval-adpd410x/eval-adpd410x>`)
+-  3D Printed Single Path Base () (Also orderable from `Shapeways <https://www.shapeways.com>`_)
+-  3D Printed Cuvette Holder () (Also orderable from `Shapeways <https://www.shapeways.com>`_)
+-  `Type 1FLP Disposable Macro Cuvettes UV Plastic (Lightpath: 10mm) <https://www.fireflysci.com/disposable-fluorescence-cells/type-1flp-disposable-macro-cuvettes-lightpath-10 mm>`_
+-  `10 mm Dia. x 6.6 mm FL, Uncoated Molded Aspheric Condenser Lens <https://www.edmundoptics.com/p/10mm-dia-x-66mm-fl-uncoated-molded-aspheric-condenser-lens/30541/>`_
+-  `12.5 x 17.5 mm, 50R/50T, Plate Beamsplitter <https://www.edmundoptics.com/p/125-x-175mm-50r50t-plate-beamsplitter/5798/>`_
+-  `Fluorescence Filter (SCHOTT GG-475, 12.5 mm Dia., Longpass Filter) <https://www.edmundoptics.com/p/gg-475-125mm-dia-longpass-filter/11320/>`_
+-  Fluorescence Photodiode Board
+
+      .. image:: images/img_20200428_165220.jpg
+         :width: 100
+
+-  Transmit Photodiode Board
+
+      .. image:: images/img_20200428_165212.jpg
+         :width: 100
+
+-  365 nm LED Board
+
+      .. image:: images/img_20200501_130028.jpg
+         :width: 100
+
+-  Male-to-female jumper headers for connection
+-  (**Optional**) Prepared samples with known quinine concentration measurement
+
+Setting up the EVAL-ADPD410X-ARDZ
+---------------------------------
+
+Configure the onboard jumper header and solder jumper connections, as shown below.
+
+|image2|
+
+========== ======================= =========
+**Header** **Setting**             **Image**
+========== ======================= =========
+P10        No connection           |image3|
+JP1        Shorted Pin 2 and Pin 3 |image4|
+IOSEL      Shorted Pin 1 and 2     |image5|
+========== ======================= =========
+
+Set the following :adi:`EVAL-ADICUP3029` switches according to their configuration on the table below.
+
+========== =====================
+**Switch** **Configuration**
+========== =====================
+UART (S2)  USB
+POWER (S5) WALL/USB
+========== =====================
+
+Connect the :adi:`EVAL-ADPD410x-ARDZ` to the :adi:`EVAL-ADICUP3029` using the headers, as shown below.
+
+|image6|
+
+Firmware Setup
+--------------
+
+Connect the :adi:`EVAL-ADICUP3029` to the PC using the micro USB to USB cable. Drag and drop the appropriate HEX file 
+from the list below to the Daplink Drive. (See :doc:`Firmware Setup </solutions/reference-designs/eval-adpd410x/eval-adpd410x>`)
+
+.. admonition:: Download
+   :class: download
+
+   
+   Pre-built HEX files can be found here:
+   
+   -  `EVAL-ADPD4100-ARDZ HEX File (ADuCM3029_demo_adpd410x_spi_waterquality.hex) <https://github.com/analogdevicesinc/EVAL-ADICUP3029/releases/download/Latest/ADuCM3029_demo_adpd410x_spi_waterquality.hex>`_
+   -  `EVAL-ADPD4101-ARDZ HEX File (ADuCM3029_demo_adpd410x_i2c_waterquality.hex) <https://github.com/analogdevicesinc/EVAL-ADICUP3029/releases/download/Latest/ADuCM3029_demo_adpd410x_i2c_waterquality.hex>`_
+   
+   The latest source code can be found here:
+   
+   -  :git-EVAL-ADICUP3029:`EVAL-ADICUP3029/tree/master/projects/ADuCM3029_demo_adpd410x <projects/ADuCM3029_demo_adpd410x>`
+   
+
+Optical Path Setup
+------------------
+
+The demo utilizes an optical path similar to the one used by :adi:`CN0503`, but only for a single channel. The single path base and cuvette holder are available as 3D-printable designs () and can also be ordered using Shapeways.
+
+-  Assemble the cuvette holder. See `Assembling the Tower <https://wiki.analog.com/resources/eval/user-guides/circuits-from-the-lab/cn0503>`_ for instructions.
+-  Insert the 365 nm LED Board to the base, as shown below.
+-  Insert the Transmit Photodiode Board at the bottom of the base, as shown below. The Transmit Photodiode Board uses the same photodiode as the one used as reference in the :adi:`CN0503`.
+-  Insert the Fluorescence Photodiode Board to the base, as shown below.
+-  Insert the monochromatic or fluorescence filter to the slit in front of the Fluorescence Photodiode Board, as shown below.
+-  Insert the cuvette with the quinine sample to measure.
+
+.. image:: images/fluorescence_topviewpath.png
+   :width: 400 px
+
+Hardware Connection
+-------------------
+
+Connect the 365 nm LED Board, Transmit Photodiode Board, and Fluorescence Photodiode Board to the prototyping connectors of the :adi:`EVAL-ADPD410x-ARDZ`, as shown below.
+
+|image7|
+
+Software Setup
+--------------
+
+This demo uses a PyADI-IIO example script. See :doc:`Software Setup </solutions/reference-designs/eval-adpd410x/eval-adpd410x>` for the complete installation instructions from libiio to pyadi-iio.
+
+-  Connect the :adi:`EVAL-ADPD410x-ARDZ` to the :adi:`EVAL-ADICUP3029`.
+-  Connect the :adi:`EVAL-ADICUP3029` to the PC using the micro-USB cable and note the serial port from the Device Manager as in :doc:`Connection </solutions/reference-designs/eval-adpd410x/eval-adpd410x>`.
+-  Open command prompt or terminal and navigate through the examples folder inside the downloaded or cloned *pyadi-iio* directory.
+-  Run the example script using the command. ``...\pyadi-iio\examples>python adpd410x_demo.py``
+-  The script will ask for a serial port. Input the noted serial port and press Enter. In cases when the board is not found, press the reset button (S1) on the :adi:`EVAL-ADPD410x-ARDZ` and input the noted serial port again.
+
+      |image8|
+
+-  When the board is detected, you will be asked to specify the demo application
+   to use. Since this setup is only applicable for fluorescence measurements,
+   enter 1.
+
+      |image9|
+
+-  A plot will appear showing the measured and computed quinine concentration.
+   You have the option to save a copy of the displayed waveform at any point in
+   time using the matplotlib controls at the top. Remove the cuvette and replace
+   the quinine sample with a different concentration to observe the measurement
+   change.
+
+      |image10|
+
+.. important::
+
+   The demo script uses the same polynomial approximation used in :ref:`Computing Quinine Concentration <fluorescence-measurement>`.
+
+Reference Links
+---------------
+
+-  :doc:`Hardware User Guide </solutions/reference-designs/eval-adpd410x/eval-adpd410x>`
+
+.. |image1| image:: images/fluorescence_path.png
+   :width: 600
+.. |image2| image:: images/fl_adpd410x_jumperconn.jpg
+   :width: 400
+.. |image3| image:: images/p10_empty.png
+   :width: 200
+.. |image4| image:: images/jp1_5v.png
+   :width: 200
+.. |image5| image:: images/iosel_shunt.png
+   :width: 200
+.. |image6| image:: images/arduinoconnection.jpg
+   :width: 400
+.. |image7| image:: images/demo_connection.png
+   :width: 600
+.. |image8| image:: images/pyadiiio_example2_comport.png
+   :width: 400
+.. |image9| image:: images/demo_selectapplication.png
+   :width: 400
+.. |image10| image:: images/demo_fluorescenceresult.png
+   :width: 400

--- a/docs/solutions/reference-designs/eval-adpd410x/images/20220105_094532.jpg
+++ b/docs/solutions/reference-designs/eval-adpd410x/images/20220105_094532.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7e3eee6345a5fe13a7bfa3d5db38da48cd8e3765f2775e9d0914d5081a118a11
+size 2963517

--- a/docs/solutions/reference-designs/eval-adpd410x/images/activetimeslots_odr.png
+++ b/docs/solutions/reference-designs/eval-adpd410x/images/activetimeslots_odr.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1413aa6588d75e6dce1afb9d784a4142b2ab705ec48cc28714c7934158f31241
+size 4177

--- a/docs/solutions/reference-designs/eval-adpd410x/images/adpd4100_r8_r9.png
+++ b/docs/solutions/reference-designs/eval-adpd410x/images/adpd4100_r8_r9.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6f61eda7591cdce57dd8e6cf579b81cb721ec79e7c63b179d1f85389257eb2c0
+size 3167

--- a/docs/solutions/reference-designs/eval-adpd410x/images/adpd4100_support.png
+++ b/docs/solutions/reference-designs/eval-adpd410x/images/adpd4100_support.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2a350595581867dd0334da3cd3aabd803256b0e14b1bb66291d82ec1b5a16970
+size 3959

--- a/docs/solutions/reference-designs/eval-adpd410x/images/adpd4101_r6_r7.png
+++ b/docs/solutions/reference-designs/eval-adpd410x/images/adpd4101_r6_r7.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:77ae4ebc00d5a951700f0166ff4c31909048d1d118cfe1a7d38a8b66893b9d06
+size 3791

--- a/docs/solutions/reference-designs/eval-adpd410x/images/adpd4101_support.png
+++ b/docs/solutions/reference-designs/eval-adpd410x/images/adpd4101_support.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:346721c4ee18e8df984f5f05cc595a7fa43fe6d0f145da62eb9bf40ba2179816
+size 3860

--- a/docs/solutions/reference-designs/eval-adpd410x/images/arduinoconnection.jpg
+++ b/docs/solutions/reference-designs/eval-adpd410x/images/arduinoconnection.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ea4a3c813f51e3387479f1433aa5ddae36cd6f98baca28eef8b515734737258f
+size 2038484

--- a/docs/solutions/reference-designs/eval-adpd410x/images/coveredled.jpg
+++ b/docs/solutions/reference-designs/eval-adpd410x/images/coveredled.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:710869c06173331be918e716e59948f1323bb0221ecf5cb5f3bb47e0fb81b208
+size 1155413

--- a/docs/solutions/reference-designs/eval-adpd410x/images/coveredledresult.png
+++ b/docs/solutions/reference-designs/eval-adpd410x/images/coveredledresult.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ab37848512b94683e4ca55e4d28063a30587c3c4e07c2b840b03d570f3aa2e65
+size 12942

--- a/docs/solutions/reference-designs/eval-adpd410x/images/daplink_windows_explorer.png
+++ b/docs/solutions/reference-designs/eval-adpd410x/images/daplink_windows_explorer.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a13d3272a9eddcdeb9298a7fa9bf9b7e3bfcb841f060244680fdc59cf9e23f0b
+size 77188

--- a/docs/solutions/reference-designs/eval-adpd410x/images/demo_connection.png
+++ b/docs/solutions/reference-designs/eval-adpd410x/images/demo_connection.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6ba49710d68073bb5bf6840ce34de3b7068168f596d679e2390a4fb4900339b3
+size 185293

--- a/docs/solutions/reference-designs/eval-adpd410x/images/demo_fluorescenceresult.png
+++ b/docs/solutions/reference-designs/eval-adpd410x/images/demo_fluorescenceresult.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:df21d2b887f19cdb028055468cda9e0f3493bd693cbb78b41eadf023dcda11f9
+size 27566

--- a/docs/solutions/reference-designs/eval-adpd410x/images/demo_selectapplication.png
+++ b/docs/solutions/reference-designs/eval-adpd410x/images/demo_selectapplication.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:30b1de5c5dcb0112e6f3cf7b874f10a61162711afd4664b25767627bf55434f0
+size 2912

--- a/docs/solutions/reference-designs/eval-adpd410x/images/fl_adpd410x_jumperconn.jpg
+++ b/docs/solutions/reference-designs/eval-adpd410x/images/fl_adpd410x_jumperconn.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:63000218103ac2b8def6289bd3208ba561533280fd4619f7d70286108a222877
+size 800865

--- a/docs/solutions/reference-designs/eval-adpd410x/images/fluorescence_path.png
+++ b/docs/solutions/reference-designs/eval-adpd410x/images/fluorescence_path.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:48cde5b458123ea9bccccf8c92fffff05eb7da7102daa8531d2c50956905a252
+size 13444

--- a/docs/solutions/reference-designs/eval-adpd410x/images/fluorescence_topviewpath.png
+++ b/docs/solutions/reference-designs/eval-adpd410x/images/fluorescence_topviewpath.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a5e95254b1ea276cda59998e5b84c1efe748dfc1367258aade1c2d5049bbefd0
+size 29958

--- a/docs/solutions/reference-designs/eval-adpd410x/images/i2c.jpg
+++ b/docs/solutions/reference-designs/eval-adpd410x/images/i2c.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:62c0c127fecfad76c35e661b2ad5bd5d6f5c0f0420f24ec25abdec16bf6cd1c3
+size 2017458

--- a/docs/solutions/reference-designs/eval-adpd410x/images/iio-oscilloscopedebugwindow.png
+++ b/docs/solutions/reference-designs/eval-adpd410x/images/iio-oscilloscopedebugwindow.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7c569c755397cca8887ecbb5e34e4b5cb7c6a4cfbdc35d98533c6f52994a3b09
+size 23827

--- a/docs/solutions/reference-designs/eval-adpd410x/images/iio-oscilloscopedetecteddevice.png
+++ b/docs/solutions/reference-designs/eval-adpd410x/images/iio-oscilloscopedetecteddevice.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:93d1022f4193724ef71c98ebef89d0b1bd77c53b92f0bd278ff37875a17821e5
+size 18738

--- a/docs/solutions/reference-designs/eval-adpd410x/images/iio-oscilloscopemanualcontext.png
+++ b/docs/solutions/reference-designs/eval-adpd410x/images/iio-oscilloscopemanualcontext.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8409dd3d567b880b78652ba405c21a80f09874ff357ee1fbfe9b94f6a1d7335b
+size 17040

--- a/docs/solutions/reference-designs/eval-adpd410x/images/iio-oscilloscopeplot.png
+++ b/docs/solutions/reference-designs/eval-adpd410x/images/iio-oscilloscopeplot.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1080d15ee86115413186992556efa44ec054a22244f867f8aae1a1d864ef8ffd
+size 43955

--- a/docs/solutions/reference-designs/eval-adpd410x/images/iio-oscilloscopeplotinstructions.png
+++ b/docs/solutions/reference-designs/eval-adpd410x/images/iio-oscilloscopeplotinstructions.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b172f3544f3d2fa0581ddf5fb5582c4ece344ef45e35a4e33c760ca477cf36a0
+size 39038

--- a/docs/solutions/reference-designs/eval-adpd410x/images/iio-oscilloscopeserialcontext.png
+++ b/docs/solutions/reference-designs/eval-adpd410x/images/iio-oscilloscopeserialcontext.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b1a5ea3b08ec92c01cc325a72799c47705d6e3167f06d26dd05b66cb4221268c
+size 15536

--- a/docs/solutions/reference-designs/eval-adpd410x/images/iio_info_-_output.png
+++ b/docs/solutions/reference-designs/eval-adpd410x/images/iio_info_-_output.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ead5d3a51087c77a97bd55cac39b4a984636d1ebe2b8963bbd863c550ac7ef5b
+size 58396

--- a/docs/solutions/reference-designs/eval-adpd410x/images/img_20200428_165212.jpg
+++ b/docs/solutions/reference-designs/eval-adpd410x/images/img_20200428_165212.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:89ca5d1e5d7340e6c8327f0e87b85056fa3b06c3f496a5c0b4f1b958fc517520
+size 497471

--- a/docs/solutions/reference-designs/eval-adpd410x/images/img_20200428_165220.jpg
+++ b/docs/solutions/reference-designs/eval-adpd410x/images/img_20200428_165220.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d3d1fc0bd5b2db8569d851d7dd3fef66720e533f63cb17e4c38943e109cae8a8
+size 458805

--- a/docs/solutions/reference-designs/eval-adpd410x/images/img_20200501_130028.jpg
+++ b/docs/solutions/reference-designs/eval-adpd410x/images/img_20200501_130028.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0e8bcf84f04453696d1d1a1d40988453224c67d1fcd419121bb8f17088b899c3
+size 135453

--- a/docs/solutions/reference-designs/eval-adpd410x/images/img_20220720_150406.jpg
+++ b/docs/solutions/reference-designs/eval-adpd410x/images/img_20220720_150406.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5f5b0d69c3f1c6eed70e98f92815a06514471d7a8de543eb47e8c8edcf085059
+size 401140

--- a/docs/solutions/reference-designs/eval-adpd410x/images/img_20220722_130556.jpg
+++ b/docs/solutions/reference-designs/eval-adpd410x/images/img_20220722_130556.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:db899d19e54e362a8c365d56ca1aa71bc8eba380fb532188204ec8ed376a67c3
+size 700663

--- a/docs/solutions/reference-designs/eval-adpd410x/images/iosel_shunt.png
+++ b/docs/solutions/reference-designs/eval-adpd410x/images/iosel_shunt.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:324160803815b56e247f2687b93039881138a692d55ed5d5c828d7028f408228
+size 3118

--- a/docs/solutions/reference-designs/eval-adpd410x/images/jp1_5v.png
+++ b/docs/solutions/reference-designs/eval-adpd410x/images/jp1_5v.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fa9796bc3c8cd342ac1f42352821c49a35659c9739a836e4d3bff89ca3a6ea92
+size 6361

--- a/docs/solutions/reference-designs/eval-adpd410x/images/mountedjigtestresult.png
+++ b/docs/solutions/reference-designs/eval-adpd410x/images/mountedjigtestresult.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:86834e51d76e7cc653453074e35e438b4213f3127035686915f335e0fb2373a4
+size 20040

--- a/docs/solutions/reference-designs/eval-adpd410x/images/noloadtestresult.png
+++ b/docs/solutions/reference-designs/eval-adpd410x/images/noloadtestresult.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:52d093d48c060af45b9d97711ec39f1168de0068ef1e35b7a82b13f447c7aed8
+size 20087

--- a/docs/solutions/reference-designs/eval-adpd410x/images/openledresult.png
+++ b/docs/solutions/reference-designs/eval-adpd410x/images/openledresult.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dae02306efe550fc3e52d35d78bcbe2ef227465072a77c1db1b834f9aed55395
+size 12923

--- a/docs/solutions/reference-designs/eval-adpd410x/images/p10_empty.png
+++ b/docs/solutions/reference-designs/eval-adpd410x/images/p10_empty.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8898daf13aa7a1d1c42b0c69ee0ca86c556a0f6dea7cba44104bcbc0b843ddea
+size 11340

--- a/docs/solutions/reference-designs/eval-adpd410x/images/p10_shunt.png
+++ b/docs/solutions/reference-designs/eval-adpd410x/images/p10_shunt.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5c59136a6e1f87be6558b99ff277ce86c20debfe67e96fc52776c7f373841585
+size 2637

--- a/docs/solutions/reference-designs/eval-adpd410x/images/p9_p13_p17_p22_p11_p15_p19_p24.png
+++ b/docs/solutions/reference-designs/eval-adpd410x/images/p9_p13_p17_p22_p11_p15_p19_p24.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b02f6c2954b4f8984c418d1ed346191acade6b7630150a88ece06de618cf4cfe
+size 3356

--- a/docs/solutions/reference-designs/eval-adpd410x/images/pinassignment.jpg
+++ b/docs/solutions/reference-designs/eval-adpd410x/images/pinassignment.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a9695b193553f3f6c550fa641713ee201ba396cfd3b393cbd39f59cb05c4bf2d
+size 1046083

--- a/docs/solutions/reference-designs/eval-adpd410x/images/pinassignmentdiagram.png
+++ b/docs/solutions/reference-designs/eval-adpd410x/images/pinassignmentdiagram.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2b6998d7c313400e3cb495326c425941822863db670d707f52c25037ece34013
+size 51775

--- a/docs/solutions/reference-designs/eval-adpd410x/images/pyadiiio_example1_comport.png
+++ b/docs/solutions/reference-designs/eval-adpd410x/images/pyadiiio_example1_comport.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:14e50d982338f453dffb6e0f9fda3cfea0c68f365aa92447f5de618045910476
+size 4996

--- a/docs/solutions/reference-designs/eval-adpd410x/images/pyadiiio_example1_read.png
+++ b/docs/solutions/reference-designs/eval-adpd410x/images/pyadiiio_example1_read.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c026c0207c391501862330a61a5a0b4f90d1f1ce49c741a4fc17ca09a7d7ff7e
+size 9743

--- a/docs/solutions/reference-designs/eval-adpd410x/images/pyadiiio_example2_comport.png
+++ b/docs/solutions/reference-designs/eval-adpd410x/images/pyadiiio_example2_comport.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:41f6b273f43dcaf1186d76ed60a3641b0870a786de638da24efb043b9da0039f
+size 16321

--- a/docs/solutions/reference-designs/eval-adpd410x/images/pyadiiio_example2_inputchannels.png
+++ b/docs/solutions/reference-designs/eval-adpd410x/images/pyadiiio_example2_inputchannels.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b54f90e7b50035e9a3f78632a4234f803b567443556e575a26c058e0aa6b51e7
+size 36149

--- a/docs/solutions/reference-designs/eval-adpd410x/images/pyadiiio_example2_plot.png
+++ b/docs/solutions/reference-designs/eval-adpd410x/images/pyadiiio_example2_plot.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4fe97d6e04be8ec5c89f04dfa80074a22c578388c37f2b9e1c0f8067eafc2f31
+size 56255

--- a/docs/solutions/reference-designs/eval-adpd410x/images/rawchanneliio.png
+++ b/docs/solutions/reference-designs/eval-adpd410x/images/rawchanneliio.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:91a21e3b78d39c0da1ab37a9b99ffbb2532ed26e1fc03e9cf3b9fb7f963777c0
+size 3585

--- a/docs/solutions/reference-designs/eval-adpd410x/images/sampling_frequency_iio.png
+++ b/docs/solutions/reference-designs/eval-adpd410x/images/sampling_frequency_iio.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:591024e0430cbd35b035eec0bb7687e7224edaad7e2abfec3d343f0ce05584c0
+size 10489

--- a/docs/solutions/reference-designs/eval-adpd410x/images/screenshot_2022-07-22_133731.png
+++ b/docs/solutions/reference-designs/eval-adpd410x/images/screenshot_2022-07-22_133731.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:819dfd3973f699a8f3bcc6b4157243944cf0655e097dc58b416c746c36889477
+size 63050

--- a/docs/solutions/reference-designs/eval-adpd410x/images/screenshot_2022-07-22_133951.png
+++ b/docs/solutions/reference-designs/eval-adpd410x/images/screenshot_2022-07-22_133951.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:db7fa23d6776385c201e76b49583dffa389867c11a42677bbb815fc14a129d5d
+size 61881

--- a/docs/solutions/reference-designs/eval-adpd410x/images/softwarewindow.png
+++ b/docs/solutions/reference-designs/eval-adpd410x/images/softwarewindow.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:937ef858e1a90ea4bbca3cca31dfa0e6262d90b2c8a264bc1b2ffb8049972368
+size 8228

--- a/docs/solutions/reference-designs/eval-adpd410x/images/spi.jpg
+++ b/docs/solutions/reference-designs/eval-adpd410x/images/spi.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7e9e877ca1005145d40cda5d2cb84b3a0453a925087e1f030fab19bba8ec236a
+size 2018859

--- a/docs/solutions/reference-designs/eval-adpd410x/images/testjig_connection.jpg
+++ b/docs/solutions/reference-designs/eval-adpd410x/images/testjig_connection.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6f1560a37ab4a5302fc3b36e3099276265f67514a630c8144b41fde38e1a79a9
+size 198170

--- a/docs/solutions/reference-designs/eval-adpd410x/images/testschematic.png
+++ b/docs/solutions/reference-designs/eval-adpd410x/images/testschematic.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:494d00d8e78726c4e3d3d3c0c68b205128fab9f0cd591322bbe767c696f3f795
+size 101067

--- a/docs/solutions/reference-designs/eval-adpd410x/images/timeslot_datastructure.png
+++ b/docs/solutions/reference-designs/eval-adpd410x/images/timeslot_datastructure.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7da81f369611679e32761230da2fa750ea26f940aa0e5c4c7e9bda71f6bd1ec4
+size 43766

--- a/docs/solutions/reference-designs/eval-adpd410x/images/timeslot_example.png
+++ b/docs/solutions/reference-designs/eval-adpd410x/images/timeslot_example.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fc0697be0701fb3f286e43a8cfe0cd8331914d2fb00f7958e9e3d5d0cf4817b2
+size 21982

--- a/docs/solutions/reference-designs/eval-adpd410x/images/timeslot_inputoptions.png
+++ b/docs/solutions/reference-designs/eval-adpd410x/images/timeslot_inputoptions.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5dffbf4408544e6179b420fe5e4adac94230faf2f82a6a01dab279b8e4e21e3e
+size 25684

--- a/docs/solutions/reference-designs/eval-adpd410x/images/timeslot_inputs.png
+++ b/docs/solutions/reference-designs/eval-adpd410x/images/timeslot_inputs.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:840fa04a9cc9889f54dd6c7fca9451d530d18e352bc41f3a1db10720903a0964
+size 8348

--- a/docs/solutions/reference-designs/eval-adpd410x/images/timeslot_led.png
+++ b/docs/solutions/reference-designs/eval-adpd410x/images/timeslot_led.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e6f810926139ae1c95a1ca5b4a7ea7938fe52b1fc1f40d1c4c9972c12ef923c3
+size 24986

--- a/docs/solutions/reference-designs/eval-adpd410x/images/timeslot_pairoptions.png
+++ b/docs/solutions/reference-designs/eval-adpd410x/images/timeslot_pairoptions.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fb99250b0cbd5012227b3187d78ceaab81f06f86ed350b43bdce2922afd3c904
+size 11348

--- a/docs/solutions/reference-designs/eval-adpd410x/images/timeslot_precond.png
+++ b/docs/solutions/reference-designs/eval-adpd410x/images/timeslot_precond.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ddf846c7dc3e8778a3baf04814193952c2f75174089fa357b3670919485b894c
+size 19415

--- a/docs/solutions/reference-designs/eval-adpd410x/images/timeslot_tiares.png
+++ b/docs/solutions/reference-designs/eval-adpd410x/images/timeslot_tiares.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1806db4d61c1de8b46e8e033fc88971858fc7a1bf0072200ea1e06f990318b42
+size 7755

--- a/docs/solutions/reference-designs/eval-adpd410x/images/timeslot_tiavref.png
+++ b/docs/solutions/reference-designs/eval-adpd410x/images/timeslot_tiavref.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0a841fcc989fc21a0360c118dcfc8721a28f7a6de509e0745c2470651781a7ca
+size 8362

--- a/docs/solutions/reference-designs/eval-adpd410x/images/turbidity-connectiondiagram.png
+++ b/docs/solutions/reference-designs/eval-adpd410x/images/turbidity-connectiondiagram.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fca73785d739c48811da824b6b3338d73819964276e58be1148648e2a1232d8f
+size 162602

--- a/docs/solutions/reference-designs/eval-adpd410x/index.rst
+++ b/docs/solutions/reference-designs/eval-adpd410x/index.rst
@@ -1,0 +1,82 @@
+.. _eval_adpd410x eval:
+
+EVAL-ADPD410X-ARDZ
+==================
+
+ADPD4100/ADPD4101 Arduino Shields
+
+.. figure:: EVAL-ADPD4100-ARDZ_ANGLE-evaluation-board.jpg
+   :align: center
+   :width: 600 px
+   :alt: EVAL-ADPD410x-ARDZ
+
+Overview
+--------
+
+:adi:`EVAL-ADPD4100-ARDZ <EVAL-ADPD410x-ARDZ>` and :adi:`EVAL-ADPD4101-ARDZ <EVAL-ADPD410x-ARDZ>` 
+are simple, Arduino form-factor breakout board for developing :adi:`ADPD4100` and :adi:`ADPD4101` 
+applications, respectively. The ADPD4101, interfaced through I2C, and the ADPD4100, 
+interfaced through SPI, are highly versatile, multimodal sensor front ends, 
+stimulating up to eight light emitting diodes (LEDs) and measuring 
+the return signal on up to eight separate current inputs. 
+
+There are a number of other evaluation platforms for these devices, 
+including the :adi:`EVAL-ADPD4100Z-PPG`, optimized for photoplethysmograph applications, 
+and the reference design :adi:`CN0503`, optimized for optical liquid analysis applications 
+(colorimetry, turbidity, fluorescence). The :adi:`EVAL-ADPD410X-ARDZ` boards come in handy 
+for adapting these evaluation boards to meet specific application requirements, 
+as well as for "ground up" development of new applications.
+
+Features
+--------
+
+- On-board LED for quick and easy bring up
+- Breakaway Prototyping Board for customized application needs 
+- 8-Channels of LEDs and photodiodes connections
+- Standard 0.1 inch headers 
+
+Applications
+------------
+
+- Wearable health and fitness monitors: heart rate monitors (HRMs),
+  heart rate variability (HRV), stress, blood pressure 
+  estimation, SpO2, hydration, body composition 
+- Industrial monitoring: CO, CO2, smoke, and aerosol detection 
+- Home patient monitoring 
+
+.. admonition:: Getting Started
+
+   The :adi:`EVAL-ADPD410x-ARDZ` can be used for a wide range of applications, 
+   and the following demos are meant to show examples of the flexibility of the board. 
+   To get started with setup, configuration, and example use cases, 
+   please proceed to the Quick Start Guide and follow the provided demo pages.
+
+   - :doc:`Quick Start Guide </solutions/reference-designs/eval-adpd410x/eval-adpd410x>`
+   - :ref:`Fluorescence Demo <eval_adpd410x fluorescence_demo>`
+   - :ref:`Turbidity Demo <eval_adpd410x turbidity_demo>`
+
+Recommendations
+---------------
+
+People who follow the flow that is outlined, have a much better experience with
+things. However, like many things, documentation is never as complete as it
+should be. If you have any questions, feel free to ask on our
+:ez:`Analog Devices EngineerZone <Reference Designs>` forum, but before that, 
+please make sure you read our documentation thoroughly.
+
+Warning
+-------
+
+.. esd-warning::
+
+Help and support
+----------------
+
+Please go to :ez:`Analog Devices EngineerZone <Reference Designs>` page.
+
+.. toctree::
+   :hidden:
+
+   eval-adpd410x
+   fluorescence
+   turbidity

--- a/docs/solutions/reference-designs/eval-adpd410x/turbidity.rst
+++ b/docs/solutions/reference-designs/eval-adpd410x/turbidity.rst
@@ -1,0 +1,186 @@
+.. _eval_adpd410x turbidity_demo:
+
+Turbidity Measurement Demo
+===========================
+
+The :adi:`EVAL-ADPD410x-ARDZ` allows users to take advantage of the flexibility 
+of the :adi:`ADPD4100` and :adi:`ADPD4101` as multimodal sensor front ends to a 
+wide range of applications. One example of a specialized application is the :adi:`CN0409`, 
+a reference design for turbidity measurement. This demonstration shows 
+how to measure turbidity using a similar method, but using the :adi:`EVAL-ADPD410x-ARDZ`.
+
+General Description/Overview
+-----------------------------
+
+The International Organization for Standardization (ISO) developed 
+a design standard known as ISO 7027 Water Quality—Determination of Turbidity, 
+which is best known for its requirement of a monochromatic light source. 
+Most instruments that comply with this standard use an 860 nm LED light source 
+and a primary detector at an angle of 90°. Additional detection angles are allowed, 
+such as a detector at an angle of 180°, to increase the range of measurable turbidity levels.
+
+The demo uses a network of 860 nm infrared emitters and silicon PIN photodiodes
+to achieve a water turbidity measurement system. The system can measure low to
+high water turbidity levels ranging from 0 FTU to 1000 FTU.
+
+Demo Requirements
+-----------------
+
+The following is a list of items needed to replicate this demo:
+
+-  :adi:`EVAL-ADPD410x-ARDZ`
+-  :adi:`EVAL-ADICUP3029` with firmware (see Firmware Setup)
+-  Host computer with PyADI-IIO and relevant dependencies installed (See :doc:`EVAL-ADPD410X-ARDZ Python Example </solutions/reference-designs/eval-adpd410x/eval-adpd410x>`)
+-  `Type 1FLP Disposable Macro Cuvettes UV Plastic (Lightpath: 10 mm) <https://www.fireflysci.com/disposable-fluorescence-cells/type-1flp-disposable-macro-cuvettes-lightpath-10 mm>`_
+-  `QED-123 Infrared LED <https://www.digikey.com/en/products/detail/on-semiconductor/QED123/187398>`_
+-  2 x `QSD123 Infrared Photo Transistor <https://www.digikey.com/en/products/detail/onsemi/QSD123/187443>`_
+-  2 x `18-pin Single Row Female Headers <https://www.digikey.com/en/products/detail/samtec-inc/SSQ-118-03-F-S/6692999>`_
+-  4 x `6-pin Single Row Female Headers <https://www.digikey.ph/en/products/detail/samtec-inc/SSQ-106-03-F-S/6678741>`_
+-  6 x Female-to-Female Jumper Headers for Connection
+-  (**Optional**) Samples with known turbidity concentration
+
+Setting up the EVAL-ADPD410X-ARDZ
+---------------------------------
+
+Configure the onboard jumper header and solder jumper connections, as shown below.
+
+|image1|
+
+========== ======================= =========
+**Header** **Setting**             **Image**
+========== ======================= =========
+P10        No connection           |image2|
+JP1        Shorted Pin 2 and Pin 3 |image3|
+IOSEL      Shorted Pin 1 and 2     |image4|
+========== ======================= =========
+
+Set the following :adi:`EVAL-ADICUP3029` switches according to their configuration on the table below.
+
+========== =====================
+**Switch** **Configuration**
+========== =====================
+UART (S2)  USB
+POWER (S5) WALL/USB
+========== =====================
+
+Connect the :adi:`EVAL-ADPD410x-ARDZ` to the :adi:`EVAL-ADICUP3029` using the headers, as shown below.
+
+|image5|
+
+Firmware Setup
+--------------
+
+- Connect the :adi:`EVAL-ADICUP3029` to the PC using the micro USB to USB cable. 
+- Drag and drop the appropriate HEX file from the list below to the DAPlink drive
+  (see :doc:`Firmware Setup </solutions/reference-designs/eval-adpd410x/eval-adpd410x>`)
+
+.. admonition:: Download
+   :class: download
+
+   
+   Pre-built HEX files can be found here:
+   
+   -  `EVAL-ADPD4100-ARDZ HEX File (ADuCM3029_demo_adpd410x_spi_waterquality.hex) <https://github.com/analogdevicesinc/EVAL-ADICUP3029/releases/download/Latest/ADuCM3029_demo_adpd410x_spi_waterquality.hex>`_
+   -  `EVAL-ADPD4101-ARDZ HEX File (ADuCM3029_demo_adpd410x_i2c_waterquality.hex) <https://github.com/analogdevicesinc/EVAL-ADICUP3029/releases/download/Latest/ADuCM3029_demo_adpd410x_i2c_waterquality.hex>`_
+   
+   The latest source code can be found here:
+   
+   -  :git-EVAL-ADICUP3029:`EVAL-ADICUP3029/tree/master/projects/ADuCM3029_demo_adpd410x <projects/ADuCM3029_demo_adpd410x>`
+   
+
+DIY Test Board Setup
+--------------------
+
+To set up the optical path, use the prototype board that comes in the box with 
+the :adi:`EVAL-ADPD410x-ARDZ` as a base. The connection diagram for 
+the QED123 LED and the two QSD123 is shown below:
+
+.. image:: images/turbidity-connectiondiagram.png
+   :width: 600
+
+-  To connect to the :adi:`EVAL-ADPD410x-ARDZ`, solder the two 18-pin single row female headers 
+   at the bottom sides of the prototype board.
+-  Solder the four 6-pin female headers enclosing a 5 x 5 pad space as a DIY cuvette holder.
+-  Solder the LEDs and photodiodes at 3 adjacent sides of the cuvette holder and directed inward.
+   A photo of a completed test board setup mounted on the :adi:`EVAL-ADPD410X-ARDZ` and 
+   the :adi:`EVAL-ADICUP3029` is shown below using Female-to-Female headers for connection.
+
+.. image:: images/img_20220720_150406.jpg
+   :width: 600
+
+You can place a sample placed in a cuvette to the square space at the center, as
+shown below.
+
+.. image:: images/img_20220722_130556.jpg
+   :width: 600
+
+Software Setup
+--------------
+
+This demo uses a PyADI-IIO example script. See :doc:`Software Setup </solutions/reference-designs/eval-adpd410x/eval-adpd410x>` 
+for the complete installation instructions from libiio to pyadi-iio.
+
+-  Connect the :adi:`EVAL-ADPD410x-ARDZ` to the :adi:`EVAL-ADICUP3029`.
+-  Connect the :adi:`EVAL-ADICUP3029` to the PC using the micro USB cable and note the serial port 
+   from the Device Manager as in :doc:`Connection </solutions/reference-designs/eval-adpd410x/eval-adpd410x>`.
+-  Open command prompt or terminal and navigate through the examples folder inside the downloaded or cloned *pyadi-iio* directory.
+-  Run the example script using the command. ``...\pyadi-iio\examples>python adpd410x_demo.py``
+-  The script will ask for a serial port. Input the noted serial port and press Enter. In cases when the board is not found, 
+   press the reset button (S1) on the :adi:`EVAL-ADPD410x-ARDZ` and input the noted serial port again.
+
+   |image6|
+
+-  When the board is detected, you will be asked to specify the demo application
+   to use. Since this setup is only applicable for turbidity measurements, enter
+   3.
+
+   |image7|
+
+-  A plot will appear showing the measured and computed turbidity in FTU. You
+   have the option to save a copy of the displayed waveform at any point in time
+   using the matplotlib controls at the top. Remove the cuvette and replace the
+   sample with a different turbidity to observe the measurement change.
+
+   **Low Turbidity Sample**
+
+   |image8|
+
+   **High Turbidity Sample**
+
+   |image9|
+
+.. important::
+
+   The measurements obtained have not been tested and verified with the actual
+   turbidity measurement, and is not expected to be accurate. The demo showcases
+   a proof-of-concept DIY setup for turbidity measurement, which users can tweak
+   and improve upon.
+
+.. important::
+
+   The demo script uses the same approximation used in 
+   :ref:`Linear Approximation using 3-Point Calibration <turbidity>`.
+
+Reference Links
+---------------
+
+-  :doc:`Hardware User Guide </solutions/reference-designs/eval-adpd410x/eval-adpd410x>`
+
+.. |image1| image:: images/fl_adpd410x_jumperconn.jpg
+   :width: 400
+.. |image2| image:: images/p10_empty.png
+   :width: 200
+.. |image3| image:: images/jp1_5v.png
+   :width: 200
+.. |image4| image:: images/iosel_shunt.png
+   :width: 200
+.. |image5| image:: images/arduinoconnection.jpg
+   :width: 400
+.. |image6| image:: images/pyadiiio_example2_comport.png
+   :width: 400
+.. |image7| image:: images/demo_selectapplication.png
+   :width: 400
+.. |image8| image:: images/screenshot_2022-07-22_133951.png
+   :width: 400
+.. |image9| image:: images/screenshot_2022-07-22_133731.png
+   :width: 400


### PR DESCRIPTION
## Summary
- Move eval-adpd410x wiki documentation to `solutions/reference-designs/eval-adpd410x/`
- 4 RST files with 62 localized images
- Generated stub `index.rst` with toctree

## Test plan
- [ ] Sphinx build passes without errors
- [ ] All toctree entries resolve correctly
- [ ] Images render properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)