### PR TITLE
reference-designs/eval-adxrs290-pmdz: Add eval-adxrs290-pmdz documentation

### DIFF
--- a/docs/solutions/reference-designs/eval-adxrs290-pmdz/eval-adxrs290-pmdz.rst
+++ b/docs/solutions/reference-designs/eval-adxrs290-pmdz/eval-adxrs290-pmdz.rst
@@ -1,0 +1,546 @@
+.. _eval_adxrs290_pmdz eval:
+
+ADXRS290 Gyroscope PMOD Demo
+============================
+
+Device Driver Support
+---------------------
+
+Two example device driver solutions are provided for controling the
+**EVAL-ADXRS290-PMDZ** using the no-OS device driver on the
+**EVAL-ADICUP3029** platform and Linux device driver on the
+**Raspberry Pi** platform.
+
+1. **EVAL-ADICUP3029**
+
+   The ADICUP3029 example application uses the ADXRS290 no-OS driver, and
+   emulates the Linux IIO framework through the tinyiiod daemon library. The
+   application communicates with the host computer via the serial backend, over
+   a USB-UART physical connection. This facilitates rapid application
+   development on a host computer, independent from embedded code development.
+
+2. **Raspberry Pi**
+
+   The Linux driver uses the Industrial Input/Output (IIO) framework, greatly
+   simplifying the development of applicaiton code via the cross-platform Libiio
+   library, which is written in C and includes bindings for Python, MATLAB, C#,
+   and other languages. Application code can run directly on the platform board,
+   communicating with the device over the local bakend, or from a remote host
+   over the network or USB backends.
+
+Similarly, utility software (iio_info, IIO Oscilloscope, PyADI-IIO, etc.) can be
+used for both the EVAL-ADXRS290-PMDZ on Raspberry PI and on ADICUP3029.
+
+----
+
+General Setup Using ADICUP3029
+------------------------------
+
+The :adi:`EVAL-ADXRS290-PMDZ` can be used with 
+:dokuwiki:`ADICUP3029 </resources/eval/user-guides/eval-adicup3029>`
+
+.. figure:: images/adxrs290_architecture.png
+   :align: center
+   :width: 400
+
+   Software Architecture
+
+Demo Requirements
+~~~~~~~~~~~~~~~~~
+
+The following is a list of items needed in order to replicate this demo.
+
+**Hardware:**
+
+ -  :adi:`EVAL-ADICUP3029`
+ -  :adi:`EVAL-ADXRS290-PMDZ`
+ -  Micro-USB to USB cable
+ -  PC or Laptop with a USB port
+
+**Software:**
+
+There are two basic ways to program the ADICUP3029 with the software for the
+ADXRS290.
+
+ -  Dragging and Dropping the HEX file to the DAPLINK drive
+ -  Building, Compiling, and Debugging using CCES
+
+Using the drag and drop method, the software is going to be a version that
+Analog Devices creates for testing and evaluation purposes. This is the EASIEST
+way to get started with the reference design.
+
+Importing the project into CrossCore is going to allow you to change parameters
+and customize the software to fit your needs, but will be a bit more advanced
+and will require you to download the CrossCore toolchain.
+
+The software for the **ADICUP3029_ADXRS290** demo can be found here:
+
+.. admonition:: Download
+   :class: download
+
+   Prebuilt ADXRS290_IIO HEX File
+   
+   -  :git-no-OS:`ADXRS290-PMDZ.zip <releases/download/last_commit/adxrs290-pmdz.zip+>`
+   
+   Complete ADXRS290_IIO Source Files
+   
+   -  :git-no-OS:`ADXRS290 tinyiiod project source for ADICUP3029 platform <projects/adxrs290-pmdz>`
+   
+
+To build the project from source, follow the instructions in the
+:git-no-OS:`no-os wiki <wiki+>`.
+
+Setting up the Hardware
+~~~~~~~~~~~~~~~~~~~~~~~
+
+#.  Connect **EVAL-ADXRS290-PMDZ** board at connector **P8** of
+    the **EVAL-ADICUP3029**.
+#.  Connect a micro-USB cable to the P10 connector of the EVAL-ADICUP3029
+    and connect it to a computer. The final setup should look similar
+    to the picture below.
+
+.. image:: images/pmodtoadicup_v2.jpg
+
+Flashing the Firmware/Program
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. image:: images/adicup3029_settings.jpg
+   :width: 900
+
+#. Make sure the following switches are as shown from the table below:
+#. Connect the ADICuP3029 to the PC host via micro-USB cable as shown below.
+#. From your PC, open My Computer and look for the DAPLINK drive, if you see
+   this then the drivers are complete and correct.
+
+    .. image:: images/daplink_in_mycomputer.jpg
+       :width: 600
+
+#. Simply extract the provided zip file. Do note that when you extract the zip
+   file, there are two Hex file compressed inside. For this demo use the
+   **adxrs290-pmdz_aducm3029_iio_uart.hex**. Then drag and drop this Hex file
+   to the DAPLINK drive and your ADICUP3029 board will be programmed. The DS2
+   (red) LED will blink rapidly.
+#. The DS2 will stop blinking and will stay ON once the programming is done.
+
+.. note::
+
+   An alternative human-readable Command Line Interface (CLI) program is also
+   available for the ADXRS290 Pmod on the EVAL-ADXRS290-PMDZ:
+   :dokuwiki:`ADXRS290 Gyroscope PMOD Command Line Interface Demo <resources/eval/user-guides/eval-adicup3029/reference_designs/demo_adxrs290_pmod>`
+
+----
+
+General Setup Using Raspberry Pi
+--------------------------------
+
+The :adi:`EVAL-ADXRS290-PMDZ` can be used with a Raspberry Pi.
+
+Demo Requirements
+~~~~~~~~~~~~~~~~~
+
+The following is a list of items needed in order to replicate this demo.
+
+-  **Hardware**
+
+   -  :adi:`EVAL-ADXRS290-PMDZ` Circuit Evaluation Board
+   -  Raspberry PI Zero, Zero W, 3B+, or 4
+   -  16GB (or larger) Class 10 (or faster) micro-SD card
+   -  5Vdc, 2.5 A power supply with micro USB connector (USB-C power
+      supply for Raspberry Pi 4)
+   -  Electrical connection hardware (choose one):
+
+      -  12x 15cm socket-to-socket jumpers such as
+         `these from Schmartboard <https://schmartboard.com/wire-jumpers/female-jumpers/5-inch/>`_
+
+         -  `DesignSpark HAT to Pmod Adapter <https://reference.digilentinc.com/reference/add-ons/pmod-hat/start>`_
+
+   -  User interface setup (choose one):
+
+      -  HDMI monitor, keyboard, mouse plugged directly into Raspberry Pi
+      -  Host Windows/Linux/Mac computer on same network as Raspberry Pi
+
+-  **Software**
+
+   -  :external+kuiper:doc:`Kuiper Images <index>`
+
+Loading Image on SD Card
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+In order to control the **EVAL-ADXRS290-PMDZ** from the Raspberry Pi,
+you will need to install ADI Kuiper Linux on an SD card. Complete
+instructions, including where to download the SD card image, how to
+write it to the SD card, and how to configure the system are provided
+at :external+kuiper:doc:`Kuiper Images <index>`.
+
+Write the image and follow the system configuration procedure.
+
+Configuring the SD Card
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Follow the Hardware Configuration procedure under
+**Preparing the Image: Raspberry Pi** in the
+:external+kuiper:doc:`Kuiper Images <index>` page, substituting
+the following lines in **config.txt**:
+
+.. code-block::
+
+   dtoverlay=rpi-adxrs290
+
+Setting up the Hardware
+~~~~~~~~~~~~~~~~~~~~~~~
+
+To set up the circuit for evaluation, consider the following steps:
+
+.. image:: images/rpi_pmod_con.jpg
+
+.. important::
+
+   Do note that the I/O pins of the Raspberry Pi board are only
+   3.3V tolerant. Any peripheral to be attached should be powered
+   by a source not exceeding 3.3V.
+
+#.  Connect **EVAL-ADXRS290-PMDZ** board at male header connector
+    of the **Raspberry Pi**.
+#.  Burn the SD card with the proper ADI Kuiper Linux image. Insert
+    the burned SD card on the designated slot on the RPi.
+#.  Connect the system to a monitor using an HDMI cable through
+    the mini HDMI connector on the RPi.
+#.  Connect a USB keyboard and mouse to the RPi through the
+    USB ports.
+#.  Power on the RPi board by plugging in a 5V power supply
+    with a micro-USB connector. The final setup should look
+    similar to the picture below.
+
+.. image:: images/system_con.jpg
+
+----
+
+Software (both ADICUP3029 and Raspberry Pi)
+-------------------------------------------
+
+Connection
+~~~~~~~~~~
+
+To be able to connect your device, the software must be able to create a
+context. The context creation in the software depends on the backend used to
+connect to the device as well as the platform where the EVAL-ADXRS290-PMDZ is
+attached. Two platforms are currently supported for the ADXRS290: Raspberry Pi
+using the ADI Kuiper Linux and the ADICUP3029 running the ADXRS290 IIO demo
+project. The user needs to supply a URI which will be used in the context
+creation.
+
+The Libiio is a library for interfacing with IIO devices.
+
+.. admonition:: Download
+   :class: download
+
+   Install the :git-libiio:`Libiio package <releases+>` on your machine.
+
+The :doc:`iio_info </software/libiio/cli>` command is a part of the
+libIIO package that reports all IIO attributes.
+
+Upon installation, simply enter the command on the terminal command line to
+access it.
+
+For RPI Direct Local Access:
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block::
+
+   iio_info
+
+For Windows machine connected to Raspberry Pi:
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block::
+
+   iio_info -u ip:<ip address of your ip>
+
+Example:
+
+-  If your Raspberry Pi has the IP address 192.168.1.7, you have to
+   use *iio_info -u ip::192.168.1.7* as your URI
+
+.. note::
+
+   Do note that the Windows machine and the RPI board should be connected
+   to the same network in order for the machine to detect the device.
+
+For Windows machine connected to ADICUP3029:
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block::
+
+   iio_info -u serial:<serial port>
+
+Examples:
+
+-  In a Windows machine, you can check the port of your ADICUP3029
+   via Device Manager in the Ports (COM & LPT) section. If your
+   device is in COM4, you have to use *iio_info -u serial:COM4*
+   as your URI.
+-  In a Unix-based machine, you will see it under the /dev/ directory
+   in this format "ttyUSBn", where n is a number depending on how
+   many serial USB devices attached. If you see that your device
+   is ttyUSB0, you have to use serial:/dev/ttyUSB0 as your URI.
+
+IIO Commands
+^^^^^^^^^^^^
+
+There are different commands that can be used to manage the device being used.
+The :doc:`iio_attr </software/libiio/cli>` command reads and writes IIO attributes.
+
+.. code-block::
+
+   analog@analog:~$ iio_attr [OPTION]...
+
+Example:
+
+-  To look at the context attributes, enter this code on the terminal:
+
+.. code-block::
+
+   analog@analog:~$ iio_attr -a -C
+
+The :doc:`iio_reg </software/libiio/cli>` command reads or writes SPI or I2C
+registers in an IIO device. This is generally not needed for end
+applications, but can be useful in debugging drivers. Note that you
+need to specify a context using the *-u* qualifier when you are not
+directly accessing the device via RPI or when you are using the
+ADICUP3029 platform.
+
+.. code-block::
+
+   analog@analog:~$ iio_reg -u <context> <device> <register> [<value>]
+
+Example:
+
+-  To to read the device ID (register = 0x02) of an ADXRS90 interfaced
+   via RPI from a Windows machine, enter the following code on
+   the terminal:
+
+.. code-block::
+
+   iio_reg -u ip:<ip address> adxrs290 0x02
+
+----
+
+IIO Oscilloscope
+~~~~~~~~~~~~~~~~
+
+.. important::
+
+   Make sure to download/update to the latest version of IIO-Oscilloscope found on this
+   :git-iio-oscilloscope:`link <releases+>`.
+
+-  Once done with the installation or an update of the latest IIO-Oscilloscope, open
+   the application. The user needs to supply a URI which will be used in the context
+   creation of the IIO Oscilloscope and the instructions can be seen from the
+   previous section.
+-  Press refresh to display available IIO Devices, once adxrs290 appeared, press
+   connect.
+
+.. image:: images/iio_osc_connection.jpg
+   :align: center
+   :width: 500
+
+Debug Panel
+^^^^^^^^^^^
+
+Below is the Debug panel of ADXRS290 wherein you can directly access the
+attributes of the device.
+
+.. image:: images/adxrs290_debug.png
+   :width: 500
+
+DMM Panel
+^^^^^^^^^
+
+Access the DMM panel to see the instantaneous reading of the X and Y's angular
+velocities.
+
+.. image:: images/adxrs290_dmm-2.png
+   :width: 500
+
+Waveform Panel
+^^^^^^^^^^^^^^
+
+The Waveform panel, also known as the Capture window, displays the real-time
+waveform of ADXRS290's response.
+
+.. image:: images/iio_osc_graph.jpg
+   :width: 500
+
+.. note::
+
+   The readings from the DMM panel will freeze upon activation of the real-time
+   plot in the waveform panel i.e. the two panels are designed to be used
+   separately and not simultaneously.
+
+----
+
+PyADI-IIO
+~~~~~~~~~
+
+:ref:`PyADI-IIO <pyadi-iio>` is a python abstraction module for ADI hardware
+with IIO drivers to make them easier to use. This module provides
+device-specific APIs built on top of the current libIIO python bindings.
+These interfaces try to match the driver naming as much as possible without
+the need to understand the complexities of libIIO and IIO.
+
+Install PyADI-IIO using one of the methods in :ref:`PyADI-IIO <pyadi-iio>`.
+
+The ADXRS290 example requires a number of packages to be installed before
+it can be used. To ensure that all required packages are present, we will
+be installing them in a virtual environment so that other python projects
+will not be affected by this added configuration. Make sure that
+`virtualenv <https://pypi.org/project/virtualenv/>`_ has been installed
+before proceeding.
+
+Creating a Virtual Environment
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+#. Open a command prompt and navigate to the *pyadi-iio* directory.
+#. Create a virtual environment by entering the following command:
+
+   .. code-block:: none
+
+      D:\pyadi-iio>python -m venv adxrs290
+
+   Note that the last argument *adxrs290* is just the name of the
+   virtual environment to be created. It can be replaced by any
+   other name or identifier that you prefer. In case the code
+   above does not work, try:
+
+   .. code-block:: none
+
+      D:\pyadi-iio>virtualenv adxrs290
+
+#. Input the following command to activate the virtual environment:
+
+   .. code-block:: none
+
+      D:\pyadi-iio>adxrs290\Scripts\activate
+
+Installing the Packages
+^^^^^^^^^^^^^^^^^^^^^^^
+
+Upon activation of the virtual environment, enter the
+following commands:
+
+.. code-block::
+
+   (adxrs290) D:\pyadi-iio>pip install -r requirements.txt
+   (adxrs290) D:\pyadi-iio>pip install -r examples/requirements_adiplot.txt
+   (adxrs290) D:\pyadi-iio>python setup.py install
+
+.. important::
+
+   One of the packages in *requirements_adiplot.txt* is the PyQt5.
+   If you already have a pre-installed PyQt5 prior to the installation
+   of the packages, we suggest that you uninstall the said package
+   in the virtual environment. Duplicate installations may sometimes
+   cause errors that inhibit the system from displaying the real-time
+   plot. This can easily be done by inputting the command:
+   *pip uninstall PyQt5* while the virtual environment is active.
+
+Running the Example
+^^^^^^^^^^^^^^^^^^^
+
+#. Connect the ADXRS290 to the device platform you've chosen.
+#. If interfaced via RPI, connect your laptop to the same network
+   as the ADXRS290 and take note of its IP address. For ADICUP3029,
+   take note of the serial port used.
+#. On the source code, go to the *examples* folder and open
+   *adxrs290.py*. Provide the necessary context in order to detect
+   the device. Make sure that only one context source is active
+   and the other one is commented out depending on whether you are
+   using the RPI board or the ADICUP3029.
+#. Run the example by typing this line on the command prompt:
+
+   .. code-block:: none
+
+      D:\pyadi-iio\examples>python adxrs290.py
+
+   .. admonition:: Download
+      :class: download
+
+      Below is a copy of the python script:
+
+      :download:`adxrs290.py <resources/adxrs290.zip>`
+
+     It will return these lines of data on the terminal:
+
+   .. image:: images/adxrs290_output.png
+      :alt: Output on Terminal
+      :align: center
+      :width: 700
+
+#. You can opt to see a real-time plot of ADXRS290's output.
+   To do this, open *adxrs290.py* and set *enable_plot* to
+   True.
+   
+    .. image:: images/adxrs290_enable-plot.png
+       :width: 500
+   
+ 
+ A plot will pop-up after running the code:
+
+ .. image:: images/adxrs290_plot.png
+    :alt: ADXRS290's Real-time Plot
+    :align: center
+    :width: 500
+
+----
+
+Video Guides
+~~~~~~~~~~~~
+
+Unboxing
+^^^^^^^^
+
+.. image:: https://img.youtube.com/vi/Z4bt3IdRFEQ/maxresdefault.jpg
+    :width: 600px
+    :target: https://www.youtube.com/watch?v=Z4bt3IdRFEQ
+
+EVAL-ADICUP3029 Demo
+^^^^^^^^^^^^^^^^^^^^
+
+.. image:: https://img.youtube.com/vi/LwD-MHoSlWk/maxresdefault.jpg
+    :width: 600px
+    :target: https://www.youtube.com/watch?v=LwD-MHoSlWk
+
+Schematic, PCB Layout, Bill of Materials
+----------------------------------------
+
+.. admonition:: Download
+   :class: download
+
+   :adi:`EVAL-ADXRS20-PMDZ Design & Integration Files <media/en/evaluation-documentation/evaluation-design-files/eval-adxrs290-pmdz-designsupport.zip>`
+
+   -  Schematic
+   -  PCB Layout
+   -  Bill of Materials
+   -  Allegro Project
+   
+Additional Information and Useful Links
+---------------------------------------
+
+-  :adi:`ADXRS290 Product Page <ADXRS290>`
+
+Reference Demos & Software
+--------------------------
+
+-  :git-no-OS:`ADXRS290 No-OS Build Instruction Guide <wiki+>`
+-  :git-no-OS:`ADXRS290 No-OS Drivers <projects/adxrs290-pmdz>`
+-  :external+kuiper:doc:`Kuiper Images <index>`
+
+Registration
+------------
+
+.. tip::
+
+   Receive software update notifications, documentation updates, view the latest videos,
+   and more when you register your hardware.
+   `Register <https://form.analog.com/Form_Pages/FeedBack/EVAL-ADXRS290-PMDZ?&v=Rev A>`_
+   to receive all these great benefits and more!

--- a/docs/solutions/reference-designs/eval-adxrs290-pmdz/images/adicup3029_settings.jpg
+++ b/docs/solutions/reference-designs/eval-adxrs290-pmdz/images/adicup3029_settings.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1a2b9ad61052c19dd19252275ea1963eb4edcd36edf7e8253f988b9090705e5a
+size 61467

--- a/docs/solutions/reference-designs/eval-adxrs290-pmdz/images/adxrs290_architecture.png
+++ b/docs/solutions/reference-designs/eval-adxrs290-pmdz/images/adxrs290_architecture.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7761f6fe96dacde95b3d772336f1d84de603cc83a35022fe6ea57ec4c01b1265
+size 15369

--- a/docs/solutions/reference-designs/eval-adxrs290-pmdz/images/adxrs290_debug.png
+++ b/docs/solutions/reference-designs/eval-adxrs290-pmdz/images/adxrs290_debug.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:143fdcd5e5f755d3095de70e77747a8136390bee739cdd17f077299fface433d
+size 95887

--- a/docs/solutions/reference-designs/eval-adxrs290-pmdz/images/adxrs290_dmm-2.png
+++ b/docs/solutions/reference-designs/eval-adxrs290-pmdz/images/adxrs290_dmm-2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ed6fb7d8e8a1561a14237c894b8b26b7abac2b84eed392283ace22a7d85605f2
+size 51545

--- a/docs/solutions/reference-designs/eval-adxrs290-pmdz/images/adxrs290_enable-plot.png
+++ b/docs/solutions/reference-designs/eval-adxrs290-pmdz/images/adxrs290_enable-plot.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:68f945cc776b77d210fc52eae0a4c0dd77ab7434e76217284ff0d71d11dc9f65
+size 5871

--- a/docs/solutions/reference-designs/eval-adxrs290-pmdz/images/adxrs290_output.png
+++ b/docs/solutions/reference-designs/eval-adxrs290-pmdz/images/adxrs290_output.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:248c7c9855e4c3b7c214d58594d3b4da7f24c58d187ee67f9614937d0d1064f1
+size 167904

--- a/docs/solutions/reference-designs/eval-adxrs290-pmdz/images/adxrs290_plot.png
+++ b/docs/solutions/reference-designs/eval-adxrs290-pmdz/images/adxrs290_plot.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c9372a244e30195dbb5c2630205bf4d144f054f813ea891cdacfc84c3ce60b53
+size 77038

--- a/docs/solutions/reference-designs/eval-adxrs290-pmdz/images/daplink_in_mycomputer.jpg
+++ b/docs/solutions/reference-designs/eval-adxrs290-pmdz/images/daplink_in_mycomputer.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c3eb33c237ea1cac943254cdb260aac8587e6de10de1d2217d809c206b639c5c
+size 87450

--- a/docs/solutions/reference-designs/eval-adxrs290-pmdz/images/eval-adxrs290-pmdz.png
+++ b/docs/solutions/reference-designs/eval-adxrs290-pmdz/images/eval-adxrs290-pmdz.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:27e7ef7ae96b5992f78b525151e50b9fd729c93a15598275873b3f382aebe426
+size 1399986

--- a/docs/solutions/reference-designs/eval-adxrs290-pmdz/images/example_serial_output.png
+++ b/docs/solutions/reference-designs/eval-adxrs290-pmdz/images/example_serial_output.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:14850803db0f9eca5388fa69c951c52473c5cec4f4d32fbc4e4e01eb3d585185
+size 161919

--- a/docs/solutions/reference-designs/eval-adxrs290-pmdz/images/iio_osc_connection.jpg
+++ b/docs/solutions/reference-designs/eval-adxrs290-pmdz/images/iio_osc_connection.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0edc21bdb15b0f8cc4cf55e324da1f033ba5c65125558176d9c51016f7f61b70
+size 52819

--- a/docs/solutions/reference-designs/eval-adxrs290-pmdz/images/iio_osc_graph.jpg
+++ b/docs/solutions/reference-designs/eval-adxrs290-pmdz/images/iio_osc_graph.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:66ebc897293a209d1f8d7916268984961d1bf0d105f3000cffde23dc734ad932
+size 102195

--- a/docs/solutions/reference-designs/eval-adxrs290-pmdz/images/pmodtoadicup_v2.jpg
+++ b/docs/solutions/reference-designs/eval-adxrs290-pmdz/images/pmodtoadicup_v2.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c45c27a492254f3d6833224aa6a4ea7309c8159017fe2d9356dce38313e0a1cb
+size 109276

--- a/docs/solutions/reference-designs/eval-adxrs290-pmdz/images/roll_and_pitch.png
+++ b/docs/solutions/reference-designs/eval-adxrs290-pmdz/images/roll_and_pitch.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f4b24e4a64a7ae6a4e7b3888a192b9d1eaa338c2f5b5fa49e9b9721899625b06
+size 90902

--- a/docs/solutions/reference-designs/eval-adxrs290-pmdz/images/rpi_pmod_con.jpg
+++ b/docs/solutions/reference-designs/eval-adxrs290-pmdz/images/rpi_pmod_con.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5276fe32aacfc22246a07764794bf1b7e047ca843ef64dd7289c8e1684926360
+size 495018

--- a/docs/solutions/reference-designs/eval-adxrs290-pmdz/images/spi_comm.png
+++ b/docs/solutions/reference-designs/eval-adxrs290-pmdz/images/spi_comm.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a5197f1c54a83dc31b55f3478d01050dcbd71fbb1ddd1cde74d2f9ac5cce1461
+size 40285

--- a/docs/solutions/reference-designs/eval-adxrs290-pmdz/images/system_con.jpg
+++ b/docs/solutions/reference-designs/eval-adxrs290-pmdz/images/system_con.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4be0ecb6451660c9c48d060cc2a56a102d3919a242ebee15bebcca4b0cf85c99
+size 83592

--- a/docs/solutions/reference-designs/eval-adxrs290-pmdz/index.rst
+++ b/docs/solutions/reference-designs/eval-adxrs290-pmdz/index.rst
@@ -1,0 +1,122 @@
+.. _eval_adxrs290_pmdz:
+
+EVAL-ADXRS290-PMDZ
+==================
+
+Ultralow Noise, Dual-Axis MEMS Gyroscope for Stabilization Applications
+
+.. image:: images/eval-adxrs290-pmdz.png
+   :align: center
+   :width: 200
+
+Overview
+--------
+
+The :adi:`EVAL-ADXRS290-PMDZ` is a simple Pmod form factor evaluation board for
+the :adi:`ADXRS290`, a high-performance MEMS pitch-and-roll (dual-axis in-plane)
+angular rate sensor (gyroscope) designed for use in stabilization applications.
+
+The solution senses and digitizes the **X-axis** and **Y-axis** (also called
+**roll** and **pitch**) angular rates, producing a positive reading for
+clockwise rotation about the X-axis and Y-axis.
+
+.. image:: images/roll_and_pitch.png
+   :align: center
+   :width: 200
+
+The :adi:`ADXRS290` provides an output full-scale range of ±100°/s with 
+a sensitivity of 200 LSB/°/s. Its resonating disk sensor structure enables 
+angular rate measurement about the axes normal to the sides of the package 
+around an  in-plane axis. Angular rate data is formatted 
+as a 16-bit two's complement and is accessible through an SPI digital interface. 
+The ADXRS290 exhibits a low noise floor of 0.004°/s/√Hz and features programmable 
+high-pass and lowpass filters.
+
+The ADXRS290 communicates via 4-wire SPI and operates as a peripheral 
+(subordinate) device, with a maximum clock frequency of 12 MHz.
+
+.. image:: images/spi_comm.png
+   :align: center
+   :width: 300
+
+The digital communication on the :adi:`EVAL-ADXRS290-PMDZ` is
+accomplished using a standard expanded SPI PMOD port.
+
++------------------+------------+
+| Connector P1     |            |
++==================+============+
+| **Description**  | **Pin(s)** |
++------------------+------------+
+| SS               | 1          |
++------------------+------------+
+| MOSI             | 2          |
++------------------+------------+
+| MISO             | 3          |
++------------------+------------+
+| SCLK             | 4          |
++------------------+------------+
+| GND              | 5, 11      |
++------------------+------------+
+| IOVDD            | 6, 12      |
++------------------+------------+
+| SYNC             | 7          |        
++------------------+------------+
+
+Features
+--------
+
+-  Pitch and roll rate gyroscope
+-  Ultralow noise: 0.004°/s/√Hz
+-  High vibration rejection over a wide frequency range
+-  Power saving standby mode
+-  80 µA current consumption in standby mode
+-  Fast startup time from standby mode: <100 ms
+-  Low delay of <0.5 ms for a 30 Hz input at the widest bandwidth setting
+-  Serial peripheral interface (SPI) digital output
+-  Programmable high-pass and low-pass filters
+-  2000 g powered acceleration survivability
+-  2.7V to 5.0V operation
+-  −25°C to +85°C operation
+-  PMOD form factor
+
+Applications
+------------
+
+- Optical image stabilization
+- Platform stabilization
+- Wearable products
+
+.. admonition:: Getting Started
+
+   The :adi:`EVAL-ADXRS290-PMDZ` can be used for a wide range of applications, 
+   and the following demos are meant to show examples of the flexibility of the board. 
+   To get started with setup, configuration, and example use cases, 
+   please proceed to the PMOD Guide and follow the provided serial terminal setup.
+
+   - :doc:`PMOD Guide </solutions/reference-designs/eval-adxrs290-pmdz/eval-adxrs290-pmdz>`
+   - :ref:`Serial Terminal Setup <eval_adxrs290_pmdz uart_serial_terminal>`
+
+Recommendations
+---------------
+
+People who follow the flow that is outlined, have a much better experience with
+things. However, like many things, documentation is never as complete as it
+should be. If you have any questions, feel free to ask on our
+:ez:`EngineerZone forums <help-and-support>`, but before that, please make
+sure you read our documentation thoroughly.
+
+Warning
+-------
+
+.. esd-warning::
+
+Help and Support
+----------------
+
+Please go to :ez:`Help and Support <help-and-support>` page.
+
+.. toctree::
+   :hidden:
+
+   eval-adxrs290-pmdz
+   uart_serial_terminal

--- a/docs/solutions/reference-designs/eval-adxrs290-pmdz/resources/adxrs290.zip
+++ b/docs/solutions/reference-designs/eval-adxrs290-pmdz/resources/adxrs290.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8e0932554b816cb019e1ab4ccd90ec82dfbcf93a18903d9ec3bf2e3ed5c66d57
+size 2197

--- a/docs/solutions/reference-designs/eval-adxrs290-pmdz/uart_serial_terminal.rst
+++ b/docs/solutions/reference-designs/eval-adxrs290-pmdz/uart_serial_terminal.rst
@@ -1,0 +1,83 @@
+.. _eval_adxrs290_pmdz uart_serial_terminal:
+
+Outputting Data
+===============
+
+Serial Terminal Setup
+---------------------
+
+A serial terminal is an application that runs on a PC or laptop that is used to
+display data and interact with a connected device (including many of the
+Circuits from the Lab reference designs). The device's UART peripheral is most
+often connected to a UART to USB interface IC, which appears as a traditional
+COM port on the host PC/ laptop. (Traditionally, the device's UART port would
+have been connected to an RS-232 line driver / receiver and connected to the PC
+via a 9-pin or 25-pin serial port.) There are many open-source applications,
+and while there are many choices, typically we use one of the following:
+
+- `Tera Term <https://ttssh2.osdn.jp/index.html.en>`_
+- `PuTTY <https://www.putty.org/>`_
+- `RealTerm <https://realterm.sourceforge.io/>`_
+
+Before continuing, please make sure you download and install one of the above
+programs.
+
+There are several parameters on all serial terminal programs that must be setup
+properly in order for the PC and the connected device to communicate. Below are
+the common settings that must match on both the PC side and the connected UART
+device.
+
+- **COM Port** - This is the physical connection made to your PC or Laptop,
+  typically made through a USB cable but can be any serial communications cable.
+  You can determine the COM port assigned to your device by visiting the device
+  manager on your computer. Another method for identifying which COM port is
+  associated with a USB-based device is to look at which COM ports are present
+  before plugging in your device, then plug in your device, and look for a new
+  COM port.
+- **Baud Rate** - This is the speed at which data is being transferred from the
+  connected device to your PC. These parameters must be the same on both devices
+  or data will be corrupted. The default setting for most of the reference
+  designs is 115200.
+- **Data Bits** - The number of data bits per transfer. Typically UART transmits
+  ASCII codes back to the serial port so by default this is almost always set to
+  8-Bits.
+- **Stop Bits** - The number of "stop" conditions per transmission. This is
+  usually set to 1, but can be set to 2 for redundancy.
+- **Parity** - Is a way to check for errors during the UART transmission.
+  Unless otherwise specified, set parity to "none".
+- **Flow Control** - Is a way to ensure that data between fast and slow devices
+  on the same UART bus is not lost during transmission. This is typically not
+  implemented in a simple system, and unless otherwise specified, set to "none".
+
+In many instances there are other options that each of the different serial
+terminal applications provide, such as **local line echo** or **local line
+editing**, and features like this can be turned on or off depending on your
+preferences.
+
+**Example setup using PuTTY**
+
+#. Plug in your connected device using a USB cable or other serial cable.
+#. Wait for the device driver of the connected device to install on your PC or
+   Laptop.
+#. Open your device manager, and find out which COM port was assigned to your
+   device.
+#. Open up your serial terminal program (PuTTY for this example).
+#. Click on the serial configuration tab or window, and input the settings to
+   match the requirements of your connected device. The default baud rate for
+   most of the reference designs is 115200. Make sure that you use the correct
+   baud rate for your application.
+#. Ensure you click on the checkboxes for **Implicit CR in every LF** and
+   **Implicit LF in every CF**.
+#. Ensure that local echo and line editing are enabled, so that you can see what
+   you type and are able to correct mistakes. (Some devices may echo typed
+   characters - if so, you will see each typed character twice. If this happens,
+   turn off local echo.)
+
+.. tip::
+
+   If you see nothing in the serial terminal, try hitting the reset button on
+   the embedded development board.
+
+.. image:: images/example_serial_output.png
+   :align: center
+   :width: 600


### PR DESCRIPTION
## Summary
- Move eval-adxrs290-pmdz wiki documentation to `solutions/reference-designs/eval-adxrs290-pmdz/`
- 3 RST files with 17 localized images
- Generated stub `index.rst` with toctree

## Test plan
- [ ] Sphinx build passes without errors
- [ ] All toctree entries resolve correctly
- [ ] Images render properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)