### PR TITLE
ad-apardpfwd-sl: Add production testing guide

### DIFF
--- a/docs/solutions/reference-designs/ad-apard32690-sl/ad-apardpfwd-sl/index.rst
+++ b/docs/solutions/reference-designs/ad-apard32690-sl/ad-apardpfwd-sl/index.rst
@@ -321,3 +321,8 @@ Help and Support
 
 For questions and more information about this product, connect with us through
 the Analog Devices :ez:`/` .
+
+.. toctree::
+   :hidden:
+
+   production_testing/index

--- a/docs/solutions/reference-designs/ad-apard32690-sl/ad-apardpfwd-sl/production_testing/images/cable_connections.png
+++ b/docs/solutions/reference-designs/ad-apard32690-sl/ad-apardpfwd-sl/production_testing/images/cable_connections.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ef40b892f3529d77207c5a32b827cc88ccabbc91916a17d7a56c856bc55b3009
+size 701702

--- a/docs/solutions/reference-designs/ad-apard32690-sl/ad-apardpfwd-sl/production_testing/images/system_setup.png
+++ b/docs/solutions/reference-designs/ad-apard32690-sl/ad-apardpfwd-sl/production_testing/images/system_setup.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b7ebb7da61cb60f6e1333a9a359325e38529aea6f1107446f2bd1d046b9ba7be
+size 7068142

--- a/docs/solutions/reference-designs/ad-apard32690-sl/ad-apardpfwd-sl/production_testing/images/test_process_1_wifi_connection.png
+++ b/docs/solutions/reference-designs/ad-apard32690-sl/ad-apardpfwd-sl/production_testing/images/test_process_1_wifi_connection.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:596bd2864c83b74fb0977349c661a724dee57b214cf434c403c577103aec06c5
+size 288635

--- a/docs/solutions/reference-designs/ad-apard32690-sl/ad-apardpfwd-sl/production_testing/images/test_process_2_reboot_conn.png
+++ b/docs/solutions/reference-designs/ad-apard32690-sl/ad-apardpfwd-sl/production_testing/images/test_process_2_reboot_conn.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2506a7ffa56096fc9f31209d3da27e95b5bbf048c351e418bb441ed2c34dcc44
+size 57895

--- a/docs/solutions/reference-designs/ad-apard32690-sl/ad-apardpfwd-sl/production_testing/images/test_process_3_reboot_conn.png
+++ b/docs/solutions/reference-designs/ad-apard32690-sl/ad-apardpfwd-sl/production_testing/images/test_process_3_reboot_conn.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:25afe2dc3dc26af83a4e29c5c4ed16672f6423e9227268480e69caab96fcb002
+size 35122

--- a/docs/solutions/reference-designs/ad-apard32690-sl/ad-apardpfwd-sl/production_testing/images/testing_command_1.png
+++ b/docs/solutions/reference-designs/ad-apard32690-sl/ad-apardpfwd-sl/production_testing/images/testing_command_1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:26bd1339866b9e1c33607faa56162ce477f877ce36aa338ef0ac1f572a26fa9d
+size 228675

--- a/docs/solutions/reference-designs/ad-apard32690-sl/ad-apardpfwd-sl/production_testing/images/testing_command_1_passed.png
+++ b/docs/solutions/reference-designs/ad-apard32690-sl/ad-apardpfwd-sl/production_testing/images/testing_command_1_passed.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9adacb26b1c4621672f90d234ba1e3f0ea366710a4bba16be8eeec83229ab49c
+size 558681

--- a/docs/solutions/reference-designs/ad-apard32690-sl/ad-apardpfwd-sl/production_testing/images/testing_command_1_result.png
+++ b/docs/solutions/reference-designs/ad-apard32690-sl/ad-apardpfwd-sl/production_testing/images/testing_command_1_result.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f0832d9a500bc3a38be4b2c3621e38bc25677221bab76fd41e17032e489e88da
+size 600306

--- a/docs/solutions/reference-designs/ad-apard32690-sl/ad-apardpfwd-sl/production_testing/index.rst
+++ b/docs/solutions/reference-designs/ad-apard32690-sl/ad-apardpfwd-sl/production_testing/index.rst
@@ -1,0 +1,147 @@
+.. _ad-apardpfwd-sl production_testing:
+
+Production Testing
+==================
+
+Overview
+--------
+
+The purpose of the test procedure is to identify connectivity issues, poor
+soldering, and potential manufacturing defects. Some of the issues are directly
+identified by explicit part-targeted tests, others are implicit, by running
+adjacent tests.
+
+Test Duration
+-------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 70 30
+
+   * - Step Description
+     - Estimate Time (minutes)
+   * - Test bench setup
+     - 5 min
+   * - Software test
+     - 5 min
+   * - **Total time**
+     - **10 min**
+
+Test Requirements
+-----------------
+
+Required Hardware
+~~~~~~~~~~~~~~~~~
+
+* Raspberry Pi 4
+* HDMI cable
+* :adi:`AD-RPI-T1LPSE-SL` board
+* 1 x :adi:`AD-APARD32690-SL` board
+* 1 x :adi:`AD-SWIOT1L-SL` board
+* :adi:`MAX32625PICO` (DAPLink programmer)
+* 2 x T1L cables
+* 1 x 12V power supply
+* 1 x :adi:`AD-APARDPFW-SL` (Device Under Test)
+
+Required Software
+~~~~~~~~~~~~~~~~~
+
+The test image is provided on a pre-configured SD card.
+
+* 1 x SD card with the test image
+
+Required Setup
+~~~~~~~~~~~~~~
+
+#. Insert the SD card into the Raspberry Pi.
+
+#. Connect the Raspberry Pi to a monitor.
+
+#. Connect the AD-RPI-T1LPSE-SL on top of the Raspberry Pi.
+
+#. Connect the AD-APARDPFW-SL on top of AD-APARD32690-SL.
+
+#. Connect the AD-RPI-T1LPSE-SL using a T1L cable to AD-APARDPFW-SL board
+   port **P7**.
+
+#. Connect the AD-SWIOT1L-SL to AD-APARDPFW-SL board port **P8** using a T1L
+   cable.
+
+#. Connect the DAPLink programmer to the Raspberry Pi and to the
+   AD-APARD32690-SL board.
+
+#. Power the Raspberry Pi through AD-APARDPFW-SL using a 12V power supply.
+
+.. figure:: images/cable_connections.png
+   :width: 45em
+
+   Cable connections
+
+.. figure:: images/system_setup.png
+   :width: 45em
+
+   Complete system setup
+
+Test Process
+------------
+
+Wi-Fi Setup
+~~~~~~~~~~~
+
+Make sure the Raspberry Pi is connected to Wi-Fi before starting the tests.
+
+#. Power the Raspberry Pi.
+
+#. Press **CONTROL+C** to exit the test screen.
+
+#. Click on the network and type in the password.
+
+   .. figure:: images/test_process_1_wifi_connection.png
+      :width: 45em
+
+      Wi-Fi connection
+
+#. After successfully connecting, reboot the Raspberry Pi by following the
+   instructions below.
+
+   .. list-table::
+      :widths: 50 50
+      :header-rows: 0
+
+      * - .. figure:: images/test_process_2_reboot_conn.png
+
+        - .. figure:: images/test_process_3_reboot_conn.png
+
+Running the Tests
+~~~~~~~~~~~~~~~~~
+
+After the Raspberry Pi reboots, the test screen will appear on the monitor.
+
+.. figure:: images/testing_command_1.png
+   :width: 45em
+
+   Test menu
+
+1) System Test
+^^^^^^^^^^^^^^
+
+Type **1** into the terminal then press **ENTER** to start "1) System Test".
+
+.. figure:: images/testing_command_1_result.png
+   :width: 45em
+
+   System test in progress
+
+If the test is **PASSED**, the DUT is functional. Unplug it from the
+AD-RPI-T1LPSE-SL, then from the AD-APARD32690-SL board, and connect the next
+device under test.
+
+.. figure:: images/testing_command_1_passed.png
+   :width: 45em
+
+   System test passed
+
+.. attention::
+
+   If at any point the test fails, retry testing for up to 3 times before
+   considering the board defective.


### PR DESCRIPTION
Add comprehensive production testing documentation for the AD-APARDPFW-SL 10BASE-T1L power forwarder board. This guide is intended for manufacturing and QA teams to verify board functionality.

Content includes:
- Test duration estimates (10 min total)
- Required hardware list (Raspberry Pi 4, DAPLink, T1L cables, etc.)
- Step-by-step setup instructions with images
- Cable connections and system setup overview

Test process documentation:
- Wi-Fi setup on Raspberry Pi
- 1) System Test
- Pass/fail criteria and retry guidelines

The documentation is deployed here: https://plescaevelyn.github.io/adi-documentation/pull/9/solutions/reference-designs/ad-apard32690-sl/ad-apardpfwd-sl/production_testing/index.html

## Type
- [x] Documentation
- [ ] Bug fix
- [ ] New feature
- [ ] Continuous integration

## Checklist
- [x] I have performed a self-review of changes
- [x] I have followed the guidelines:
  * https://analogdevicesinc.github.io/documentation/contributing/docs_guidelines.html
  * https://analogdevicesinc.github.io/doctools/docs_guidelines/index.html
  * https://analogdevicesinc.github.io/documentation/contributing/creating_new_pages.html#documentation-structure
- [x] I have used the appropriate roles and directives:
  * https://analogdevicesinc.github.io/doctools/docs_guidelines/roles.html
  * https://analogdevicesinc.github.io/doctools/docs_guidelines/directives.html
- [x] I ensured that binary data was committed to git lfs:
  * https://analogdevicesinc.github.io/documentation/contributing/creating_new_pages.html#adding-images-and-other-binary-files
- [x] I have built the pages I edited or created, using either `make html` or `adoc serve`:
  * https://analogdevicesinc.github.io/doctools/cli.html#serve
- [x] I have signed-off my commits and believe my contribution improves the repository.
