### PR TITLE
ad-apardspoe-sl: Add production testing guide

### DIFF
--- a/docs/solutions/reference-designs/ad-apard32690-sl/ad-apardspoe-sl/index.rst
+++ b/docs/solutions/reference-designs/ad-apard32690-sl/ad-apardspoe-sl/index.rst
@@ -277,3 +277,8 @@ Help and Support
 
 For questions and more information about this product, connect with us through
 the Analog Devices :ez:`/` .
+
+.. toctree::
+   :hidden:
+
+   production_testing/index

--- a/docs/solutions/reference-designs/ad-apard32690-sl/ad-apardspoe-sl/production_testing/images/rpi_setup.png
+++ b/docs/solutions/reference-designs/ad-apard32690-sl/ad-apardspoe-sl/production_testing/images/rpi_setup.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:492dc95008c1610255188439ff9cbe8abbaa50ae3ef672cb9f1eb808fb395f00
+size 1563751

--- a/docs/solutions/reference-designs/ad-apard32690-sl/ad-apardspoe-sl/production_testing/images/system_setup.png
+++ b/docs/solutions/reference-designs/ad-apard32690-sl/ad-apardspoe-sl/production_testing/images/system_setup.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3d69e81d9f44097fd05dc4c378aefc2f1e470b3bceacdd1a179c3eb75c501670
+size 1318457

--- a/docs/solutions/reference-designs/ad-apard32690-sl/ad-apardspoe-sl/production_testing/images/terminal_command_1.png
+++ b/docs/solutions/reference-designs/ad-apard32690-sl/ad-apardspoe-sl/production_testing/images/terminal_command_1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c768b8e9dbb6aa5d04fdd21f83f2c7e91ac993f0ad000640cd1c931ddae32b6f
+size 228674

--- a/docs/solutions/reference-designs/ad-apard32690-sl/ad-apardspoe-sl/production_testing/images/terminal_command_1_passed.png
+++ b/docs/solutions/reference-designs/ad-apard32690-sl/ad-apardspoe-sl/production_testing/images/terminal_command_1_passed.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eb78ffb704b336a17315a8e544790296c89b89cec41f03b23220e118d4b14756
+size 260720

--- a/docs/solutions/reference-designs/ad-apard32690-sl/ad-apardspoe-sl/production_testing/images/test_process_1_wifi_connection.png
+++ b/docs/solutions/reference-designs/ad-apard32690-sl/ad-apardspoe-sl/production_testing/images/test_process_1_wifi_connection.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:596bd2864c83b74fb0977349c661a724dee57b214cf434c403c577103aec06c5
+size 288635

--- a/docs/solutions/reference-designs/ad-apard32690-sl/ad-apardspoe-sl/production_testing/images/test_process_2_reboot_conn.png
+++ b/docs/solutions/reference-designs/ad-apard32690-sl/ad-apardspoe-sl/production_testing/images/test_process_2_reboot_conn.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2506a7ffa56096fc9f31209d3da27e95b5bbf048c351e418bb441ed2c34dcc44
+size 57895

--- a/docs/solutions/reference-designs/ad-apard32690-sl/ad-apardspoe-sl/production_testing/images/test_process_3_reboot_conn.png
+++ b/docs/solutions/reference-designs/ad-apard32690-sl/ad-apardspoe-sl/production_testing/images/test_process_3_reboot_conn.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:25afe2dc3dc26af83a4e29c5c4ed16672f6423e9227268480e69caab96fcb002
+size 35122

--- a/docs/solutions/reference-designs/ad-apard32690-sl/ad-apardspoe-sl/production_testing/index.rst
+++ b/docs/solutions/reference-designs/ad-apard32690-sl/ad-apardspoe-sl/production_testing/index.rst
@@ -1,0 +1,131 @@
+.. _ad-apardspoe-sl production_testing:
+
+Production Testing
+==================
+
+Overview
+--------
+
+The purpose of the test procedure is to identify connectivity issues, poor
+soldering, and potential manufacturing defects. Some of the issues are directly
+identified by explicit part-targeted tests, others are implicit, by running
+adjacent tests.
+
+Test Duration
+-------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 70 30
+
+   * - Step Description
+     - Estimate Time (minutes)
+   * - Test bench setup
+     - 3 min
+   * - Software test
+     - 5 min
+   * - **Total time**
+     - **8 min**
+
+Test Requirements
+-----------------
+
+Required Hardware
+~~~~~~~~~~~~~~~~~
+
+* Raspberry Pi 4
+* HDMI cable
+* Mouse and keyboard
+* 1 x :adi:`AD-RPI-T1LPSE-SL` board
+* 1 x :adi:`AD-APARD32690-SPOE` (Device Under Test)
+* 1 x :adi:`AD-APARD32690-SL` board
+* 1 x T1L cable
+* 12V power supply USB Type-C
+* :adi:`MAX32625PICO` (DAPLink programmer)
+
+Required Software
+~~~~~~~~~~~~~~~~~
+
+The test image is provided on a pre-configured SD card.
+
+Required Setup
+~~~~~~~~~~~~~~
+
+#. Insert the SD card into the Raspberry Pi.
+
+#. Connect the Raspberry Pi to a monitor, keyboard, and mouse.
+
+#. Insert the AD-RPI-T1LPSE-SL on top of the Raspberry Pi.
+
+#. Connect the AD-APARD32690-SPOE shield on top of the AD-APARD32690-SL board.
+
+#. Connect the T1L cable to AD-RPI-T1LPSE-SL and the AD-APARD32690-SL board.
+
+#. Connect the DAPLink cable to the AD-APARD32690-SL board and plug it into the
+   Raspberry Pi.
+
+#. Power the AD-RPI-T1LPSE-SL using a Type-C power supply (12V).
+
+.. figure:: images/rpi_setup.png
+   :width: 45em
+
+   Raspberry Pi setup
+
+.. figure:: images/system_setup.png
+   :width: 45em
+
+   Complete system setup
+
+Test Process
+------------
+
+Wi-Fi Setup
+~~~~~~~~~~~
+
+Make sure the Raspberry Pi is connected to Wi-Fi before starting the tests.
+
+#. Power the Raspberry Pi.
+
+#. Press **CONTROL+C** to exit the test screen.
+
+#. Click on the network and type in the password.
+
+   .. figure:: images/test_process_1_wifi_connection.png
+      :width: 45em
+
+      Wi-Fi connection
+
+#. After successfully connecting, reboot the Raspberry Pi by following the
+   instructions below.
+
+   .. list-table::
+      :widths: 50 50
+      :header-rows: 0
+
+      * - .. figure:: images/test_process_2_reboot_conn.png
+
+        - .. figure:: images/test_process_3_reboot_conn.png
+
+Running the Tests
+~~~~~~~~~~~~~~~~~
+
+After the Raspberry Pi reboots, the test screen will appear on the monitor.
+
+.. figure:: images/terminal_command_1.png
+   :width: 45em
+
+   Test menu
+
+1) System Test
+^^^^^^^^^^^^^^
+
+Type **1** into the terminal then press **ENTER** to start "1) System Test".
+Connect the T1L cable to port 1.
+
+If the test is **PASSED**, the DUT is functional. Continue testing the other
+boards.
+
+.. figure:: images/terminal_command_1_passed.png
+   :width: 45em
+
+   System test passed


### PR DESCRIPTION
Add comprehensive production testing documentation for the AD-APARD32690-SPOE SPoE shield board. This guide is intended for manufacturing and QA teams to verify board functionality.

Content includes:
- Test duration estimates (8 min total)
- Required hardware list (Raspberry Pi 4, DAPLink, T1L cable, etc.)
- Step-by-step setup instructions with images
- Raspberry Pi and system setup overview

Test process documentation:
- Wi-Fi setup on Raspberry Pi
- 1) System Test
- Pass/fail criteria

The documentation page is deployed here: **https://plescaevelyn.github.io/adi-documentation/pull/10/solutions/reference-designs/ad-apard32690-sl/ad-apardspoe-sl/production_testing/index.html**

## Type
- [x] Documentation
- [ ] Bug fix
- [ ] New feature
- [ ] Continuous integration

## Checklist
- [x] I have performed a self-review of changes
- [x] I have followed the guidelines:
  * https://analogdevicesinc.github.io/documentation/contributing/docs_guidelines.html
  * https://analogdevicesinc.github.io/doctools/docs_guidelines/index.html
  * https://analogdevicesinc.github.io/documentation/contributing/creating_new_pages.html#documentation-structure
- [x] I have used the appropriate roles and directives:
  * https://analogdevicesinc.github.io/doctools/docs_guidelines/roles.html
  * https://analogdevicesinc.github.io/doctools/docs_guidelines/directives.html
- [x] I ensured that binary data was committed to git lfs:
  * https://analogdevicesinc.github.io/documentation/contributing/creating_new_pages.html#adding-images-and-other-binary-files
- [x] I have built the pages I edited or created, using either `make html` or `adoc serve`:
  * https://analogdevicesinc.github.io/doctools/cli.html#serve
- [x] I have signed-off my commits and believe my contribution improves the repository.
