### PR TITLE
ad-rpi-t1lpse-sl: Add production testing guide

### DIFF
--- a/docs/solutions/reference-designs/ad-rpi-t1lpse-sl/production_testing/images/ftdi_programming_board_disconnection.png
+++ b/docs/solutions/reference-designs/ad-rpi-t1lpse-sl/production_testing/images/ftdi_programming_board_disconnection.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:205d25ba2f5c6a2fc775e85b44f23bb808fa38a0e3f9047b6f30ca32e56b4c80
+size 48111

--- a/docs/solutions/reference-designs/ad-rpi-t1lpse-sl/production_testing/images/ftdi_programming_connection_setup.png
+++ b/docs/solutions/reference-designs/ad-rpi-t1lpse-sl/production_testing/images/ftdi_programming_connection_setup.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cec465b10bbb89fd1f6fc49d3c60e1906847d1f0061efb0936943615d8a7896d
+size 97030

--- a/docs/solutions/reference-designs/ad-rpi-t1lpse-sl/production_testing/images/ftdi_programming_firmware_programming_commands.png
+++ b/docs/solutions/reference-designs/ad-rpi-t1lpse-sl/production_testing/images/ftdi_programming_firmware_programming_commands.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:989bee3eb64bdb317d2369fb9bc49c85a928bf2e17da4897363cf5624ae1671b
+size 98696

--- a/docs/solutions/reference-designs/ad-rpi-t1lpse-sl/production_testing/images/ftdi_programming_firmware_programming_completion_message.png
+++ b/docs/solutions/reference-designs/ad-rpi-t1lpse-sl/production_testing/images/ftdi_programming_firmware_programming_completion_message.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a7b374cfef9cfce807521ee75eb96e6602f600961f154bf00d1fe86c3542e7a7
+size 202279

--- a/docs/solutions/reference-designs/ad-rpi-t1lpse-sl/production_testing/images/ftdi_programming_required_setup.png
+++ b/docs/solutions/reference-designs/ad-rpi-t1lpse-sl/production_testing/images/ftdi_programming_required_setup.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3eeb267fd102ae5bd67494d4b980d0c3264fac2133871f9aa8d7cc5e6dfa839a
+size 2016195

--- a/docs/solutions/reference-designs/ad-rpi-t1lpse-sl/production_testing/images/reboot1.png
+++ b/docs/solutions/reference-designs/ad-rpi-t1lpse-sl/production_testing/images/reboot1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:57c5f41f5244b48a50e85ad1ca94b1bedf6ac61185def7e354de18ded95de116
+size 90585

--- a/docs/solutions/reference-designs/ad-rpi-t1lpse-sl/production_testing/images/rpi_setup.png
+++ b/docs/solutions/reference-designs/ad-rpi-t1lpse-sl/production_testing/images/rpi_setup.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:84c8a07f7124db4171fa08e3db967e146a10911c1bb48e577d0383bcddb4af19
+size 1585828

--- a/docs/solutions/reference-designs/ad-rpi-t1lpse-sl/production_testing/images/system_setup.png
+++ b/docs/solutions/reference-designs/ad-rpi-t1lpse-sl/production_testing/images/system_setup.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9cdd7a447424f9476461589f849b2451a23dccadaf73979f8c8b5cb936069acf
+size 1918967

--- a/docs/solutions/reference-designs/ad-rpi-t1lpse-sl/production_testing/images/test_command_1.png
+++ b/docs/solutions/reference-designs/ad-rpi-t1lpse-sl/production_testing/images/test_command_1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ae4ca749398c2d28b0116d4faf0706f0d1609a5454a5ebb3ff4f44d05c4c1043
+size 24216

--- a/docs/solutions/reference-designs/ad-rpi-t1lpse-sl/production_testing/images/test_command_1_board.png
+++ b/docs/solutions/reference-designs/ad-rpi-t1lpse-sl/production_testing/images/test_command_1_board.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6a17fdf0387384f3a840f693d1390b9129568dcc8a988f7e913dc1562bcd5269
+size 1096816

--- a/docs/solutions/reference-designs/ad-rpi-t1lpse-sl/production_testing/images/test_command_1_passed.png
+++ b/docs/solutions/reference-designs/ad-rpi-t1lpse-sl/production_testing/images/test_command_1_passed.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:065c62f8145f4f682a59dbc8cd190d306a195207c15bd2ef446dd15f49288e85
+size 22555

--- a/docs/solutions/reference-designs/ad-rpi-t1lpse-sl/production_testing/images/test_monitor.png
+++ b/docs/solutions/reference-designs/ad-rpi-t1lpse-sl/production_testing/images/test_monitor.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:26bd1339866b9e1c33607faa56162ce477f877ce36aa338ef0ac1f572a26fa9d
+size 228675

--- a/docs/solutions/reference-designs/ad-rpi-t1lpse-sl/production_testing/images/wifi_connection.png
+++ b/docs/solutions/reference-designs/ad-rpi-t1lpse-sl/production_testing/images/wifi_connection.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f4fe823f7420fdedd8b6f78a582cde66c1891f54f0c8ac07b51c1e5f011d8496
+size 6602332

--- a/docs/solutions/reference-designs/ad-rpi-t1lpse-sl/production_testing/index.rst
+++ b/docs/solutions/reference-designs/ad-rpi-t1lpse-sl/production_testing/index.rst
@@ -1,0 +1,215 @@
+.. _ad-rpi-t1lpse-sl production_testing:
+
+Production Testing
+==================
+
+Overview
+--------
+
+The purpose of the test procedure is to identify connectivity issues, poor
+soldering, and potential manufacturing defects. Some of the issues are directly
+identified by explicit part-targeted tests, others are implicit, by running
+adjacent tests.
+
+.. note::
+
+   Before production testing the AD-RPI-T1LPSE-SL board, the FTDI chip needs to
+   be programmed. See the :ref:`rpit1lpse_ftdi_programming` section below.
+
+.. _rpit1lpse_ftdi_programming:
+
+FTDI Programming
+----------------
+
+Programming the board is done using the MAX77958_2S3 software, which can only
+be installed on Windows.
+
+Required Hardware
+~~~~~~~~~~~~~~~~~
+
+* Raspberry Pi used for production testing
+* 1 x PC with Windows 10
+* MAX77958EVKIT-2S3 V1.0.0
+* Usb Type-C cable
+* :adi:`MAX32625PICO` (Daplink programmer)
+* Usb to I2C adapter board
+
+Required Software
+~~~~~~~~~~~~~~~~~
+
+* ``secure_update_BC58_verD005.bin`` - binary file containing the firmware
+* MAX77958EVKIT-2S3 V1.0.0 installed on Windows 10 - available from the
+  `ADI Software Download page <https://www.analog.com/en/design-center/evaluation-hardware-and-software/software/software-download.html?swpart=SFW0011130G>`__
+
+Required Setup
+~~~~~~~~~~~~~~
+
+.. figure:: images/ftdi_programming_required_setup.png
+   :width: 45em
+
+   FTDI programming required setup
+
+Programming Procedure
+~~~~~~~~~~~~~~~~~~~~~
+
+#. Power the device under test and make sure S2 switch is in position as shown
+   in the image above.
+
+#. Connect the mini programmer to the PC and open the MAX77958EVKIT-2S3 V1.0.0
+   application. This step can be done only once and the app can be kept open
+   for programming the next board.
+
+   .. figure:: images/ftdi_programming_connection_setup.png
+      :width: 45em
+
+      Connection setup
+
+#. In the opened app, connect to the test board by clicking on
+   **Device -> Connect -> Yes -> Read and Close**.
+
+#. In the opened MAX77958_2S3 app, click on **Tools -> Firmware Update... ->
+   Open** -> select ``secure_update_BC58_verD005.bin`` in the folder where it
+   is saved -> **Open -> Start**.
+
+   .. figure:: images/ftdi_programming_firmware_programming_commands.png
+      :width: 45em
+
+      Commands to program the firmware
+
+#. Wait for the board to be programmed until the "...Completed" message is
+   displayed.
+
+   .. figure:: images/ftdi_programming_firmware_programming_completion_message.png
+      :width: 45em
+
+      Completion message for writing the firmware
+
+#. Disconnect the board from MAX77958_2S3 application by clicking
+   **Device -> Disconnect**.
+
+   .. figure:: images/ftdi_programming_board_disconnection.png
+      :width: 45em
+
+      How to disconnect the board from MAX77958_2S3 application
+
+After disconnecting the board from the PC, follow the instructions in the
+testing procedure below.
+
+Test Duration
+-------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 70 30
+
+   * - Step Description
+     - Estimate Time (minutes)
+   * - Test bench setup
+     - 3 min
+   * - Software test
+     - 5 min
+   * - **Total time**
+     - **8 min**
+
+Test Requirements
+-----------------
+
+Required Hardware
+~~~~~~~~~~~~~~~~~
+
+* Raspberry Pi 4
+* HDMI cable
+* Mouse and keyboard
+* :adi:`AD-RPI-T1LPSE-SL` (Device Under Test)
+* T1L cable and :adi:`AD-SWIOT1L-SL` board
+* 12V power supply Usb Type-C
+
+Required Software
+~~~~~~~~~~~~~~~~~
+
+The test image is provided on a pre-configured SD card.
+
+Required Setup
+~~~~~~~~~~~~~~
+
+#. Insert the SD card into the Raspberry Pi.
+
+#. Connect the Raspberry Pi to a monitor, keyboard, and mouse.
+
+#. Insert the AD-RPI-T1LPSE-SL on top of the Raspberry Pi.
+
+#. Connect the T1L cable to AD-RPI-T1LPSE-SL and the AD-SWIOT1L-SL board.
+
+#. Power the AD-RPI-T1LPSE-SL using a Type-C power supply (12V).
+
+.. figure:: images/rpi_setup.png
+   :width: 45em
+
+   Raspberry Pi setup
+
+.. figure:: images/system_setup.png
+   :width: 45em
+
+   Complete system setup
+
+Test Process
+------------
+
+Wi-Fi Setup
+~~~~~~~~~~~
+
+Make sure the Raspberry Pi is connected to Wi-Fi before starting the tests.
+
+#. Power the Raspberry Pi.
+
+#. Press **CONTROL+C** to exit the test screen.
+
+#. Click on the network and type in the password.
+
+   .. figure:: images/wifi_connection.png
+      :width: 45em
+
+      Wi-Fi connection
+
+#. After successfully connecting, reboot the Raspberry Pi by following the
+   instructions below.
+
+   .. figure:: images/reboot1.png
+      :width: 45em
+
+      Reboot instructions
+
+Running the Tests
+~~~~~~~~~~~~~~~~~
+
+After the Raspberry Pi reboots, the test screen will appear on the monitor.
+
+.. figure:: images/test_monitor.png
+   :width: 45em
+
+   Test menu
+
+1) System Test
+^^^^^^^^^^^^^^
+
+Type **1** into the terminal then press **ENTER** to start "1) System Test".
+
+.. figure:: images/test_command_1.png
+   :width: 45em
+
+   Starting the System test
+
+Connect the T1L cable to port 1.
+
+.. figure:: images/test_command_1_board.png
+   :width: 45em
+
+   T1L cable connection to port 1
+
+If the test is **PASSED**, the DUT is functional. Continue testing the other
+boards.
+
+.. figure:: images/test_command_1_passed.png
+   :width: 45em
+
+   System test passed


### PR DESCRIPTION
Add comprehensive production testing documentation for the AD-RPI-T1LPSE-SL 10BASE-T1L PSE development platform. This guide is intended for manufacturing and QA teams to verify board functionality.

Content includes:
- FTDI programming procedure (performed before production testing)
  - Required hardware and software for FTDI chip programming
  - MAX77958EVKIT-2S3 software usage instructions
  - Step-by-step firmware flashing procedure
- Test duration estimates (8 min total)
- Required hardware list (Raspberry Pi 4, T1L cable, AD-SWIOT1L-SL, etc.)
- Step-by-step setup instructions with images

Test process documentation:
- Wi-Fi setup on Raspberry Pi
- 1) System Test with T1L cable connection
- Pass/fail criteria

The documentation page is deployed here: https://plescaevelyn.github.io/adi-documentation/pull/13/solutions/reference-designs/ad-rpi-t1lpse-sl/production_testing/index.html

## Type
- [x] Documentation
- [ ] Bug fix
- [ ] New feature
- [ ] Continuous integration

## Checklist
- [x] I have performed a self-review of changes
- [x] I have followed the guidelines:
  * https://analogdevicesinc.github.io/documentation/contributing/docs_guidelines.html
  * https://analogdevicesinc.github.io/doctools/docs_guidelines/index.html
  * https://analogdevicesinc.github.io/documentation/contributing/creating_new_pages.html#documentation-structure
- [x] I have used the appropriate roles and directives:
  * https://analogdevicesinc.github.io/doctools/docs_guidelines/roles.html
  * https://analogdevicesinc.github.io/doctools/docs_guidelines/directives.html
- [x] I ensured that binary data was committed to git lfs:
  * https://analogdevicesinc.github.io/documentation/contributing/creating_new_pages.html#adding-images-and-other-binary-files
- [x] I have built the pages I edited or created, using either `make html` or `adoc serve`:
  * https://analogdevicesinc.github.io/doctools/cli.html#serve
- [x] I have signed-off my commits and believe my contribution improves the repository.
