### PR TITLE
ad-t1lusb-ebz: Add production testing guide

### DIFF
--- a/docs/solutions/reference-designs/ad-apard32690-sl/ad-t1lusb-ebz/index.rst
+++ b/docs/solutions/reference-designs/ad-apard32690-sl/ad-t1lusb-ebz/index.rst
@@ -149,3 +149,8 @@ Analog Devices will provide **limited** online
 support for anyone using the reference design with Analog Devices components via
 the :ez:`EngineerZone Reference Designs <reference-designs>` forum.
 
+.. toctree::
+   :hidden:
+
+   production_testing/index
+

--- a/docs/solutions/reference-designs/ad-apard32690-sl/ad-t1lusb-ebz/production_testing/images/reboot1.png
+++ b/docs/solutions/reference-designs/ad-apard32690-sl/ad-t1lusb-ebz/production_testing/images/reboot1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:57c5f41f5244b48a50e85ad1ca94b1bedf6ac61185def7e354de18ded95de116
+size 90585

--- a/docs/solutions/reference-designs/ad-apard32690-sl/ad-t1lusb-ebz/production_testing/images/rpi_connections.png
+++ b/docs/solutions/reference-designs/ad-apard32690-sl/ad-t1lusb-ebz/production_testing/images/rpi_connections.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4dc1cc71513bbdacf30a9780e00192bea3af895bd41b5faff758b07d739cbd27
+size 382880

--- a/docs/solutions/reference-designs/ad-apard32690-sl/ad-t1lusb-ebz/production_testing/images/system_connection.png
+++ b/docs/solutions/reference-designs/ad-apard32690-sl/ad-t1lusb-ebz/production_testing/images/system_connection.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f152d39fbb056bb757306a4e17ffee0094ac9e3ae0516577d7b8231f949b4fca
+size 542652

--- a/docs/solutions/reference-designs/ad-apard32690-sl/ad-t1lusb-ebz/production_testing/images/test_command_1.png
+++ b/docs/solutions/reference-designs/ad-apard32690-sl/ad-t1lusb-ebz/production_testing/images/test_command_1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:45db170dbfd27156247b3e0a6fb8264da71831b8f4565b701dbd625e89098860
+size 106440

--- a/docs/solutions/reference-designs/ad-apard32690-sl/ad-t1lusb-ebz/production_testing/images/test_monitor.png
+++ b/docs/solutions/reference-designs/ad-apard32690-sl/ad-t1lusb-ebz/production_testing/images/test_monitor.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:81cf73b11c01005e2152a5fc81d79b7e08ef4ca3102efdb461ccefb1efb5f341
+size 27032

--- a/docs/solutions/reference-designs/ad-apard32690-sl/ad-t1lusb-ebz/production_testing/images/usb_c.png
+++ b/docs/solutions/reference-designs/ad-apard32690-sl/ad-t1lusb-ebz/production_testing/images/usb_c.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7ff18596a8a1df00d922774ae430c714513c9e4f0b3ff1f159d32d8dea7f6089
+size 258573

--- a/docs/solutions/reference-designs/ad-apard32690-sl/ad-t1lusb-ebz/production_testing/images/wifi_connection.png
+++ b/docs/solutions/reference-designs/ad-apard32690-sl/ad-t1lusb-ebz/production_testing/images/wifi_connection.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f4fe823f7420fdedd8b6f78a582cde66c1891f54f0c8ac07b51c1e5f011d8496
+size 6602332

--- a/docs/solutions/reference-designs/ad-apard32690-sl/ad-t1lusb-ebz/production_testing/index.rst
+++ b/docs/solutions/reference-designs/ad-apard32690-sl/ad-t1lusb-ebz/production_testing/index.rst
@@ -1,0 +1,133 @@
+.. _ad-t1lusb-ebz production_testing:
+
+Production Testing
+==================
+
+Overview
+--------
+
+The purpose of the test procedure is to identify connectivity issues, poor
+soldering, and potential manufacturing defects.
+
+Test Duration
+-------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 70 30
+
+   * - Step Description
+     - Estimate Time (minutes)
+   * - Test bench setup
+     - 5 min
+   * - Software test
+     - 1 min
+   * - **Total time**
+     - **6 min**
+
+Test Requirements
+-----------------
+
+Required Hardware
+~~~~~~~~~~~~~~~~~
+
+* 1 x :adi:`AD-SWIOT1L-SL` board
+* 24V power supply for the AD-SWIOT1L-SL board
+* Raspberry Pi, power supply, Mini-HDMI cable
+* Mouse and keyboard
+* T1L-to-Usb cable and :adi:`AD-T1LUSB2.0-EBZ` (media converter) as Device
+  Under Test (DUT)
+* Usb-A to Type-C cable for the media converter
+
+Required Software
+~~~~~~~~~~~~~~~~~
+
+The test image is provided on a pre-configured SD card.
+
+Required Setup
+~~~~~~~~~~~~~~
+
+#. Insert the SD card into the Raspberry Pi and power it.
+
+#. Connect the HDMI cable between Rpi and the monitor, insert mouse and
+   keyboard dongle into the Rpi's Usb port.
+
+   .. figure:: images/rpi_connections.png
+      :width: 45em
+
+      Raspberry Pi connections
+
+#. Connect the T1L-TO-Usb cable into the AD-SWIOT1L-SL and into the
+   AD-T1LUSB2.0-EBZ (media converter).
+
+   .. figure:: images/system_connection.png
+      :width: 45em
+
+      System connection
+
+#. Connect a Usb Type-C cable to the media converter and plug the other side
+   into the Raspberry Pi.
+
+   .. figure:: images/usb_c.png
+      :width: 45em
+
+      Usb-C connection
+
+#. Power the AD-SWIOT1L-SL.
+
+Test Process
+------------
+
+Wi-Fi Setup
+~~~~~~~~~~~
+
+Before starting the testing procedure, make sure the Raspberry Pi is connected
+to Wi-Fi.
+
+#. After the Rpi boots the OS, press **CONTROL+C** to exit the test screen.
+
+#. Click on the Wi-Fi network you want to connect to.
+
+   .. figure:: images/wifi_connection.png
+      :width: 45em
+
+      Wi-Fi connection
+
+#. Type in the password.
+
+#. After successfully connecting, reboot the Raspberry Pi by following the
+   instructions below.
+
+   .. figure:: images/reboot1.png
+      :width: 45em
+
+      Reboot instructions
+
+Running the Tests
+~~~~~~~~~~~~~~~~~
+
+After the Raspberry Pi reboots, the test screen will appear on the monitor.
+
+.. figure:: images/test_monitor.png
+   :width: 45em
+
+   Test menu
+
+1) T1L TO Usb Test
+^^^^^^^^^^^^^^^^^^
+
+Type **1** into the terminal then press **ENTER** to start the
+"1) T1L TO Usb TEST".
+
+.. figure:: images/test_command_1.png
+   :width: 45em
+
+   T1L TO Usb test
+
+In case a failure occurred, a **FAILED** message will be displayed.
+
+After the **PASSED** message is displayed, disconnect the media converter and
+T1L cable and test the next pair.
+
+Once you are done testing, press **2** and **ENTER** to power off the
+Raspberry Pi.


### PR DESCRIPTION
Add comprehensive production testing documentation for the AD-T1LUSB2.0-EBZ 10BASE-T1L to USB media converter board. This guide is intended for manufacturing and QA teams to verify board functionality.

Content includes:
- Test duration estimates (6 min total)
- Required hardware list (AD-SWIOT1L-SL, Raspberry Pi, T1L cable, etc.)
- Step-by-step setup instructions with images
- System connection and USB-C connection diagrams

Test process documentation:
- Wi-Fi setup on Raspberry Pi
- 1) T1L TO USB Test
- Pass/fail criteria

The documentation page is deployed here: **https://plescaevelyn.github.io/adi-documentation/pull/14/solutions/reference-designs/ad-apard32690-sl/ad-t1lusb-ebz/production_testing/index.html**

## Type
- [x] Documentation
- [ ] Bug fix
- [ ] New feature
- [ ] Continuous integration

## Checklist
- [x] I have performed a self-review of changes
- [x] I have followed the guidelines:
  * https://analogdevicesinc.github.io/documentation/contributing/docs_guidelines.html
  * https://analogdevicesinc.github.io/doctools/docs_guidelines/index.html
  * https://analogdevicesinc.github.io/documentation/contributing/creating_new_pages.html#documentation-structure
- [x] I have used the appropriate roles and directives:
  * https://analogdevicesinc.github.io/doctools/docs_guidelines/roles.html
  * https://analogdevicesinc.github.io/doctools/docs_guidelines/directives.html
- [x] I ensured that binary data was committed to git lfs:
  * https://analogdevicesinc.github.io/documentation/contributing/creating_new_pages.html#adding-images-and-other-binary-files
- [x] I have built the pages I edited or created, using either `make html` or `adoc serve`:
  * https://analogdevicesinc.github.io/doctools/cli.html#serve
- [x] I have signed-off my commits and believe my contribution improves the repository.
