### PR TITLE
ad-acevsecrdset-sl: Add production testing documentation

### DIFF
--- a/docs/solutions/reference-designs/ad-acevsecrdset-sl/production_testing/images/dut_reset.png
+++ b/docs/solutions/reference-designs/ad-acevsecrdset-sl/production_testing/images/dut_reset.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8554c1916774c1d2ea1eeadcc47c35188f2be7729abc350f9dc862a164091252
+size 375667

--- a/docs/solutions/reference-designs/ad-acevsecrdset-sl/production_testing/images/dut_setup.png
+++ b/docs/solutions/reference-designs/ad-acevsecrdset-sl/production_testing/images/dut_setup.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0661247e47968e91b670cb07b82a0fbb2ecb148f6ca9b743a2a20a9ca2a87d79
+size 350990

--- a/docs/solutions/reference-designs/ad-acevsecrdset-sl/production_testing/images/reboot1.png
+++ b/docs/solutions/reference-designs/ad-acevsecrdset-sl/production_testing/images/reboot1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:57c5f41f5244b48a50e85ad1ca94b1bedf6ac61185def7e354de18ded95de116
+size 90585

--- a/docs/solutions/reference-designs/ad-acevsecrdset-sl/production_testing/images/rpi_setup.png
+++ b/docs/solutions/reference-designs/ad-acevsecrdset-sl/production_testing/images/rpi_setup.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7af3732f18f21ff35ce6138969e1c37387c51a6d4a0aff0a38278d4cb000735f
+size 192254

--- a/docs/solutions/reference-designs/ad-acevsecrdset-sl/production_testing/images/test_command_1_led_check_passed.png
+++ b/docs/solutions/reference-designs/ad-acevsecrdset-sl/production_testing/images/test_command_1_led_check_passed.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:592331f7660885930f2a452bd8fc07cb11558a228375c098fbec25853b3ec1fa
+size 13836

--- a/docs/solutions/reference-designs/ad-acevsecrdset-sl/production_testing/images/test_command_1_run.png
+++ b/docs/solutions/reference-designs/ad-acevsecrdset-sl/production_testing/images/test_command_1_run.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7649ec80db584be973bdca1871e6e267e85df4fed36b89190b3a2e0cf1147edd
+size 94693

--- a/docs/solutions/reference-designs/ad-acevsecrdset-sl/production_testing/images/test_command_2_poweroff.png
+++ b/docs/solutions/reference-designs/ad-acevsecrdset-sl/production_testing/images/test_command_2_poweroff.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dc7cfaeac4ed8376331046ba057941f451d1111c7b4de08c4c5925341dd26d08
+size 8151

--- a/docs/solutions/reference-designs/ad-acevsecrdset-sl/production_testing/images/test_monitor.png
+++ b/docs/solutions/reference-designs/ad-acevsecrdset-sl/production_testing/images/test_monitor.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:af4068a39fc4f904a0bdbedb2466a9236a98af83d84676caa020f413de45c371
+size 11372

--- a/docs/solutions/reference-designs/ad-acevsecrdset-sl/production_testing/images/wifi_connection.png
+++ b/docs/solutions/reference-designs/ad-acevsecrdset-sl/production_testing/images/wifi_connection.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f4fe823f7420fdedd8b6f78a582cde66c1891f54f0c8ac07b51c1e5f011d8496
+size 6602332

--- a/docs/solutions/reference-designs/ad-acevsecrdset-sl/production_testing/index.rst
+++ b/docs/solutions/reference-designs/ad-acevsecrdset-sl/production_testing/index.rst
@@ -1,0 +1,142 @@
+.. _ad-acevsecrdset-sl production_testing:
+
+Production Testing
+==================
+
+Overview
+--------
+
+The purpose of this test procedure is to identify connectivity issues, poor
+soldering, and potential manufacturing defects in the :adi:`AD-ACEVSECRDSET-SL`
+board. Some issues are directly identified by explicit part-targeted tests,
+while others are detected implicitly by running adjacent tests.
+
+Test Duration
+-------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 70 30
+
+   * - Step Description
+     - Estimated Time (minutes)
+   * - Test bench setup
+     - 5 min
+   * - Software test
+     - 5 min
+   * - **Total time**
+     - **10 min**
+
+Test Requirements
+-----------------
+
+Required Hardware
+~~~~~~~~~~~~~~~~~
+
+* :adi:`MAX32625PICO` (Daplink programmer)
+* :adi:`AD-ACEVSECRDSET-SL` board
+* Raspberry Pi 4, power cable, HDMI cable
+* Mouse and keyboard
+* Power cable for AD-ACEVSECRDSET-SL board
+
+Required Software
+~~~~~~~~~~~~~~~~~
+
+* SD card with the test image
+
+Required Setup
+~~~~~~~~~~~~~~
+
+* Insert the SD card into the Raspberry Pi.
+
+* Connect the Raspberry Pi to a monitor and power it.
+
+  .. figure:: images/rpi_setup.png
+     :width: 45em
+
+     Raspberry Pi Setup
+
+* Connect the :adi:`MAX32625PICO` (Daplink programmer) to the Raspberry Pi
+  and the DUT.
+
+* Power the DUT.
+
+* Connect the mouse and keyboard to the Raspberry Pi.
+
+  .. figure:: images/dut_setup.png
+     :width: 45em
+
+     DUT Setup
+
+Test Process
+------------
+
+Wi-Fi Setup
+~~~~~~~~~~~
+
+Ensure the Raspberry Pi is connected to Wi-Fi before starting the tests. If
+the test screen is already running, you will need to exit it first to configure
+the network connection.
+
+* After the Raspberry Pi boots, press **Ctrl+C** to exit the test screen.
+
+* Click on the Wi-Fi icon in the system tray and select the network you want
+  to connect to.
+
+  .. figure:: images/wifi_connection.png
+     :width: 45em
+
+     Wi-Fi Network Selection
+
+* Type in the password and connect to the network.
+
+* After connecting successfully, reboot the Raspberry Pi by navigating to the
+  application menu, selecting **Logout**, then choosing **Reboot** from the
+  shutdown options.
+
+  .. figure:: images/reboot1.png
+     :width: 45em
+
+     Reboot Options
+
+Running the Tests
+~~~~~~~~~~~~~~~~~
+
+* After the Raspberry Pi reboots, the test screen will appear on the monitor.
+
+  .. figure:: images/test_monitor.png
+     :width: 45em
+
+     Test Screen
+
+* Type **1** and press **ENTER** to start the **System Test**.
+
+  .. figure:: images/test_command_1_run.png
+     :width: 45em
+
+     Starting System Test
+
+* Press the reset button on the board and press **ENTER**.
+
+  .. figure:: images/dut_reset.png
+     :width: 45em
+
+     Press Reset Button on DUT
+
+* Visually check if **LED STATUS 1** is on. If all tests pass, you will see
+  a confirmation message.
+
+  .. figure:: images/test_command_1_led_check_passed.png
+     :width: 45em
+
+     LED Check Passed
+
+* If all tests pass, you can move onto the next D.U.T.
+
+* When you are done testing, press **2** and hit **ENTER** to power off the
+  Raspberry Pi.
+
+  .. figure:: images/test_command_2_poweroff.png
+     :width: 45em
+
+     Power Off Raspberry Pi


### PR DESCRIPTION
Documentation page is deployed here: **https://plescaevelyn.github.io/adi-documentation/pull/16/solutions/reference-designs/ad-acevsecrdset-sl/production_testing/index.html**

## Type
- [x] Documentation
- [ ] Bug fix
- [ ] New feature
- [ ] Continuous integration

## Checklist
- [x] I have performed a self-review of changes
- [x] I have followed the guidelines:
  * https://analogdevicesinc.github.io/documentation/contributing/docs_guidelines.html
  * https://analogdevicesinc.github.io/doctools/docs_guidelines/index.html
  * https://analogdevicesinc.github.io/documentation/contributing/creating_new_pages.html#documentation-structure
- [x] I have used the appropriate roles and directives:
  * https://analogdevicesinc.github.io/doctools/docs_guidelines/roles.html
  * https://analogdevicesinc.github.io/doctools/docs_guidelines/directives.html
- [x] I ensured that binary data was committed to git lfs:
  * https://analogdevicesinc.github.io/documentation/contributing/creating_new_pages.html#adding-images-and-other-binary-files
- [x] I have built the pages I edited or created, using either `make html` or `adoc serve`:
  * https://analogdevicesinc.github.io/doctools/cli.html#serve
- [x] I have signed-off my commits and believe my contribution improves the repository.
