### PR TITLE
adrd8012-01z: Add production testing documentation

### DIFF
--- a/docs/solutions/reference-designs/adrd8012-01Z/index.rst
+++ b/docs/solutions/reference-designs/adrd8012-01Z/index.rst
@@ -303,18 +303,14 @@ Now open 8 instances of Gstreamer for each port(5004-5011).
     rtpvrawdepay ! videoconvert ! fpsdisplaysink video-sink=xvimagesink
     text-overlay=true sync=false
 
-..
-   Enable after adding new content
+User Guides
+-----------
 
-   User Guides
-   -----------
+.. toctree::
+   :titlesonly:
+   :maxdepth: 1
 
-   .. toctree::
-      :titlesonly:
-      :maxdepth: 1
-      :glob:
-
-      */index
+   production_testing/index
 
 Help and Support
 ----------------

--- a/docs/solutions/reference-designs/adrd8012-01Z/production_testing/images/dut_setup.png
+++ b/docs/solutions/reference-designs/adrd8012-01Z/production_testing/images/dut_setup.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0275118971e14072f3b950f73861a958cc10ff3ec80ccc40ea4b9ae360738094
+size 612407

--- a/docs/solutions/reference-designs/adrd8012-01Z/production_testing/images/loopback_connections.png
+++ b/docs/solutions/reference-designs/adrd8012-01Z/production_testing/images/loopback_connections.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:79bb34e03f754513657ce0ef11b82e4534d1816bffd9d03eae774cc99642014a
+size 328711

--- a/docs/solutions/reference-designs/adrd8012-01Z/production_testing/images/qna_connections.png
+++ b/docs/solutions/reference-designs/adrd8012-01Z/production_testing/images/qna_connections.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1bf800285fb0a32a32116dc142284feaafd0a017536927cdc8211f3c41ecf3e7
+size 313077

--- a/docs/solutions/reference-designs/adrd8012-01Z/production_testing/images/test_command_1.png
+++ b/docs/solutions/reference-designs/adrd8012-01Z/production_testing/images/test_command_1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bbe5a010567f280f81139d9b400ddc4271d9ad474b90d5523a4543353db41a65
+size 46741

--- a/docs/solutions/reference-designs/adrd8012-01Z/production_testing/images/test_command_1_passed.png
+++ b/docs/solutions/reference-designs/adrd8012-01Z/production_testing/images/test_command_1_passed.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d79c73a3bd8638a4cbdeb20892b357a3dfc29350c06e6a5a5bd22c8d09fff141
+size 52586

--- a/docs/solutions/reference-designs/adrd8012-01Z/production_testing/images/test_command_2.png
+++ b/docs/solutions/reference-designs/adrd8012-01Z/production_testing/images/test_command_2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:72e6201512a3583edce91818c85f3d98032dbe3d9511c5c4a3f5de74d7ced61e
+size 199059

--- a/docs/solutions/reference-designs/adrd8012-01Z/production_testing/images/test_command_2_passed.png
+++ b/docs/solutions/reference-designs/adrd8012-01Z/production_testing/images/test_command_2_passed.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f2060af8f6970a7c994120f8f91f37104e62c72690a56fc4775825ec094b562d
+size 15863

--- a/docs/solutions/reference-designs/adrd8012-01Z/production_testing/images/test_command_2_pattern.png
+++ b/docs/solutions/reference-designs/adrd8012-01Z/production_testing/images/test_command_2_pattern.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6780c7e044b0254c9923a1725539d96663bce8e9de068c87487b4fc5c7a06eb1
+size 214789

--- a/docs/solutions/reference-designs/adrd8012-01Z/production_testing/images/test_command_2_prompt.png
+++ b/docs/solutions/reference-designs/adrd8012-01Z/production_testing/images/test_command_2_prompt.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f6e4e452c6b7331f3f6aa5b512d63cd9c61a94bac09c3a110217b372fc62293b
+size 243881

--- a/docs/solutions/reference-designs/adrd8012-01Z/production_testing/images/test_command_2_second_prompt.png
+++ b/docs/solutions/reference-designs/adrd8012-01Z/production_testing/images/test_command_2_second_prompt.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4c983e69d11fb9367a6ccccde7d531b25289e14ccecc17050cb81a4399d6c359
+size 9497

--- a/docs/solutions/reference-designs/adrd8012-01Z/production_testing/images/test_command_3.png
+++ b/docs/solutions/reference-designs/adrd8012-01Z/production_testing/images/test_command_3.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:14304b3c646fe28d5cb73f9262ab4f3e942125a73120067e48097488583c56a1
+size 49993

--- a/docs/solutions/reference-designs/adrd8012-01Z/production_testing/images/test_command_3_config.png
+++ b/docs/solutions/reference-designs/adrd8012-01Z/production_testing/images/test_command_3_config.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9c27e57561582124f1ade521b7249529e6715b0b84d8347540a0895d137fc27a
+size 48176

--- a/docs/solutions/reference-designs/adrd8012-01Z/production_testing/images/test_command_3_pattern.png
+++ b/docs/solutions/reference-designs/adrd8012-01Z/production_testing/images/test_command_3_pattern.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3abb526980ab6770d9650c0af59a7b741909edb7618af51f0d225a1669ed4c07
+size 40636

--- a/docs/solutions/reference-designs/adrd8012-01Z/production_testing/images/test_command_3_prompt.png
+++ b/docs/solutions/reference-designs/adrd8012-01Z/production_testing/images/test_command_3_prompt.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2e337ec3575effdacb251be5f3f43e89b4a3ff82a5ef518a96f1510449949801
+size 9430

--- a/docs/solutions/reference-designs/adrd8012-01Z/production_testing/images/test_laptop_powerup.png
+++ b/docs/solutions/reference-designs/adrd8012-01Z/production_testing/images/test_laptop_powerup.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ad106349be6a1f55a106490e75e3fba4aa4425f3735670c783bcbcc822a0d684
+size 65494

--- a/docs/solutions/reference-designs/adrd8012-01Z/production_testing/images/test_terminal.png
+++ b/docs/solutions/reference-designs/adrd8012-01Z/production_testing/images/test_terminal.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:44af782317e043f79c782aab01c49987a9ddafa3b55978e8ebce1c929389cbd3
+size 27267

--- a/docs/solutions/reference-designs/adrd8012-01Z/production_testing/index.rst
+++ b/docs/solutions/reference-designs/adrd8012-01Z/production_testing/index.rst
@@ -1,0 +1,192 @@
+.. _adrd8012-01z production_testing:
+
+Production Testing
+==================
+
+Overview
+--------
+
+The purpose of this test procedure is to identify connectivity issues, poor
+soldering, and potential manufacturing defects in the ADRD8012-01Z board.
+Some issues are directly identified by explicit part-targeted tests, while
+others are detected implicitly by running adjacent tests.
+
+Test Duration
+-------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 70 30
+
+   * - Step Description
+     - Estimated Time (minutes)
+   * - Test bench setup
+     - 5 min
+   * - Software test
+     - 10 min
+   * - **Total time**
+     - **15 min**
+
+Test Requirements
+-----------------
+
+Required Hardware
+~~~~~~~~~~~~~~~~~
+
+* 1 x ADRD8012-01Z board (device under test)
+* 1 x AMD KRIA KV26 System-on-Module
+* 1 x microUSB to USB cable
+* 1 x SD card for the DUT
+* 1 x wire for UART testing
+* 4 x `Digilent Pcam 5C <https://digilent.com/shop/pcam-5c-5-mp-fixed-focus-color-camera-module/>`_ cameras
+* 4 x :adi:`AD-GMSL716MIPI-EVK` (GMSL serializer evaluation kit)
+* 4 x Fakra cables that connect to the DUT board
+* 1 x QNA-T310G1S and SFP+ to thunderbolt cable
+* Power supply for ADRD8012-01Z board
+* 1 x GPIO loopback connector
+* 1 x test laptop and power cable
+
+Required Software
+~~~~~~~~~~~~~~~~~
+
+* Test image provided on the testing laptop
+
+Required Setup
+~~~~~~~~~~~~~~
+
+* Insert the SD card into the ADRD8012-01Z device under test.
+
+* Attach the KRIA system-on-module on the ADRD8012-01Z.
+
+* Plug the microUSB cable into the ADRD8012-01Z and into the laptop.
+
+* Connect the Rx and Tx pins of the UART connector using a wire.
+
+* Plug in the SFP+ cable into the carrier and into the QNA-T310G1S.
+
+* Power the QNA-T310G1S using a Type C thunderbolt cable and plug it into the
+  laptop.
+
+* Attach the GPIO loopback on the GPIO connector.
+
+* Connect each Pcam 5C camera to an :adi:`AD-GMSL716MIPI-EVK` serializer, then
+  connect each serializer to one of the ports on the quad mini Fakra connector
+  (**PORT 2**) on the ADRD8012-01Z board.
+
+  .. figure:: images/dut_setup.png
+     :width: 45em
+
+     DUT Setup Overview
+
+  .. figure:: images/loopback_connections.png
+     :width: 45em
+
+     GPIO and UART Loopback Connections
+
+  .. figure:: images/qna_connections.png
+     :width: 45em
+
+     QNA-T310G1S Connections
+
+Test Process
+------------
+
+Running the Tests
+~~~~~~~~~~~~~~~~~
+
+* After completing the test setup, power on the test laptop and you will see a
+  login screen.
+
+  .. figure:: images/test_laptop_powerup.png
+     :width: 45em
+
+     Test Laptop Login Screen
+
+* Enter the password **analog** to login.
+
+* When the menu appears, type **1** in the terminal to start the
+  **System Test**.
+
+  .. figure:: images/test_terminal.png
+     :width: 45em
+
+     Test Menu
+
+* Follow the on-screen prompts:
+
+  * When prompted, verify the MicroUSB cable is connected to the carrier UART
+    and press **ENTER**.
+  * When prompted to insert the GPIO loopback, press **ENTER**.
+  * When prompted to connect the wire between UART Rx and Tx, press **ENTER**.
+
+  .. figure:: images/test_command_1.png
+     :width: 45em
+
+     System Test Prompts
+
+* If all tests pass, you will see a green **PASSED** message.
+
+  .. figure:: images/test_command_1_passed.png
+     :width: 45em
+
+     System Test Passed
+
+* Make sure the cameras are connected to **PORT 2** and type **2** in the
+  terminal to start the **GMSL P2 Cameras Test**.
+
+  .. figure:: images/test_command_2.png
+     :width: 45em
+
+     Starting GMSL P2 Cameras Test
+
+* The device tree will load and the DUT will reboot. Wait until
+  "Connection to DUT OK" appears.
+
+  .. figure:: images/test_command_2_prompt.png
+     :width: 45em
+
+     Waiting for Board to Come Online
+
+* When prompted, press **ENTER** to confirm the cameras are connected to
+  port 2.
+
+  .. figure:: images/test_command_2_pattern.png
+     :width: 45em
+
+     GMSL Port 2 Configuration
+
+* If the test passes, you will see a confirmation message.
+
+  .. figure:: images/test_command_2_passed.png
+     :width: 45em
+
+     GMSL P2 Cameras Test Passed
+
+* Move the cameras to **PORT 1** and type **3** in the terminal to start the
+  **GMSL P1 Cameras Test**.
+
+  .. figure:: images/test_command_3.png
+     :width: 45em
+
+     Starting GMSL P1 Cameras Test
+
+* Wait for the board to come online and follow the same procedure as for
+  PORT 2.
+
+  .. figure:: images/test_command_3_config.png
+     :width: 45em
+
+     GMSL Port 1 Configuration
+
+  .. figure:: images/test_command_3_pattern.png
+     :width: 45em
+
+     GMSL Port 1 Camera Pattern
+
+  .. figure:: images/test_command_3_prompt.png
+     :width: 45em
+
+     GMSL P1 Cameras Test Result
+
+* When all tests are complete, type **4** in the terminal to power off the
+  board.


### PR DESCRIPTION
Documentation is deployed here: **https://plescaevelyn.github.io/adi-documentation/pull/17/solutions/reference-designs/adrd8012-01Z/production_testing/index.html**

## Type
- [x] Documentation
- [ ] Bug fix
- [ ] New feature
- [ ] Continuous integration

## Checklist
- [x] I have performed a self-review of changes
- [x] I have followed the guidelines:
  * https://analogdevicesinc.github.io/documentation/contributing/docs_guidelines.html
  * https://analogdevicesinc.github.io/doctools/docs_guidelines/index.html
  * https://analogdevicesinc.github.io/documentation/contributing/creating_new_pages.html#documentation-structure
- [x] I have used the appropriate roles and directives:
  * https://analogdevicesinc.github.io/doctools/docs_guidelines/roles.html
  * https://analogdevicesinc.github.io/doctools/docs_guidelines/directives.html
- [x] I ensured that binary data was committed to git lfs:
  * https://analogdevicesinc.github.io/documentation/contributing/creating_new_pages.html#adding-images-and-other-binary-files
- [x] I have built the pages I edited or created, using either `make html` or `adoc serve`:
  * https://analogdevicesinc.github.io/doctools/cli.html#serve
- [x] I have signed-off my commits and believe my contribution improves the repository.
