### PR TITLE
solutions: ad-jupiter-ebz: Add production testing documentation

### DIFF
--- a/docs/solutions/reference-designs/ad-jupiter-ebz/index.rst
+++ b/docs/solutions/reference-designs/ad-jupiter-ebz/index.rst
@@ -3,7 +3,7 @@
 AD-JUPITER-EBZ
 ==============
 
-Software-Defined Radio.
+Software-Defined Radio Module.
 
 Overview
 --------
@@ -145,15 +145,18 @@ feel free to ask.
    known-issues
    reference-design
    profile-generation
+   production_testing/production-testing
 
 Downloads
 ---------
 
-Binaries:
-
 Osc for windows can be downloaded directly from Github. Go to to the following link and download the latest release.
 
  - :git-iio-oscilloscope:`IIO-Scope <releases+>`
+
+Scopy can be downloaded directly from Github. Go to the following link and download the latest release.
+
+ - :git-scopy:`Scopy <releases+>`
 
 The latest boot files for adrv9002 (for all supported carriers) can be found in the latest Kuiper Image release (note one can choose between downloading the full image or just the boot partition):
 

--- a/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/Jupiter_SDR_test_procedure.docx
+++ b/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/Jupiter_SDR_test_procedure.docx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a907b1dde9d4f2b50265ec418197803928f7a8e730cd6ff663e808c5c6b2121c
+size 15655387

--- a/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/images/50_ohm_terminator.png
+++ b/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/images/50_ohm_terminator.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1ac8b5e296828f582b2c4d4b339e978f50fadeb616c3c1c28c922ed5aa99a73b
+size 187993

--- a/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/images/add_on_board_conn_test_seq_2.jpg
+++ b/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/images/add_on_board_conn_test_seq_2.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9f15d84fc14748c679cda68ca8be50fd9dceda61a1abc06e0d6861ad7839b55e
+size 78744

--- a/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/images/cable_remover_key.jpg
+++ b/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/images/cable_remover_key.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a834b5e5780b2486a3e5aa745ace8fda00a6272c9e7c1a6d900382e37a3a693b
+size 42024

--- a/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/images/dut_cable_insertion.jpg
+++ b/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/images/dut_cable_insertion.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5fa19831c474ba8abd7623f662c1dd108eecbd50f0aa7c8cc67ba780593242e4
+size 339579

--- a/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/images/dut_cable_removal.jpg
+++ b/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/images/dut_cable_removal.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ce1456bd8f0ec53d113fd80181d9dd6842d6ada3f720308dde1b84d38f95e34d
+size 70468

--- a/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/images/dut_conn_test_seq_2.png
+++ b/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/images/dut_conn_test_seq_2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:034fa54357ad2ed49440048b08765f1ded688fec78824026c12e214c25e52079
+size 1615887

--- a/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/images/external_ref_clock_mcs_cable.jpg
+++ b/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/images/external_ref_clock_mcs_cable.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4310fb3095c54cbc0eb1dfaf18f99f3ed456dafe590b0cace4c6031511ab563d
+size 161391

--- a/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/images/external_ref_clock_sma_cable_conn.jpg
+++ b/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/images/external_ref_clock_sma_cable_conn.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d934bbfb9a4950c20d98f4356623c3b9f8abe89986b644c605d4c3806a0b1729
+size 42966

--- a/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/images/fixture_placing.png
+++ b/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/images/fixture_placing.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ff98b0c941597da674a7167db40d2979b8d35f14f670e5ed83e178619a768c36
+size 206719

--- a/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/images/hdmi_display_port_adapter.png
+++ b/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/images/hdmi_display_port_adapter.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e43cdeb89fd940b990a787c22b225602cb06954e455fe5d627986a9709d55ef5
+size 33770

--- a/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/images/label_position.png
+++ b/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/images/label_position.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:65c26c530ee46ce7c83fcbdcbb254d41028e83119bbc80366ebd43042754770b
+size 862267

--- a/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/images/label_position_test_seq_2.png
+++ b/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/images/label_position_test_seq_2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:74453fd8faaf16d0da2d826c8fd7a1f2eba42e85af1ad751716d2f2dc2042128
+size 109134

--- a/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/images/label_writer.jpg
+++ b/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/images/label_writer.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a1db8d71c78ad3a6c16aa869009a604fd7d1b4703a825fc07e50e35e83d87d8b
+size 10348

--- a/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/images/main_board_add_on_board_conn_test_seq_2.jpeg
+++ b/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/images/main_board_add_on_board_conn_test_seq_2.jpeg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:13878ea2b88dd93d9292a8bccf949ac68178e060c3e5d07be9453f9dfe177f41
+size 122107

--- a/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/images/main_board_labeling_example.png
+++ b/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/images/main_board_labeling_example.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e6eea88b89e70fe7f65700c2b04cc2003724a128aae903da5e887c046491d6bb
+size 112454

--- a/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/images/main_board_labeling_example_test_seq_3.png
+++ b/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/images/main_board_labeling_example_test_seq_3.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:429394dbbf8471773e106f7904744998c27ba6624ecc93e6fe50756e6dd33177
+size 30529

--- a/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/images/manandaddonboardconnection.png
+++ b/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/images/manandaddonboardconnection.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e128270ac5137c4191fc6cb7837e2d5ca9beacc72cc232e9e9ec25b218507f55
+size 698497

--- a/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/images/micro_hdmi.jpg
+++ b/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/images/micro_hdmi.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6da85125104e0ee01a37b0b97e795f1327a73587b655cd75fd7d0dea463a1b5f
+size 4461

--- a/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/images/mini_hdmi_to_hdmi.png
+++ b/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/images/mini_hdmi_to_hdmi.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a64b68e8b24de2fef556980c6b4243443be467d594150a33395e748adfd4bc4a
+size 26464

--- a/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/images/mouse_keyboard.png
+++ b/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/images/mouse_keyboard.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:468edc27c77dd0596464d9f49cc0ec8872ea4b5e644e6ae07e41baf7f3315668
+size 38297

--- a/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/images/otg_cable_conn.png
+++ b/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/images/otg_cable_conn.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6a78cf5e1b2e092167d4718710b7d537b9a9b663e6424774c4a642c6bcf5bdf5
+size 1257105

--- a/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/images/portable_display.png
+++ b/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/images/portable_display.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c713362028252f6d645460e1dcb50ce91eaf9b507d954310c1cb422e5a7d4c06
+size 91127

--- a/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/images/power_button_test_seq_2.png
+++ b/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/images/power_button_test_seq_2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3e8864585a99e8a22ba388b5ab9d5c6dfd45be5a8f647241a7561b152e0124a3
+size 1127442

--- a/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/images/power_button_test_seq_3.png
+++ b/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/images/power_button_test_seq_3.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2e879a176b7b5f3473c227d96b0bb38391e0ff68fd29b64be2a03d89a3b20dbc
+size 624788

--- a/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/images/protective_foam_test_seq_3.jpg
+++ b/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/images/protective_foam_test_seq_3.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a74679ea6556391663a60bd01397f9ae9be2b61a953c7d4f2e859ac20ea31baa
+size 92804

--- a/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/images/qr_reader.jpg
+++ b/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/images/qr_reader.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4fb99642e2618020fa1ae6c3e174cac74f131e6e69902467a47bb3d10c98ade6
+size 17703

--- a/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/images/remove_ufl_cables_w_key_test_seq_2.jpg
+++ b/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/images/remove_ufl_cables_w_key_test_seq_2.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8f45495b6af0a1d70b6f842b605ada5b984aecce5316ded0a1883af99999bb5f
+size 30076

--- a/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/images/replug_rotated_otg_cable.png
+++ b/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/images/replug_rotated_otg_cable.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:41bfcf20a920ec5412ca526eb43b53f91d94f255f4924d851d557232750b0a58
+size 1016878

--- a/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/images/rf_loopback_cable_conn_test_seq_2.jpg
+++ b/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/images/rf_loopback_cable_conn_test_seq_2.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:30765bfe4bd3db3ece13a76fc33a3ab5b1b4cd29fcd3b05bbb996dfa8412b9ff
+size 163360

--- a/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/images/rf_loopback_label_b.jpg
+++ b/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/images/rf_loopback_label_b.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:91debe49e573cd0ebb863538a49bb629bd939bcdc625e7c5ecd29f23eb03847a
+size 19740

--- a/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/images/rpi5.jpg
+++ b/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/images/rpi5.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f583ce071d2904076c6d666460a02f07a2d1aef8176aaebccd5416d0ac09f579
+size 11840

--- a/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/images/rpi5_source.jpg
+++ b/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/images/rpi5_source.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:12e97c3721d0513d56e9c452b4f9376093bb63c53e460e425d7454571b144028
+size 6401

--- a/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/images/rpi_connection_1.jpg
+++ b/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/images/rpi_connection_1.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d2adff15abe16222ad4443f245fe01008642382fd27b1eeb59601418905f7712
+size 267468

--- a/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/images/rpi_pwr_shield_conn.png
+++ b/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/images/rpi_pwr_shield_conn.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a3f981f2f890eb06403a88fe239815f948d9739689bf7c416102fbc219b2ed82
+size 1212448

--- a/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/images/sd_card.jpg
+++ b/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/images/sd_card.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b6983a6381c0e85c9995ad44cba52508a6ba3d041f75ab38e333f3439d48f165
+size 3380

--- a/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/images/sd_card_slot.png
+++ b/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/images/sd_card_slot.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:61daacb3661de4e86b3d1a73ad3805d263377be4125468498ae3ce179cec6905
+size 854469

--- a/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/images/sma_quick_connect_adapters.png
+++ b/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/images/sma_quick_connect_adapters.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:727c3ce1c554eb1e8138864e09f511415fa06756a1c0ce547b03c730f71a551b
+size 53640

--- a/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/images/spacer.jpg
+++ b/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/images/spacer.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f9f7149d5714646b336c84bf8e0698a2fd884b602d09b30b015d848d26aa71c1
+size 2875

--- a/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/images/test_command_1_host_mode.png
+++ b/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/images/test_command_1_host_mode.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:96b570868b85db605023b1948a094994fc4774d06d6b76db0bf18c427374025d
+size 253491

--- a/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/images/test_command_1_passed.png
+++ b/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/images/test_command_1_passed.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:385cc75eafc04fc5dc2ebf6dbeb00fdf10c5f56665040c21aa7b5ff9dd451255
+size 25696

--- a/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/images/test_command_1_power_cable_conn_to_dut.png
+++ b/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/images/test_command_1_power_cable_conn_to_dut.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bc23050e979682ed21b2fd108bd644b92d7ff06dbe59176f94353dc609bcada3
+size 476810

--- a/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/images/test_command_1_repeat_test.png
+++ b/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/images/test_command_1_repeat_test.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:151f93d6d3db5a9e15e732248381dc99e80e47abd39cdfffa549a79444522d80
+size 77762

--- a/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/images/test_command_1_short_power_bttn_press.png
+++ b/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/images/test_command_1_short_power_bttn_press.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ce3abd43461d5302478739c91899963e3043051fd6419f0c2c6c71bfc768a91e
+size 55418

--- a/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/images/test_command_1_stop_test.png
+++ b/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/images/test_command_1_stop_test.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9d65c94ff8608cd0c8e99d61677c2cbd43b0b619f74c258a8ecd8371fdfd9c4f
+size 39126

--- a/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/images/test_command_1_usb_power_boot.png
+++ b/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/images/test_command_1_usb_power_boot.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:32fda336bca86f7a4001571d590c9bd524154c343eaf2c75cc0aa785095eb24b
+size 268932

--- a/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/images/test_command_1_usb_power_boot_usb_c_conn.jpg
+++ b/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/images/test_command_1_usb_power_boot_usb_c_conn.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a51d03318acc2449d30fb6d7b8dd93f6983be7fa78fa3f5588a55d48b5b0e531
+size 216675

--- a/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/images/test_command_2_addon_test.png
+++ b/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/images/test_command_2_addon_test.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2254660a6d6868daf805e3203720ee0bfaee826e0034a67795e35333a7c55366
+size 311891

--- a/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/images/test_command_2_addon_test_passed.png
+++ b/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/images/test_command_2_addon_test_passed.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:38f7cd2f765561e8c3ce0a1f54cbc80dd438b67a7a8c1ebaa6dd8e049ccd8799
+size 244148

--- a/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/images/test_command_3_system_test.png
+++ b/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/images/test_command_3_system_test.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:461148f9e98cb7f76282ce226d9301f0d77f29df9cc9911db90e71d88acdfdd8
+size 112922

--- a/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/images/test_command_3_test_status_led.jpg
+++ b/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/images/test_command_3_test_status_led.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a6d4eb47b81ab81e90fb80d52082e8a5087d1960a328347b7d4c08bc8b033249
+size 94819

--- a/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/images/test_command_5_repair_sd_card.png
+++ b/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/images/test_command_5_repair_sd_card.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fd2294d5afb4583a88da6c6ef8f3ec43ed52c2ec9efec92d30d3bf7c67e410fe
+size 155043

--- a/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/images/test_main_board.png
+++ b/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/images/test_main_board.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:24fe13932a0e586beb56fb13c6da60dd09efa369ef8d7da65f5ad36ef66caa3d
+size 3190611

--- a/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/images/test_screen.png
+++ b/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/images/test_screen.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3a8982c5d070a3a99e24d07a5c1ab2d22dffb83efede75a5798a7121bb7fc0d0
+size 23634

--- a/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/images/test_system_setup.png
+++ b/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/images/test_system_setup.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:aafa2813f54aa8b3828e58a4bb3b9857b8f74180b7f0dd5ef9ae2a8f26726071
+size 1100070

--- a/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/images/ufi_cable.jpg
+++ b/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/images/ufi_cable.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:53b08639b0e1f9ac175104c371e53a734caadae88710a732bc65944072a1abf4
+size 1966

--- a/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/images/ufl_cable_main_board_conn_test_seq_2.jpg
+++ b/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/images/ufl_cable_main_board_conn_test_seq_2.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7f6caf1c860cfa5f67fd3f6b273c23b5bf828c6f814f5a6f92c7c09eefb4550e
+size 118460

--- a/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/images/unplug_loopback_cable_test_seq_2.jpg
+++ b/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/images/unplug_loopback_cable_test_seq_2.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fdc7e3fe25f2c6afe8504c5771bc77fd77243259e36a9d826ac7a176f82bd227
+size 117289

--- a/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/images/usb_data_type_c_between_pi_and_dut_plug.png
+++ b/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/images/usb_data_type_c_between_pi_and_dut_plug.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f955c7f13c489c6ed0fa5783604d5441b8d5e5a3faa5c7bef512d34743351bdc
+size 280840

--- a/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/images/usb_data_type_c_between_pi_and_dut_replug.png
+++ b/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/images/usb_data_type_c_between_pi_and_dut_replug.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5293ec36cebc2cf0668f834a55b2356610d2a8ac8c895c6045dfad443ab36974
+size 236063

--- a/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/production-testing.rst
+++ b/docs/solutions/reference-designs/ad-jupiter-ebz/production_testing/production-testing.rst
@@ -1,0 +1,738 @@
+Production Testing
+==================
+
+Overview
+--------
+
+The purpose of the test procedure is to identify connectivity issues, poor
+soldering, and potential manufacturing defects. Some of the issues are directly
+identified by explicit part-targeted tests, others are implicit, by running
+adjacent tests.
+
+There is only one test fixture that will be used to test three different hardware
+platforms:
+
+#. Jupiter Main Board
+#. Jupiter Add-on Board
+#. Jupiter System
+
+Once the initial setup for one of the hardware platforms is done, it is highly
+recommended that all the hardware platforms of the same type be tested before
+changing the setup to test another hardware platform. It is mandatory to run the
+Main Board and Add-on Board tests before System testing because the Jupiter
+System should include only boards that previously passed the manufacturing
+testing.
+
+Test Duration
+-------------
+
+Sequence 1 - Main Board
+^^^^^^^^^^^^^^^^^^^^^^^
+
+.. list-table::
+   :header-rows: 1
+   :widths: 70 30
+
+   * - Step Description
+     - Estimated Time (minutes)
+   * - Test bench setup
+     - 3 min
+   * - Software test
+     - 10 min
+   * - **Total time**
+     - **13 min**
+
+Sequence 2 - Add-on Board
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. list-table::
+   :header-rows: 1
+   :widths: 70 30
+
+   * - Step Description
+     - Estimated Time (minutes)
+   * - Test bench setup
+     - 3 min
+   * - Software test
+     - 4 min
+   * - **Total time**
+     - **7 min**
+
+Sequence 3 - System Test
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. list-table::
+   :header-rows: 1
+   :widths: 70 30
+
+   * - Step Description
+     - Estimated Time (minutes)
+   * - Test bench setup
+     - 2 min
+   * - Software test
+     - 4 min
+   * - **Total time**
+     - **6 min**
+
+Test Requirements
+-----------------
+
+.. note::
+
+   Please test all main boards first, then perform the add-on boards testing,
+   and last, test the entire system in the enclosure.
+
+Required Hardware
+^^^^^^^^^^^^^^^^^
+
+Initial Setup
+"""""""""""""
+
+.. list-table::
+   :widths: 50 50
+   :header-rows: 0
+
+   * - 1x Raspberry Pi 4 + Power supply
+     - .. figure:: images/rpi5.jpg
+
+   * - 1x Micro HDMI cable for Raspberry Pi
+     - .. figure:: images/micro_hdmi.jpg
+
+   * - 1x Mouse and keyboard for Raspberry Pi
+     - .. figure:: images/mouse_keyboard.png
+
+   * - 1x Test SD card for Raspberry Pi
+     - .. figure:: images/sd_card.jpg
+
+   * - 1x Portable Display + Power Supply
+     - .. figure:: images/portable_display.png
+
+   * - 1x QR code reader
+     - .. figure:: images/qr_reader.jpg
+
+   * - RPI PWR shield connection
+     - .. figure:: images/rpi_pwr_shield_conn.png
+
+   * - External Reference Clock and MCS cables
+     - .. figure:: images/external_ref_clock_mcs_cable.jpg
+
+.. note::
+
+   * 1x 4 Port Ethernet Switch + Ethernet cables (3 pieces: 1x 20cm, 1x 50cm, 1 for main switch)
+   * Ethernet switch must be connected to the internet.
+   * 1x USB Type A to USB Type C cable
+
+DUT Setup
+"""""""""
+
+.. list-table::
+   :widths: 50 50
+   :header-rows: 0
+
+   * - 1x HDMI to Display Port adapter
+     - .. figure:: images/hdmi_display_port_adapter.png
+
+   * - 1x Mini HDMI to HDMI cable
+     - .. figure:: images/mini_hdmi_to_hdmi.png
+
+   * - 10x SMA quick connect adapters
+     - .. figure:: images/sma_quick_connect_adapters.png
+
+   * - 4x 50 Ohm terminators
+     - .. figure:: images/50_ohm_terminator.png
+
+   * - 4x uFL cables
+     - .. figure:: images/ufi_cable.jpg
+
+   * - 1x uFL cable remover key
+     - .. figure:: images/cable_remover_key.jpg
+
+   * - 2x Spacers (12 mm)
+     - .. figure:: images/spacer.jpg
+
+Additional DUT items (no image):
+
+* 1x Portable Display + Power Supply
+* 1x SATA III SSD
+* 1x SATA to eSATA cable
+* 1x USB 3 stick + USB Type C adapter
+* 1x Micro USB cable
+* 1x Test SD card for the DUT
+* 1x BR-048139 Jupiter SDR Main Board (DUT)
+* 1x GPIO loopback cable
+* 1x Add-on Interface test board
+* 2x RF loopback cables
+* 1x Reference Clock cable
+* 1x MCS cable
+* 1x Jupiter USB Type C supply + USB Type C cable
+
+.. warning::
+
+   * uFL cables must always be replaced after testing a batch of 30 Add-on boards
+   * Known good Main Board must always be replaced after testing a batch of ~900
+     tested Add-on boards
+   * SMA quick connect adapters must be replaced after testing a batch of 500 DUTs
+     or they could be replaced every time you start a new production LOT
+
+.. note::
+
+   DUT is any of the following:
+
+   * Main Board
+   * RF Add-on Board
+   * Assembled System
+
+.. note::
+
+   The test setup needs to be connected to the internet during testing process
+   to allow the test logs to be uploaded to the server.
+
+   To complete the test setup, you need to have 5 Power Outlets available:
+
+   * 2x Monitor supply
+   * 1x RPI supply
+   * 1x Ethernet Switch supply
+   * 1x DUT USB power supply
+
+Required Software
+^^^^^^^^^^^^^^^^^
+
+The test image is provided on a pre-configured SD card.
+
+Required Setup
+^^^^^^^^^^^^^^
+
+Initial Setup
+"""""""""""""
+
+.. list-table::
+   :header-rows: 1
+   :widths: 10 90
+
+   * - No.
+     - Steps
+   * - 1
+     - Insert the SD card into the Raspberry Pi
+   * - 2
+     - Make the following connections to the RPI:
+
+       * HDMI micro cable - RPI HDMI port and monitor
+       * Mouse and keyboard dongle - to RPI's USB port
+       * A to micro-USB cable - to RPI's USB port
+       * USB C - power supply
+       * USB Type A to USB Type C cable (it will be connected to the DUT during
+         test procedure)
+       * Ethernet cable PI ETH - 20cm length
+   * - 3
+     - Connect QR code reader to RPI's USB port (labeled QR READER)
+
+       **OR**
+
+       During System test, instead of QR code reader, connect the Dymo
+       LabelWriter 450 Turbo printer
+   * - 4
+     - The RPI comes with the PWR shield connected
+   * - 5
+     - Connect External Reference clock SMA cable and MCS SMA cable (CLK OUT and
+       MCS OUT)
+   * - 6
+     - Power up the Ethernet switch (label ETH PWR)
+   * - 7
+     - Power up RPI - power supply to power outlet
+
+.. figure:: images/rpi_connection_1.jpg
+   :width: 25em
+
+   Raspberry Pi connections
+
+Labeling
+""""""""
+
+The label stuck on the boards will be scanned during testing and the information
+will be stored into the board's EEPROM. Also, the test logs will contain the
+info on the labels so that we can track the logs.
+
+The label stuck on the enclosure will allow us to identify the hardware our
+customer is referring to and we can always check the testing logs to check how
+the device was performing during testing.
+
+Test Sequence 1 - Main Board Test
+---------------------------------
+
+Main Board Labeling
+^^^^^^^^^^^^^^^^^^^
+
+The label contains the board ID and its QR code:
+
+* Manufacturing Date in the format yyyymmdd
+* Board ID: a 5 digit decimal number
+
+The label will be printed by the manufacturing company on their available
+printer. The label needs to be stuck to the PCB before production testing since
+it needs to be scanned during testing.
+
+Label size: 13.81 x 6.35 mm
+
+Example: ``2023110600018``
+
+.. list-table::
+   :widths: 50 50
+   :header-rows: 0
+
+   * - Main board label position
+     - .. figure:: images/label_position.png
+
+   * - Main board labeling example
+     - .. figure:: images/main_board_labeling_example.png
+
+Main Board Test Setup
+^^^^^^^^^^^^^^^^^^^^^
+
+.. list-table::
+   :header-rows: 1
+   :widths: 10 90
+
+   * - No.
+     - Steps
+   * - 1
+     - Place BR-048139 Jupiter SDR Main Board (DUT) into the fixture
+   * - 2
+     - Insert the following cables into the DUT:
+
+       * Insert SD card into DUT
+       * Ethernet cable coming from the Ethernet Switch (DUT ETH - 50cm)
+       * eSATA cable coming from SSD
+       * HDMI to Display Port adapter + Mini HDMI to HDMI cable coming from DUT
+         Display
+       * Connect GPIO loopback cable into the GPIO connector
+       * Connect micro USB cable from RPI
+       * Add-on Interface test board
+       * Connect RF loopback cables using SMA Quick connect adapters (push and
+         click connection)
+       * Power on the monitor from DUT
+   * - 3
+     - Connect External Reference clock cable and MCS cable (CLK OUT and MCS OUT)
+       to SMA connectors of the DUT board
+   * - 4
+     - Before testing another board, or at the work day end, make sure to remove
+       all the cables from the DUT
+   * - 5
+     - After disconnecting the DUT, place a new one and repeat testing steps 2
+       and 3
+
+.. list-table::
+   :widths: 50 50
+   :header-rows: 0
+
+   * - Placing DUT into the fixture
+     - .. figure:: images/fixture_placing.png
+
+   * - DUT cable insertion
+     - .. figure:: images/dut_cable_insertion.jpg
+
+   * - External Reference clock SMA cable connection
+     - .. figure:: images/external_ref_clock_sma_cable_conn.jpg
+
+   * - DUT cable removal
+     - .. figure:: images/dut_cable_removal.jpg
+
+.. figure:: images/test_system_setup.png
+   :width: 25em
+
+   Test system setup overview
+
+Test Sequence 2 - Add-on Board Test
+-----------------------------------
+
+Add-on Board Labeling
+^^^^^^^^^^^^^^^^^^^^^
+
+The label will be identical with the one from the main board. The label needs
+to be stuck to the PCB before production testing since it needs to be scanned
+during testing.
+
+Info: Manufacturing Date and Board ID
+
+Example: ``2023110600018``
+
+.. list-table::
+   :widths: 50 50
+   :header-rows: 0
+
+   * - Add-on board label position
+     - .. figure:: images/label_position_test_seq_2.png
+
+Add-on Board Test Setup
+^^^^^^^^^^^^^^^^^^^^^^^
+
+.. list-table::
+   :header-rows: 1
+   :widths: 10 90
+
+   * - No.
+     - Steps
+   * - 1
+     - Perform the steps from initial setup / make sure the initial setup is
+       prepared
+   * - 2
+     - Insert the SD card into the main board (known good)
+   * - 3
+     - Known good main board and Add-on board (DUT) connections:
+
+       Fix down the main board using 12 mm spacers
+   * - 4
+     - Stick the QR code label to the add-on board
+   * - 5
+     - Connect uFL cables to the main board (known as good)
+   * - 6
+     - Connect add-on board using uFL cables and add-on interface connector
+   * - 7
+     - Connect the Ethernet cable coming from the Ethernet Switch (DUT ETH - 50cm)
+   * - 8
+     - Connect the USB Type C power supply to USB_POWER port
+   * - 9
+     - Press the Power button to power on the board. The LED should turn blue
+   * - 10
+     - Wait for the test to finish. Make sure the power LED is RED, then:
+
+       * Unplug the loopback cables (make sure you hold the add-on board)
+       * Using uFL Cable Remover Key, disconnect the uFL cables from the DUT
+       * Leave uFLs on the main board connected
+   * - 11
+     - Connect the next add-on board
+   * - 12
+     - Repeat testing steps 4 to 10
+
+.. list-table::
+   :widths: 50 50
+   :header-rows: 0
+
+   * - Main board and add-on board connection
+     - .. figure:: images/manandaddonboardconnection.png
+
+   * - DUT connections for add-on board test
+     - .. figure:: images/dut_conn_test_seq_2.png
+
+   * - uFL cable connection to main board
+     - .. figure:: images/ufl_cable_main_board_conn_test_seq_2.jpg
+
+   * - Add-on board connection
+     - .. figure:: images/add_on_board_conn_test_seq_2.jpg
+
+   * - RF loopback cable connection
+     - .. figure:: images/rf_loopback_cable_conn_test_seq_2.jpg
+
+   * - RF loopback cable (labeled B)
+     - .. figure:: images/rf_loopback_label_b.jpg
+
+   * - Power button press
+     - .. figure:: images/power_button_test_seq_2.png
+
+   * - Unplug loopback cables
+     - .. figure:: images/unplug_loopback_cable_test_seq_2.jpg
+
+   * - Remove uFL cables using key
+     - .. figure:: images/remove_ufl_cables_w_key_test_seq_2.jpg
+
+Test Sequence 3 - System Test
+-----------------------------
+
+.. attention::
+
+   When the system is assembled, make sure the Main Board and Add-on Board
+   placed in the same enclosure have the same IDs.
+
+System Labeling
+^^^^^^^^^^^^^^^
+
+The label will be printed by the testing application only if it PASSes the test.
+
+Label size: 46 x 78 mm (Dymo 99016-2)
+
+Printer: Dymo LabelWriter 450 Turbo
+
+The System label has the following format shown below. Stick the label on the
+bottom of the enclosure.
+
+.. list-table::
+   :widths: 50 50
+   :header-rows: 0
+
+   * - Dymo LabelWriter 450 Turbo
+     - .. figure:: images/label_writer.jpg
+
+   * - System label example
+     - .. figure:: images/main_board_labeling_example_test_seq_3.png
+
+System Test Setup
+^^^^^^^^^^^^^^^^^
+
+.. list-table::
+   :header-rows: 1
+   :widths: 10 90
+
+   * - No.
+     - Steps
+   * - 1
+     - Perform the steps from initial setup / make sure the initial setup is
+       prepared
+   * - 2
+     - Place the support board along with protective foam on DUT place
+   * - 3
+     - Insert the SD card into the SD Card Slot of the enclosure
+   * - 4
+     - Connect RF loopback cables using SMA Quick connect adapters on the add-on
+       board ports (labeled B)
+   * - 5
+     - Connect the RF terminators on the MAIN BOARD ports using quick connect
+       (labeled A)
+   * - 6
+     - Connect the Ethernet cable coming from the Ethernet Switch (DUT ETH - 50cm)
+   * - 7
+     - Press the Power button to power on the board. The LED should turn blue,
+       press Enter
+   * - 8
+     - Wait for the test to finish
+   * - 9
+     - Unplug the loopback cables and terminators. Unplug ETH cable
+   * - 10
+     - Connect another DUT and perform testing steps 3-8
+
+.. list-table::
+   :widths: 50 50
+   :header-rows: 0
+
+   * - Support board with protective foam
+     - .. figure:: images/protective_foam_test_seq_3.jpg
+
+   * - SD card slot on enclosure
+     - .. figure:: images/sd_card_slot.png
+
+   * - Power button press for system test
+     - .. figure:: images/power_button_test_seq_3.png
+
+Test Process
+------------
+
+Running the Test Software
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+After the Raspberry Pi boots up, the test screen will appear on the monitor as
+shown below.
+
+.. figure:: images/test_screen.png
+   :width: 45em
+
+   Test screen
+
+The following test menu should appear:
+
+.. code-block:: text
+
+   Please enter your choice:
+   1) TEST MAIN BOARD
+   2) Add-ON test
+   3) System Test
+   4) Power-Off Pi
+   5) Repair SD card
+
+1) Test Main Board
+""""""""""""""""""
+
+Type "1" into the terminal then press ENTER to start **1) TEST MAIN BOARD**.
+
+.. figure:: images/test_main_board.png
+   :width: 45em
+
+   Test Main Board option
+
+**Test USB_DATA boot:**
+
+During this test, perform the following:
+
+#. Press shortly on the power button and wait for the LED to turn RED
+#. Unplug the ETH cable (DUT ETH)
+#. Plug the USB-C power cable in USB_DATA port of the DUT
+
+.. list-table::
+   :widths: 50 50
+   :header-rows: 0
+
+   * - Power cable connection to DUT
+     - .. figure:: images/test_command_1_power_cable_conn_to_dut.png
+
+   * - USB-C connection to USB_DATA port
+     - .. figure:: images/test_command_1_usb_power_boot_usb_c_conn.jpg
+
+#. Press the button again to power up the board
+#. Wait for the board to boot (LED should turn blue); it will take about 30
+   seconds to fully boot the board
+
+.. figure:: images/test_command_1_short_power_bttn_press.png
+   :width: 45em
+
+   Short power button press
+
+**Test USB_POWER boot:**
+
+During this test, perform the following:
+
+#. Plug in the DUT ETH cable
+#. Plug the USB-C power cable in USB_POWER port of the DUT
+
+.. figure:: images/test_command_1_usb_power_boot.png
+   :width: 45em
+
+   USB_POWER boot test
+
+**USB_DATA port testing - Host mode:**
+
+Plug OTG cable with a connected USB3 flash device (OTG cable labeled USB DONGLE)
+in the DATA USB C port.
+
+.. list-table::
+   :widths: 50 50
+   :header-rows: 0
+
+   * - OTG cable connection
+     - .. figure:: images/otg_cable_conn.png
+
+   * - Host mode test
+     - .. figure:: images/test_command_1_host_mode.png
+
+Replug OTG cable but rotated 180 degrees:
+
+.. figure:: images/replug_rotated_otg_cable.png
+   :width: 45em
+
+   Replug OTG cable rotated 180 degrees
+
+**USB_DATA port testing - Device mode:**
+
+Plug in USB_DATA Type C cable between Pi and DUT:
+
+.. figure:: images/usb_data_type_c_between_pi_and_dut_plug.png
+   :width: 45em
+
+   USB_DATA Type C cable between Pi and DUT
+
+Replug cable but rotated 180 degrees:
+
+.. figure:: images/usb_data_type_c_between_pi_and_dut_replug.png
+   :width: 45em
+
+   Replug USB_DATA Type C cable rotated 180 degrees
+
+After the test suite passed, a green "PASSED" message will appear on the screen.
+
+.. figure:: images/test_command_1_passed.png
+   :width: 45em
+
+   Test Main Board passed
+
+When at least one test is failing, at the end of the test suite a "FAILED"
+message will be displayed.
+
+.. note::
+
+   In case a failure occurred, a "FAILED" message will be displayed and you will
+   be prompted to enter a new command.
+
+   If at any point a test fails, you are prompted with a message saying:
+   "Do you want to repeat test?". In case the test failed due to an unconnected
+   cable, or some exceptional reason, you can opt to repeat the last test as
+   shown below:
+
+   .. figure:: images/test_command_1_repeat_test.png
+      :width: 45em
+
+      Repeat test option
+
+   Alternatively, if you realize that there is something wrong with the board
+   and you do not wish to continue with the rest of the procedure, you can press
+   "n" + "ENTER" and stop the test, which will also prompt a test failure:
+
+   .. figure:: images/test_command_1_stop_test.png
+      :width: 45em
+
+      Stop test option
+
+2) Add-on Test
+""""""""""""""
+
+Type "2" into the terminal and press ENTER to start **2) Add-ON test**.
+
+.. figure:: images/test_command_2_addon_test.png
+   :width: 45em
+
+   Add-on test option
+
+In case a failure occurred, a "FAILED" message will be displayed.
+
+After the test is passed, a green "PASSED" message will appear on the screen.
+
+.. figure:: images/test_command_2_addon_test_passed.png
+   :width: 45em
+
+   Add-on test passed
+
+3) System Test
+""""""""""""""
+
+Type "3" and press ENTER to start **3) System Test**.
+
+Make sure:
+
+* SD card inserted in slot
+* Ethernet cable connected
+* RF Loopback cables on the ADD-ON ports
+* RF terminators on the MAIN BOARD ports
+* Dymo Label printer is inserted into Raspberry Pi USB port (instead of QR code
+  reader)
+
+Press ENTER to continue.
+
+.. figure:: images/test_command_3_system_test.png
+   :width: 45em
+
+   System test
+
+After the system test PASSes, a QR code label will be printed and should be
+stuck on the bottom of the enclosure.
+
+**Test Status LED:**
+
+Is Status LED blinking?
+
+.. figure:: images/test_command_3_test_status_led.jpg
+   :width: 45em
+
+   Test status LED
+
+Pass Criteria
+"""""""""""""
+
+* **Main boards test:** Test 1) has successfully passed
+* **Add-on boards:** Test 2) has successfully passed
+* **System:** Test 3) has successfully passed
+
+5) Repair SD Card
+"""""""""""""""""
+
+.. note::
+
+   In the unlikely case the board is not behaving as expected, run the
+   **5) Repair SD card** option in order to repair the boot image. Please be
+   aware that you will be required to input the password ``analog`` three times
+   during the repair steps.
+
+.. figure:: images/test_command_5_repair_sd_card.png
+   :width: 45em
+
+   Repair SD card option
+
+4) Power-Off Pi
+"""""""""""""""
+
+When you are done testing, press "4" and press ENTER to power-off the
+Raspberry Pi.


### PR DESCRIPTION
Add production testing page for Jupiter SDR with test procedures for main board, add-on board, and system testing sequences.

This doc page is deployed here: https://plescaevelyn.github.io/adi-documentation/pull/18/solutions/reference-designs/ad-jupiter-ebz/production_testing/production-testing.html

## Type
- [x] Documentation
- [ ] Bug fix
- [ ] New feature
- [ ] Continuous integration

## Checklist
- [x] I have performed a self-review of changes
- [x] I have followed the guidelines:
  * https://analogdevicesinc.github.io/documentation/contributing/docs_guidelines.html
  * https://analogdevicesinc.github.io/doctools/docs_guidelines/index.html
  * https://analogdevicesinc.github.io/documentation/contributing/creating_new_pages.html#documentation-structure
- [x] I have used the appropriate roles and directives:
  * https://analogdevicesinc.github.io/doctools/docs_guidelines/roles.html
  * https://analogdevicesinc.github.io/doctools/docs_guidelines/directives.html
- [x] I ensured that binary data was committed to git lfs:
  * https://analogdevicesinc.github.io/documentation/contributing/creating_new_pages.html#adding-images-and-other-binary-files
- [x] I have built the pages I edited or created, using either `make html` or `adoc serve`:
  * https://analogdevicesinc.github.io/doctools/cli.html#serve
- [x] I have signed-off my commits and believe my contribution improves the repository.
