### PR TITLE
docs: Fix broken release links and adaq8092 sys level doc

### DIFF
--- a/docs/solutions/reference-designs/ad7768-1-evb/prerequisites.rst
+++ b/docs/solutions/reference-designs/ad7768-1-evb/prerequisites.rst
@@ -51,7 +51,7 @@ from the FPGA, we use the following:
 
 #. :external+scopy:doc:`Scopy <index>` v2.0 or later (must contain the IIO
    plugin)
-#. :git-iio-oscilloscope:`IIO Oscilloscope <releases>`
+#. :git-iio-oscilloscope:`IIO Oscilloscope <releases+>`
 #. UART terminal application (PuTTY/TeraTerm/Minicom), 115200 8N1
 
 .. note::

--- a/docs/solutions/reference-designs/ad7768-1-evb/quickstart/zed.rst
+++ b/docs/solutions/reference-designs/ad7768-1-evb/quickstart/zed.rst
@@ -441,7 +441,7 @@ IIO Oscilloscope
 
 .. important::
    Make sure to download/update to the latest version of
-   :git-iio-oscilloscope:`IIO Oscilloscope <releases>`.
+   :git-iio-oscilloscope:`IIO Oscilloscope <releases+>`.
 
 #. Once done with the installation or an update of the latest IIO Oscilloscope,
    open the application. The user needs to supply a URI which will be used in the

--- a/docs/solutions/reference-designs/eval-ad738xfmcz/prerequisites.rst
+++ b/docs/solutions/reference-designs/eval-ad738xfmcz/prerequisites.rst
@@ -53,7 +53,7 @@ received from the FPGA, we use the following:
 
 #. :external+scopy:doc:`Scopy <index>` v2.0 or later (must contain
    the IIO plugin)
-#. :git-iio-oscilloscope:`IIO Oscilloscope <releases>`
+#. :git-iio-oscilloscope:`IIO Oscilloscope <releases+>`
 #. UART terminal application (PuTTY/TeraTerm/Minicom), 115200 8N1
 
 .. note::

--- a/docs/solutions/reference-designs/eval-ad738xfmcz/quickstart/zed.rst
+++ b/docs/solutions/reference-designs/eval-ad738xfmcz/quickstart/zed.rst
@@ -704,7 +704,7 @@ IIO Oscilloscope
 .. important::
 
    Make sure to download/update to the latest version of
-   :git-iio-oscilloscope:`IIO Oscilloscope <releases>`.
+   :git-iio-oscilloscope:`IIO Oscilloscope <releases+>`.
 
 #. Once done with the installation or an update of the latest IIO
    Oscilloscope, open the application. The user needs to supply a
@@ -928,7 +928,7 @@ IIO Oscilloscope
 .. important::
 
    Make sure to download/update to the latest version of
-   :git-iio-oscilloscope:`IIO Oscilloscope <releases>`.
+   :git-iio-oscilloscope:`IIO Oscilloscope <releases+>`.
 
 #. Once done with the installation or an update of the latest IIO
    Oscilloscope, open the application. The user needs to supply a

--- a/docs/solutions/reference-designs/eval-ad7768-evb/prerequisites.rst
+++ b/docs/solutions/reference-designs/eval-ad7768-evb/prerequisites.rst
@@ -50,7 +50,7 @@ Normally, for basic functionalities regarding visualizing the data received
 from the FPGA, we use the following:
 
 #. :external+scopy:doc:`Scopy <index>` v2.0 or later (must contain the IIO plugin)
-#. :git-iio-oscilloscope:`IIO Oscilloscope <releases>`
+#. :git-iio-oscilloscope:`IIO Oscilloscope <releases+>`
 #. UART terminal application (PuTTY/TeraTerm/Minicom), 115200 8N1
 
 .. note::

--- a/docs/solutions/reference-designs/eval-ad7768-evb/quickstart/zed.rst
+++ b/docs/solutions/reference-designs/eval-ad7768-evb/quickstart/zed.rst
@@ -760,7 +760,7 @@ IIO Oscilloscope
 
 .. important::
    Make sure to download/update to the latest version of
-   :git-iio-oscilloscope:`IIO Oscilloscope <releases>`.
+   :git-iio-oscilloscope:`IIO Oscilloscope <releases+>`.
 
 #. Once done with the installation or an update of the latest IIO Oscilloscope,
    open the application. The user needs to supply a URI which will be used in the
@@ -1673,7 +1673,7 @@ IIO Oscilloscope
 
 .. important::
    Make sure to download/update to the latest version of
-   :git-iio-oscilloscope:`IIO Oscilloscope <releases>`.
+   :git-iio-oscilloscope:`IIO Oscilloscope <releases+>`.
 
 As indicated in the boot log, the board runs an IIOD server over the serial
 (UART) connection.

--- a/docs/solutions/reference-designs/eval-ad7768-evb/user-guide.rst
+++ b/docs/solutions/reference-designs/eval-ad7768-evb/user-guide.rst
@@ -77,7 +77,7 @@ and with no-OS (bare metal). The Libiio library is cross-platform (Windows,
 Linux, Mac) with language bindings for C, C#, Python, and others. Two
 applications that can be used with it are:
 
-- :git-iio-oscilloscope:`IIO Oscilloscope <releases>`
+- :git-iio-oscilloscope:`IIO Oscilloscope <releases+>`
 - :external+scopy:doc:`Scopy <index>` v2.0 or later (must contain the IIO
   plugin)
 

--- a/docs/solutions/reference-designs/eval-ada4355-fmc/prerequisites.rst
+++ b/docs/solutions/reference-designs/eval-ada4355-fmc/prerequisites.rst
@@ -54,7 +54,7 @@ Software prerequisites
 
 #. :external+scopy:doc:`Scopy <index>` v2.0 or later (must contain
    the IIO plugin)
-#. :git-iio-oscilloscope:`IIO Oscilloscope <releases>`
+#. :git-iio-oscilloscope:`IIO Oscilloscope <releases+>`
 #. UART terminal application (PuTTY/TeraTerm/Minicom), 115200 8N1
 
 .. note::

--- a/docs/solutions/reference-designs/eval-ada4355-fmc/quickstart/zed.rst
+++ b/docs/solutions/reference-designs/eval-ada4355-fmc/quickstart/zed.rst
@@ -815,7 +815,7 @@ IIO Oscilloscope
 .. important::
 
    Make sure to download/update to the latest version of
-   :git-iio-oscilloscope:`IIO Oscilloscope <releases>`.
+   :git-iio-oscilloscope:`IIO Oscilloscope <releases+>`.
 
 #. Once done with the installation or an update of the latest IIO
    Oscilloscope, open the application. The user needs to supply a

--- a/docs/solutions/reference-designs/eval-adaq8092-fmc/images/adaq8092_pyadi_output.png
+++ b/docs/solutions/reference-designs/eval-adaq8092-fmc/images/adaq8092_pyadi_output.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8aa3494ba6ccd6ed1c150e9e8880280c0901d53442257dbe224a28081ac1c2ce
+size 27671

--- a/docs/solutions/reference-designs/eval-adaq8092-fmc/index.rst
+++ b/docs/solutions/reference-designs/eval-adaq8092-fmc/index.rst
@@ -110,7 +110,7 @@ Table of contents
      #. :external+hdl:ref:`HDL reference design <adaq8092_fmc>` which you must
         use in your FPGA.
 
-#. :ref:`Help and Support <help-and-support>`
+#. :ref:`Help and Support <adaq8092 help_and_support>`
 
 .. _adaq8092 block-diagram:
 
@@ -127,6 +127,8 @@ Warning
 -------------------------------------------------------------------------------
 
 .. esd-warning::
+
+.. _adaq8092 help_and_support:
 
 Help and support
 -------------------------------------------------------------------------------

--- a/docs/solutions/reference-designs/eval-adaq8092-fmc/quickstart/zed.rst
+++ b/docs/solutions/reference-designs/eval-adaq8092-fmc/quickstart/zed.rst
@@ -743,28 +743,6 @@ To reboot the system, run:
    :code:`sudo shutdown -h now` or the above-mentioned command for powering
    off.
 
-IIO Oscilloscope
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. important::
-
-   Make sure to download/update to the latest version of
-   :git-iio-oscilloscope:`IIO Oscilloscope <releases+>`.
-
-#. Once done with the installation or an update of the latest IIO Oscilloscope,
-   open the application. The user needs to supply a URI which will be used in the
-   context creation of the IIO Oscilloscope.
-#. Press ``Refresh`` to display available IIO Devices and press ``Connect``.
-
-    .. image:: ../images/adaq8092_zed_iio_linux.png
-        :width: 1000
-
-#. After the board is connected and a channel is enabled, hit the play button.
-   The data capture window can be seen like in the shown picture.
-
-    .. image:: ../images/adaq8092_zed_time_domain_linux.png
-        :width: 1000
-
 Using no-OS as software
 -------------------------------------------------------------------------------
 
@@ -1375,40 +1353,3 @@ connected to the proper ttyUSB or COM port:
           Parity: none
           Stop bits: 1
           Flow control: none
-
-IIO Oscilloscope
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. important::
-   Make sure to download/update to the latest version of
-   :git-iio-oscilloscope:`IIO Oscilloscope <releases+>`.
-
-As indicated in the boot log, the board runs an IIOD server over the serial
-(UART) connection.
-
-  #. Disconnect or close the serial terminal used to view the boot log.
-  #. Once done with the installation or an update of the latest IIO Oscilloscope,
-     open the application.
-  #. Select the **Serial** backend and configure the connection with the
-     settings shown at the end of the boot log:
-
-     - **Port**: the COM port (Windows) or ``/dev/ttyUSBx`` (Linux) used by the
-       UART connection
-     - **Baud rate**: ``115200``
-     - **Data size**: 8 bits
-     - **Parity**: none
-     - **Stop bits**: 1
-     - **Flow control**: none
-
-  #. Press ``Refresh`` to display the available IIO devices and press
-     ``Connect``.
-
-      .. image:: ../images/adaq8092_zed_iio_no_os.png
-         :width: 1000
-  #. After the board is connected and a channel is enabled, hit the play button.
-     The data capture window will display the sampled data.
-
-      .. image:: ../images/adaq8092_zed_time_domain_no_os.png
-         :width: 1000
-
-.. ../common/support.rst

--- a/docs/solutions/reference-designs/eval-adaq8092-fmc/user-guide.rst
+++ b/docs/solutions/reference-designs/eval-adaq8092-fmc/user-guide.rst
@@ -123,3 +123,58 @@ Schematic
 The evaluation board schematic can be found at:
 
 - :adi:`EVAL-ADAQ8092-FMCZ Schematic <media/en/technical-documentation/eval-board-schematic/eval-adaq8092-schematic.pdf>`
+
+.. include-template:: ../common/using-iio-osc.rst.jinja
+
+   has_linux: true
+   has_no_os: true
+   has_local_connection: true
+   show_linux_connection_image: true
+   linux_connection_image: images/adaq8092_zed_iio_linux.png
+   show_no_os_connection_image: true
+   no_os_connection_image: images/adaq8092_zed_iio_no_os.png
+   iio_show_data_capture: true
+   iio_data_captures:
+     - title: Linux
+       time_domain_image: images/adaq8092_zed_time_domain_linux.png
+     - title: no-OS
+       time_domain_image: images/adaq8092_zed_time_domain_no_os.png
+
+Pyadi-IIO
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:ref:`pyadi-iio` is a python abstraction module for ADI hardware with IIO
+drivers to make them easier to use.
+
+This module provides device-specific APIs built on top of the current libIIO
+python bindings. These interfaces try to match the driver naming as much as
+possible without the need to understand the complexities of libIIO and IIO.
+
+Running the Example
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+After installing and configuring PYADI-IIO in your machine, you are now ready
+to run python script examples. In our case, run the adaq8092_example.py found
+in the examples folder.
+
+#. Connect the :adi:`EVAL-ADAQ8092` to the ZedBoard.
+#. Open command prompt or terminal and navigate through the examples
+   folder inside the downloaded or cloned *pyadi-iio* directory.
+#. Run the example script using the command.
+
+.. shell::
+
+   /path/to/pyadi-iio/examples
+   $python3 adaq8092_example.py
+
+Before running the example, make sure to connect a signal generator and a clock
+source to the evaluation board as described in :ref:`adaq8092 quickstart zed`.
+
+The expected output should look like this:
+
+.. figure:: images/adaq8092_pyadi_output.png
+
+   ADAQ8092 Time Domain Output
+
+GitHub link for the python sample script:
+:git-pyadi-iio:`ADAQ8092 Python Example <examples/adaq8092_example.py>`

--- a/docs/solutions/reference-designs/eval-cn0540-ardz/quickstart/coraz7s.rst
+++ b/docs/solutions/reference-designs/eval-cn0540-ardz/quickstart/coraz7s.rst
@@ -24,7 +24,7 @@ Software
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 - `ADI Kuiper Image for CN0540 <https://swdownloads.analog.com/cse/kuiper/cn0540.tar.gz>`__
-- :git-iio-oscilloscope:`IIO-Oscilloscope <releases>`
+- :git-iio-oscilloscope:`IIO-Oscilloscope <releases+>`
 
 Setup
 -------------------------------------------------------------------------------

--- a/docs/solutions/reference-designs/eval-cn0584-ebz/index.rst
+++ b/docs/solutions/reference-designs/eval-cn0584-ebz/index.rst
@@ -430,7 +430,7 @@ Hardware Connection
 Libiio is a library used for interfacing with IIO devices and must be installed
 on your computer to interface with the hardware.
 
-Download and install the latest :git-libiio:`Libiio package <releases>` on your
+Download and install the latest :git-libiio:`Libiio package <releases+>` on your
 machine.
 
 To connect to your device, the IIO Osciloscope software must be able to create a
@@ -477,7 +477,7 @@ evaluation boards from within a Linux system.
 
 .. important::
    Make sure to download/update to the latest version of
-   :git-iio-oscilloscope:`IIO Oscilloscope <releases>`.
+   :git-iio-oscilloscope:`IIO Oscilloscope <releases+>`.
 
 #. Once done with the installation or an update of the latest IIO Oscilloscope,
    open the application. The user needs to supply a URI which will be used in the


### PR DESCRIPTION
## Type
- [x] Documentation
- [ ] Bug fix
- [ ] New feature
- [ ] Continuous integration

## Checklist
- [x] I have performed a self-review of changes
- [x] I have followed the guidelines:
  * https://analogdevicesinc.github.io/documentation/contributing/docs_guidelines.html
  * https://analogdevicesinc.github.io/doctools/docs_guidelines/index.html
  * https://analogdevicesinc.github.io/documentation/contributing/creating_new_pages.html#documentation-structure
- [x] I have used the appropriate roles and directives:
  * https://analogdevicesinc.github.io/doctools/docs_guidelines/roles.html
  * https://analogdevicesinc.github.io/doctools/docs_guidelines/directives.html
- [x] I ensured that binary data was committed to git lfs:
  * https://analogdevicesinc.github.io/documentation/contributing/creating_new_pages.html#adding-images-and-other-binary-files
- [x] I have built the pages I edited or created, using either `make html` or `adoc serve`:
  * https://analogdevicesinc.github.io/doctools/cli.html#serve
- [x] I have signed-off my commits and believe my contribution improves the repository.
