### PR TITLE
docs: Update IIO OSC template and README for no-OS support

### DIFF
--- a/docs/solutions/reference-designs/common/README.rst
+++ b/docs/solutions/reference-designs/common/README.rst
@@ -50,9 +50,25 @@ Optional Variables
    * - ``has_no_os``
      - boolean
      - Show no-OS section (default: false)
-   * - ``connection_image``
+   * - ``has_local_connection``
+     - boolean
+     - Show "Locally run on the board" subsection under Linux
+       (default: false, requires ``has_linux``)
+   * - ``show_linux_connection_image``
+     - boolean
+     - Show Linux connection image (default: false, requires ``has_linux``
+       and ``linux_connection_image``)
+   * - ``linux_connection_image``
      - path
      - Image showing IIO Oscilloscope connection (Linux only)
+   * - ``show_no_os_connection_image``
+     - boolean
+     - Show no-OS connection image (default: false, requires ``has_no_os``
+       and ``no_os_connection_image``)
+   * - ``no_os_connection_image``
+     - path
+     - Image showing IIO Oscilloscope no-OS serial connection
+       (requires ``has_no_os`` and ``show_no_os_connection_image``)
    * - ``iio_has_plugin``
      - boolean
      - Enable plugin section
@@ -99,7 +115,8 @@ Usage Example
    .. include-template:: ../../common/using-iio-osc.rst.jinja
 
       has_linux: true
-      connection_image: ../images/ADRV9002_IIO_connection_zed.png
+      show_linux_connection_image: true
+      linux_connection_image: ../images/ADRV9002_IIO_connection_zed.png
       iio_has_plugin: true
       iio_plugin_ref: adrv9002-plugin
       iio_show_data_capture: true
@@ -115,8 +132,11 @@ Usage Example
    .. include-template:: ../../common/using-iio-osc.rst.jinja
 
       has_linux: true
+      show_linux_connection_image: true
+      linux_connection_image: ../images/ADRV9002_IIO_connection_zed.png
       has_no_os: true
-      connection_image: ../images/ADRV9002_IIO_connection_zed.png
+      show_no_os_connection_image: true
+      no_os_connection_image: ../images/ADRV9002_IIO_no_os_serial.png
       iio_has_plugin: true
       iio_plugin_ref: adrv9002-plugin
       iio_show_data_capture: true
@@ -186,8 +206,8 @@ The template generates different sections based on ``has_linux`` and
 
    - **Remote run on host** - Instructions for connecting from a host PC
      via IP (with optional connection image)
-   - **Locally run on the board** - Instructions for running on the FPGA
-     with HDMI monitor
+   - **Locally run on the board** (if ``has_local_connection: true``) -
+     Instructions for running on the FPGA with HDMI monitor
 
 **For no-OS (if ``has_no_os: true``):**
 
@@ -352,7 +372,7 @@ zed.rst template for a complete integration example:
 
    .. include-template:: ../../common/using-iio-osc.rst.jinja
       os_type: linux
-      connection_image: ../images/ADRV9002_IIO_connection_zed.png
+      linux_connection_image: ../images/ADRV9002_IIO_connection_zed.png
       iio_has_plugin: true
       iio_plugin_ref: adrv9002-plugin
 

--- a/docs/solutions/reference-designs/common/using-iio-osc.rst.jinja
+++ b/docs/solutions/reference-designs/common/using-iio-osc.rst.jinja
@@ -31,14 +31,15 @@ Once the application is launched, go to Settings > Connect > URI and type
 "ip:" then the IP address of the target in the pop-up window. This IP can
 be found out with a command from the previous section of this documentation.
 
-{% if show_connection_image and connection_image %}
+{% if show_linux_connection_image and linux_connection_image %}
 
-.. image:: {{ connection_image }}
+.. image:: {{ linux_connection_image }}
    :align: center
-   :width: 600px
+   :width: 600
 
 {% endif %}
 
+{% if has_local_connection %}
 Locally run on the board
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 
@@ -50,6 +51,7 @@ Going to the top left corner icon (the menu icon), search for IIO
 Oscilloscope. Opening it will automatically connect to the setup and you
 can use the application.
 {% endif %}
+{% endif %}
 
 {% if has_no_os %}
 For no-OS
@@ -57,6 +59,31 @@ For no-OS
 For connecting IIO Oscilloscope to no-OS applications, they need to be built
 with the IIOD=y flag. This way, the no-OS applications will run an IIO daemon
 that is awaiting connections from the IIO Oscilloscope.
+
+As indicated in the boot log, the board runs an IIOD server over the serial
+(UART) connection.
+
+#. Disconnect or close the serial terminal used to view the boot log.
+#. Once done with the installation or an update of the latest IIO Oscilloscope,
+   open the application.
+#. Select the **Serial** backend and configure the connection with the settings
+   shown at the end of the boot log.
+
+   {% if show_no_os_connection_image and no_os_connection_image %}
+
+   .. image:: {{ no_os_connection_image }}
+      :align: center
+      :width: 600
+
+   {% endif %}
+   
+#. Press :guilabel:`Refresh` to display the available IIO devices and press
+   :guilabel:`Connect`.
+
+.. note::
+
+   The serial port is the COM port on Windows or ``/dev/ttyUSBx`` on Linux.
+      
 {% endif %}
 
 {% if iio_has_plugin %}


### PR DESCRIPTION
- Add no-OS serial connection instructions and image support to template
- Add has_local_connection guard for "Locally run on the board" section
- Rename connection_image to linux_connection_image
- Update README parameter table and examples with new params


## Type
- [x] Documentation
- [x] Bug fix
- [ ] New feature
- [ ] Continuous integration

## Checklist
- [x] I have performed a self-review of changes
- [x] I have followed the guidelines:
  * https://analogdevicesinc.github.io/documentation/contributing/docs_guidelines.html
  * https://analogdevicesinc.github.io/doctools/docs_guidelines/index.html
  * https://analogdevicesinc.github.io/documentation/contributing/creating_new_pages.html#documentation-structure
- [x] I have used the appropriate roles and directives:
  * https://analogdevicesinc.github.io/doctools/docs_guidelines/roles.html
  * https://analogdevicesinc.github.io/doctools/docs_guidelines/directives.html
- [x] I ensured that binary data was committed to git lfs:
  * https://analogdevicesinc.github.io/documentation/contributing/creating_new_pages.html#adding-images-and-other-binary-files
- [x] I have built the pages I edited or created, using either `make html` or `adoc serve`:
  * https://analogdevicesinc.github.io/doctools/cli.html#serve
- [x] I have signed-off my commits and believe my contribution improves the repository.
