### PR TITLE
products/adsp: Remove default HTTP server port

### DIFF
--- a/docs/products/adsp/setup.rst
+++ b/docs/products/adsp/setup.rst
@@ -201,14 +201,14 @@ Start a file server in a new terminal on your PC in the release directory:
       .. shell:: sh
 
          $ cd images-*   # Navigate to extracted release directory
-         $ python3 -m http.server 8000
+         $ python3 -m http.server
 
    .. tab-item:: Windows
 
       .. shell:: sh
 
          $ cd images-*   # Navigate to extracted release directory
-         $ python -m http.server 8000
+         $ python -m http.server
 
 Find your IP address:
 


### PR DESCRIPTION
http.server defaults to 8000 so it does not need to be specified at the command-line:

$ python3 -m http.server
Serving HTTP on 0.0.0.0 port 8000 (http://0.0.0.0:8000/) ...