### PR TITLE
products/adsp: Add Buildroot, Linux and BR2_EXTERNAL releases

### DIFF
--- a/docs/products/adsp/linux-support.rst
+++ b/docs/products/adsp/linux-support.rst
@@ -76,6 +76,7 @@ for the the Commits link with the newest version and at least one Release.
       :git-buildroot:`Commits <commits/adi-2026.02-y+>`
       :git-buildroot:`Release 1 <releases/tag/2026.02-1+>`
       :git-buildroot:`Release 2 <releases/tag/2026.02-2+>`
+      :git-buildroot:`Release 3 <releases/tag/2026.02-3+>`
     - v2027.02 (LTS):
 - :git-trusted-firmware-a:`+`
 - :git-optee_os:`+`


### PR DESCRIPTION
## Type
- [x] Documentation
- [ ] Bug fix
- [ ] New feature
- [ ] Continuous integration

## Checklist
- [x] I have performed a self-review of changes
- [x] I have followed the guidelines:
  * https://analogdevicesinc.github.io/documentation/contributing/docs_guidelines.html
  * https://analogdevicesinc.github.io/doctools/docs_guidelines/index.html
  * https://analogdevicesinc.github.io/documentation/contributing/creating_new_pages.html#documentation-structure
- [x] I have used the appropriate roles and directives:
  * https://analogdevicesinc.github.io/doctools/docs_guidelines/roles.html
  * https://analogdevicesinc.github.io/doctools/docs_guidelines/directives.html
- [ ] I ensured that binary data was committed to git lfs:
  * https://analogdevicesinc.github.io/documentation/contributing/creating_new_pages.html#adding-images-and-other-binary-files
- [x] I have built the pages I edited or created, using either `make html` or `adoc serve`:
  * https://analogdevicesinc.github.io/doctools/cli.html#serve
- [x] I have signed-off my commits and believe my contribution improves the repository.
