### PR TITLE
.github: use tasteful run-on variable

### DIFF
--- a/.github/workflows/top-level.yml
+++ b/.github/workflows/top-level.yml
@@ -9,25 +9,22 @@ env:
 
 jobs:
   build-doc:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
     permissions:
       contents: read
 
     steps:
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: "3.x"
-
     - uses: actions/checkout@v4
     - name: Install pip packages
-      working-directory: docs
       run: |
-        pip install pip --upgrade
-        pip install -r requirements.txt --upgrade
+        python3 -m venv venv
+        source ./venv/bin/activate
+        python3 -m ensurepip
+        pip3 install -r docs/requirements.txt --upgrade
 
     - name: Build doc
       run: |
+        source ./venv/bin/activate
         source .github/scripts/sphinx-build.sh
 
         export GIT_LFS_TO_LINKS="true"
@@ -47,7 +44,7 @@ jobs:
         path: docs/_build/html
 
   check-doc:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
     if: ${{ github.event_name == 'pull_request' }}
     permissions:
       contents: read
@@ -56,7 +53,10 @@ jobs:
     - uses: analogdevicesinc/doctools/checkout@action
     - name: Check writing
       run: |
-        pip install docutils vale
+        python3 -m venv venv
+        source ./venv/bin/activate
+        python3 -m ensurepip
+        pip3 install docutils vale
 
         check_vale() {
           files=$(git diff --diff-filter=ACM --no-renames --name-only $base_sha..$head_sha -- 'docs/*.rst' 'docs/**/*.rst')
@@ -111,7 +111,7 @@ jobs:
         python3 .github/scripts/dangling.py || true
 
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     needs: [build-doc]
     concurrency:
       group: gh-pages


### PR DESCRIPTION
Allows to use self-hosted if vars.runner is set, if not, gracefully fallback to ubuntu-latest. For deploy, use ubuntu-slim


## Type
- [ ] Documentation
- [ ] Bug fix
- [ ] New feature
- [ ] Continuous integration

## Checklist
- [ ] I have performed a self-review of changes
- [ ] I have followed the guidelines:
  * https://analogdevicesinc.github.io/documentation/contributing/docs_guidelines.html
  * https://analogdevicesinc.github.io/doctools/docs_guidelines/index.html
  * https://analogdevicesinc.github.io/documentation/contributing/creating_new_pages.html#documentation-structure
- [ ] I have used the appropriate roles and directives:
  * https://analogdevicesinc.github.io/doctools/docs_guidelines/roles.html
  * https://analogdevicesinc.github.io/doctools/docs_guidelines/directives.html
- [ ] I ensured that binary data was committed to git lfs:
  * https://analogdevicesinc.github.io/documentation/contributing/creating_new_pages.html#adding-images-and-other-binary-files
- [ ] I have built the pages I edited or created, using either `make html` or `adoc serve`:
  * https://analogdevicesinc.github.io/doctools/cli.html#serve
- [ ] I have signed-off my commits and believe my contribution improves the repository.
