### PR TITLE
.github: fix: use fromJSON()

### DIFF
--- a/.github/workflows/top-level.yml
+++ b/.github/workflows/top-level.yml
@@ -9,7 +9,7 @@ env:
 
 jobs:
   build-doc:
-    runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
+    runs-on: ${{ fromJSON(vars.RUNNER) || 'ubuntu-latest' }}
     permissions:
       contents: read
 


### PR DESCRIPTION
The variable needs to be parsed as JSON, GitHub somehow would pass as a string instead.
Fixes: 8af0e5bfa513 (".github: use tasteful run-on variable (#447)")


## Type
- [ ] Documentation
- [ ] Bug fix
- [ ] New feature
- [ ] Continuous integration

## Checklist
- [ ] I have performed a self-review of changes
- [ ] I have followed the guidelines:
  * https://analogdevicesinc.github.io/documentation/contributing/docs_guidelines.html
  * https://analogdevicesinc.github.io/doctools/docs_guidelines/index.html
  * https://analogdevicesinc.github.io/documentation/contributing/creating_new_pages.html#documentation-structure
- [ ] I have used the appropriate roles and directives:
  * https://analogdevicesinc.github.io/doctools/docs_guidelines/roles.html
  * https://analogdevicesinc.github.io/doctools/docs_guidelines/directives.html
- [ ] I ensured that binary data was committed to git lfs:
  * https://analogdevicesinc.github.io/documentation/contributing/creating_new_pages.html#adding-images-and-other-binary-files
- [ ] I have built the pages I edited or created, using either `make html` or `adoc serve`:
  * https://analogdevicesinc.github.io/doctools/cli.html#serve
- [ ] I have signed-off my commits and believe my contribution improves the repository.
