### PR TITLE
reference-designs/eval-ad738xfmcz: Fix libiio references to use ref instead of dokuwiki

### DIFF
--- a/docs/solutions/reference-designs/ad-gmslcamrpi-adp/amd-kria/index.rst
+++ b/docs/solutions/reference-designs/ad-gmslcamrpi-adp/amd-kria/index.rst
@@ -137,6 +137,6 @@ HDL Projects
 ------------
 
 * :external+hdl:ref:`max96724`
-* :external+hdl:ref:`ad_gmsl2eth_sl`
+* :external+hdl:ref:`adrd8012_01z`
 
 The project and the project’s overview can be found at the following links:

--- a/docs/solutions/reference-designs/eval-ad738xfmcz/linux-driver.rst
+++ b/docs/solutions/reference-designs/eval-ad738xfmcz/linux-driver.rst
@@ -557,8 +557,8 @@ More Information
 -  `IIO Linux Kernel Documentation sysfs-bus-iio-\* <https://www.kernel.org/doc/Documentation/ABI/testing>`_
 -  `IIO Documentation <https://www.kernel.org/doc/Documentation/ABI/testing/sysfs-bus-iio>`_
 -  :ref:`iio-oscilloscope`
--  :dokuwiki:`libiio - IIO system library <resources/tools-software/linux-software/libiio>`
--  :dokuwiki:`libiio - Internals <resources/tools-software/linux-software/libiio_internals>`
+-  :ref:`libiio - IIO system library <libiio>`
+-  :ref:`libiio - Internals <libiio internals>`
 -  :dokuwiki:`Pointers and good books <resources/tools-software/pointers>`
 -  `IIO High Speed <https://events.static.linuxfound.org/sites/events/files/slides/iio_high_speed.pdf>`_
 -  `Software Defined Radio using the IIO framework <http://video.fosdem.org/2015/devroom-software_defined_radio/iiosdr.mp4>`_


### PR DESCRIPTION
## Type
- [x] Documentation
- [ ] Bug fix
- [ ] New feature
- [ ] Continuous integration

## Checklist
- [x] I have performed a self-review of changes
- [x] I have followed the guidelines:
  * https://analogdevicesinc.github.io/documentation/contributing/docs_guidelines.html
  * https://analogdevicesinc.github.io/doctools/docs_guidelines/index.html
  * https://analogdevicesinc.github.io/documentation/contributing/creating_new_pages.html#documentation-structure
- [x] I have used the appropriate roles and directives:
  * https://analogdevicesinc.github.io/doctools/docs_guidelines/roles.html
  * https://analogdevicesinc.github.io/doctools/docs_guidelines/directives.html
- [ ] I ensured that binary data was committed to git lfs:
  * https://analogdevicesinc.github.io/documentation/contributing/creating_new_pages.html#adding-images-and-other-binary-files
- [x] I have built the pages I edited or created, using either `make html` or `adoc serve`:
  * https://analogdevicesinc.github.io/doctools/cli.html#serve
- [x] I have signed-off my commits and believe my contribution improves the repository.
