### PR TITLE
reference-designs/adrd4161-01z: Add production testing documentation

### DIFF
--- a/docs/solutions/reference-designs/adrd4161-01z/index.rst
+++ b/docs/solutions/reference-designs/adrd4161-01z/index.rst
@@ -101,6 +101,7 @@ User Guides
    quick-start-guide
    hardware-guide
    software-guide
+   production_testing/production-testing
 
 Help and Support
 ----------------

--- a/docs/solutions/reference-designs/adrd4161-01z/production_testing/images/adis167x_connection.png
+++ b/docs/solutions/reference-designs/adrd4161-01z/production_testing/images/adis167x_connection.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:87ada0e0cbff7642a30ba3543d083e6d3e2ea9991465413a32119a5f30903e2c
+size 1335644

--- a/docs/solutions/reference-designs/adrd4161-01z/production_testing/images/adrd4161_connections.png
+++ b/docs/solutions/reference-designs/adrd4161-01z/production_testing/images/adrd4161_connections.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a206f5abb19aef68a71085c5e738684b6b07f54e361b064580cdca9a3ee5da3f
+size 556113

--- a/docs/solutions/reference-designs/adrd4161-01z/production_testing/images/can_test_screen.png
+++ b/docs/solutions/reference-designs/adrd4161-01z/production_testing/images/can_test_screen.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4616a2b21560c7a8863f279f7bcf6509f1471c7c4c935c971b73f6adf88be8a5
+size 114436

--- a/docs/solutions/reference-designs/adrd4161-01z/production_testing/images/led_connection.png
+++ b/docs/solutions/reference-designs/adrd4161-01z/production_testing/images/led_connection.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6680cbe88fa69ae33f54ccbb2d39cde8ed3fd2d92ef1b1e95c53f416bb012726
+size 644812

--- a/docs/solutions/reference-designs/adrd4161-01z/production_testing/images/logout.png
+++ b/docs/solutions/reference-designs/adrd4161-01z/production_testing/images/logout.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:64e9cb47ea99c34de6caa499589213c5501fdd55542c731805eff3d4d09a84c4
+size 75533

--- a/docs/solutions/reference-designs/adrd4161-01z/production_testing/images/passing_can_test_screen.png
+++ b/docs/solutions/reference-designs/adrd4161-01z/production_testing/images/passing_can_test_screen.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:552eb05ad0d50420576b176e4c140266256a177e1f5a23e33908235bb3f4feb9
+size 153110

--- a/docs/solutions/reference-designs/adrd4161-01z/production_testing/images/passing_gpio_test_screen.png
+++ b/docs/solutions/reference-designs/adrd4161-01z/production_testing/images/passing_gpio_test_screen.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b3370e9d8e538cb4ca919544e453a6aad523dc368d87064c0e704c23bb890d15
+size 38572

--- a/docs/solutions/reference-designs/adrd4161-01z/production_testing/images/passing_imu_test_screen.png
+++ b/docs/solutions/reference-designs/adrd4161-01z/production_testing/images/passing_imu_test_screen.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e8ffa5978d7f13bbdc7a060c02c9c0d7f3ae053be2748992f86ca0b4d88eac88
+size 41987

--- a/docs/solutions/reference-designs/adrd4161-01z/production_testing/images/reboot.png
+++ b/docs/solutions/reference-designs/adrd4161-01z/production_testing/images/reboot.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1bb9e46f247f80ed378fd698ffd120b3f0353a870ea94ab8409b0062c9cd90d7
+size 45891

--- a/docs/solutions/reference-designs/adrd4161-01z/production_testing/images/system_connections.png
+++ b/docs/solutions/reference-designs/adrd4161-01z/production_testing/images/system_connections.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1ddbbdaef0981a43c3cbfa58ec762058bdf56548151bb94d4d67711eb5d8c52b
+size 698212

--- a/docs/solutions/reference-designs/adrd4161-01z/production_testing/images/test_screen.png
+++ b/docs/solutions/reference-designs/adrd4161-01z/production_testing/images/test_screen.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:06f86d578ee4198f504177d751d3c5d58d73bcfabead3cc9eff0719d05f6c376
+size 28748

--- a/docs/solutions/reference-designs/adrd4161-01z/production_testing/images/wifi_conn_1.png
+++ b/docs/solutions/reference-designs/adrd4161-01z/production_testing/images/wifi_conn_1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:66ee9bdc641c161cc21b5d1d8543874fd08ebb09e745a8b2b8f507a315a1d7a9
+size 361428

--- a/docs/solutions/reference-designs/adrd4161-01z/production_testing/production-testing.rst
+++ b/docs/solutions/reference-designs/adrd4161-01z/production_testing/production-testing.rst
@@ -1,0 +1,255 @@
+ADRD4161-01Z Production Testing
+================================
+
+Overview
+--------
+
+The purpose of the test procedure is to identify connectivity issues, poor
+soldering, and potential manufacturing defects. Some of the issues are directly
+identified by explicit part-targeted tests, others are implicit, by running
+adjacent tests.
+
+Test Duration
+-------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 70 30
+
+   * - Step Description
+     - Estimated Time (minutes)
+   * - Test bench setup
+     - 5 min
+   * - Software test
+     - 5 min
+   * - **Total time**
+     - **10 min**
+
+Test Requirements
+-----------------
+
+Required Hardware
+^^^^^^^^^^^^^^^^^
+
+.. list-table::
+   :widths: 10 90
+   :header-rows: 0
+
+   * - 1x
+     - Raspberry Pi 5
+   * - 1x
+     - Micro HDMI cable
+   * - 1x
+     - USB-A to USB-C data cable
+   * - 1x
+     - Mouse and keyboard
+   * - 1x
+     - Device-Under-Test (DUT) ADRD4161
+   * - 1x
+     - CAN to USB adapter
+   * - 1x
+     - ADIS167X board
+   * - 1x
+     - 12V power supply
+   * - 1x
+     - LED connector
+
+Required Software
+^^^^^^^^^^^^^^^^^
+
+The test image will be provided as a SD test card that goes into the Raspberry
+Pi.
+
+Required Setup
+^^^^^^^^^^^^^^
+
+.. list-table::
+   :header-rows: 1
+   :widths: 10 90
+
+   * - No.
+     - Steps
+   * - 1
+     - Insert the SD card into the Raspberry Pi
+   * - 2
+     - Connect the Raspberry Pi to a monitor using a micro-HDMI cable
+   * - 3
+     - Connect the mouse and keyboard to the Raspberry Pi
+   * - 4
+     - Connect the ADRD4161 (DUT) to the Raspberry Pi using the ribbon cable
+   * - 5
+     - Connect the ADIS167X board on the back of the ADRD4161 (DUT)
+   * - 6
+     - Connect the CAN to USB adapter to the ADRD4161 (DUT) and to the
+       Raspberry Pi using the USB-A to USB-C cable
+   * - 7
+     - Connect the LED connector to the ADRD4161 (DUT)
+   * - 8
+     - Connect the 12V power supply into the ADRD4161 (DUT)
+
+.. figure:: images/system_connections.png
+   :width: 30em
+
+   System connections
+
+.. figure:: images/adrd4161_connections.png
+   :width: 30em
+
+   ADRD4161 (DUT) connections
+
+.. figure:: images/adis167x_connection.png
+   :width: 30em
+
+   ADIS167X to DUT connection
+
+.. figure:: images/led_connection.png
+   :width: 30em
+
+   LED connector connection
+
+Test Process
+------------
+
+Enabling Wifi
+^^^^^^^^^^^^^
+
+Before starting the testing procedure, make sure the Raspberry Pi is connected
+to Wifi.
+
+#. After the RPi boots, press ``CONTROL+C`` to exit the test screen.
+#. Click on the Wifi network you want to connect to.
+
+.. figure:: images/wifi_conn_1.png
+   :width: 30em
+
+   Wifi connection
+
+3. Type in the password. After successfully connected, reboot the Raspberry Pi
+   by following the below instructions.
+
+.. figure:: images/logout.png
+   :width: 20em
+
+   Logout menu
+
+.. figure:: images/reboot.png
+   :width: 15em
+
+   Reboot option
+
+Running the Test Software
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+After the Raspberry Pi reboots, the test screen will appear on the monitor as
+shown below.
+
+.. figure:: images/test_screen.png
+   :width: 30em
+
+   Test screen
+
+The following test menu should appear:
+
+.. code-block:: text
+
+   [ADRD4161] Please enter your choice:
+   1) CAN Test
+   2) IMU Test
+   3) GPIO Test
+   4) Power-Off Pi
+
+1) CAN Test
+"""""""""""
+
+Type "1" into the terminal and press ``ENTER`` to start the **1) CAN Test**
+test suite.
+
+Make sure the CAN to USB adapter is connected to the ADRD4161 (DUT) and
+Raspberry Pi boards as shown in the system connections figure.
+
+.. figure:: images/can_test_screen.png
+   :width: 40em
+
+   CAN Test screen
+
+Visually check if the DS1 and DS2 LEDs are blinking. Type "y" if yes or "n"
+for not when prompted. You can see their position in the ADRD4161 connections
+and LED connector figures above.
+
+.. warning::
+
+   If a "FAILED" message appears, check the USB connection to the CAN to USB
+   adapter (found on port P7) and re-run the test for up to 3 times.
+
+If the test runs with no failures, a green "PASSED" message will appear on the
+screen.
+
+.. figure:: images/passing_can_test_screen.png
+   :width: 40em
+
+   Passing CAN Test screen
+
+2) IMU Test
+"""""""""""
+
+Type "2" into the terminal and press ``ENTER`` to start the **2) IMU Test**.
+
+Make sure the ADIS167X (IMU) board is properly connected to the ADRD4161 (DUT)
+board, as shown in the ADIS167X connection figure.
+
+.. warning::
+
+   In case a failure occurs, a "FAILED" message appears. Check the presence of
+   the ADIS167X board and its connections and re-run the test for up to 3 times.
+
+If the second test runs with no failures, a green "PASSED" message will appear
+on the screen.
+
+.. figure:: images/passing_imu_test_screen.png
+   :width: 30em
+
+   Passing IMU test screen
+
+3) GPIO Test
+""""""""""""
+
+Type "3" into the terminal and press ``ENTER`` to start the **3) GPIO Test**.
+
+Make sure the LED connector is connected to the ADRD4161 (DUT) board as shown
+in the LED connector figure.
+
+Visually check if the LED connector connected to the GPIO header is on. Type
+"y" if yes or "n" for no.
+
+.. warning::
+
+   In case a failure occurs, a "FAILED" message appears. Check that the LED
+   connector is properly connected and re-run the test for up to 3 times.
+
+If the third test runs with no failures, a green "PASSED" message will appear
+on the screen.
+
+.. figure:: images/passing_gpio_test_screen.png
+   :width: 30em
+
+   Passing GPIO test screen
+
+Pass Criteria
+"""""""""""""
+
+After the tests **1)**, **2)** and **3)** have successfully passed, you can
+consider the DUT as being functional.
+
+4) Power-Off Pi
+"""""""""""""""
+
+Type "4" and press ``ENTER`` in the terminal to power off the RPi. Disconnect
+the LED connector and CAN to USB adapter from the last tested DUT. Disconnect
+the last tested DUT from the RPi by removing the ribbon cable.
+
+Repeat the testing procedure for the next DUT.
+
+.. note::
+
+   If at any point a test fails, you should retry the test suite for up to 3
+   times.


### PR DESCRIPTION
Add production testing procedure for the ADRD4161-01Z board including:
- Test requirements (hardware and software)
- Setup instructions with connection diagrams
- Three test suites: CAN, IMU, and GPIO tests
- Pass/fail criteria and troubleshooting steps

The documentation page is deployed here: https://plescaevelyn.github.io/adi-documentation/pull/24/solutions/reference-designs/adrd4161-01z/production_testing/production-testing.html

## Type
- [x] Documentation
- [ ] Bug fix
- [ ] New feature
- [ ] Continuous integration

## Checklist
- [x] I have performed a self-review of changes
- [x] I have followed the guidelines:
  * https://analogdevicesinc.github.io/documentation/contributing/docs_guidelines.html
  * https://analogdevicesinc.github.io/doctools/docs_guidelines/index.html
  * https://analogdevicesinc.github.io/documentation/contributing/creating_new_pages.html#documentation-structure
- [x] I have used the appropriate roles and directives:
  * https://analogdevicesinc.github.io/doctools/docs_guidelines/roles.html
  * https://analogdevicesinc.github.io/doctools/docs_guidelines/directives.html
- [x] I ensured that binary data was committed to git lfs:
  * https://analogdevicesinc.github.io/documentation/contributing/creating_new_pages.html#adding-images-and-other-binary-files
- [x] I have built the pages I edited or created, using either `make html` or `adoc serve`:
  * https://analogdevicesinc.github.io/doctools/cli.html#serve
- [x] I have signed-off my commits and believe my contribution improves the repository.
