### PR TITLE
docs/adrd5161-01z: add production testing documentation

### DIFF
--- a/docs/solutions/reference-designs/adrd5161-01z/index.rst
+++ b/docs/solutions/reference-designs/adrd5161-01z/index.rst
@@ -98,6 +98,7 @@ User Guides
    hardware-guide
    software-guide
    canopen
+   production_testing/production-testing
 
 Help and Support
 ----------------

--- a/docs/solutions/reference-designs/adrd5161-01z/production_testing/images/adrd5161_battery_connections.png
+++ b/docs/solutions/reference-designs/adrd5161-01z/production_testing/images/adrd5161_battery_connections.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:59c8b8cfda69aacf14a023b43fb9e8ad227e427158d47b3e46ab39678e556c9b
+size 687435

--- a/docs/solutions/reference-designs/adrd5161-01z/production_testing/images/adrd5161_board_image.png
+++ b/docs/solutions/reference-designs/adrd5161-01z/production_testing/images/adrd5161_board_image.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9f75ed92ec5414f070ae170cf2830b53071297513cb68896aff8654f15f1374a
+size 667347

--- a/docs/solutions/reference-designs/adrd5161-01z/production_testing/images/can_to_usb_adaptor_connection.png
+++ b/docs/solutions/reference-designs/adrd5161-01z/production_testing/images/can_to_usb_adaptor_connection.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0a65e29067e6d02e4dde3418d32af455a04c9edb613a98bca4497d0b83e4c9af
+size 794473

--- a/docs/solutions/reference-designs/adrd5161-01z/production_testing/images/daplink_programmer_connection.png
+++ b/docs/solutions/reference-designs/adrd5161-01z/production_testing/images/daplink_programmer_connection.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:70c5286d7b6805c48f8d7e9f5e1d8f21d6ecc3898108359f4abb26cb60c5f0b0
+size 678572

--- a/docs/solutions/reference-designs/adrd5161-01z/production_testing/images/firmware_flash_test_menu.png
+++ b/docs/solutions/reference-designs/adrd5161-01z/production_testing/images/firmware_flash_test_menu.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8efbcae32a7a3eb60ded097d10669e87917c09755840bb4de2f83d3e2a1dc1ed
+size 78785

--- a/docs/solutions/reference-designs/adrd5161-01z/production_testing/images/firmware_flash_test_menu_passed.png
+++ b/docs/solutions/reference-designs/adrd5161-01z/production_testing/images/firmware_flash_test_menu_passed.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:964c20921efb02066b4e8f26052d770f3aef574ac770baab987c32afb34321da
+size 75178

--- a/docs/solutions/reference-designs/adrd5161-01z/production_testing/images/ftdi_programming/board_disconnection_from_app.png
+++ b/docs/solutions/reference-designs/adrd5161-01z/production_testing/images/ftdi_programming/board_disconnection_from_app.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e65d614417d49a9d93c93d6b9b054914440c838548b7fa4087d72a599a7b290e
+size 43501

--- a/docs/solutions/reference-designs/adrd5161-01z/production_testing/images/ftdi_programming/device_scanning.png
+++ b/docs/solutions/reference-designs/adrd5161-01z/production_testing/images/ftdi_programming/device_scanning.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b5978056e5f7e88c4027e961f567f2d0d4ba8a42d8a253a5beb2d313ad3ebf09
+size 93646

--- a/docs/solutions/reference-designs/adrd5161-01z/production_testing/images/ftdi_programming/firmware_programming_commands.png
+++ b/docs/solutions/reference-designs/adrd5161-01z/production_testing/images/ftdi_programming/firmware_programming_commands.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5c5fbbe5f1bce5bd7b727eba19b7da4902158191d0ce5650a77fce012bb137d4
+size 98525

--- a/docs/solutions/reference-designs/adrd5161-01z/production_testing/images/ftdi_programming/firmware_writing_completion_message.png
+++ b/docs/solutions/reference-designs/adrd5161-01z/production_testing/images/ftdi_programming/firmware_writing_completion_message.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e7e787c423738883dd7af66d07188fc9ad5e7f5393f2ad9d391b75f8bcc99514
+size 48313

--- a/docs/solutions/reference-designs/adrd5161-01z/production_testing/images/ftdi_programming/jumper_positions.png
+++ b/docs/solutions/reference-designs/adrd5161-01z/production_testing/images/ftdi_programming/jumper_positions.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7507f23db91b47f8d3c7af2e9db4ddca534a2a743f5ada3798f715e23512f1dd
+size 187504

--- a/docs/solutions/reference-designs/adrd5161-01z/production_testing/images/ftdi_programming/led_feedback_ftdi_programming.png
+++ b/docs/solutions/reference-designs/adrd5161-01z/production_testing/images/ftdi_programming/led_feedback_ftdi_programming.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:162efd9742b845b8210ee67d31cef40b87843cbb669ec804d12eea5af3dcf86a
+size 248475

--- a/docs/solutions/reference-designs/adrd5161-01z/production_testing/images/ftdi_programming/load_connection.png
+++ b/docs/solutions/reference-designs/adrd5161-01z/production_testing/images/ftdi_programming/load_connection.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:186ded7f0c9a0b0afd10b4a0a081192bf6e835f45590e5ab997905ddf3c09fc4
+size 252936

--- a/docs/solutions/reference-designs/adrd5161-01z/production_testing/images/ini_flash_test_passed.png
+++ b/docs/solutions/reference-designs/adrd5161-01z/production_testing/images/ini_flash_test_passed.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e3933108d16a3854f94eb2eef1f6510dc7dafdb34be7ddecc29b248f2dad5625
+size 99462

--- a/docs/solutions/reference-designs/adrd5161-01z/production_testing/images/logout.png
+++ b/docs/solutions/reference-designs/adrd5161-01z/production_testing/images/logout.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e393b7a1f3b6c3de4573cecf8778de4dd9770c9c8f7fb11c1a54df65c94bf109
+size 71975

--- a/docs/solutions/reference-designs/adrd5161-01z/production_testing/images/reboot.png
+++ b/docs/solutions/reference-designs/adrd5161-01z/production_testing/images/reboot.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e29b73bc1a4ed4e2f65d076dd36a8bf3c1921403a14656e92fc12649d3a0a83c
+size 47073

--- a/docs/solutions/reference-designs/adrd5161-01z/production_testing/images/resistor_board_and_connections.png
+++ b/docs/solutions/reference-designs/adrd5161-01z/production_testing/images/resistor_board_and_connections.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1d1a1ce51b67178565314aab56b955d3d9358a991553cc01046f176c2592321c
+size 1208564

--- a/docs/solutions/reference-designs/adrd5161-01z/production_testing/images/screen_output.png
+++ b/docs/solutions/reference-designs/adrd5161-01z/production_testing/images/screen_output.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ec661c7ac9696d7795e235fe3184e4d94494b33f4482ae46c26653740079d950
+size 370101

--- a/docs/solutions/reference-designs/adrd5161-01z/production_testing/images/system_test_screen_1.png
+++ b/docs/solutions/reference-designs/adrd5161-01z/production_testing/images/system_test_screen_1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ea994690599ff6aeb4d186874f622f35c383685676f53f5660545882acf1b9f1
+size 53090

--- a/docs/solutions/reference-designs/adrd5161-01z/production_testing/images/system_test_screen_2.png
+++ b/docs/solutions/reference-designs/adrd5161-01z/production_testing/images/system_test_screen_2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:687ecca85192c09575b7bb3d059e4e923a83bdb5dcb0b1889b8e84d05732fcff
+size 38786

--- a/docs/solutions/reference-designs/adrd5161-01z/production_testing/images/system_test_screen_passed.png
+++ b/docs/solutions/reference-designs/adrd5161-01z/production_testing/images/system_test_screen_passed.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:69333abf90c70595e1e910507489fc5097d0295a84327757eb650c8b754eb578
+size 31397

--- a/docs/solutions/reference-designs/adrd5161-01z/production_testing/images/test_menu.png
+++ b/docs/solutions/reference-designs/adrd5161-01z/production_testing/images/test_menu.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:44b4615baaf71c8d49940071887de8f2d5c2d0cee3b8f579c76a04b66d20ba8d
+size 17138

--- a/docs/solutions/reference-designs/adrd5161-01z/production_testing/images/usb_power_supply_connection.png
+++ b/docs/solutions/reference-designs/adrd5161-01z/production_testing/images/usb_power_supply_connection.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ffffce7f0b3b30b4cbd4818cec3d5b6c003febbdd8677d0c0bf6e93b92003925
+size 531173

--- a/docs/solutions/reference-designs/adrd5161-01z/production_testing/images/wifi_connection_1.png
+++ b/docs/solutions/reference-designs/adrd5161-01z/production_testing/images/wifi_connection_1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8b84be4687407115d806f1065795dcc4a132ab64974afb5c14358d30c12843ff
+size 358914

--- a/docs/solutions/reference-designs/adrd5161-01z/production_testing/production-testing.rst
+++ b/docs/solutions/reference-designs/adrd5161-01z/production_testing/production-testing.rst
@@ -1,0 +1,352 @@
+ADRD5161-01Z Production Testing
+===============================
+
+Overview
+--------
+
+The purpose of the test procedure is to identify connectivity issues, poor
+soldering, and potential manufacturing defects. Some of the issues are directly
+identified by explicit part-targeted tests, others are implicit, by running
+adjacent tests.
+
+.. attention::
+
+   Before running the production tests, the boards need FTDI programming.
+   See :ref:`ftdi-programming` section below.
+
+.. _ftdi-programming:
+
+FTDI Programming
+----------------
+
+Before running the production tests, the boards need FTDI programming. Follow
+the steps below to program the FTDI.
+
+Required Hardware
+^^^^^^^^^^^^^^^^^
+
+* FTDI programming fixture (resistor board with programming area)
+* ADRD5161 board (D.U.T)
+* Load resistors
+* USB cable for connection to PC
+
+Required Software
+^^^^^^^^^^^^^^^^^
+
+* MAX77958 TypeC/PD & MAX77962 Charger EV Kit application
+* Firmware binary file (``.bin``)
+
+Programming Steps
+^^^^^^^^^^^^^^^^^
+
+.. list-table::
+   :header-rows: 1
+   :widths: 10 90
+
+   * - No.
+     - Steps
+   * - 1
+     - Set up the jumper positions on the programming fixture:
+
+       * Both jumpers on I2C position
+       * Jumper on 3V3 position
+
+       .. figure:: images/ftdi_programming/jumper_positions.png
+          :width: 30em
+
+          Jumper positions for FTDI programming
+   * - 2
+     - Connect the ADRD5161 board to the load as shown below:
+
+       .. figure:: images/ftdi_programming/load_connection.png
+          :width: 30em
+
+          ADRD5161 and load connection
+   * - 3
+     - Connect the fixture to the PC via USB cable
+   * - 4
+     - Open the **MAX77958 TypeC/PD & MAX77962 Charger EV Kit** application
+   * - 5
+     - Go to **Device > Connect** to connect to the device. If scanning fails,
+       a dialog will appear asking "Could not confirm existence of devices.
+       Do you want to continue?" - click **Yes** to proceed
+
+       .. figure:: images/ftdi_programming/device_scanning.png
+          :width: 40em
+
+          Device scanning and connection
+   * - 6
+     - Once connected, go to **Tools > Firmware Update...**
+
+       .. figure:: images/ftdi_programming/firmware_programming_commands.png
+          :width: 40em
+
+          Firmware update menu navigation
+   * - 7
+     - In the Firmware Update window:
+
+       * Click **Open** to select the firmware file
+       * Navigate to the firmware location and select the appropriate
+         ``.bin`` file
+       * Click **Start** to begin programming
+   * - 8
+     - Wait for the firmware to be written. A completion message will appear:
+       "Write firmware data to the device...Completed."
+
+       .. figure:: images/ftdi_programming/firmware_writing_completion_message.png
+          :width: 30em
+
+          Firmware writing completion message
+   * - 9
+     - Verify the programming was successful by checking the LED feedback on
+       the resistor board. Once the FTDI is programmed, the red LED must be ON
+
+       .. figure:: images/ftdi_programming/led_feedback_ftdi_programming.png
+          :width: 30em
+
+          LED feedback after FTDI programming
+   * - 10
+     - Disconnect the board from the application by going to
+       **Device > Disconnect**
+
+       .. figure:: images/ftdi_programming/board_disconnection_from_app.png
+          :width: 30em
+
+          Board disconnection from application
+   * - 11
+     - Remove the board from the fixture and proceed with production testing
+
+Test Procedure
+--------------
+
+Test Duration
+^^^^^^^^^^^^^
+
+.. list-table::
+   :header-rows: 1
+   :widths: 70 30
+
+   * - Step Description
+     - Estimated Time (minutes)
+   * - Test bench setup
+     - 5 min
+   * - Software test
+     - 6 min
+   * - **Total time**
+     - **11 min**
+
+Required Hardware
+^^^^^^^^^^^^^^^^^
+
+* ADRD5161 board as Device Under Test
+* Raspberry Pi, HDMI cable, power supply, mouse and keyboard
+* Power supply USB C (20V, 5A)
+* MAXPICO 32650 programmer (Daplink)
+* CAN2USB cable
+* Battery
+* Resistor board
+
+Required Software
+^^^^^^^^^^^^^^^^^
+
+The test image will be provided as a SD test card that goes into the Raspberry
+Pi.
+
+Test Setup
+^^^^^^^^^^
+
+.. list-table::
+   :header-rows: 1
+   :widths: 10 90
+
+   * - No.
+     - Steps
+   * - 1
+     - Insert the SD card into the Raspberry Pi
+   * - 2
+     - Connect the Raspberry Pi to a monitor and power it
+   * - 3
+     - Connect the Daplink programmer to the D.U.T and the Raspberry Pi
+
+       .. figure:: images/daplink_programmer_connection.png
+          :width: 30em
+
+          Daplink programmer connection
+   * - 4
+     - Connect the CAN to USB cable to the D.U.T and the Raspberry Pi
+
+       .. figure:: images/can_to_usb_adaptor_connection.png
+          :width: 30em
+
+          CAN to USB adaptor connection
+   * - 5
+     - Connect the resistor board to -/+ on the DUT as seen in the picture below
+
+       .. figure:: images/resistor_board_and_connections.png
+          :width: 30em
+
+          Resistor board and connections
+   * - 6
+     - Connect the battery to XT60 connector on the D.U.T and the balancing
+       connector (picture below)
+
+       .. figure:: images/adrd5161_battery_connections.png
+          :width: 30em
+
+          Battery connections
+   * - 7
+     - Connect the power supply USB C into the D.U.T
+
+       .. figure:: images/usb_power_supply_connection.png
+          :width: 20em
+
+          USB power supply connection
+
+Enabling Wifi
+^^^^^^^^^^^^^
+
+Before starting the testing procedure, make sure the Raspberry Pi is connected
+to Wifi.
+
+#. After the RPi boots, press **CONTROL+C** to exit the test screen
+#. Click on the Wifi network you want to connect to
+
+   .. figure:: images/wifi_connection_1.png
+      :width: 30em
+
+      Wifi network selection
+
+#. Type in the password
+#. After connecting successfully, reboot the Raspberry Pi by following the
+   instructions below:
+
+   .. figure:: images/logout.png
+      :width: 20em
+
+      Logout menu
+
+   .. figure:: images/reboot.png
+      :width: 15em
+
+      Reboot option
+
+Running the Test Software
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+After reboot, the following test menu should appear:
+
+.. figure:: images/test_menu.png
+   :width: 25em
+
+   Test menu
+
+.. code-block:: text
+
+   Please enter your choice:
+   1) MAX17320 Ini Flash
+   2) Firmware Flash
+   3) System Test
+   4) Power-Off Pi
+
+1) MAX17320 Ini Flash
+"""""""""""""""""""""
+
+Type "1" into the terminal and press **ENTER** to start **1) MAX17320 Ini
+Flash**.
+
+Please verify that the programmer is connected to header P7, then press Enter.
+
+.. figure:: images/ini_flash_test_passed.png
+   :width: 35em
+
+   MAX17320 Ini Flash test passed
+
+After the first test is passed, move on by writing "2" in the terminal.
+
+2) Firmware Flash
+"""""""""""""""""
+
+Type "2" into the terminal and press **ENTER** to start **2) Firmware Flash**.
+
+Please verify that the programmer is connected to header P7, then press Enter.
+
+.. figure:: images/firmware_flash_test_menu.png
+   :width: 25em
+
+   Firmware Flash menu selection
+
+.. figure:: images/firmware_flash_test_menu_passed.png
+   :width: 35em
+
+   Firmware Flash test passed
+
+3) System Test
+""""""""""""""
+
+Type "3" in the terminal in order to run **3) System Test**.
+
+The system test will:
+
+* Connect to CAN network
+* Read Object Dictionary Values including:
+
+  * Battery Cell Voltages
+  * Current
+  * Battery Status
+  * Charger Status
+  * Temperature
+  * Ah Returned During Last Charge
+  * Battery Voltage
+  * Battery State of Charge
+
+.. figure:: images/system_test_screen_1.png
+   :width: 30em
+
+   System Test - CAN network connection and readings
+
+.. figure:: images/system_test_screen_2.png
+   :width: 30em
+
+   System Test - Object Dictionary values
+
+If no errors are found, the message "No Errors. System test passed." will be
+displayed.
+
+.. figure:: images/system_test_screen_passed.png
+   :width: 30em
+
+   System Test passed
+
+Next, you will need to unplug the USB C power supply from the D.U.T. When
+prompted, check if the red LED is on (see picture below) and type **y** or
+**n**.
+
+For the current test, read the display on the board. The value should be
+approximately 500 mA. If around that value, type **y**.
+
+.. figure:: images/screen_output.png
+   :width: 35em
+
+   LED and current verification
+
+After all tests pass, a green **PASSED** message will appear on the screen.
+
+.. warning::
+
+   If a **FAILED** message appears, check the connections and verify that all
+   cables are properly connected. You may repeat the failed test if it was due
+   to a connection issue.
+
+4) Power-Off Pi
+"""""""""""""""
+
+When you are done testing, press "4" and press **ENTER** to power-off the
+Raspberry Pi.
+
+Pass Criteria
+^^^^^^^^^^^^^
+
+* **MAX17320 Ini Flash:** Test 1) has successfully passed
+* **Firmware Flash:** Test 2) has successfully passed
+* **System Test:** Test 3) has successfully passed with LED verification and
+  current reading approximately 500 mA


### PR DESCRIPTION
Add production testing procedure for ADRD5161-01Z BMS board including:
- FTDI programming steps with firmware update procedure
- Test bench setup and hardware requirements
- Test process with MAX17320 Ini Flash, Firmware Flash, and System Test
- Pass criteria and troubleshooting guidance

This page is deployed here: https://plescaevelyn.github.io/adi-documentation/pull/25/solutions/reference-designs/adrd5161-01z/production_testing/production-testing.html

## Type
- [x] Documentation
- [ ] Bug fix
- [ ] New feature
- [ ] Continuous integration

## Checklist
- [x] I have performed a self-review of changes
- [x] I have followed the guidelines:
  * https://analogdevicesinc.github.io/documentation/contributing/docs_guidelines.html
  * https://analogdevicesinc.github.io/doctools/docs_guidelines/index.html
  * https://analogdevicesinc.github.io/documentation/contributing/creating_new_pages.html#documentation-structure
- [x] I have used the appropriate roles and directives:
  * https://analogdevicesinc.github.io/doctools/docs_guidelines/roles.html
  * https://analogdevicesinc.github.io/doctools/docs_guidelines/directives.html
- [x] I ensured that binary data was committed to git lfs:
  * https://analogdevicesinc.github.io/documentation/contributing/creating_new_pages.html#adding-images-and-other-binary-files
- [x] I have built the pages I edited or created, using either `make html` or `adoc serve`:
  * https://analogdevicesinc.github.io/doctools/cli.html#serve
- [x] I have signed-off my commits and believe my contribution improves the repository.
