### PR TITLE
reference-designs/ad-gmsl792mipi-evk: Add production testing document…

### DIFF
--- a/docs/solutions/reference-designs/ad-gmsl792mipi-evk/index.rst
+++ b/docs/solutions/reference-designs/ad-gmsl792mipi-evk/index.rst
@@ -251,3 +251,9 @@ reference design with Analog Devices components via the
 
 It should be noted that the older the tools' versions and release branches are,
 the lower the chances to receive support from ADI engineers.
+
+.. toctree::
+   :titlesonly:
+   :maxdepth: 1
+
+   production_testing/index

--- a/docs/solutions/reference-designs/ad-gmsl792mipi-evk/production_testing/images/camera_connections.png
+++ b/docs/solutions/reference-designs/ad-gmsl792mipi-evk/production_testing/images/camera_connections.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f9307a9414f3bfb5835837b3404f0f867b411fa67e01cedbaf694c0f8305461e
+size 353210

--- a/docs/solutions/reference-designs/ad-gmsl792mipi-evk/production_testing/images/communication_test_screen_1.png
+++ b/docs/solutions/reference-designs/ad-gmsl792mipi-evk/production_testing/images/communication_test_screen_1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2177d5c3396503d976bdc9d0dd67e58a60d030aa0732bff79b288155eb086dd5
+size 28004

--- a/docs/solutions/reference-designs/ad-gmsl792mipi-evk/production_testing/images/communication_test_screen_passed.png
+++ b/docs/solutions/reference-designs/ad-gmsl792mipi-evk/production_testing/images/communication_test_screen_passed.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b48ae7cdb2b8f9a581517538241d55bc4801b75f4f40269a2747881f4dd79b40
+size 23472

--- a/docs/solutions/reference-designs/ad-gmsl792mipi-evk/production_testing/images/data_streaming_test_1.png
+++ b/docs/solutions/reference-designs/ad-gmsl792mipi-evk/production_testing/images/data_streaming_test_1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:02fb09153dc5180c093902e42f3468dcc9793f76893704f8c0da9a2776979273
+size 89214

--- a/docs/solutions/reference-designs/ad-gmsl792mipi-evk/production_testing/images/data_streaming_test_passed.png
+++ b/docs/solutions/reference-designs/ad-gmsl792mipi-evk/production_testing/images/data_streaming_test_passed.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7d1f9b84bf19610fdee1742cc48fbce4fa055b09fab686e523218589a7a79394
+size 26016

--- a/docs/solutions/reference-designs/ad-gmsl792mipi-evk/production_testing/images/logout.png
+++ b/docs/solutions/reference-designs/ad-gmsl792mipi-evk/production_testing/images/logout.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:65175d919c7e3b45f8f2368115cdb2b8ee86cb83d0a60c3053131a417d207403
+size 59171

--- a/docs/solutions/reference-designs/ad-gmsl792mipi-evk/production_testing/images/reboot.png
+++ b/docs/solutions/reference-designs/ad-gmsl792mipi-evk/production_testing/images/reboot.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9a797aa5d8bc3362861452286baddfab5d09b67f8211af2f82333181066b6b1c
+size 27679

--- a/docs/solutions/reference-designs/ad-gmsl792mipi-evk/production_testing/images/system_connections.png
+++ b/docs/solutions/reference-designs/ad-gmsl792mipi-evk/production_testing/images/system_connections.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:597c3089b735fbc375785f6a317f4d19312d9f7f431fcfccf95527c8787ac591
+size 250679

--- a/docs/solutions/reference-designs/ad-gmsl792mipi-evk/production_testing/images/test_screen.png
+++ b/docs/solutions/reference-designs/ad-gmsl792mipi-evk/production_testing/images/test_screen.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:12e6785629cbed7a945af5bbfa3ffd4ae6db6db5ea515fd590b8c925d81d762e
+size 9652

--- a/docs/solutions/reference-designs/ad-gmsl792mipi-evk/production_testing/images/wifi_connection.png
+++ b/docs/solutions/reference-designs/ad-gmsl792mipi-evk/production_testing/images/wifi_connection.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:197b012e93c77259c2de871f971322f4d29aaff43824ee126d15b70291dd6746
+size 284411

--- a/docs/solutions/reference-designs/ad-gmsl792mipi-evk/production_testing/index.rst
+++ b/docs/solutions/reference-designs/ad-gmsl792mipi-evk/production_testing/index.rst
@@ -1,0 +1,166 @@
+.. _ad-gmsl792mipi-evk production_testing:
+
+AD-GMSL792MIPI-EVK Production Testing
+=====================================
+
+Overview
+--------
+
+The purpose of the test procedure is to identify connectivity issues, poor
+soldering, and potential manufacturing defects. Some of the issues are directly
+identified by explicit part-targeted tests, others are implicit, by running
+adjacent tests.
+
+Test Duration
+-------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 70 30
+
+   * - Step Description
+     - Estimated Time (minutes)
+   * - Test bench setup
+     - 4 min
+   * - Software test
+     - 4 min
+   * - **Total time**
+     - **8 min**
+
+Test Requirements
+-----------------
+
+Required Hardware
+~~~~~~~~~~~~~~~~~
+
+* Raspberry Pi 5 + HDMI cable + power supply
+* Mouse and keyboard
+* 2 x IMX219 cameras
+* 2 x flex cables
+* 2 x FAKRA cables
+* Device under test: :adi:`AD-GMSL792MIPI-EVK`
+* Power supply with USB Type-C for AD-GMSL792MIPI-EVK board
+
+Required Software
+~~~~~~~~~~~~~~~~~
+
+* SD card with the test image (provided for the Raspberry Pi)
+
+Required Setup
+~~~~~~~~~~~~~~
+
+.. list-table::
+   :header-rows: 1
+   :widths: 10 90
+
+   * - No.
+     - Steps
+   * - 1
+     - Insert the SD card into the Raspberry Pi 5.
+   * - 2
+     - Connect the Raspberry Pi to a monitor and power it.
+   * - 3
+     - Connect the FAKRA cables to the cameras on AD-GMSL793MIPI-EVK.
+   * - 4
+     - Connect the camera cables to the AD-GMSL792MIPI-EVK.
+   * - 5
+     - Connect the P1 and P2 connectors of the D.U.T. using flex cables to
+       P0 and P1 on the Raspberry Pi 5.
+   * - 6
+     - Power the D.U.T.
+
+.. figure:: images/system_connections.png
+   :width: 45em
+
+   System Connections
+
+.. figure:: images/camera_connections.png
+   :width: 45em
+
+   Camera Connections
+
+Test Process
+------------
+
+Wi-Fi Setup
+~~~~~~~~~~~
+
+Ensure the Raspberry Pi is connected to Wi-Fi before starting the tests.
+
+* Power on the Raspberry Pi. If the test screen appears automatically, press
+  **CTRL+C** to exit the test application.
+
+* Click on the Wi-Fi network you want to connect to.
+
+  .. figure:: images/wifi_connection.png
+     :width: 45em
+
+     Wi-Fi Network Selection
+
+* Enter the password when prompted.
+
+* After connecting successfully, reboot the Raspberry Pi. Navigate to the
+  application menu and select **Logout**.
+
+  .. figure:: images/logout.png
+     :width: 45em
+
+     Logout Menu
+
+* Select **Reboot** from the shutdown options.
+
+  .. figure:: images/reboot.png
+     :width: 45em
+
+     Reboot Option
+
+Running the Tests
+~~~~~~~~~~~~~~~~~
+
+* After the Raspberry Pi reboots, the test screen will appear automatically.
+
+  .. figure:: images/test_screen.png
+     :width: 45em
+
+     Test Screen
+
+Communication Test
+^^^^^^^^^^^^^^^^^^
+
+* Type **1** from the keyboard to start **1) Communication Test**.
+
+  .. figure:: images/communication_test_screen_1.png
+     :width: 45em
+
+     Communication Test Selection
+
+* Visually check if the DS1 LED is ON and type **y** or **n** accordingly.
+
+* If the test passes, you will see a **PASSED** message.
+
+  .. figure:: images/communication_test_screen_passed.png
+     :width: 45em
+
+     Communication Test Passed
+
+Data Streaming Test
+^^^^^^^^^^^^^^^^^^^
+
+* Type **2** from the keyboard to start **2) Data streaming test**.
+
+  .. figure:: images/data_streaming_test_1.png
+     :width: 45em
+
+     Data Streaming Test Selection
+
+* Connect the cameras as shown above.
+
+* If the test passes, you will see a **PASSED** message.
+
+  .. figure:: images/data_streaming_test_passed.png
+     :width: 45em
+
+     Data Streaming Test Passed
+
+* If the test is successful, you can consider the device under test functional
+  and continue testing the next boards.


### PR DESCRIPTION
…ation

Add production testing procedure for the AD-GMSL792MIPI-EVK board, including test requirements, setup instructions, and step-by-step guide for Communication Test and Data Streaming Test.

This documentation page is deployed here: https://plescaevelyn.github.io/adi-documentation/pull/4/solutions/reference-designs/ad-gmsl792mipi-evk/production_testing/index.html

## Type
- [x] Documentation
- [ ] Bug fix
- [ ] New feature
- [ ] Continuous integration

## Checklist
- [x] I have performed a self-review of changes
- [x] I have followed the guidelines:
  * https://analogdevicesinc.github.io/documentation/contributing/docs_guidelines.html
  * https://analogdevicesinc.github.io/doctools/docs_guidelines/index.html
  * https://analogdevicesinc.github.io/documentation/contributing/creating_new_pages.html#documentation-structure
- [x] I have used the appropriate roles and directives:
  * https://analogdevicesinc.github.io/doctools/docs_guidelines/roles.html
  * https://analogdevicesinc.github.io/doctools/docs_guidelines/directives.html
- [x] I ensured that binary data was committed to git lfs:
  * https://analogdevicesinc.github.io/documentation/contributing/creating_new_pages.html#adding-images-and-other-binary-files
- [x] I have built the pages I edited or created, using either `make html` or `adoc serve`:
  * https://analogdevicesinc.github.io/doctools/cli.html#serve
- [x] I have signed-off my commits and believe my contribution improves the repository.
