### PR TITLE
reference-designs/ad-gmsl793mipi-evk: Add production testing document…

### DIFF
--- a/docs/solutions/reference-designs/ad-gmsl793mipi-evk/index.rst
+++ b/docs/solutions/reference-designs/ad-gmsl793mipi-evk/index.rst
@@ -217,6 +217,15 @@ Design & Integration Files
    - Bill of Materials
    - Allegro Project
 
+User Guides
+~~~~~~~~~~~
+
+.. toctree::
+   :titlesonly:
+   :maxdepth: 1
+
+   production_testing/index
+
 Help and Support
 ~~~~~~~~~~~~~~~~
 

--- a/docs/solutions/reference-designs/ad-gmsl793mipi-evk/production_testing/images/camera_connection.png
+++ b/docs/solutions/reference-designs/ad-gmsl793mipi-evk/production_testing/images/camera_connection.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3dea3f9d196f1a5905935d5d23d4b8f9d6b8bc83503c91bbcfdee60eb6b9996e
+size 296491

--- a/docs/solutions/reference-designs/ad-gmsl793mipi-evk/production_testing/images/communication_test_passed.png
+++ b/docs/solutions/reference-designs/ad-gmsl793mipi-evk/production_testing/images/communication_test_passed.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f77b5350f6ff3492933a8e4e0ff8f89972e4bce42a3af1d54e218bbfed8b439c
+size 23434

--- a/docs/solutions/reference-designs/ad-gmsl793mipi-evk/production_testing/images/communication_test_screen.png
+++ b/docs/solutions/reference-designs/ad-gmsl793mipi-evk/production_testing/images/communication_test_screen.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:47e2f28f23abf909376b4f53839163f9e709cecb4ddacea77c8892788f329f9b
+size 27996

--- a/docs/solutions/reference-designs/ad-gmsl793mipi-evk/production_testing/images/data_streaming_test_passed.png
+++ b/docs/solutions/reference-designs/ad-gmsl793mipi-evk/production_testing/images/data_streaming_test_passed.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6d44c4bffb60fa5a29cc5dbd70dce603c7e335e44ebf566a0769355222d42ed4
+size 25567

--- a/docs/solutions/reference-designs/ad-gmsl793mipi-evk/production_testing/images/data_streaming_test_screen.png
+++ b/docs/solutions/reference-designs/ad-gmsl793mipi-evk/production_testing/images/data_streaming_test_screen.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:404b08cb2a101fc71bfdd25ef8535f1293c2908e8e608d3687ecf73a3a87a3ae
+size 89136

--- a/docs/solutions/reference-designs/ad-gmsl793mipi-evk/production_testing/images/logout.png
+++ b/docs/solutions/reference-designs/ad-gmsl793mipi-evk/production_testing/images/logout.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:664ecc201be3c7963e64e06147b5e487efd236c09e8adab177f86e623ee6bb70
+size 57965

--- a/docs/solutions/reference-designs/ad-gmsl793mipi-evk/production_testing/images/reboot.png
+++ b/docs/solutions/reference-designs/ad-gmsl793mipi-evk/production_testing/images/reboot.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3ff0f8b105b74b41449c50cafb714cc3b4957b5ad3fd278359b91b2b8b457895
+size 25945

--- a/docs/solutions/reference-designs/ad-gmsl793mipi-evk/production_testing/images/system_setup.png
+++ b/docs/solutions/reference-designs/ad-gmsl793mipi-evk/production_testing/images/system_setup.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:114b53e326edbdac448cf452bae65e67f45b97507af2d5f7696d1da6ceb4fc0b
+size 250172

--- a/docs/solutions/reference-designs/ad-gmsl793mipi-evk/production_testing/images/test_screen.png
+++ b/docs/solutions/reference-designs/ad-gmsl793mipi-evk/production_testing/images/test_screen.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5dbb9ae9a2372bd700b475c3e738044644671f30fbc3843d9a8e17dc7e618af1
+size 9664

--- a/docs/solutions/reference-designs/ad-gmsl793mipi-evk/production_testing/images/wifi_connection.png
+++ b/docs/solutions/reference-designs/ad-gmsl793mipi-evk/production_testing/images/wifi_connection.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9695d9df3ae6732e4d80d592046d092e10c004c397d24355bff04b94efe23f86
+size 288143

--- a/docs/solutions/reference-designs/ad-gmsl793mipi-evk/production_testing/index.rst
+++ b/docs/solutions/reference-designs/ad-gmsl793mipi-evk/production_testing/index.rst
@@ -1,0 +1,155 @@
+.. _ad-gmsl793mipi-evk production_testing:
+
+AD-GMSL793MIPI-EVK Production Testing
+=====================================
+
+Overview
+--------
+
+This document describes the production testing procedure for the
+:adi:`AD-GMSL793MIPI-EVK` board. The procedure focuses on identifying
+connectivity issues, poor soldering, and potential manufacturing defects.
+Some issues are directly identified by explicit part-targeted tests, while
+others are implicit, detected by running adjacent tests.
+
+Test Duration
+-------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 70 30
+
+   * - Step Description
+     - Estimated Time (minutes)
+   * - Test bench setup
+     - 4 min
+   * - Software test
+     - 4 min
+   * - **Total time**
+     - **8 min**
+
+Test Requirements
+-----------------
+
+Required Hardware
+~~~~~~~~~~~~~~~~~
+
+* Raspberry Pi 5 + HDMI cable + power supply
+* Mouse and keyboard
+* 2 x IMX219 cameras
+* 2 x flex cables
+* 2 x Fakra cables
+* 1 x :adi:`AD-GMSL792MIPI-EVK` (GMSL792MIPI evkit)
+* 2 x :adi:`AD-GMSL793MIPI-EVK` as Device Under Test (D.U.T.)
+* Power supply with USB Type-C for AD-GMSL792MIPI-EVK board
+
+Required Software
+~~~~~~~~~~~~~~~~~
+
+* SD card with the test image (provided separately)
+
+Required Setup
+~~~~~~~~~~~~~~
+
+#. Insert the SD card into the Raspberry Pi 5.
+
+#. Connect the Raspberry Pi to a monitor and power it on.
+
+#. Connect the Fakra cables to the cameras, then connect the cameras to the
+   AD-GMSL793MIPI-EVK boards (D.U.T.).
+
+#. Plug the D.U.T. boards into the AD-GMSL792MIPI-EVK.
+
+#. Connect the P1 and P2 connectors of the D.U.T. using flex cables to P0 and
+   P1 on the Raspberry Pi 5.
+
+#. Power the AD-GMSL792MIPI-EVK using the USB Type-C power supply.
+
+   .. figure:: images/system_setup.png
+      :width: 45em
+
+      Complete System Setup
+
+   .. figure:: images/camera_connection.png
+      :width: 45em
+
+      Camera Connection Detail
+
+Test Process
+------------
+
+Wi-Fi Setup
+~~~~~~~~~~~
+
+Ensure the Raspberry Pi is connected to Wi-Fi before starting the tests. If
+the test screen is already running, you will need to exit it first to configure
+the network connection.
+
+#. Power on the Raspberry Pi. If the test screen appears automatically, press
+   **CTRL+C** to exit the test application.
+
+#. Click on the Wi-Fi network you want to connect to.
+
+   .. figure:: images/wifi_connection.png
+      :width: 45em
+
+      Wi-Fi Network Selection
+
+#. Type in the password and connect to the network.
+
+#. After connecting successfully, reboot the Raspberry Pi by navigating to the
+   application menu, selecting **Logout**, then choosing **Reboot** from the
+   shutdown options.
+
+   .. figure:: images/logout.png
+      :width: 45em
+
+      Logout Menu
+
+   .. figure:: images/reboot.png
+      :width: 45em
+
+      Reboot Options
+
+Running the Tests
+~~~~~~~~~~~~~~~~~
+
+#. After the Raspberry Pi reboots, the test screen will appear on the monitor.
+
+   .. figure:: images/test_screen.png
+      :width: 45em
+
+      Test Menu Screen
+
+#. Type **1** from the keyboard to start **1) Communication Test**.
+
+   .. figure:: images/communication_test_screen.png
+      :width: 45em
+
+      Communication Test Selection
+
+#. Visually check if the DS1 LED is ON and type **y** or **n** accordingly.
+
+#. If the test shows **PASSED**, you can proceed to the next test.
+
+   .. figure:: images/communication_test_passed.png
+      :width: 45em
+
+      Communication Test Passed
+
+#. Type **2** in the terminal to start **2) Data Streaming Test**.
+
+   .. figure:: images/data_streaming_test_screen.png
+      :width: 45em
+
+      Data Streaming Test Selection
+
+#. If the test shows **PASSED**, the device under test is functional.
+
+   .. figure:: images/data_streaming_test_passed.png
+      :width: 45em
+
+      Data Streaming Test Passed
+
+#. To test additional D.U.T. boards, replace the AD-GMSL793MIPI-EVK boards
+   and repeat the test procedure from step 1 of this section.


### PR DESCRIPTION
…ation

Add production testing procedure for the AD-GMSL793MIPI-EVK board, including test bench setup, Wi-Fi configuration, and step-by-step instructions for communication and data streaming tests.

This documentation page is deployed here: https://plescaevelyn.github.io/adi-documentation/pull/5/solutions/reference-designs/ad-gmsl793mipi-evk/production_testing/index.html

## Type
- [x] Documentation
- [ ] Bug fix
- [ ] New feature
- [ ] Continuous integration

## Checklist
- [x] I have performed a self-review of changes
- [x] I have followed the guidelines:
  * https://analogdevicesinc.github.io/documentation/contributing/docs_guidelines.html
  * https://analogdevicesinc.github.io/doctools/docs_guidelines/index.html
  * https://analogdevicesinc.github.io/documentation/contributing/creating_new_pages.html#documentation-structure
- [x] I have used the appropriate roles and directives:
  * https://analogdevicesinc.github.io/doctools/docs_guidelines/roles.html
  * https://analogdevicesinc.github.io/doctools/docs_guidelines/directives.html
- [x] I ensured that binary data was committed to git lfs:
  * https://analogdevicesinc.github.io/documentation/contributing/creating_new_pages.html#adding-images-and-other-binary-files
- [x] I have built the pages I edited or created, using either `make html` or `adoc serve`:
  * https://analogdevicesinc.github.io/doctools/cli.html#serve
- [x] I have signed-off my commits and believe my contribution improves the repository.
