### PR TITLE
reference-designs/eval_ad7616: Added documentation files

### DIFF
--- a/docs/solutions/reference-designs/eval-ad7616-sdz/images/AD7616-P-TAG-chip-illustration.png
+++ b/docs/solutions/reference-designs/eval-ad7616-sdz/images/AD7616-P-TAG-chip-illustration.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d436ea5937f2df9755dfa974e94baf865a40ad42544ef7d3933eb58ed1ba0a70
+size 540033

--- a/docs/solutions/reference-designs/eval-ad7616-sdz/images/ad7616_sdp-k1_setup.jpg
+++ b/docs/solutions/reference-designs/eval-ad7616-sdz/images/ad7616_sdp-k1_setup.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:66bfaac2ade6f868fafb988559e4507326b0107c140c34b22f1d2ebbacfda047
+size 102501

--- a/docs/solutions/reference-designs/eval-ad7616-sdz/images/ad7616sdp.jpeg
+++ b/docs/solutions/reference-designs/eval-ad7616-sdz/images/ad7616sdp.jpeg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:98a38653c4d9a03297c5acf860a7f870152677eb556233eb9e4bbcc23abd1aa5
+size 154562

--- a/docs/solutions/reference-designs/eval-ad7616-sdz/images/eval-ad7616-sdz-top.png
+++ b/docs/solutions/reference-designs/eval-ad7616-sdz/images/eval-ad7616-sdz-top.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:331c1e7f359718906463fba2444be9af2eb5c45ec70048db9bb18abf3b9b622a
+size 560608

--- a/docs/solutions/reference-designs/eval-ad7616-sdz/images/zed_ad7616.jpeg
+++ b/docs/solutions/reference-designs/eval-ad7616-sdz/images/zed_ad7616.jpeg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:30a84227201718297748a0177e7af2045a78023335de21c2f82f933de17c6286
+size 181762

--- a/docs/solutions/reference-designs/eval-ad7616-sdz/images/zed_connections.jpeg
+++ b/docs/solutions/reference-designs/eval-ad7616-sdz/images/zed_connections.jpeg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f50540e10edbbe5dc06ecad528638fd6ac0ea4c7b99e03d81226563bd0e7f71e
+size 171053

--- a/docs/solutions/reference-designs/eval-ad7616-sdz/images/zed_jumper.jpeg
+++ b/docs/solutions/reference-designs/eval-ad7616-sdz/images/zed_jumper.jpeg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b205bd7c2d37a12e3746dfeadf10edec48733c42e6f030233519a1e39136049e
+size 203737

--- a/docs/solutions/reference-designs/eval-ad7616-sdz/images/zed_power.jpeg
+++ b/docs/solutions/reference-designs/eval-ad7616-sdz/images/zed_power.jpeg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:016c035116518b41dac5118b0fd05e5101a8e5082baf43865970586b6e098ab6
+size 171177

--- a/docs/solutions/reference-designs/eval-ad7616-sdz/images/zedboard-2.png
+++ b/docs/solutions/reference-designs/eval-ad7616-sdz/images/zedboard-2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8d6f2b5ed274a447c24ae5b64386f48e14e0606b1404d566b1c421f7200c9d88
+size 645689

--- a/docs/solutions/reference-designs/eval-ad7616-sdz/index.rst
+++ b/docs/solutions/reference-designs/eval-ad7616-sdz/index.rst
@@ -1,0 +1,108 @@
+.. _eval-ad7616-sdz:
+
+EVAL-AD7616-SDZ
+===============================================================================
+
+Overview
+-------------------------------------------------------------------------------
+
+.. image:: images/AD7616-P-TAG-chip-illustration.png
+   :width: 200
+   :align: left
+
+The :adi:`EVAL-AD7616SDZ` is an evaluation board for the :adi:`AD7616`, a
+16-bit, data acquisition system (DAS) that supports dual simultaneous sampling
+of 16 channels. The AD7616 operates from a single 5V supply and can accommodate
+±10V, ±5V, and ±2.5V true bipolar input signals while sampling at throughput
+rates up to 1 MSPS per channel pair with 90 dB SNR. Higher SNR performance can
+be achieved with the on-chip oversampling mode; 92 dB for an oversampling ratio
+of 2.
+
+The input clamp protection circuitry can tolerate voltages up to ±20V. The
+AD7616 has 1 MΩ analog input impedance regardless of sampling frequency. The
+single supply operation, on-chip filtering, and high input impedance eliminate
+the need for driver op-amps and external bipolar supplies.
+
+Each device contains analog input clamp protection, a dual, 16-bit charge
+redistribution successive approximation analog-to-digital converter (ADC),
+a flexible digital filter, a 2.5V reference and reference buffer, and
+high-speed serial and parallel interfaces.
+
+Applications:
+
+- Powerline monitoring
+- Protective relays
+- Multiphase motor control
+- Instrumentation and control systems
+- Data acquisition systems (DAS)
+
+.. image:: images/eval-ad7616-sdz-top.png
+   :width: 500
+
+Supported Devices
+-------------------------------------------------------------------------------
+
+- :adi:`AD7616`
+
+Supported Carriers
+-------------------------------------------------------------------------------
+
+- :xilinx:`ZC706` (FMC via SDP-I-FMC)
+- :xilinx:`ZedBoard` (FMC via SDP-I-FMC)
+- `SDP-K1 <https://www.analog.com/en/design-center/evaluation-hardware-and-software/evaluation-boards-kits/SDP-K1.html>`_
+  (fly-wire, No-OS)
+
+.. toctree::
+   :hidden:
+
+   prerequisites
+   user-guide
+   quickstart/index
+
+Table of contents
+-------------------------------------------------------------------------------
+
+#. :ref:`eval-ad7616-sdz prerequisites` — hardware and software you need to
+   get started
+#. :ref:`eval-ad7616-sdz user-guide` — block diagrams and HDL design
+   reference
+#. :ref:`eval-ad7616-sdz quickstart`:
+
+   #. :ref:`eval-ad7616-sdz quickstart zedboard` — using ZedBoard with
+      SDP-I-FMC
+   #. :ref:`eval-ad7616-sdz quickstart zc706` — using ZC706
+   #. :ref:`eval-ad7616-sdz quickstart sdp-k1` — using SDP-K1 (No-OS,
+      bare metal)
+
+#. HDL reference design
+
+   - :external+hdl:ref:`AD7616 HDL Project <ad7616_sdz>` — complete HDL
+     reference design for the EVAL-AD7616-SDZ board
+
+#. No-OS driver resources
+
+   - `AD7616 No-OS Example Project (ZedBoard/ZC706)
+     <https://analogdevicesinc.github.io/no-OS/projects/adc/ad7616-sdz.html>`_
+   - `AD7616 No-OS Example Project (SDP-K1)
+     <https://analogdevicesinc.github.io/no-OS/projects/adc/ad7616-st.html>`_
+   - :git-no-OS:`AD7616 No-OS Driver <drivers/adc/ad7616>`
+
+#. Device resources
+
+   - :adi:`AD7616 Product Page <AD7616>` — datasheet, pricing, samples
+   - :adi:`EVAL-AD7616SDZ Evaluation Board <EVAL-AD7616SDZ>`
+
+Recommendations
+-------------------------------------------------------------------------------
+
+Start with the :ref:`eval-ad7616-sdz prerequisites` to ensure you have all
+required hardware and software. Then follow the quickstart guide for your
+carrier board.
+
+For questions not covered in the documentation, visit the
+:ez:`EngineerZone forums <data_converters/precision_adcs>`.
+
+Help and support
+-------------------------------------------------------------------------------
+
+Please go to :ref:`Help and Support <help-and-support>` page.

--- a/docs/solutions/reference-designs/eval-ad7616-sdz/prerequisites.rst
+++ b/docs/solutions/reference-designs/eval-ad7616-sdz/prerequisites.rst
@@ -1,0 +1,53 @@
+.. _eval-ad7616-sdz prerequisites:
+
+Prerequisites
+===============================================================================
+
+What you need depends on which carrier platform you are targeting. As a
+minimum, you need to start out with:
+
+Hardware prerequisites
+-------------------------------------------------------------------------------
+
+#. The :adi:`EVAL-AD7616SDZ` evaluation board
+#. A carrier platform — see the table below for supported options
+
+   .. list-table::
+      :header-rows: 1
+
+      * - Carrier
+        - Interface to EVAL-AD7616
+        - Additional hardware required
+      * - :xilinx:`ZedBoard`
+        - FMC
+        - :adi:`SDP-I-FMC` adapter board
+      * - :xilinx:`ZC706`
+        - FMC
+        - :adi:`SDP-I-FMC` adapter board
+      * - :adi:`SDP-K1`
+        - Fly-wire (SPI)
+        - STLINK-V3 programmer
+
+#. Power supplies:
+
+   - Both the :adi:`EVAL-AD7616SDZ` and the carrier must be powered via their
+     respective connectors.
+
+Software prerequisites
+-------------------------------------------------------------------------------
+
+#. **Xilinx Vivado and Vitis** — the supported version can be found on the
+   :git-hdl:`HDL releases page`.
+   Required when targeting ZedBoard or ZC706 (FPGA-based flow).
+
+#. **A UART terminal** (e.g. Tera Term or PuTTY):
+
+   - ZedBoard / ZC706: baud rate **115200** (PS UART console)
+   - SDP-K1: baud rate **230400** (IIO serial interface)
+
+#. **STLINK-V3 drivers** — required when using the SDP-K1 carrier to flash the
+   firmware.
+
+#. **IIO Oscilloscope** (optional) — can be used to visualize the captured data
+   when running the No-OS IIO project on the SDP-K1.
+

--- a/docs/solutions/reference-designs/eval-ad7616-sdz/quickstart/index.rst
+++ b/docs/solutions/reference-designs/eval-ad7616-sdz/quickstart/index.rst
@@ -1,0 +1,34 @@
+.. _eval-ad7616-sdz quickstart:
+
+Quick start guides
+===============================================================================
+
+The quick start guides provide step-by-step instructions for an initial system
+setup of the :adi:`EVAL-AD7616SDZ` on various carrier platforms. They walk
+through hardware configuration, building or flashing the firmware, and making
+an initial connection to the device.
+
+.. toctree::
+
+   On ZedBoard <zedboard>
+   On ZC706 <zc706>
+   On SDP-K1 <sdp-k1>
+
+Supported carriers
+-------------------------------------------------------------------------------
+
+.. list-table::
+   :header-rows: 1
+
+   * - Carrier
+     - HDL
+     - No-OS
+   * - :xilinx:`ZedBoard`
+     - Yes
+     - Yes
+   * - :xilinx:`ZC706`
+     - Yes
+     - Yes
+   * - SDP-K1
+     - ---
+     - Yes

--- a/docs/solutions/reference-designs/eval-ad7616-sdz/quickstart/sdp-k1.rst
+++ b/docs/solutions/reference-designs/eval-ad7616-sdz/quickstart/sdp-k1.rst
@@ -1,0 +1,171 @@
+.. _eval-ad7616-sdz quickstart sdp-k1:
+
+SDP-K1 Quick Start Guide
+===============================================================================
+
+.. image:: ../images/ad7616_sdp-k1_setup.jpg
+   :width: 800
+
+.. esd-warning::
+
+This guide provides quick instructions on how to setup the
+:adi:`EVAL-AD7616SDZ` on:
+
+- :adi:`SDP-K1` using a fly-wire SPI connection
+
+Using no-OS as software
+-------------------------------------------------------------------------------
+
+Necessary files
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The following files are needed:
+
+- no-OS project: :git-no-OS:`projects/ad7616-st`
+
+Instructions on how to build the project from source can be found here:
+
+- :external+no-OS:doc:`build_guide`
+
+Required software
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- AMD Xilinx Vitis or STM32CubeIDE — see the :external+no-OS:doc:`build_guide`
+  for the supported toolchain
+- A UART terminal (Putty/Tera Term/Minicom, etc.) with baud rate 230400 (8N1)
+- (Optional) `IIO Oscilloscope <https://analogdevicesinc.github.io/documentation/software/iio-oscilloscope/>`__
+  to visualize the captured data over the IIO serial backend
+
+Required hardware
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- :adi:`SDP-K1` microcontroller board and its power supply
+- :adi:`EVAL-AD7616SDZ` evaluation board and its power supply
+- STLINK-V3 programmer
+- Fly-wires for SPI connections
+
+More details as to why you need these, can be found at
+:ref:`eval-ad7616-sdz prerequisites`.
+
+Testing
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Creating the setup
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Follow the steps in this order, to avoid damaging the components:
+
+#. Configure the EVAL-AD7616-SDZ jumpers as follows for the SDP-K1:
+
+   .. list-table::
+      :header-rows: 1
+
+      * - Jumper/Solder link
+        - Position
+        - Description
+      * - SL1
+        - Unmounted
+        - Channel Sequencer Enable
+      * - SL2
+        - Unmounted
+        - RC Enable Input
+      * - SL3
+        - Unmounted
+        - Selects 1 MISO mode
+      * - SL4
+        - Unmounted
+        - Oversampling Ratio Selection OS2
+      * - SL5
+        - Mounted
+        - If mounted, selects serial interface
+      * - SL6
+        - Unmounted
+        - Oversampling Ratio Selection OS1
+      * - SL7
+        - Unmounted
+        - Oversampling Ratio Selection OS0
+      * - LK40
+        - A
+        - Onboard 5V power supply selected
+      * - LK41
+        - A
+        - Onboard 3.3V power supply selected
+
+#. Connect the :adi:`EVAL-AD7616SDZ` to the :adi:`SDP-K1` Arduino header
+   using fly-wires as follows:
+
+   .. list-table::
+      :header-rows: 1
+
+      * - EVAL-AD7616-SDZ
+        - SDP-K1 Arduino
+      * - SCLK
+        - D13
+      * - DB10/SDI
+        - D11
+      * - DB12/SDOA
+        - D12
+      * - CS
+        - D10
+      * - CONVST
+        - D5
+      * - RESET
+        - D7
+      * - BUSY
+        - D6
+
+#. Connect the power supply to the :adi:`EVAL-AD7616SDZ` barrel jack
+#. Connect the power supply to the :adi:`SDP-K1` barrel jack
+#. Connect the STLINK-V3 programmer to the :adi:`SDP-K1` and to your host PC
+#. Connect a USB cable for UART from the :adi:`SDP-K1` to your host PC
+#. Build and flash the no-OS project:
+
+   #. Refer to the :external+no-OS:doc:`build_guide` for toolchain setup.
+   #. Clone the no-OS repository and navigate to the project:
+
+      .. code-block:: bash
+
+         $ git clone --recursive https://github.com/analogdevicesinc/no-OS.git
+         $ cd no-OS/projects/ad7616-st
+
+   #. Build and flash the project:
+
+      .. code-block:: bash
+
+         $ make reset
+         $ make
+         $ make run
+
+      To debug instead of flash:
+
+      .. code-block:: bash
+
+         $ make debug
+
+#. Connect to the IIO server running on the SDP-K1:
+
+   - **IIO Oscilloscope**: connect using the serial backend at
+     ``serial:/dev/ttyUSB0,230400`` (or the appropriate COM port on Windows)
+   - **UART terminal**: open at **230400** baud to view the console log
+
+.. warning::
+
+   Make sure to power both the :adi:`EVAL-AD7616SDZ` and the :adi:`SDP-K1`
+   via their respective barrel jack connectors.
+
+.. TODO: uncomment when no-OS boot log is available
+.. Console output
+.. ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+..
+.. The project launches an IIO server on the SDP-K1. After connecting via
+.. IIO Oscilloscope or ``iio_info -u serial:/dev/ttyUSB0,230400``, the AD7616
+.. channels become available for data capture and visualization.
+..
+.. The following is what is printed in the serial console when the application
+.. starts:
+..
+.. .. collapsible:: Complete console log
+..
+..    ::
+..
+..       .. TODO: Paste the complete console output here.

--- a/docs/solutions/reference-designs/eval-ad7616-sdz/quickstart/zc706.rst
+++ b/docs/solutions/reference-designs/eval-ad7616-sdz/quickstart/zc706.rst
@@ -1,0 +1,153 @@
+.. _eval-ad7616-sdz quickstart zc706:
+
+ZC706 Quick Start Guide
+===============================================================================
+
+.. image:: ../../images/zc706.png
+   :width: 1000
+
+.. esd-warning::
+
+This guide provides quick instructions on how to setup the
+:adi:`EVAL-AD7616SDZ` on:
+
+- :xilinx:`ZC706` using the :adi:`SPD-I-FMC` adapter
+
+Using no-OS as software
+-------------------------------------------------------------------------------
+
+Necessary files
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The following files are needed:
+
+- HDL boot file: ``system_top.xsa``
+- no-OS project: :git-no-OS:`projects/ad7616-sdz`
+
+Instructions on how to build the HDL boot file from source can be found here:
+
+- :external+hdl:ref:`ad7616_sdz` build documentation.
+  More HDL build details at :external+hdl:ref:`build_hdl`.
+
+Required software
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- AMD Xilinx Vivado and Vitis (downloading Vitis from
+  `here <https://www.xilinx.com/support/download/index.html/content/xilinx/en/downloadNav/vitis.html>`_
+  will include Vivado as well)
+- A UART terminal (Putty/Tera Term/Minicom, etc.) with baud rate 115200 (8N1)
+
+Required hardware
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- :xilinx:`ZC706` FPGA board and its power supply (12 V DC)
+- :adi:`EVAL-AD7616SDZ` evaluation board and a 7 V to 9 V DC power supply (J7)
+- :adi:`SDP-I-FMC` adapter board
+- 2 x Micro-USB cable (UART & JTAG)
+
+More details as to why you need these, can be found at
+:ref:`eval-ad7616-sdz prerequisites`.
+
+Testing
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Creating the setup
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. .. image:: ../images/ad7616_zc706_setup.jpg
+..    :width: 900
+
+Follow the steps in this order, to avoid damaging the components:
+
+#. Connect the :adi:`EVAL-AD7616SDZ` to the :adi:`SPD-I-FMC` adapter
+#. Plug the :adi:`SPD-I-FMC` into the FMC connector of the :xilinx:`ZC706`
+#. Set the VADJ voltage on the ZC706 to **3.3 V**
+
+   .. warning::
+
+      Because of the :adi:`SPD-I-FMC`, the VADJ level on the ZC706 must be
+      set to **3.3 V**.
+
+#. Configure the EVAL-AD7616-SDZ resistors (on the back) as follows:
+
+   .. list-table::
+      :header-rows: 1
+
+      * - Jumper/Solder link
+        - Position
+        - Description
+      * - SL1
+        - Unmounted
+        - Channel Sequencer Enable
+      * - SL2
+        - Unmounted
+        - RC Enable Input
+      * - SL3
+        - Unmounted
+        - Selects 1 MISO mode
+      * - SL4
+        - Unmounted
+        - Oversampling Ratio Selection OS2
+      * - SL5
+        - Mounted
+        - If mounted, selects serial interface
+      * - SL6
+        - Unmounted
+        - Oversampling Ratio Selection OS1
+      * - SL7
+        - Unmounted
+        - Oversampling Ratio Selection OS0
+      * - LK40
+        - A
+        - Onboard 5V power supply selected
+      * - LK41
+        - A
+        - Onboard 3.3V power supply selected
+
+   .. note::
+
+      The configuration above selects the **serial** interface (SL5 mounted).
+      To use the **parallel** interface instead, unmount SL5.
+
+#. Connect Micro-USB cable to the UART connector on the ZC706 and to your
+   host PC
+#. Connect Micro-USB cable to the JTAG connector on the ZC706 and to your host 
+   PC
+#. Connect the power supply to the :xilinx:`ZC706`
+#. Connect a 7 V to 9 V DC power supply to the :adi:`EVAL-AD7616SDZ`
+   power jack (J7)
+#. Ensure both boards share a common ground connection
+#. Build the HDL project:
+
+   #. Verify you have the correct version of Vivado installed. The supported
+      version is listed on the :git-hdl:`HDL releases page <releases>`.
+   #. Build the HDL project to generate the ``system_top.xsa`` file using the
+      :external+hdl:ref:`build_hdl` guide.
+
+      .. important::
+
+         The make command varies based on the interface you want to use:
+
+            - **Serial** interface:
+
+            .. code-block:: bash
+
+               $ make SER_PAR_N=1
+
+            - **Parallel** interface:
+
+            .. code-block:: bash
+
+               $ make SER_PAR_N=0
+
+#. Refer to the `AD7616 No-Os Example Project <https://analogdevicesinc.github.io/no-OS/projects/adc/ad7616-sdz.html#xilinx-platform>`_
+   for instructions on how to build and run the no-OS project on the ZC706.
+#. Turn on the power switch on the ZC706
+#. Observe console output messages on your terminal (use the first ttyUSB or
+   COM port registered)
+
+.. Console output
+.. ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. TODO: Add the console output from the no-OS AD7616 application running on
+.. the ZC706.

--- a/docs/solutions/reference-designs/eval-ad7616-sdz/quickstart/zedboard.rst
+++ b/docs/solutions/reference-designs/eval-ad7616-sdz/quickstart/zedboard.rst
@@ -1,0 +1,169 @@
+.. _eval-ad7616-sdz quickstart zedboard:
+
+ZedBoard Quick Start Guide
+===============================================================================
+
+.. image:: ../../images/ZedBoard.png
+   :width: 500
+
+.. esd-warning::
+
+This guide provides quick instructions on how to setup the
+:adi:`EVAL-AD7616SDZ` on:
+
+- :xilinx:`ZedBoard` using the :adi:`SPD-I-FMC` adapter
+
+Using no-OS as software
+-------------------------------------------------------------------------------
+
+Necessary files
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The following files are needed:
+
+- HDL boot file: ``system_top.xsa``
+- no-OS project: :git-no-OS:`projects/ad7616-sdz`
+
+Instructions on how to build the HDL boot file from source can be found here:
+
+- :external+hdl:ref:`ad7616_sdz` build documentation.
+  More HDL build details at :external+hdl:ref:`build_hdl`.
+
+Required software
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- AMD Xilinx Vivado and Vitis (downloading Vitis from
+  `here <https://www.xilinx.com/support/download/index.html/content/xilinx/en/downloadNav/vitis.html>`_
+  will include Vivado as well)
+- A UART terminal (Putty/Tera Term/Minicom, etc.) with baud rate 115200 (8N1)
+
+Required hardware
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- :xilinx:`ZedBoard` FPGA board and its power supply (12 V DC)
+- :adi:`EVAL-AD7616SDZ` evaluation board and a 7 V to 9 V DC power supply (J7)
+- :adi:`SDP-I-FMC` adapter board
+- 2x Micro-USB cables, one for UART (J14) and one for JTAG (J17)
+
+More details as to why you need these, can be found at
+:ref:`eval-ad7616-sdz prerequisites`.
+
+Testing
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Creating the setup
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Follow the steps in this order, to avoid damaging the components:
+
+#. Connect the :adi:`EVAL-AD7616SDZ` to the :adi:`SPD-I-FMC` adapter
+
+   .. image:: ../images/ad7616sdp.jpeg
+      :width: 500
+
+#. Plug the :adi:`SPD-I-FMC` into the FMC connector of the :xilinx:`ZedBoard`
+
+   .. image:: ../images/zed_ad7616.jpeg
+      :width: 500
+
+#. Set the VADJ jumper on the ZedBoard to **3.3 V**
+
+   .. image:: ../images/zed_jumper.jpeg
+      :width: 500
+
+   .. warning::
+
+      Because of the :adi:`SPD-I-FMC`, the VADJ level on the ZedBoard must be 
+      set to **3.3 V**.
+
+#. Configure the EVAL-AD7616-SDZ resistors (on the back) as follows:
+
+   .. list-table::
+      :header-rows: 1
+
+      * - Jumper/Solder link
+        - Position
+        - Description
+      * - SL1
+        - Unmounted
+        - Channel Sequencer Enable
+      * - SL2
+        - Unmounted
+        - RC Enable Input
+      * - SL3
+        - Unmounted
+        - Selects 1 MISO mode
+      * - SL4
+        - Unmounted
+        - Oversampling Ratio Selection OS2
+      * - SL5
+        - Mounted
+        - If mounted, selects serial interface
+      * - SL6
+        - Unmounted
+        - Oversampling Ratio Selection OS1
+      * - SL7
+        - Unmounted
+        - Oversampling Ratio Selection OS0
+      * - LK40
+        - A
+        - Onboard 5V power supply selected
+      * - LK41
+        - A
+        - Onboard 3.3V power supply selected
+
+   .. note::
+
+      The configuration above selects the **serial** interface (SL5 mounted).
+      To use the **parallel** interface instead, unmount SL5.
+
+#. Connect Micro-USB cable to the UART connector (J14) on the ZedBoard and
+   to your host PC
+#. Connect Micro-USB cable to the JTAG connector (J17) on the ZedBoard and
+   to your host PC
+#. Connect the power supply to the :xilinx:`ZedBoard`
+
+   .. image:: ../images/zed_connections.jpeg
+      :width: 500
+
+#. Connect a 7 V to 9 V DC power supply to the :adi:`EVAL-AD7616SDZ`
+   power jack (J7)
+
+   .. image:: ../images/zed_power.jpeg
+      :width: 500
+
+#. Ensure both boards share a common ground connection
+#. Build the HDL project:
+
+   #. Verify you have the correct version of Vivado installed. The supported
+      version is listed on the :git-hdl:`HDL releases page <releases>`.
+   #. Build the HDL project to generate the ``system_top.xsa`` file using the
+      :external+hdl:ref:`build_hdl` guide.
+
+      .. important::
+
+         The make command varies based on the interface you want to use:
+
+            - **Serial** interface:
+
+            .. code-block:: bash
+
+               $ make SER_PAR_N=1
+
+            - **Parallel** interface:
+
+            .. code-block:: bash
+
+               $ make SER_PAR_N=0
+ 
+#. Refer to the `AD7616 No-Os Example Project <https://analogdevicesinc.github.io/no-OS/projects/adc/ad7616-sdz.html#xilinx-platform>`_
+   for instructions on how to build and run the no-OS project on the ZedBoard.
+#. Turn on the power switch on the ZedBoard
+#. Observe console output messages on your terminal (use the first ttyUSB or
+   COM port registered)
+
+.. Console output
+.. ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. TODO: Add the console output from the no-OS AD7616 application running on
+.. the ZedBoard.

--- a/docs/solutions/reference-designs/eval-ad7616-sdz/user-guide.rst
+++ b/docs/solutions/reference-designs/eval-ad7616-sdz/user-guide.rst
@@ -1,0 +1,167 @@
+.. _eval-ad7616-sdz user-guide:
+
+User guide
+===============================================================================
+
+HDL reference design
+-------------------------------------------------------------------------------
+
+An in-depth presentation and instructions about the HDL design can be found in
+the :external+hdl:ref:`HDL User Guide <user_guide>`. For a detailed description
+of the ``axi_ad7616`` core, refer to its documentation page.
+
+Data path
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The HDL data path is structured as follows:
+
+- The **parallel** interface is controlled by the ``axi_ad7616`` IP core.
+- The **serial** interface is controlled by the **SPI Engine Framework**.
+- Data is written into memory by a DMA (``axi_dmac`` core).
+- All control pins of the device are driven by GPIOs.
+
+Switching between interface types
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Before powering up the board, choose the required interface and configure the
+hardware jumpers as described in the quickstart guide for your carrier. Then
+build the HDL project with the matching parameter:
+
+Serial interface:
+
+.. code-block:: bash
+
+   $ make SER_PAR_N=1
+
+Parallel interface:
+
+.. code-block:: bash
+
+   $ make SER_PAR_N=0
+
+CPU/memory interconnect addresses
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. list-table::
+   :header-rows: 1
+
+   * - Instance
+     - Address
+   * - axi_ad7616_dma
+     - 0x44A30000
+   * - ad7616_pwm_gen
+     - 0x44B00000
+   * - spi_ad7616_axi_regmap
+     - 0x44A00000
+   * - axi_ad7616
+     - 0x44A80000
+
+.. note::
+
+   - ``spi_ad7616_axi_regmap`` is instantiated only when ``SER_PAR_N=1``
+   - ``axi_ad7616`` is instantiated only when ``SER_PAR_N=0``
+
+PL interrupts
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+PS7 EMIO offset = 54
+
+.. list-table::
+   :header-rows: 1
+
+   * - Instance
+     - HDL interrupt
+     - PS7 interrupt
+   * - ---
+     - 0
+     - 89
+   * - ---
+     - 1
+     - 90
+   * - ---
+     - 2
+     - 91
+   * - ---
+     - 3
+     - 92
+   * - ---
+     - 4
+     - 93
+   * - ---
+     - 5
+     - 94
+   * - ---
+     - 6
+     - 95
+   * - ---
+     - 7
+     - 96
+   * - ---
+     - 8
+     - 104
+   * - ---
+     - 9
+     - 105
+   * - axi_ad7616
+     - 10
+     - 106
+   * - ---
+     - 11
+     - 107
+   * - spi_ad7616
+     - 12
+     - 108
+   * - axi_ad7616_dma
+     - 13
+     - 109
+   * - ---
+     - 14
+     - 110
+   * - ---
+     - 15
+     - 111
+
+.. note::
+
+   - ``spi_ad7616`` is instantiated only when ``SER_PAR_N=1``
+   - ``axi_ad7616`` is instantiated only when ``SER_PAR_N=0``
+
+GPIO signals
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+PS7 EMIO offset = 54
+
+.. list-table::
+   :header-rows: 1
+
+   * - GPIO signal
+     - GPIO number
+     - HDL GPIO number
+   * - adc_reset_n
+     - 97
+     - 43
+   * - adc_hw_rngsel
+     - 96–95
+     - 42–41
+   * - adc_os
+     - 94–92
+     - 40–38
+   * - adc_seq_en
+     - 91
+     - 37
+   * - adc_burst
+     - 90
+     - 36
+   * - adc_chsel
+     - 89–87
+     - 35–33
+   * - adc_crcen
+     - 86
+     - 32
+
+Downloads
+-------------------------------------------------------------------------------
+
+- :git-hdl:`HDL project <projects/ad7616_sdz>`
+- :git-no-OS:`No-OS project (ZedBoard/ZC706) <projects/ad7616-sdz>`
+- :git-no-OS:`No-OS project (SDP-K1) <projects/ad7616-st>`


### PR DESCRIPTION
-added landing page, quickstarts, prerequisites, user guide and images


## Type
- [x] Documentation
- [ ] Bug fix
- [ ] New feature
- [ ] Continuous integration

## Checklist
- [x] I have performed a self-review of changes
- [x] I have followed the guidelines:
  * https://analogdevicesinc.github.io/documentation/contributing/docs_guidelines.html
  * https://analogdevicesinc.github.io/doctools/docs_guidelines/index.html
  * https://analogdevicesinc.github.io/documentation/contributing/creating_new_pages.html#documentation-structure
- [x] I have used the appropriate roles and directives:
  * https://analogdevicesinc.github.io/doctools/docs_guidelines/roles.html
  * https://analogdevicesinc.github.io/doctools/docs_guidelines/directives.html
- [x] I ensured that binary data was committed to git lfs:
  * https://analogdevicesinc.github.io/documentation/contributing/creating_new_pages.html#adding-images-and-other-binary-files
- [x] I have built the pages I edited or created, using either `make html` or `adoc serve`:
  * https://analogdevicesinc.github.io/doctools/cli.html#serve
- [x] I have signed-off my commits and believe my contribution improves the repository.
