### PR TITLE
reference-designs: Add AD974x system level doc and quickstart guides

### DIFF
--- a/docs/solutions/reference-designs/eval-ad974x-fmc/images/ad9744-bottom.jpeg
+++ b/docs/solutions/reference-designs/eval-ad974x-fmc/images/ad9744-bottom.jpeg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c6e33f8c7bf533ca82b57341722adb535e5460de60892a1df664394aa60c89e9
+size 143785

--- a/docs/solutions/reference-designs/eval-ad974x-fmc/images/ad9744-top.jpeg
+++ b/docs/solutions/reference-designs/eval-ad974x-fmc/images/ad9744-top.jpeg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7d499160877b67b4daa0786368e3577b4c8bece6e69d630027328712522a80df
+size 216405

--- a/docs/solutions/reference-designs/eval-ad974x-fmc/images/ad9744_ace.jpeg
+++ b/docs/solutions/reference-designs/eval-ad974x-fmc/images/ad9744_ace.jpeg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e80ef55c00a2080d2802007beabb9f482db088d786f19868f780341c573f96ce
+size 40850

--- a/docs/solutions/reference-designs/eval-ad974x-fmc/images/ad9744_ace_error.jpeg
+++ b/docs/solutions/reference-designs/eval-ad974x-fmc/images/ad9744_ace_error.jpeg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:043f0cb45cff44c35023ad0513f14417c5e20812550532601c49f3c0ef268cd3
+size 24494

--- a/docs/solutions/reference-designs/eval-ad974x-fmc/images/ad9744_ace_install.jpeg
+++ b/docs/solutions/reference-designs/eval-ad974x-fmc/images/ad9744_ace_install.jpeg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1a54e7af7d1c4ecca24e549baf1c6daf3e598f053be0d96a9701a0b9e3d2ea12
+size 57523

--- a/docs/solutions/reference-designs/eval-ad974x-fmc/images/ad9744_block_diagram.jpeg
+++ b/docs/solutions/reference-designs/eval-ad974x-fmc/images/ad9744_block_diagram.jpeg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f308eb35b85b93fec699136dc4a89de0147dd94ef4ba53be68ef35a5046fa740
+size 176948

--- a/docs/solutions/reference-designs/eval-ad974x-fmc/images/ad9744_chip_icon.jpeg
+++ b/docs/solutions/reference-designs/eval-ad974x-fmc/images/ad9744_chip_icon.jpeg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:807b49c89b7ad3bf12c213f171caf9f40ce400a295932dc329bd0295ffbcc239
+size 204221

--- a/docs/solutions/reference-designs/eval-ad974x-fmc/images/ad9744_dpg.jpeg
+++ b/docs/solutions/reference-designs/eval-ad974x-fmc/images/ad9744_dpg.jpeg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e8d967f49dd62509a6c157bc260be8d9fe21e24a7552f43c21097e79af727d96
+size 32419

--- a/docs/solutions/reference-designs/eval-ad974x-fmc/images/ad9744_eval_board.jpeg
+++ b/docs/solutions/reference-designs/eval-ad974x-fmc/images/ad9744_eval_board.jpeg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:844ac6ea20daaff33a81e5e23e36e4d2dff2e07a65dea98dbd4d464e0be3965d
+size 127643

--- a/docs/solutions/reference-designs/eval-ad974x-fmc/images/ad9744_led.jpeg
+++ b/docs/solutions/reference-designs/eval-ad974x-fmc/images/ad9744_led.jpeg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1fc9678b797c8d4de25604ef847696d6550b4cfac24661ba8fe94a028dac320e
+size 181491

--- a/docs/solutions/reference-designs/eval-ad974x-fmc/images/ad9744_output.jpeg
+++ b/docs/solutions/reference-designs/eval-ad974x-fmc/images/ad9744_output.jpeg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:71b2811af82c540fbffd173a74b18ec15fbff8cc382522322f6cbaa029e26a64
+size 44679

--- a/docs/solutions/reference-designs/eval-ad974x-fmc/images/ad9744_sdp_h1.jpeg
+++ b/docs/solutions/reference-designs/eval-ad974x-fmc/images/ad9744_sdp_h1.jpeg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d8ade3b150d95b7db50889d77d99e8248b4ec71e28559372b182f58e7b352ccd
+size 29828

--- a/docs/solutions/reference-designs/eval-ad974x-fmc/images/ad9744_zed.jpeg
+++ b/docs/solutions/reference-designs/eval-ad974x-fmc/images/ad9744_zed.jpeg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0756d59d781e92b87f2bdee380970c79e04ccd2192fd6048971f802bf8587415
+size 1797786

--- a/docs/solutions/reference-designs/eval-ad974x-fmc/images/python_plot_ad3552r.jpeg
+++ b/docs/solutions/reference-designs/eval-ad974x-fmc/images/python_plot_ad3552r.jpeg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:22877a2cb751ba27889754fee85b6f8be088d2ac4a853d409f1852fd0ba9a6d3
+size 37760

--- a/docs/solutions/reference-designs/eval-ad974x-fmc/images/zed_board.jpeg
+++ b/docs/solutions/reference-designs/eval-ad974x-fmc/images/zed_board.jpeg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e7e8b5d930df05f4a165f3e15e42d96a6db48ade0102e8607b432eb077769390
+size 1518833

--- a/docs/solutions/reference-designs/eval-ad974x-fmc/images/zed_vadj_sd_boot.jpeg
+++ b/docs/solutions/reference-designs/eval-ad974x-fmc/images/zed_vadj_sd_boot.jpeg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:381b4bd68747c8239c533b68cb109426e67053176112737a25a71a1096ea3c8d
+size 340657

--- a/docs/solutions/reference-designs/eval-ad974x-fmc/index.rst
+++ b/docs/solutions/reference-designs/eval-ad974x-fmc/index.rst
@@ -1,0 +1,145 @@
+.. _eval-ad974x fmc ebz:
+
+EVAL-AD974X
+===============================================================================
+
+14-Bit / 12-Bit / 10-Bit / 8-Bit, 210 MSPS TxDAC D/A Converter Evaluation Board.
+
+.. image:: ./images/ad9744_chip_icon.jpeg
+   :align: left
+   :width: 150
+
+Overview
+-------------------------------------------------------------------------------
+
+The :adi:`EVAL-AD9740` / :adi:`EVAL-AD9742`/ :adi:`EVAL-AD9744` /
+:adi:`EVAL-AD9748` evaluation board allows users to easily set up and test the
+32-lead lead frame chip scale package (LFCSP) of the :adi:`AD9740` /
+:adi:`AD9742` / :adi:`AD9744` / :adi:`AD9748` devices. Paying careful attention
+to layout and circuit design, combined with a prototyping area, allows the user
+to effectively evaluate the AD9740, AD9742, AD9744, and AD9748 in applications
+that require high resolution and high speed conversion. 
+
+The evaluation board interfaces with an FPGA carrier via an FMC LPC
+connector, using the `ZedBoard <https://www.avnet.com/wps/portal/us/
+products/avnet-boards/avnet-board-families/zedboard/>`_ (Zynq-7000
+SoC) as the supported FPGA platform.
+
+Features:
+
+- High performance member of pin-compatible TxDAC product family
+- Excellent SFDR performance
+- Twos complement or straight binary data format
+- Differential current outputs: 2 mA to 20 mA
+- Power dissipation: 135 mW at 3.3 V
+- Power-down mode: 15 mW at 3.3 V
+- On-chip 1.2 V reference
+- CMOS-compatible digital interface
+- 32-lead LFCSP package
+- Edge triggered latches
+
+Applications:
+
+- Direct IFs 
+- Base stations 
+- Wireless local loops 
+- Digital radio links 
+- Direct digital synthesis (DDS) 
+- Instrumentation
+
+.. figure:: ./images/ad9744_eval_board.jpeg
+   :alt: Photo of the EVAL-AD974x evaluation board
+   :align: center
+   :width: 600
+
+   EVAL-AD974x
+
+.. toctree::
+   :hidden:
+
+   user-guide
+   prerequisites
+   quickstart/index
+
+Recommendations
+-------------------------------------------------------------------------------
+
+People who follow the flow that is outlined have a much better experience
+with things. However, like many things, documentation is never as complete
+as it should be. If you have any questions, feel free to ask on our
+:ez:`/`, but before that, please make sure you read our documentation
+thoroughly.
+
+To better understand the :adi:`AD9740` / :adi:`AD9742` / :adi:`AD9744` /
+:adi:`AD9748`, we recommend using the :adi:`EVAL-AD9740 <EVAL-AD39740>` /
+:adi:`EVAL-AD9742 <EVAL-AD39742>` / :adi:`EVAL-AD9744 <EVAL-AD39744>` /
+:adi:`EVAL-AD9748 <EVAL-AD39748>` evaluation board together with the
+`ZedBoard <https://www.avnet.com/wps/portal/us/products/avnet-boards/
+avnet-board-families/zedboard/>`_ FPGA development kit.
+
+Table of contents
+-------------------------------------------------------------------------------
+
+#. Using the evaluation board/full stack reference design that we offer:
+
+   #. :ref:`Prerequisites <eval-ad974x fmc ebz prerequisites>` - what you
+      need to get started
+   #. :ref:`Quick start guides <eval-ad974x fmc ebz quickstart>`:
+
+      #. Using the :ref:`ZedBoard <eval-ad974x fmc ebz quickstart zed>`
+      #. Using the :ref:`SDP-H1 <eval-ad974x fmc ebz quickstart sdp-h1-ace>`
+
+   #. Linux Applications
+
+      #. :ref:`iio-oscilloscope`
+      #. :external+scopy:doc:`Scopy <index>`
+
+#. Design with the AD9740 / AD9742 / AD744 / AD9748
+
+   - :ref:`eval-ad974x fmc ebz block-diagram`
+
+     - :adi:`AD9740` product page
+     - :adi:`AD9742` product page
+     - :adi:`AD9744` product page
+     - :adi:`AD9748` product page
+
+   - Resources for designing a custom AD974x-based platform:
+
+     #. For Linux software:
+
+        #. About the device driver:
+
+           - :external+linux:ref:`AXI-DMAC DMA Controller Linux driver <axi-dmac>`
+
+     #. :external+hdl:ref:`HDL reference design <ad9740_fmc>` which you
+        must use in your FPGA.
+
+#. :ref:`Help and Support <help-and-support>`
+
+.. _eval-ad974x fmc ebz block-diagram:
+
+Block diagram
+-------------------------------------------------------------------------------
+
+The :adi:`AD9740` HDL reference design on the ZedBoard uses the
+:external+hdl:ref:`AXI AD9740 <axi_ad9740>` IP core to interface the
+DAC via a parallel bus. The AXI-DMAC streams sample data from DDR memory
+to the IP core, which drives the AD974x at up to 210 MSPS.
+
+.. figure:: ./images/ad9744_block_diagram.jpeg
+   :alt: AD974x block diagram
+
+   AD974x block diagram.
+
+ADI articles
+-------------------------------------------------------------------------------
+
+#. :adi:`AD9740 Product Page <AD9740>`
+#. :adi:`AD9742 Product Page <AD9742>`
+#. :adi:`AD9744 Product Page <AD9744>`
+#. :adi:`AD9748 Product Page <AD9748>`
+
+Warning
+-------------------------------------------------------------------------------
+
+.. esd-warning::

--- a/docs/solutions/reference-designs/eval-ad974x-fmc/index.rst
+++ b/docs/solutions/reference-designs/eval-ad974x-fmc/index.rst
@@ -18,7 +18,7 @@ The :adi:`EVAL-AD9740` / :adi:`EVAL-AD9742`/ :adi:`EVAL-AD9744` /
 :adi:`AD9742` / :adi:`AD9744` / :adi:`AD9748` devices. Paying careful attention
 to layout and circuit design, combined with a prototyping area, allows the user
 to effectively evaluate the AD9740, AD9742, AD9744, and AD9748 in applications
-that require high resolution and high speed conversion. 
+that require high resolution and high speed conversion.
 
 The evaluation board interfaces with an FPGA carrier via an FMC LPC
 connector, using the `ZedBoard <https://www.avnet.com/wps/portal/us/
@@ -40,11 +40,11 @@ Features:
 
 Applications:
 
-- Direct IFs 
-- Base stations 
-- Wireless local loops 
-- Digital radio links 
-- Direct digital synthesis (DDS) 
+- Direct IFs
+- Base stations
+- Wireless local loops
+- Digital radio links
+- Direct digital synthesis (DDS)
 - Instrumentation
 
 .. figure:: ./images/ad9744_eval_board.jpeg
@@ -71,10 +71,10 @@ as it should be. If you have any questions, feel free to ask on our
 thoroughly.
 
 To better understand the :adi:`AD9740` / :adi:`AD9742` / :adi:`AD9744` /
-:adi:`AD9748`, we recommend using the :adi:`EVAL-AD9740 <EVAL-AD39740>` /
-:adi:`EVAL-AD9742 <EVAL-AD39742>` / :adi:`EVAL-AD9744 <EVAL-AD39744>` /
-:adi:`EVAL-AD9748 <EVAL-AD39748>` evaluation board together with the
-`ZedBoard <https://www.avnet.com/wps/portal/us/products/avnet-boards/
+:adi:`AD9748`, we recommend using the :adi:`EVAL-AD9740 <EVAL-AD9740>` /
+:adi:`EVAL-AD9742 <EVAL-AD9742>` / :adi:`EVAL-AD9744 <EVAL-AD9744>` /
+:adi:`EVAL-AD9748 <EVAL-AD9748>` evaluation board together with the
+`Zedboard <https://www.avnet.com/wps/portal/us/products/avnet-boards/
 avnet-board-families/zedboard/>`_ FPGA development kit.
 
 Table of contents
@@ -94,7 +94,7 @@ Table of contents
       #. :ref:`iio-oscilloscope`
       #. :external+scopy:doc:`Scopy <index>`
 
-#. Design with the AD9740 / AD9742 / AD744 / AD9748
+#. Design with the AD9740 / AD9742 / AD9744 / AD9748
 
    - :ref:`eval-ad974x fmc ebz block-diagram`
 
@@ -121,7 +121,7 @@ Table of contents
 Block diagram
 -------------------------------------------------------------------------------
 
-The :adi:`AD9740` HDL reference design on the ZedBoard uses the
+The :adi:`AD9740` HDL reference design on the Zedboard uses the
 :external+hdl:ref:`AXI AD9740 <axi_ad9740>` IP core to interface the
 DAC via a parallel bus. The AXI-DMAC streams sample data from DDR memory
 to the IP core, which drives the AD974x at up to 210 MSPS.

--- a/docs/solutions/reference-designs/eval-ad974x-fmc/prerequisites.rst
+++ b/docs/solutions/reference-designs/eval-ad974x-fmc/prerequisites.rst
@@ -9,7 +9,7 @@ to start out with:
 Hardware prerequisites
 -------------------------------------------------------------------------------
 
-#. One of the AD35xxR evaluation boards:
+#. One of the AD974x evaluation boards:
 
    - :adi:`EVAL-AD9740 <EVAL-AD9740>` - 10-bit variant
    - :adi:`EVAL-AD9742 <EVAL-AD9742>` - 12-bit variant
@@ -28,21 +28,21 @@ Software prerequisites
 -------------------------------------------------------------------------------
 
 The following files must be placed on the micro-SD card boot partition
-before powering on the ZedBoard. They are available as part of the ADI
+before powering on the Zedboard. They are available as part of the ADI
 Kuiper Linux image:
 
-- ``BOOT.BIN`` - pre-built boot binary for the EVAL-AD3552R on ZedBoard
+- ``BOOT.BIN`` - pre-built boot binary for the EVAL-AD9740 / EVAL-AD9742 /
+  EVAL-AD9744 / EVAL-AD9748 on Zedboard
 - ``uImage`` - Linux kernel image
-- ``devicetree.dtb`` - device tree blob for the ZedBoard + EVAL-AD9740 /
+- ``devicetree.dtb`` - device tree blob for the Zedboard + EVAL-AD9740 /
   EVAL-AD9742 / EVAL-AD9744 / EVAL-AD9748
 
 For basic data visualization and DAC control we use:
 
-#. `libiio <https://github.com/analogdevicesinc/libiio/releases>`_
-   (required by pyadi-iio on the host PC)
+#. :git-libiio:`libiio <releases/latest+>` (required by pyadi-iio on the host PC)
 #. :git-pyadi-iio:`PyADI-IIO </>` - optional Python scripting interface
 
 .. note::
 
    :adi:`ADI <>` does not offer FPGA carrier platforms for sale or loan;
-   obtaining a ZedBoard is a normal part of evaluation and development.
+   obtaining a Zedboard is a normal part of evaluation and development.

--- a/docs/solutions/reference-designs/eval-ad974x-fmc/prerequisites.rst
+++ b/docs/solutions/reference-designs/eval-ad974x-fmc/prerequisites.rst
@@ -1,0 +1,48 @@
+.. _eval-ad974x fmc ebz prerequisites:
+
+Prerequisites
+===============================================================================
+
+What you need depends on what you are trying to do. As a minimum, you need
+to start out with:
+
+Hardware prerequisites
+-------------------------------------------------------------------------------
+
+#. One of the AD35xxR evaluation boards:
+
+   - :adi:`EVAL-AD9740 <EVAL-AD9740>` - 10-bit variant
+   - :adi:`EVAL-AD9742 <EVAL-AD9742>` - 12-bit variant
+   - :adi:`EVAL-AD9744 <EVAL-AD9744>` - 14-bit variant
+   - :adi:`EVAL-AD9748 <EVAL-AD9748>` -  8-bit variant
+
+#. `ZedBoard <https://www.avnet.com/wps/portal/us/products/avnet-boards/
+   avnet-board-families/zedboard/>`_ Rev D or later (Zynq-7000 SoC)
+#. 16 GB (or larger) Class 10 micro-SD card
+#. 12 V, 3 A power supply for the ZedBoard
+#. Micro-USB cable (UART, J14 on ZedBoard)
+#. Ethernet cable
+#. An oscilloscope for monitoring DAC outputs (J4, J5 SMB connectors)
+
+Software prerequisites
+-------------------------------------------------------------------------------
+
+The following files must be placed on the micro-SD card boot partition
+before powering on the ZedBoard. They are available as part of the ADI
+Kuiper Linux image:
+
+- ``BOOT.BIN`` - pre-built boot binary for the EVAL-AD3552R on ZedBoard
+- ``uImage`` - Linux kernel image
+- ``devicetree.dtb`` - device tree blob for the ZedBoard + EVAL-AD9740 /
+  EVAL-AD9742 / EVAL-AD9744 / EVAL-AD9748
+
+For basic data visualization and DAC control we use:
+
+#. `libiio <https://github.com/analogdevicesinc/libiio/releases>`_
+   (required by pyadi-iio on the host PC)
+#. :git-pyadi-iio:`PyADI-IIO </>` - optional Python scripting interface
+
+.. note::
+
+   :adi:`ADI <>` does not offer FPGA carrier platforms for sale or loan;
+   obtaining a ZedBoard is a normal part of evaluation and development.

--- a/docs/solutions/reference-designs/eval-ad974x-fmc/quickstart/index.rst
+++ b/docs/solutions/reference-designs/eval-ad974x-fmc/quickstart/index.rst
@@ -19,8 +19,8 @@ IIO client usage.
 Supported carriers
 -------------------------------------------------------------------------------
 
-The :adi:`EVAL-AD9740`, :adi:`EVAL-AD9742`, :adi:`EVAL-AD9744` or 
-:adi:`EVAL-AD9748` connects to the FPGA carrier via an FMC LPC connector. 
+The :adi:`EVAL-AD9740`, :adi:`EVAL-AD9742`, :adi:`EVAL-AD9744` or
+:adi:`EVAL-AD9748` connects to the FPGA carrier via an FMC LPC connector.
 VADJ must be set to 3.3 V.
 
 .. list-table::
@@ -36,7 +36,7 @@ VADJ must be set to 3.3 V.
      - FMC LPC
      - FMC LPC
      - FMC LPC
-   * - `SDP-H1 <https://www.analog.com/en/resources/evaluation-hardware-and-software/evaluation-boards-kits/eval-sdp-h1.html>`_
+   * - :adi:`SDP-H1 <EVAL-SDP-H1>`
      - FMC LPC
      - FMC LPC
      - FMC LPC
@@ -56,7 +56,7 @@ Supported environments
      - Yes
      - Yes
      - No
-   * - `SDP-H1 <https://www.analog.com/en/resources/evaluation-hardware-and-software/evaluation-boards-kits/eval-sdp-h1.html>`_
+   * - :adi:`SDP-H1 <EVAL-SDP-H1>`
      - No
      - No
      - No
@@ -71,7 +71,7 @@ avnet-board-families/zedboard/>`_ via the FMC LPC connector (P1 on the
 evaluation board, FMC on the ZedBoard). Before inserting the evaluation
 board, set VADJ to 3.3 V and configure the ZedBoard for SD card boot.
 
-The :adi:`EVAL-AD9740`, :adi:`EVAL-AD9742`, :adi:`EVAL-AD9744` or 
+The :adi:`EVAL-AD9740`, :adi:`EVAL-AD9742`, :adi:`EVAL-AD9744` or
 :adi:`EVAL-AD9748` can also be controlled with the :adi:`EVAL-SDP-H1` controller
 board and the :adi:`ACE` software, without any FPGA or Linux system.
 
@@ -82,7 +82,7 @@ ZedBoard + EVAL-AD974X
      :alt: ZedBoard with EVAL-AD9744 inserted into the FMC LPC connector
      :width: 800
 
-     ZedBoard with EVAL-AD974X hardware setup                                                                                                                                                                                                                                                                                                                       
+     ZedBoard with EVAL-AD974X hardware setup
 
 Go to :ref:`the quick start guide <eval-ad974x fmc ebz quickstart zed>`.
 

--- a/docs/solutions/reference-designs/eval-ad974x-fmc/quickstart/index.rst
+++ b/docs/solutions/reference-designs/eval-ad974x-fmc/quickstart/index.rst
@@ -1,0 +1,98 @@
+.. _eval-ad974x fmc ebz quickstart:
+
+Quick start
+===============================================================================
+
+The quick start guide provides step-by-step instructions for setting up
+the :adi:`EVAL-AD9740`, :adi:`EVAL-AD9742`, :adi:`EVAL-AD9744` or
+:adi:`EVAL-AD9748` evaluation board on the supported FPGA development
+board. This guide covers SD card preparation, hardware setup, and Linux
+IIO client usage.
+
+.. toctree::
+
+   On ZedBoard <zed>
+   On SDP-H1 <sdp-h1-ace>
+
+.. _ad974x fmc ebz carriers:
+
+Supported carriers
+-------------------------------------------------------------------------------
+
+The :adi:`EVAL-AD9740`, :adi:`EVAL-AD9742`, :adi:`EVAL-AD9744` or 
+:adi:`EVAL-AD9748` connects to the FPGA carrier via an FMC LPC connector. 
+VADJ must be set to 3.3 V.
+
+.. list-table::
+   :header-rows: 1
+
+   * - FPGA board
+     - :adi:`EVAL-AD9740 <EVAL-AD9740>`
+     - :adi:`EVAL-AD9742 <EVAL-AD9742>`
+     - :adi:`EVAL-AD9744 <EVAL-AD9744>`
+     - :adi:`EVAL-AD9748 <EVAL-AD9748>`
+   * - `ZedBoard <https://www.avnet.com/wps/portal/us/products/avnet-boards/avnet-board-families/zedboard/>`_
+     - FMC LPC
+     - FMC LPC
+     - FMC LPC
+     - FMC LPC
+   * - `SDP-H1 <https://www.analog.com/en/resources/evaluation-hardware-and-software/evaluation-boards-kits/eval-sdp-h1.html>`_
+     - FMC LPC
+     - FMC LPC
+     - FMC LPC
+     - FMC LPC
+
+Supported environments
+-------------------------------------------------------------------------------
+
+.. list-table::
+   :header-rows: 1
+
+   * - FPGA board
+     - HDL
+     - Linux software
+     - No-OS software
+   * - `ZedBoard <https://www.avnet.com/wps/portal/us/products/avnet-boards/avnet-board-families/zedboard/>`_
+     - Yes
+     - Yes
+     - No
+   * - `SDP-H1 <https://www.analog.com/en/resources/evaluation-hardware-and-software/evaluation-boards-kits/eval-sdp-h1.html>`_
+     - No
+     - No
+     - No
+
+Hardware setup
+-------------------------------------------------------------------------------
+
+The :adi:`EVAL-AD9740`, :adi:`EVAL-AD9742`, :adi:`EVAL-AD9744` or
+:adi:`EVAL-AD9748` connects to the
+`ZedBoard <https://www.avnet.com/wps/portal/us/products/avnet-boards/
+avnet-board-families/zedboard/>`_ via the FMC LPC connector (P1 on the
+evaluation board, FMC on the ZedBoard). Before inserting the evaluation
+board, set VADJ to 3.3 V and configure the ZedBoard for SD card boot.
+
+The :adi:`EVAL-AD9740`, :adi:`EVAL-AD9742`, :adi:`EVAL-AD9744` or 
+:adi:`EVAL-AD9748` can also be controlled with the :adi:`EVAL-SDP-H1` controller
+board and the :adi:`ACE` software, without any FPGA or Linux system.
+
+ZedBoard + EVAL-AD974X
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+  .. figure:: ../images/ad9744_zed.jpeg
+     :alt: ZedBoard with EVAL-AD9744 inserted into the FMC LPC connector
+     :width: 800
+
+     ZedBoard with EVAL-AD974X hardware setup                                                                                                                                                                                                                                                                                                                       
+
+Go to :ref:`the quick start guide <eval-ad974x fmc ebz quickstart zed>`.
+
+SDP-H1 + EVAL-AD974X + ACE
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+  .. figure:: ../images/ad9744_sdp_h1.jpeg
+     :alt: AD9744-FMC-EBZ Evaluation Board with SDP-H1
+     :width: 800
+
+     AD9744-FMC-EBZ Evaluation Board with SDP-H1.
+
+Go to :ref:`the quick start guide <eval-ad974x fmc ebz quickstart sdp-h1-ace>`.

--- a/docs/solutions/reference-designs/eval-ad974x-fmc/quickstart/sdp-h1-ace.rst
+++ b/docs/solutions/reference-designs/eval-ad974x-fmc/quickstart/sdp-h1-ace.rst
@@ -1,0 +1,323 @@
+.. _eval-ad974x fmc ebz quickstart sdp-h1-ace:
+
+SDP-H1 quick start
+===============================================================================
+
+This user guide describes both the hardware and software setup needed to acquire
+data capture from :adi:`EVAL-AD9740`, :adi:`EVAL-AD9742`, :adi:`EVAL-AD9744` or
+:adi:`EVAL-AD9748` evaluation boards to characterize the AD9748 8-bit, AD9740
+10-bit, AD9742 12-bit, and AD9744 14-bit, 210 MSPS TxDAC digital-to-analog
+converters.
+
+The evaluation boards have an FMC form-factor with FMC connector that is
+compatible to the Vita 57.1 standard. The boards provide provision for on-board
+clocking (using ACE software for control) or external direct clocking. The
+:adi:`EVAL-SDP-H1` controller board automatically formats the data and sends it
+to the evaluation board, which simplifies the evaluation of the device. The
+evaluation board receives power from the SDP-H1 power supply.
+
+This guide shows how AD9740-FMC-EBZ, AD9742-FMC-EBZ, AD9744-FMC-EBZ or
+AD9748-FMC-EBZ work with SDP-H1 controller board developed by Analog Devices.
+Link to the previous user guide document is provided for customers who still
+have the DPG2 controller board.
+
+  .. figure:: ../images/ad9744_sdp_h1.jpeg
+     :alt: AD9744-FMC-EBZ Evaluation Board with SDP-H1
+     :width: 800
+
+     AD9744-FMC-EBZ Evaluation Board with SDP-H1.
+
+**Reconfiguring the Evaluation Board**
+
+This section details the quick start procedures for setting up the
+:adi:`EVAL-AD9740`, :adi:`EVAL-AD9742`, :adi:`EVAL-AD9744` or :adi:`EVAL-AD9748`
+evaluation board.
+Refer to the table below to configure the clock and output option of the
+evaluation board.
+
+- **Clock Configuration**
+
+The evaluation board has a provision for on-board or external clocking
+configuration.
+
+  .. list-table::
+     :header-rows: 1
+
+     * - Steps
+       - On-board (ADF4351)
+       - External Clock (J3 and J4)
+     * - Install (0-ohm, 0402)
+       - R46, R47, R50, R51
+       - R42, R44, R45, R48, R49
+     * - Don't Install
+       - R44, R45, R48, R49
+       - R43, R46, R47, R50, R51
+
+- The on-board clocking configuration is implemented by default.
+- For external clocking configuration, split the output of a High-Frequency
+  Clock Source (e.g. SMA100A) using an SMA T-adapter and connect to J3 and J4 of
+  the evaluation board. Set SMA to desired clock frequency and 16dBm output.
+
+- **Output Configuration**
+
+The evaluation board has a provision for single-ended or differential output.
+The single-ended configuration is implemented by default.
+
+  .. list-table::
+     :header-rows: 1
+
+     * - Steps
+       - Single Ended Output (J1 Only)
+       - Differential Output (J1 and J2)
+     * - Install
+       - T1 (ADT1-1+)
+       - R19, R20 (0-ohm)
+     * - Don't Install
+       - R19, R20 (0-ohm)
+       - T1 (ADT1-1+)
+
+- **Board Jumpers Configuration**
+
+A 0402, 0-ohm resistor are installed on the jumpers. Move these 0-ohm resistors
+accordingly to the required configuration as shown bellow.
+
+  .. list-table::
+     :header-rows: 1
+
+     * - Name
+       - Function
+       - Options
+     * - JP1
+       - DAC input data mode.
+       - 1 for twos complement, 3 for straight binary (default)
+     * - JP2
+       - Clock input mode
+       - 1 for differential receiver, 3 for single-ended receiver, Float for PECL receiver (default)
+     * - JP3
+       - ADF4351 RF Power Down
+       - 1 for power up (default), 2 for power down
+
+
+**Software Installation**
+
+The ACE software and DPGDownloader Lite are needed to configure the device.
+ACE is the software that is used to load the registers in the ADF4351 while
+DPGDownloader Lite is used to load the vector into the evaluation board.
+Install ACE from this link Analysis | Control | Evaluation (ACE) Software.
+During installation, expand the High-Speed DAC Components list and select the
+DPG Lite and HSDAC eval boards support through SDP drivers checkboxes. The
+plugins for this board can be downloaded from the plugin manager in the ACE
+software.
+
+  .. figure:: ../images/ad9744_ace_install.jpeg
+     :alt: DPG Lite Installation
+     :width: 800
+
+     DPG Lite Installation.
+
+**Configuring the EVB using ACE**
+
+To configure the evaluation board to output a 5.0MHz sine wave at 210MSPS with
+DPGDownloader Lite and ACE software, take the following steps:
+
+Follow the steps to set-up and configure the clocking of the eval board.
+
+#. From the initial ACE screen, click the AD9744-FMC-EBZ.
+#. On the Clocking Setup Tab, select Onboard clock (ADF4351) on the clock source
+   drop-down menu, and enter 210MHz on the DAC clock field.
+#. Click Apply and a summary window will pop up. Confirm if the entered details
+   are correct.
+
+  .. figure:: ../images/ad9744_ace.jpeg
+     :alt: AD9744 Plugin Board Wizard
+     :width: 800
+
+     AD9744 Plugin Board Wizard.
+
+**Loading a vector using DPGDownloader Lite**
+
+Follow the steps to generate and download a vector into the eval board.
+
+#. Confirm first if the DCO frequency detected is the same as the clock
+   frequency set on ACE (210MHz). Repeat the ACE process if frequencies don't
+   match.
+
+#. In the DPGDownloader Lite window, click the Add Generated Waveform dropdown
+   menu and select Single Tone as the vector type.
+
+#. Refer to bellow table for the appropriate frequency values and default
+   settings.
+
+Note: Select 14 bits DAC Resolution for all generics (AD9744, AD9740, AD9742 &
+AD9748).The NC pins are disconnected in the corresponding evaluation board.
+ 
+   .. list-table::
+     :header-rows: 1
+
+     * - FMC Pin
+       - AD9744
+       - AD9742
+       - AD9740
+       - AD9748
+     * - G9(MSB)
+       - DB13
+       - DB11
+       - DB09
+       - DB07
+     * - G10
+       - DB12
+       - DB10
+       - DB08
+       - DB06
+     * - H10
+       - DB11
+       - DB09
+       - DB07
+       - DB05
+     * - C10
+       - DB10
+       - DB08
+       - DB06
+       - DB04
+     * - H11
+       - DB09
+       - DB07
+       - DB05
+       - DB03
+     * - D11
+       - DB08
+       - DB06
+       - DB04
+       - DB02
+     * - G12
+       - DB07
+       - DB05
+       - DB03
+       - DB01
+     * - H13
+       - DB06
+       - DB04
+       - DB02
+       - DB00
+     * - G13
+       - DB05
+       - DB03
+       - DB01
+       - NC
+     * - H14
+       - DB04
+       - DB02
+       - DB00
+       - NC
+     * - C11
+       - DB03
+       - DB01
+       - NC
+       - NC
+     * - D12
+       - DB02
+       - DB00
+       - NC
+       - NC
+     * - D14
+       - DB01
+       - NC
+       - NC
+       - NC
+     * - D15
+       - DB00
+       - NC
+       - NC
+       - NC
+
+#. In the Data Playback panel, select the 1I: Single Tone - 5.01 MHz; 0.0 dB;
+   0.0° (In-Phase) option from the I Data Vector dropdown menu.
+
+#. Select the 1Q: Single Tone - 5.01 MHz; 0.0 dB; 0.0° (Quadrature) option from
+   the Q Data Vector dropdown menu.
+
+#. Click the Download button in the lower right of the Data Playback panel.
+
+#. Click the Play button, located to the left of the Download button, to begin
+   vector playback.
+
+#. The signal frequency output then appears on the spectrum analyzer.
+
+  .. figure:: ../images/ad9744_dpg.jpeg
+     :alt: DPG Lite Panel
+     :width: 800
+
+     DPG Lite Panel.
+
+**Verification**
+
+Output window that appears on the Spectrum Analyzer hardware. Ensure that the
+following options are set:
+
+#. Connect Spectrum Analyzer to SMA J1.
+#. Set the Stop frequency to 105.0MHz.
+#. Set the Ref level to 0 dBm.
+#. Set the Res BW to 220 Hz.
+#. Set the VBW to 220 Hz.
+#. Check that the DAC output, the top right Mrkr1, is approximately 5.0000 MHz and check that the amplitude is approximately 0 dBm.
+
+  .. figure:: ../images/ad9744_output.jpeg
+     :alt: AD9744 Output Spectrum
+     :width: 800
+
+     AD9744 Output Spectrum.
+
+**Troubleshooting**
+
+- **On-Board LEDs**
+
+There are two LEDs on the evaluation board, which are the 3.3V power supply LED,
+and the ADF4351 lock detect LED. These LEDs are shown in Figure 6. These two
+LEDs will light up when 3.3V is supplied to the board, and when the ADF4351
+clock chip is working properly.
+
+  .. figure:: ../images/ad9744_led.jpeg
+     :alt: AD9744-FMC-EBZ Evaluation Board LEDs
+     :width: 800
+
+     AD9744-FMC-EBZ Evaluation Board LEDs
+
+- **DPGDownloader Lite Does Not Recognize the Evaluation Board**
+
+There may be cases where the DPGDownloader Lite does not recognize the
+evaluation board. If this occurs, open the DPGDownloader Lite and unplug then
+replug the USB cable. If DPGDownloader Lite still does not recognize the
+evaluation board, there is a chance that the firmware of the board is not
+updated and the evaluation board must be reprogrammed with the new firmware.
+Contact a local Analog Devices salesperson or distributor to arrange for this
+reprogramming to be done.
+
+- **ACE Does Not Recognize the Evaluation Board**
+
+There may be cases where the AD9744 icon does not appear on the Attached
+Hardware tab of ACE, or the icon is there but once clicked, will indicate an
+Unavailable status on the bottom as shown in Figure 7. These errors can occur if
+the ACE software is started before powering up and connecting the evaluation
+board to the PC, or if the evaluation board is power cycled and ACE is not
+restarted. The most basic remedy for this issue is to close ACE and reopen it
+(restart). As long as the evaluation board is powered up and connected to the
+PC, ACE recognizes the evaluation board and will work again.
+
+  .. figure:: ../images/ad9744_ace_error.jpeg
+     :alt: Unavailable state error in ACE
+     :width: 800
+
+     Unavailable state error in ACE
+
+- **DCO Frequency is not correct or not detected**
+
+Check if the proper resistors are installed. If using the Onboard clock, check
+if DS2 LED lights up. If not, restart ACE and then reprogram the board with the
+desired clock frequency. If using an external clock source, increase the output
+power level to 20dBm. Make sure the resistors installed are properly soldered.
+
+- **DAC Output Frequency is not correct**
+
+Check if the DCO Frequency detected on the DPG Panel matches the Data Rate
+field. These two should match for proper vector generation and playing to the
+DAC.

--- a/docs/solutions/reference-designs/eval-ad974x-fmc/quickstart/sdp-h1-ace.rst
+++ b/docs/solutions/reference-designs/eval-ad974x-fmc/quickstart/sdp-h1-ace.rst
@@ -79,7 +79,7 @@ The single-ended configuration is implemented by default.
 - **Board Jumpers Configuration**
 
 A 0402, 0-ohm resistor are installed on the jumpers. Move these 0-ohm resistors
-accordingly to the required configuration as shown bellow.
+accordingly to the required configuration as shown below.
 
   .. list-table::
      :header-rows: 1
@@ -103,7 +103,7 @@ accordingly to the required configuration as shown bellow.
 The ACE software and DPGDownloader Lite are needed to configure the device.
 ACE is the software that is used to load the registers in the ADF4351 while
 DPGDownloader Lite is used to load the vector into the evaluation board.
-Install ACE from this link Analysis | Control | Evaluation (ACE) Software.
+Install ACE from :adi:`ace` (Analysis | Control | Evaluation (ACE) Software).
 During installation, expand the High-Speed DAC Components list and select the
 DPG Lite and HSDAC eval boards support through SDP drivers checkboxes. The
 plugins for this board can be downloaded from the plugin manager in the ACE
@@ -145,12 +145,14 @@ Follow the steps to generate and download a vector into the eval board.
 #. In the DPGDownloader Lite window, click the Add Generated Waveform dropdown
    menu and select Single Tone as the vector type.
 
-#. Refer to bellow table for the appropriate frequency values and default
+#. Refer to the table below for the appropriate frequency values and default
    settings.
 
-Note: Select 14 bits DAC Resolution for all generics (AD9744, AD9740, AD9742 &
-AD9748).The NC pins are disconnected in the corresponding evaluation board.
- 
+   .. note::
+
+      Select 14 bits DAC Resolution for all generics (AD9744, AD9740, AD9742 &
+      AD9748). The NC pins are disconnected in the corresponding evaluation board.
+
    .. list-table::
      :header-rows: 1
 

--- a/docs/solutions/reference-designs/eval-ad974x-fmc/quickstart/zed.rst
+++ b/docs/solutions/reference-designs/eval-ad974x-fmc/quickstart/zed.rst
@@ -1,0 +1,681 @@
+.. _eval-ad974x fmc ebz quickstart zed:
+
+ZedBoard quick start
+===============================================================================
+
+.. figure:: ../images/zed_board.jpeg
+   :alt: ZedBoard Zynq-7000 development board
+   :align: center
+   :width: 800
+
+   ZedBoard
+
+.. esd-warning::
+
+Required software
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- A UART terminal (PuTTY / Tera Term / Minicom) at 115200 baud, 8N1
+- :git-libiio:`libiio </>` installed on the host PC
+- :ref:`iio-oscilloscope` and/or
+  :external+scopy:doc:`Scopy <index>` installed on the host PC
+
+Required hardware
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- `ZedBoard <https://www.avnet.com/wps/portal/us/products/avnet-boards/
+  avnet-board-families/zedboard/>`_ Rev D or later
+- :adi:`EVAL-AD9740 <EVAL-AD9740>` evaluation board or
+- :adi:`EVAL-AD9742 <EVAL-AD9742>` evaluation board or
+- :adi:`EVAL-AD9744 <EVAL-AD9744>` evaluation board or
+- :adi:`EVAL-AD9748 <EVAL-AD9748>` evaluation board
+- 16 GB (or larger) Class 10 micro-SD card
+- 12 V, 3 A power supply
+- Micro-USB cable (UART)
+- Ethernet cable
+
+Setting up the SD card
+-------------------------------------------------------------------------------
+
+#. Download and install the ADI Kuiper Linux image by following the
+   :external+kuiper:ref:`use-kuiper-image` instructions.
+#. Copy the boot files (``BOOT.BIN``, ``uImage``, ``devicetree.dtb``)
+   from the ADI Kuiper Linux image to the FAT boot partition of the
+   SD card.
+
+   .. collapsible:: Build from source
+
+      To build the HDL bitstream and software from source, follow these steps.
+
+      **HDL reference design**
+
+      Clone the HDL repository and build the ZedBoard project:
+
+      .. shell::
+
+         $cd hdl/projects/ad9740_fmc/zed
+         $make
+
+      The bitstream is written into ``hdl/projects/ad9740_fmc/zed/ad9740_fmc_zed.sdk/``.
+
+      **Kuiper Linux kernel and device tree**
+      
+      Refer to :external+kuiper:ref:`use-kuiper-image` for building
+      ``uImage`` and ``devicetree.dtb`` for Zynq with the AD974x device
+      tree overlay.
+
+Setting up the hardware
+-------------------------------------------------------------------------------
+
+#. Insert the prepared micro-SD card into the SD card slot (J12) on the
+   ZedBoard.
+
+#. Configure the boot mode and VADJ voltage. The ZedBoard jumpers should
+   be set for SD card boot and VADJ = 3.3 V.
+
+   .. important::
+
+      Set VADJ to **3.3 V** before powering on. The AD974x uses 3.3 V
+      signaling on the FMC connector.
+
+   .. image:: ../images/zed_vadj_sd_boot.jpeg
+      :alt: ZedBoard jumper configuration for SD card boot and VADJ = 3.3 V
+      :align: center
+      :width: 500
+
+#. With the ZedBoard **powered off**, insert the
+   :adi:`EVAL-AD9740` / :adi:`EVAL-AD9742` / :adi:`EVAL-AD9744` /
+   :adi:`EVAL-AD9748` evaluation board into the FMC LPC connector.
+
+#. Connect the Micro-USB cable from J14 (USB UART) to your host PC.
+
+#. Connect the Ethernet cable to J11 (RJ-45).
+
+#. Connect SMB probes to J4 (CH0 output) and J5 (CH1 output) on the
+   evaluation board to monitor the DAC outputs.
+
+#. Connect the 12 V power supply to J20 and power on the ZedBoard.
+
+#. Wait approximately 30 seconds for the DONE LED near DISP1 to turn
+   blue, indicating the bitstream has been loaded.
+
+.. figure:: ../images/ad9744_zed.jpeg
+   :alt: EVAL-AD9744 hardware setup on ZedBoard
+   :align: center
+   :width: 700
+
+   EVAL-AD9744 hardware setup on ZedBoard.
+
+Booting
+-------------------------------------------------------------------------------
+
+Open the UART terminal (115200 baud, 8N1) on the host PC and observe the
+boot log. The system auto-logs in as ``root``.
+
+.. collapsible:: Full boot log
+
+   .. code-block:: none
+
+      U-Boot 2018.01-01677-geb93226123b (Mar 09 2026 - 12:15:19 +0200), Build: jenkins-development-build_uboot-69
+
+      Model: Zyn 0
+      Device: sdhci@e0100000
+      Manufacturer ID: 9f
+      OEM: 5449
+      Name: SD64G
+      Tran Speed: 50000000
+      Rd Block Len: 512
+      SD version 3.0
+      High Capacity: Yes
+      Capacity: 58 GiB
+      Bus Width: 4-bit
+      Erase Group Size: 512 Bytes
+      reading uEnv.txt
+      407 bytes read in 23 ms (16.6 KiB/s)
+      Loaded environment from uEnv.txt
+      Importing environment from SD ...
+      Running uenvcmd ...
+      Copying Linux from SD to RAM...
+      reading uImage
+      8897912 bytes read in 513 ms (16.5 MiB/s)
+      reading devicetree.dtb
+      18153 bytes read in 29 ms (610.4 KiB/s)
+      ** Unable to read file uramdisk.image.gz **
+      ## Booting kernel from Legacy Image at 03000000 ...
+         Image Name:   Linux-6.12.0-27067-g126deeb87ea1
+         Image Type:   ARM Linux Kernel Image (uncompressed)
+         Data Size:    8897848 Bytes = 8.5 MiB
+         Load Address: 00008000
+         Entry Point:  00008000
+         Verifying Checksum ... OK
+      ## Flattened Device Tree blob at 02a00000
+         Booting using the fdt blob at 0x2a00000
+         Loading Kernel Image ... OK
+         Loading Device Tree to 1eb12000, end 1eb196e8 ... OK
+
+      Starting kernel ...
+
+      Booting Linux on physical CPU 0x0
+      Linux version 6.12.0-27067-g126deeb87ea1-dirty (asarbu@HYB-9PqoEXICMOW) (arm-linux-gnueabi-gcc (Linaro GCC 7.5-2019.12) 7.5.0, GNU ld (Linaro_Binutils-2019.12) 2.28.2.20170706) #6 SMP PREEMPT Tue Feb 24 11:50:36 EET 2026
+      CPU: ARMv7 Processor [413fc090] revision 0 (ARMv7), cr=18c5387d
+      CPU: PIPT / VIPT nonaliasing data cache, VIPT aliasing instruction cache
+      OF: fdt: Machine model: Xilinx Zynq ZED
+      OF: fdt: earlycon: stdout-path /amba@0/uart@E0001000 not found
+      Memory policy: Data cache writealloc
+      cma: Reserved 128 MiB at 0x16800000 on node -1
+      Zone ranges:
+      Normal   [mem 0x0000000000000000-0x000000001fffffff]
+      HighMem  empty
+      Movable zone start for each node
+      Early memory node ranges
+      node   0: [mem 0x0000000000000000-0x000000001fffffff]
+      Initmem setup node 0 [mem 0x0000000000000000-0x000000001fffffff]
+      percpu: Embedded 12 pages/cpu s17356 r8192 d23604 u49152
+      Kernel command line: console=ttyPS0,115200 root=/dev/mmcblk0p2 rw earlycon rootfstype=ext4 rootwait clk_ignore_unused cpuidle.off=1
+      Dentry cache hash table entries: 65536 (order: 6, 262144 bytes, linear)
+      Inode-cache hash table entries: 32768 (order: 5, 131072 bytes, linear)
+      Built 1 zonelists, mobility grouping on.  Total pages: 131072
+      mem auto-init: stack:off, heap alloc:off, heap free:off
+      SLUB: HWalign=64, Order=0-3, MinObjects=0, CPUs=2, Nodes=1
+      rcu: Preemptible hierarchical RCU implementation.
+      rcu:    RCU restricting CPUs from NR_CPUS=4 to nr_cpu_ids=2.
+      rcu: RCU calculated value of scheduler-enlistment delay is 10 jiffies.
+      rcu: Adjusting geometry for rcu_fanout_leaf=16, nr_cpu_ids=2
+      NR_IRQS: 16, nr_irqs: 16, preallocated irqs: 16
+      efuse mapped to (ptrval)
+      slcr mapped to (ptrval)
+      L2C: platform modifies aux control register: 0x72360000 -> 0x72760000
+      L2C: DT/platform modifies aux control register: 0x72360000 -> 0x72760000
+      L2C-310 erratum 769419 enabled
+      L2C-310 enabling early BRESP for Cortex-A9
+      L2C-310 full line of zeros enabled for Cortex-A9
+      L2C-310 ID prefetch enabled, offset 1 lines
+      L2C-310 dynamic clock gating enabled, standby mode enabled
+      L2C-310 cache controller enabled, 8 ways, 512 kB
+      L2C-310: CACHE_ID 0x410000c8, AUX_CTRL 0x76760001
+      rcu: srcu_init: Setting srcu_struct sizes based on contention.
+      zynq_clock_init: clkc starts at (ptrval)
+      Zynq clock init
+      sched_clock: 64 bits at 167MHz, resolution 6ns, wraps every 4398046511103ns
+      clocksource: arm_global_timer: mask: 0xffffffffffffffff max_cycles: 0x26703d7dd8, max_idle_ns: 440795208065 ns
+      Switching to timer-based delay loop, resolution 6ns
+      Console: colour dummy device 80x30
+      Calibrating delay loop (skipped), value calculated using timer frequency.. 333.33 BogoMIPS (lpj=1666666)
+      CPU: Testing write buffer coherency: ok
+      CPU0: Spectre v2: using BPIALL workaround
+      pid_max: default: 32768 minimum: 301
+      Mount-cache hash table entries: 1024 (order: 0, 4096 bytes, linear)
+      Mountpoint-cache hash table entries: 1024 (order: 0, 4096 bytes, linear)
+      CPU0: thread -1, cpu 0, socket 0, mpidr 80000000
+      Setting up static identity map for 0x100000 - 0x100060
+      rcu: Hierarchical SRCU implementation.
+      rcu:    Max phase no-delay instances is 1000.
+      smp: Bringing up secondary CPUs ...
+      CPU1: thread -1, cpu 1, socket 0, mpidr 80000001
+      CPU1: Spectre v2: using BPIALL workaround
+      smp: Brought up 1 node, 2 CPUs
+      SMP: Total of 2 processors activated (666.66 BogoMIPS).
+      CPU: All CPU(s) started in SVC mode.
+      Memory: 359484K/524288K available (12288K kernel code, 906K rwdata, 10972K rodata, 1024K init, 500K bss, 32468K reserved, 131072K cma-reserved, 0K highmem)
+      devtmpfs: initialized
+      VFP support v0.3: implementor 41 architecture 3 part 30 variant 9 rev 4
+      clocksource: jiffies: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 19112604462750000 ns
+      futex hash table entries: 512 (order: 3, 32768 bytes, linear)
+      pinctrl core: initialized pinctrl subsystem
+      NET: Registered PF_NETLINK/PF_ROUTE protocol family
+      DMA: preallocated 256 KiB pool for atomic coherent allocations
+      thermal_sys: Registered thermal governor 'step_wise'
+      platform axi: Fixed dependency cycle(s) with /axi/interrupt-controller@f8f01000
+      platform replicator: Fixed dependency cycle(s) with /axi/etb@f8801000
+      amba f8801000.etb: Fixed dependency cycle(s) with /replicator
+      platform replicator: Fixed dependency cycle(s) with /axi/tpiu@f8803000
+      amba f8803000.tpiu: Fixed dependency cycle(s) with /replicator
+      platform replicator: Fixed dependency cycle(s) with /axi/funnel@f8804000
+      amba f8804000.funnel: Fixed dependency cycle(s) with /axi/ptm@f889d000
+      amba f8804000.funnel: Fixed dependency cycle(s) with /axi/ptm@f889c000
+      amba f8804000.funnel: Fixed dependency cycle(s) with /replicator
+      amba f8804000.funnel: Fixed dependency cycle(s) with /axi/ptm@f889c000
+      amba f889c000.ptm: Fixed dependency cycle(s) with /axi/funnel@f8804000
+      amba f8804000.funnel: Fixed dependency cycle(s) with /axi/ptm@f889d000
+      amba f889d000.ptm: Fixed dependency cycle(s) with /axi/funnel@f8804000
+      platform 70e00000.lcd-controller: Fixed dependency cycle(s) with /fpga-axi@0/i2c@41600000/hdmi@39
+      hw-breakpoint: found 5 (+1 reserved) breakpoint and 1 watchpoint registers.
+      hw-breakpoint: maximum watchpoint size is 4 bytes.
+      e0001000.serial: ttyPS0 at MMIO 0xe0001000 (irq = 26, base_baud = 3125000) is a xuartps
+      printk: legacy console [ttyPS0] enabled
+      SCSI subsystem initialized
+      debugfs: Directory 'fixed-supply' with parent 'regulator' already present!
+      usbcore: registered new interface driver usbfs
+      debugfs: Directory 'fixed-supply' with parent 'regulator' already present!
+      usbcore: registered new interface driver hub
+      usbcore: registered new device driver usb
+      mc: Linux media interface: v0.10
+      videodev: Linux video capture interface: v2.00
+      pps_core: LinuxPPS API ver. 1 registered
+      pps_core: Software ver. 5.3.6 - Copyright 2005-2007 Rodolfo Giometti <giometti@linux.it>
+      PTP clock support registered
+      jesd204: found 0 devices and 0 topologies
+      FPGA manager framework
+      Advanced Linux Sound Architecture Driver Initialized.
+      clocksource: Switched to clocksource arm_global_timer
+      NET: Registered PF_INET protocol family
+      IP idents hash table entries: 8192 (order: 4, 65536 bytes, linear)
+      tcp_listen_portaddr_hash hash table entries: 512 (order: 0, 4096 bytes, linear)
+      Table-perturb hash table entries: 65536 (order: 6, 262144 bytes, linear)
+      TCP established hash table entries: 4096 (order: 2, 16384 bytes, linear)
+      TCP bind hash table entries: 4096 (order: 4, 65536 bytes, linear)
+      TCP: Hash tables configured (established 4096 bind 4096)
+      UDP hash table entries: 256 (order: 1, 8192 bytes, linear)
+      UDP-Lite hash table entries: 256 (order: 1, 8192 bytes, linear)
+      NET: Registered PF_UNIX/PF_LOCAL protocol family
+      RPC: Registered named UNIX socket transport module.
+      RPC: Registered udp transport module.
+      RPC: Registered tcp transport module.
+      RPC: Registered tcp-with-tls transport module.
+      RPC: Registered tcp NFSv4.1 backchannel transport module.
+      workingset: timestamp_bits=30 max_order=17 bucket_order=0
+      NFS: Registering the id_resolver key type
+      Key type id_resolver registered
+      Key type id_legacy registered
+      nfs4filelayout_init: NFSv4 File Layout Driver Registering...
+      nfs4flexfilelayout_init: NFSv4 Flexfile Layout Driver Registering...
+      fuse: init (API version 7.41)
+      io scheduler mq-deadline registered
+      io scheduler kyber registered
+      io scheduler bfq registered
+      zynq-pinctrl 700.pinctrl: zynq pinctrl initialized
+      ledtrig-cpu: registered to indicate activity on CPUs
+      dma-pl330 f8003000.dma-controller: Loaded driver for PL330 DMAC-241330
+      dma-pl330 f8003000.dma-controller:      DBUFF-128x8bytes Num_Chans-8 Num_Peri-4 Num_Events-16
+      brd: module loaded
+      loop: module loaded
+      Registered mathworks_ip class
+      spi-nor spi0.0: found s25fl256s1, expected n25q128a11
+      5 fixed-partitions partitions found on MTD device spi0.0
+      Creating 5 MTD partitions on "spi0.0":
+      0x000000000000-0x000000500000 : "boot"
+      0x000000500000-0x000000520000 : "bootenv"
+      0x000000520000-0x000000540000 : "config"
+      0x000000540000-0x000000fc0000 : "image"
+      0x000000fc0000-0x000002000000 : "spare"
+      MACsec IEEE 802.1AE
+      tun: Universal TUN/TAP device driver, 1.6
+      hwmon hwmon0: temp1_input not attached to any thermal zone
+      macb e000b000.ethernet eth0: Cadence GEM rev 0x00020118 at 0xe000b000 irq 40 (00:e0:22:02:be:d7)
+      usbcore: registered new interface driver asix
+      usbcore: registered new interface driver ax88179_178a
+      usbcore: registered new interface driver cdc_ether
+      usbcore: registered new interface driver net1080
+      usbcore: registered new interface driver cdc_subset
+      usbcore: registered new interface driver zaurus
+      usbcore: registered new interface driver cdc_ncm
+      usbcore: registered new interface driver r8153_ecm
+      usbcore: registered new interface driver uas
+      usbcore: registered new interface driver usb-storage
+      usbcore: registered new interface driver usbserial_generic
+      usbserial: USB Serial support registered for generic
+      usbcore: registered new interface driver ftdi_sio
+      usbserial: USB Serial support registered for FTDI USB Serial Device
+      usbcore: registered new interface driver upd78f0730
+      usbserial: USB Serial support registered for upd78f0730
+      ULPI transceiver vendor/product ID 0x0451/0x1507
+      Found TI TUSB1210 ULPI transceiver.
+      ULPI integrity check: passed.
+      ci_hdrc ci_hdrc.0: EHCI Host Controller
+      ci_hdrc ci_hdrc.0: new USB bus registered, assigned bus number 1
+      ci_hdrc ci_hdrc.0: USB 2.0 started, EHCI 1.00
+      usb usb1: New USB device found, idVendor=1d6b, idProduct=0002, bcdDevice= 6.12
+      usb usb1: New USB device strings: Mfr=3, Product=2, SerialNumber=1
+      usb usb1: Product: EHCI Host Controller
+      usb usb1: Manufacturer: Linux 6.12.0-27067-g126deeb87ea1-dirty ehci_hcd
+      usb usb1: SerialNumber: ci_hdrc.0
+      hub 1-0:1.0: USB hub found
+      hub 1-0:1.0: 1 port detected
+      i2c_dev: i2c /dev entries driver
+      platform 70e00000.lcd-controller: Fixed dependency cycle(s) with /fpga-axi@0/i2c@41600000/hdmi@39
+      i2c 0-0039: Fixed dependency cycle(s) with /fpga-axi@0/lcd-controller@70e00000
+      adv7511 0-0039: supply avdd not found, using dummy regulator
+      adv7511 0-0039: supply dvdd not found, using dummy regulator
+      adv7511 0-0039: supply pvdd not found, using dummy regulator
+      adv7511 0-0039: supply bgvdd not found, using dummy regulator
+      adv7511 0-0039: supply dvdd-3v not found, using dummy regulator
+      at24 1-0050: supply vcc not found, using dummy regulator
+      at24 1-0050: 256 byte 24c02 EEPROM, writable, 1 bytes/write
+      gspca_main: v2.14.0 registered
+      usbcore: registered new interface driver uvcvideo
+      cdns-wdt f8005000.watchdog: Xilinx Watchdog Timer with timeout 10s
+      Xilinx Zynq CpuIdle Driver started
+      failed to register cpuidle driver
+      sdhci: Secure Digital Host Controller Interface driver
+      sdhci: Copyright(c) Pierre Ossman
+      sdhci-pltfm: SDHCI platform and OF driver helper
+      clocksource: ttc_clocksource: mask: 0xffff max_cycles: 0xffff, max_idle_ns: 537538477 ns
+      timer #0 at (ptrval), irq=46
+      hid: raw HID events driver (C) Jiri Kosina
+      usbcore: registered new interface driver usbhid
+      usbhid: USB HID core driver
+      SPI driver fb_seps525 has no spi_device_id for syncoam,seps525
+      adi-axi-dac 44a70000.spi: AXI DAC IP core (9.02.b) probed
+      mmc0: SDHCI controller on e0100000.mmc [e0100000.mmc] using ADMA
+      armv7-pmu f8891000.pmu: hw perfevents: no interrupt-affinity property, guessing.
+      hw perfevents: enabled with armv7_cortex_a9 PMU driver, 7 (8000003f) counters available
+      axi_sysid 45000000.sysid: AXI System ID core version (1.01.a) found
+      axi_sysid 45000000.sysid: [ad35xxr_evb] on [zed] git branch <main> git <194cb2059da9757f3de014a479446705ec88be08> clean [2026-04-06 07:05:12] UTC
+      mmc0: new high speed SDXC card at address 5048
+      fpga_manager fpga0: Xilinx Zynq FPGA Manager registered
+      usbcore: registered new interface driver snd-usb-audio
+      mmcblk0: mmc0:5048 SD64G 58.0 GiB
+      axi-i2s 77600000.i2s: probed, capture enabled, playback enabled
+      mmcblk0: p1 p2 p3
+      NET: Registered PF_INET6 protocol family
+      Segment Routing with IPv6
+      In-situ OAM (IOAM) with IPv6
+      sit: IPv6, IPv4 and MPLS over IPv4 tunneling driver
+      NET: Registered PF_PACKET protocol family
+      NET: Registered PF_IEEE802154 protocol family
+      Key type dns_resolver registered
+      Registering SWP/SWPB emulation handler
+      of-fpga-region fpga-region: FPGA Region probed
+      [drm] Initialized axi_hdmi_drm 1.0.0 for 70e00000.lcd-controller on minor 0
+      axi-hdmi 70e00000.lcd-controller: [drm] Cannot find any crtc or sizes
+      axi-hdmi 70e00000.lcd-controller: [drm] Cannot find any crtc or sizes
+      ad3552r-hs dac@0.1.auto: Target SPI mode: 2 !
+      debugfs: File 'Capture' in directory 'dapm' already present!
+      input: gpio-keys as /devices/soc0/gpio-keys/input/input0
+      of_cfs_init
+      of_cfs_init: OK
+      clk: Not disabling unused clocks
+      ALSA device list:
+      #0: HDMI monitor
+      #1: ZED ADAU1761
+      EXT4-fs (mmcblk0p2): recovery complete
+      EXT4-fs (mmcblk0p2): mounted filesystem 61c00ade-b582-4574-a434-d56f9cb59143 r/w with ordered data mode. Quota mode: disabled.
+      VFS: Mounted root (ext4 filesystem) on device 179:2.
+      devtmpfs: mounted
+      Freeing unused kernel image (initmem) memory: 1024K
+      Run /sbin/init as init process
+      systemd[1]: System time before build time, advancing clock.
+      systemd[1]: Failed to look up module alias 'autofs4': Function not implemented
+      systemd[1]: systemd 247.3-7+rpi1+deb11u6 running in system mode. (+PAM +AUDIT +SELINUX +IMA +APPARMOR +SMACK +SYSVINIT +UTMP +LIBCRYPTSETUP +GCRYPT +GNUTLS +ACL +XZ +LZ4 +ZSTD +SECCOMP +BLKID +ELFUTILS +KMOD +IDN2 -IDN +PCRE2 default-hierarchy=unified)
+      systemd[1]: Detected architecture arm.
+
+      Welcome to Kuiper GNU/Linux 11.2 (bullseye)!
+
+      systemd[1]: Set hostname to <analog>.
+      systemd[1]: /lib/systemd/system/plymouth-start.service:16: Unit configured to use KillMode=none. This is unsafe, as it disables systemd's process lifecycle management for the service. Please update your service to use a safer KillMode=, such as 'mixed' or 'control-group'. Support for KillMode=none is deprecated and will eventually be removed.
+      systemd[1]: /lib/systemd/system/iiod.service:14: Invalid environment assignment, ignoring: $IIOD_EXTRA_OPTS=
+      systemd[1]: Queued start job for default target Graphical Interface.
+      random: crng init done
+      systemd[1]: system-getty.slice: unit configures an IP firewall, but the local system does not support BPF/cgroup firewalling.
+      systemd[1]: (This warning is only shown for the first unit using IP firewalling.)
+      systemd[1]: Created slice system-getty.slice.
+      [  OK  ] Created slice system-getty.slice.
+      systemd[1]: Created slice system-modprobe.slice.
+      [  OK  ] Created slice system-modprobe.slice.
+      systemd[1]: Created slice system-serial\x2dgetty.slice.
+      [  OK  ] Created slice system-serial\x2dgetty.slice.
+      systemd[1]: Created slice system-systemd\x2dfsck.slice.
+      [  OK  ] Created slice system-systemd\x2dfsck.slice.
+      systemd[1]: Created slice User and Session Slice.
+      [  OK  ] Created slice User and Session Slice.
+      systemd[1]: Started Forward Password Requests to Wall Directory Watch.
+      [  OK  ] Started Forward Password R…uests to Wall Directory Watch.
+      systemd[1]: Condition check resulted in Arbitrary Executable File Formats File System Automount Point being skipped.
+      systemd[1]: Reached target Slices.
+      [  OK  ] Reached target Slices.
+      systemd[1]: Reached target Swap.
+      [  OK  ] Reached target Swap.
+      systemd[1]: Listening on Syslog Socket.
+      [  OK  ] Listening on Syslog Socket.
+      systemd[1]: Listening on fsck to fsckd communication Socket.
+      [  OK  ] Listening on fsck to fsckd communication Socket.
+      systemd[1]: Listening on initctl Compatibility Named Pipe.
+      [  OK  ] Listening on initctl Compatibility Named Pipe.
+      systemd[1]: Condition check resulted in Journal Audit Socket being skipped.
+      systemd[1]: Listening on Journal Socket (/dev/log).
+      [  OK  ] Listening on Journal Socket (/dev/log).
+      systemd[1]: Listening on Journal Socket.
+      [  OK  ] Listening on Journal Socket.
+      systemd[1]: Listening on udev Control Socket.
+      [  OK  ] Listening on udev Control Socket.
+      systemd[1]: Listening on udev Kernel Socket.
+      [  OK  ] Listening on udev Kernel Socket.
+      systemd[1]: Condition check resulted in Huge Pages File System being skipped.
+      systemd[1]: Condition check resulted in POSIX Message Queue File System being skipped.
+      systemd[1]: Mounting RPC Pipe File System...
+               Mounting RPC Pipe File System...
+      systemd[1]: Mounting Kernel Debug File System...
+               Mounting Kernel Debug File System...
+      systemd[1]: Condition check resulted in Kernel Trace File System being skipped.
+      systemd[1]: Condition check resulted in Kernel Module supporting RPCSEC_GSS being skipped.
+      systemd[1]: Starting Restore / save the current clock...
+               Starting Restore / save the current clock...
+      systemd[1]: Starting Set the console keyboard layout...
+               Starting Set the console keyboard layout...
+      systemd[1]: Condition check resulted in Create list of static device nodes for the current kernel being skipped.
+      systemd[1]: Starting Load Kernel Module configfs...
+               Starting Load Kernel Module configfs...
+      systemd[1]: Starting Load Kernel Module drm...
+               Starting Load Kernel Module drm...
+      systemd[1]: Starting Load Kernel Module fuse...
+               Starting Load Kernel Module fuse...
+      systemd[1]: Condition check resulted in Set Up Additional Binary Formats being skipped.
+      systemd[1]: Condition check resulted in File System Check on Root Device being skipped.
+      systemd[1]: Starting Journal Service...
+               Starting Journal Service...
+      systemd[1]: Starting Load Kernel Modules...
+               Starting Load Kernel Modules...
+      systemd[1]: Starting Remount Root and Kernel File Systems...
+               Starting Remount Root and Kernel File Systems...
+      systemd[1]: Starting Coldplug All udev Devices...
+               Starting Coldplug All udev Devices...
+      systemd[1]: Mounted RPC Pipe File System.
+      [  OK  ] Mounted RPC Pipe File System.
+      systemd[1]: Mounted Kernel Debug File System.
+      [  OK  ] Mounted Kernel Debug File System.
+      systemd[1]: Started Journal Service.
+      [  OK  ] Started Journal Service.
+      [  OK  ] Finished Restore / save the current clock.
+      [  OK  ] Finished Load Kernel Module configfs.
+      [  OK  ] Finished Load Kernel Module drm.
+      [  OK  ] Finished Load Kernel Module fuse.
+      [FAILED] Failed to start Load Kernel Modules.
+      See 'systemctl status systemd-modules-load.service' for details.
+      [  OK  ] Finished Set the console keyboard layout.
+               Mounting FUSE Control File System...
+               Mounting Kernel Configuration File System...
+               Starting Apply Kernel Variables...
+      [  OK  ] Mounted FUSE Control File System.
+      [  OK  ] Mounted Kernel Configuration File System.
+      [  OK  ] Finished Apply Kernel Variables.
+      [  OK  ] Finished Coldplug All udev Devices.
+      [  OK  ] Finished Remount Root and Kernel File Systems.
+               Starting Helper to synchronize boot up for ifupdown...
+               Starting Flush Journal to Persistent Storage...
+               Starting Load/Save Random Seed...
+               Starting Create System Users...
+               Starting Wait for udev To …plete Device Initialization...
+      [  OK  ] Finished Helper to synchronize boot up for ifupdown.
+      [  OK  ] Finished Create System Users.
+      [  OK  ] Finished Load/Save Random Seed.
+               Starting Create Static Device Nodes in /dev...
+      [  OK  ] Finished Flush Journal to Persistent Storage.
+      [  OK  ] Finished Create Static Device Nodes in /dev.
+      [  OK  ] Reached target Local File Systems (Pre).
+               Starting Rule-based Manage…for Device Events and Files...
+      [  OK  ] Started Rule-based Manager for Device Events and Files.
+               Starting Show Plymouth Boot Screen...
+      [  OK  ] Started Show Plymouth Boot Screen.
+      [  OK  ] Started Forward Password R…s to Plymouth Directory Watch.
+      [  OK  ] Reached target Local Encrypted Volumes.
+      [  OK  ] Found device /dev/ttyPS0.
+      [  OK  ] Found device /dev/disk/by-partuuid/5c29002e-01.
+      [  OK  ] Finished Wait for udev To Complete Device Initialization.
+               Starting File System Check…isk/by-partuuid/5c29002e-01...
+               Starting Load Kernel Modules...
+      [  OK  ] Started File System Check Daemon to report status.
+      [FAILED] Failed to start Load Kernel Modules.
+      See 'systemctl status systemd-modules-load.service' for details.
+      [  OK  ] Finished File System Check…/disk/by-partuuid/5c29002e-01.
+               Mounting /boot...
+      [  OK  ] Mounted /boot.
+      [  OK  ] Reached target Local File Systems.
+               Starting Set console font and keymap...
+               Starting Raise network interfaces...
+               Starting Preprocess NFS configuration...
+               Starting Tell Plymouth To Write Out Runtime Data...
+               Starting Create Volatile Files and Directories...
+      [  OK  ] Finished Set console font and keymap.
+      [  OK  ] Finished Tell Plymouth To Write Out Runtime Data.
+      [  OK  ] Finished Preprocess NFS configuration.
+      [  OK  ] Reached target NFS client services.
+      [  OK  ] Reached target Remote File Systems (Pre).
+      [  OK  ] Reached target Remote File Systems.
+      [  OK  ] Finished Create Volatile Files and Directories.
+               Starting Network Time Synchronization...
+               Starting Update UTMP about System Boot/Shutdown...
+      [  OK  ] Finished Update UTMP about System Boot/Shutdown.
+               Starting Load Kernel Modules...
+      [  OK  ] Started Network Time Synchronization.
+      [  OK  ] Finished Raise network interfaces.
+      [  OK  ] Reached target System Time Set.
+      [  OK  ] Reached target System Time Synchronized.
+      [FAILED] Failed to start Load Kernel Modules.
+      See 'systemctl status systemd-modules-load.service' for details.
+      [  OK  ] Reached target System Initialization.
+      [  OK  ] Started CUPS Scheduler.
+      [  OK  ] Started Daily apt download activities.
+      [  OK  ] Started Daily apt upgrade and clean activities.
+      [  OK  ] Started Periodic ext4 Onli…ata Check for All Filesystems.
+      [  OK  ] Started Discard unused blocks once a week.
+      [  OK  ] Started Daily rotation of log files.
+      [  OK  ] Started Daily man-db regeneration.
+      [  OK  ] Started Daily Cleanup of Temporary Directories.
+      [  OK  ] Reached target Paths.
+      [  OK  ] Reached target Timers.
+      [  OK  ] Listening on Avahi mDNS/DNS-SD Stack Activation Socket.
+      [  OK  ] Listening on CUPS Scheduler.
+      [  OK  ] Listening on D-Bus System Message Bus Socket.
+      [  OK  ] Listening on Erlang Port Mapper Daemon Activation Socket.
+      [  OK  ] Listening on GPS (Global P…ioning System) Daemon Sockets.
+      [  OK  ] Listening on triggerhappy.socket.
+      [  OK  ] Reached target Sockets.
+      [  OK  ] Reached target Basic System.
+               Starting Analog Devices power up/down sequence...
+               Starting Save/Restore Sound Card State...
+               Starting Avahi mDNS/DNS-SD Stack...
+      [  OK  ] Started Regular background program processing daemon.
+      [  OK  ] Started D-Bus System Message Bus.
+               Starting dphys-swapfile - …unt, and delete a swap file...
+               Starting Remove Stale Onli…t4 Metadata Check Snapshots...
+      [  OK  ] Started fan-control.
+               Starting Fix DP audio and X11 for Jupiter...
+               Starting Creating IIOD Context Attributes......
+               Starting Authorization Manager...
+               Starting DHCP Client Daemon...
+               Starting LSB: Switch to on…nless shift key is pressed)...
+               Starting LSB: rng-tools (Debian variant)...
+               Starting System Logging Service...
+               Starting User Login Management...
+               Starting triggerhappy global hotkey daemon...
+               Starting Disk Manager...
+               Starting WPA supplicant...
+      [  OK  ] Finished Save/Restore Sound Card State.
+      [  OK  ] Finished Fix DP audio and X11 for Jupiter.
+      [  OK  ] Reached target Sound Card.
+      [  OK  ] Started triggerhappy global hotkey daemon.
+      [  OK  ] Started System Logging Service.
+      [  OK  ] Started DHCP Client Daemon.
+      [  OK  ] Started LSB: rng-tools (Debian variant).
+      [  OK  ] Finished dphys-swapfile - …mount, and delete a swap file.
+      [  OK  ] Started User Login Management.
+      [  OK  ] Started WPA supplicant.
+      [  OK  ] Started Avahi mDNS/DNS-SD Stack.
+      [  OK  ] Reached target Network.
+      [  OK  ] Reached target Network is Online.
+               Starting CUPS Scheduler...
+      [  OK  ] Started Erlang Port Mapper Daemon.
+               Starting HTTP based time synchronization tool...
+               Starting Internet superserver...
+               Starting /etc/rc.local Compatibility...
+               Starting OpenBSD Secure Shell server...
+               Starting Permit User Sessions...
+      [  OK  ] Started Unattended Upgrades Shutdown.
+      [  OK  ] Started Internet superserver.
+      [  OK  ] Finished Remove Stale Onli…ext4 Metadata Check Snapshots.
+      [  OK  ] Started HTTP based time synchronization tool.
+      [  OK  ] Started /etc/rc.local Compatibility.
+      [  OK  ] Finished Permit User Sessions.
+      [  OK  ] Started Authorization Manager.
+               Starting Modem Manager...
+               Starting Light Display Manager...
+               Starting Hold until boot process finishes up...
+      [  OK  ] Started LSB: Switch to ond…(unless shift key is pressed).
+      [FAILED] Failed to start VNC Server for X11.
+
+      Raspbian GNU/Linux 11 analog ttyPS0
+
+      analog login: root (automatic login)
+
+      Linux analog 6.12.0-27067-g126deeb87ea1-dirty #6 SMP PREEMPT Tue Feb 24 11:50:36 EET 2026 armv7l
+
+      The programs included with the Debian GNU/Linux system are free software;
+      the exact distribution terms for each program are described in the
+      individual files in /usr/share/doc/*/copyright.
+
+      Debian GNU/Linux comes with ABSOLUTELY NO WARRANTY, to the extent
+      permitted by applicable law.
+      Last login: Fri Nov  8 15:17:16 GMT 2024 on ttyPS0
+      root@analog:~#
+
+
+Useful commands
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Check network address:
+
+.. shell::
+
+   $ifconfig eth0
+
+List IIO devices:
+
+.. shell::
+
+   $iio_info | grep iio:device
+
+Power down the board safely:
+
+.. shell::
+
+   $poweroff
+
+Using PyADI-IIO
+-------------------------------------------------------------------------------
+
+Install :git-pyadi-iio:`PyADI-IIO </>` on the host PC, then run the
+example script:
+
+.. code-block:: bash
+
+   export PYTHONPATH=/path/to/pyadi-iio/
+   python examples/ad3552r_hs_example.py ip:<ip-address-of-zedboard>
+
+The script generates an 80 kHz sine wave in offset-binary uint16 format
+and streams it to both DAC channels in cyclic mode. Expected output:
+
+.. code-block:: none
+
+   uri: ip:<ip-address-of-zedboard>
+   sample rate: 33333333
+   Sample data min: 1
+   Sample data max: 65534
+
+A matplotlib window will appear showing the generated waveform. The DAC
+outputs on J4 and J5 should show a clean 80 kHz sine wave.
+
+.. image:: ../images/python_plot_ad3552r.jpeg
+   :alt: PyADI-IIO matplotlib output showing AD974x sine wave
+   :align: center
+   :width: 500
+

--- a/docs/solutions/reference-designs/eval-ad974x-fmc/quickstart/zed.rst
+++ b/docs/solutions/reference-designs/eval-ad974x-fmc/quickstart/zed.rst
@@ -23,8 +23,8 @@ Required software
 Required hardware
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-- `ZedBoard <https://www.avnet.com/wps/portal/us/products/avnet-boards/
-  avnet-board-families/zedboard/>`_ Rev D or later
+- `ZedBoard <https://www.avnet.com/wps/portal/us/products/avnet-boards/avnet-board-families/zedboard/>`_
+  Rev D or later
 - :adi:`EVAL-AD9740 <EVAL-AD9740>` evaluation board or
 - :adi:`EVAL-AD9742 <EVAL-AD9742>` evaluation board or
 - :adi:`EVAL-AD9744 <EVAL-AD9744>` evaluation board or
@@ -59,7 +59,7 @@ Setting up the SD card
       The bitstream is written into ``hdl/projects/ad9740_fmc/zed/ad9740_fmc_zed.sdk/``.
 
       **Kuiper Linux kernel and device tree**
-      
+
       Refer to :external+kuiper:ref:`use-kuiper-image` for building
       ``uImage`` and ``devicetree.dtb`` for Zynq with the AD974x device
       tree overlay.

--- a/docs/solutions/reference-designs/eval-ad974x-fmc/user-guide.rst
+++ b/docs/solutions/reference-designs/eval-ad974x-fmc/user-guide.rst
@@ -61,8 +61,8 @@ Schematic, PCB layout, and bill of materials
 Software guide
 -------------------------------------------------------------------------------
 
-Linux-based IIO (using Kuiper Linux on the ZedBoard) software environment is 
-available: 
+Linux-based IIO (using Kuiper Linux on the ZedBoard) software environment is
+available:
 
 Linux IIO environment
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/solutions/reference-designs/eval-ad974x-fmc/user-guide.rst
+++ b/docs/solutions/reference-designs/eval-ad974x-fmc/user-guide.rst
@@ -1,0 +1,621 @@
+.. _eval-ad974x fmc ebz user-guide:
+
+User guide
+===============================================================================
+
+This page covers hardware configuration of the
+:adi:`EVAL-AD9740 <EVAL-AD9740>` / :adi:`EVAL-AD9742 <EVAL-AD9742>` /
+:adi:`EVAL-AD9744 <EVAL-AD9744>` / :adi:`EVAL-AD9748 <EVAL-AD9748>`
+evaluation boards and the software environments available for evaluation.
+
+Hardware configuration
+-------------------------------------------------------------------------------
+
+VADJ and SD boot settings (ZedBoard)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Before inserting the evaluation board, configure the ZedBoard for SD card
+boot and set the VADJ supply to 3.3 V.
+
+.. important::
+
+   The :adi:`EVAL-AD9740 <EVAL-AD9740>` / :adi:`EVAL-AD9742 <EVAL-AD9742>` /
+   :adi:`EVAL-AD9744 <EVAL-AD9744>` / :adi:`EVAL-AD9748 <EVAL-AD9748>` uses
+   3.3 V logic levels on the FMC connector. VADJ must be set to 3.3 V before
+   powering on. Applying a different voltage may damage the evaluation board.
+
+Set the boot mode jumpers on the ZedBoard to SD card boot (MIO[2:6] = 1) and
+configure the VADJ selection jumper for 3.3 V output.
+
+.. figure:: ./images/zed_vadj_sd_boot.jpeg
+   :alt: ZedBoard SD boot jumper settings
+   :align: center
+   :width: 600
+
+   ZedBoard SD boot jumper settings.
+
+Power supply
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The :adi:`EVAL-AD9740 <EVAL-AD9740>` / :adi:`EVAL-AD9742 <EVAL-AD9742>` /
+:adi:`EVAL-AD9744 <EVAL-AD9744>` / :adi:`EVAL-AD9748 <EVAL-AD9748>` includes a
+complete on-board power solution. Two DC/DC converters (LTC3601, ADM7154)
+generate 3.3 V from the 12 V supplied through the FMC connector.
+
+Schematic, PCB layout, and bill of materials
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. list-table::
+   :widths: 60 40
+   :header-rows: 1
+
+   * - Description
+     - Download
+   * - EVAL-AD974X Schematic
+     - :adi:`EVAL-AD74X Schematic <media/en/technical-documentation/eval-board-schematic/eval-ad9744-schematic.pdf>`
+   * - EVAL-AD974X PCB Layout
+     - :adi:`EVAL-AD974X PCB <media/en/technical-documentation/evaluation-documentation/eval-ad9744-pcb-layout.pdf>`
+   * - EVAL-AD974X Bill of Materials
+     - :adi:`EVAL-AD974X BOM <media/en/technical-documentation/evaluation-documentation/eval-ad9744-bom.csv>`
+
+Software guide
+-------------------------------------------------------------------------------
+
+Linux-based IIO (using Kuiper Linux on the ZedBoard) software environment is 
+available: 
+
+Linux IIO environment
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ZedBoard runs ADI Kuiper Linux with the ``adi-axi-dac`` kernel driver
+and the ``axi-ad9740`` Linux IIO driver.
+
+Available client applications on the host:
+
+- :ref:`iio-oscilloscope` - graphical IIO data visualization and DAC
+  control
+- :external+scopy:doc:`Scopy <index>` - oscilloscope and waveform
+  generator
+- :git-pyadi-iio:`PyADI-IIO </>` - Python scripting interface
+
+.. collapsible:: Linux boot log
+
+   .. code-block:: none
+
+    U-Boot 2018.01-01677-geb93226123b (Mar 09 2026 - 12:15:19 +0200), Build: jenkins-development-build_uboot-69
+
+    Model: Zyn 0
+    Device: sdhci@e0100000
+    Manufacturer ID: 9f
+    OEM: 5449
+    Name: SD64G
+    Tran Speed: 50000000
+    Rd Block Len: 512
+    SD version 3.0
+    High Capacity: Yes
+    Capacity: 58 GiB
+    Bus Width: 4-bit
+    Erase Group Size: 512 Bytes
+    reading uEnv.txt
+    407 bytes read in 23 ms (16.6 KiB/s)
+    Loaded environment from uEnv.txt
+    Importing environment from SD ...
+    Running uenvcmd ...
+    Copying Linux from SD to RAM...
+    reading uImage
+    8897912 bytes read in 513 ms (16.5 MiB/s)
+    reading devicetree.dtb
+    18153 bytes read in 29 ms (610.4 KiB/s)
+    ** Unable to read file uramdisk.image.gz **
+    ## Booting kernel from Legacy Image at 03000000 ...
+      Image Name:   Linux-6.12.0-27067-g126deeb87ea1
+      Image Type:   ARM Linux Kernel Image (uncompressed)
+      Data Size:    8897848 Bytes = 8.5 MiB
+      Load Address: 00008000
+      Entry Point:  00008000
+      Verifying Checksum ... OK
+    ## Flattened Device Tree blob at 02a00000
+      Booting using the fdt blob at 0x2a00000
+      Loading Kernel Image ... OK
+      Loading Device Tree to 1eb12000, end 1eb196e8 ... OK
+
+    Starting kernel ...
+
+    Booting Linux on physical CPU 0x0
+    Linux version 6.12.0-27067-g126deeb87ea1-dirty (asarbu@HYB-9PqoEXICMOW) (arm-linux-gnueabi-gcc (Linaro GCC 7.5-2019.12) 7.5.0, GNU ld (Linaro_Binutils-2019.12) 2.28.2.20170706) #6 SMP PREEMPT Tue Feb 24 11:50:36 EET 2026
+    CPU: ARMv7 Processor [413fc090] revision 0 (ARMv7), cr=18c5387d
+    CPU: PIPT / VIPT nonaliasing data cache, VIPT aliasing instruction cache
+    OF: fdt: Machine model: Xilinx Zynq ZED
+    OF: fdt: earlycon: stdout-path /amba@0/uart@E0001000 not found
+    Memory policy: Data cache writealloc
+    cma: Reserved 128 MiB at 0x16800000 on node -1
+    Zone ranges:
+      Normal   [mem 0x0000000000000000-0x000000001fffffff]
+      HighMem  empty
+    Movable zone start for each node
+    Early memory node ranges
+      node   0: [mem 0x0000000000000000-0x000000001fffffff]
+    Initmem setup node 0 [mem 0x0000000000000000-0x000000001fffffff]
+    percpu: Embedded 12 pages/cpu s17356 r8192 d23604 u49152
+    Kernel command line: console=ttyPS0,115200 root=/dev/mmcblk0p2 rw earlycon rootfstype=ext4 rootwait clk_ignore_unused cpuidle.off=1
+    Dentry cache hash table entries: 65536 (order: 6, 262144 bytes, linear)
+    Inode-cache hash table entries: 32768 (order: 5, 131072 bytes, linear)
+    Built 1 zonelists, mobility grouping on.  Total pages: 131072
+    mem auto-init: stack:off, heap alloc:off, heap free:off
+    SLUB: HWalign=64, Order=0-3, MinObjects=0, CPUs=2, Nodes=1
+    rcu: Preemptible hierarchical RCU implementation.
+    rcu:    RCU restricting CPUs from NR_CPUS=4 to nr_cpu_ids=2.
+    rcu: RCU calculated value of scheduler-enlistment delay is 10 jiffies.
+    rcu: Adjusting geometry for rcu_fanout_leaf=16, nr_cpu_ids=2
+    NR_IRQS: 16, nr_irqs: 16, preallocated irqs: 16
+    efuse mapped to (ptrval)
+    slcr mapped to (ptrval)
+    L2C: platform modifies aux control register: 0x72360000 -> 0x72760000
+    L2C: DT/platform modifies aux control register: 0x72360000 -> 0x72760000
+    L2C-310 erratum 769419 enabled
+    L2C-310 enabling early BRESP for Cortex-A9
+    L2C-310 full line of zeros enabled for Cortex-A9
+    L2C-310 ID prefetch enabled, offset 1 lines
+    L2C-310 dynamic clock gating enabled, standby mode enabled
+    L2C-310 cache controller enabled, 8 ways, 512 kB
+    L2C-310: CACHE_ID 0x410000c8, AUX_CTRL 0x76760001
+    rcu: srcu_init: Setting srcu_struct sizes based on contention.
+    zynq_clock_init: clkc starts at (ptrval)
+    Zynq clock init
+    sched_clock: 64 bits at 167MHz, resolution 6ns, wraps every 4398046511103ns
+    clocksource: arm_global_timer: mask: 0xffffffffffffffff max_cycles: 0x26703d7dd8, max_idle_ns: 440795208065 ns
+    Switching to timer-based delay loop, resolution 6ns
+    Console: colour dummy device 80x30
+    Calibrating delay loop (skipped), value calculated using timer frequency.. 333.33 BogoMIPS (lpj=1666666)
+    CPU: Testing write buffer coherency: ok
+    CPU0: Spectre v2: using BPIALL workaround
+    pid_max: default: 32768 minimum: 301
+    Mount-cache hash table entries: 1024 (order: 0, 4096 bytes, linear)
+    Mountpoint-cache hash table entries: 1024 (order: 0, 4096 bytes, linear)
+    CPU0: thread -1, cpu 0, socket 0, mpidr 80000000
+    Setting up static identity map for 0x100000 - 0x100060
+    rcu: Hierarchical SRCU implementation.
+    rcu:    Max phase no-delay instances is 1000.
+    smp: Bringing up secondary CPUs ...
+    CPU1: thread -1, cpu 1, socket 0, mpidr 80000001
+    CPU1: Spectre v2: using BPIALL workaround
+    smp: Brought up 1 node, 2 CPUs
+    SMP: Total of 2 processors activated (666.66 BogoMIPS).
+    CPU: All CPU(s) started in SVC mode.
+    Memory: 359484K/524288K available (12288K kernel code, 906K rwdata, 10972K rodata, 1024K init, 500K bss, 32468K reserved, 131072K cma-reserved, 0K highmem)
+    devtmpfs: initialized
+    VFP support v0.3: implementor 41 architecture 3 part 30 variant 9 rev 4
+    clocksource: jiffies: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 19112604462750000 ns
+    futex hash table entries: 512 (order: 3, 32768 bytes, linear)
+    pinctrl core: initialized pinctrl subsystem
+    NET: Registered PF_NETLINK/PF_ROUTE protocol family
+    DMA: preallocated 256 KiB pool for atomic coherent allocations
+    thermal_sys: Registered thermal governor 'step_wise'
+    platform axi: Fixed dependency cycle(s) with /axi/interrupt-controller@f8f01000
+    platform replicator: Fixed dependency cycle(s) with /axi/etb@f8801000
+    amba f8801000.etb: Fixed dependency cycle(s) with /replicator
+    platform replicator: Fixed dependency cycle(s) with /axi/tpiu@f8803000
+    amba f8803000.tpiu: Fixed dependency cycle(s) with /replicator
+    platform replicator: Fixed dependency cycle(s) with /axi/funnel@f8804000
+    amba f8804000.funnel: Fixed dependency cycle(s) with /axi/ptm@f889d000
+    amba f8804000.funnel: Fixed dependency cycle(s) with /axi/ptm@f889c000
+    amba f8804000.funnel: Fixed dependency cycle(s) with /replicator
+    amba f8804000.funnel: Fixed dependency cycle(s) with /axi/ptm@f889c000
+    amba f889c000.ptm: Fixed dependency cycle(s) with /axi/funnel@f8804000
+    amba f8804000.funnel: Fixed dependency cycle(s) with /axi/ptm@f889d000
+    amba f889d000.ptm: Fixed dependency cycle(s) with /axi/funnel@f8804000
+    platform 70e00000.lcd-controller: Fixed dependency cycle(s) with /fpga-axi@0/i2c@41600000/hdmi@39
+    hw-breakpoint: found 5 (+1 reserved) breakpoint and 1 watchpoint registers.
+    hw-breakpoint: maximum watchpoint size is 4 bytes.
+    e0001000.serial: ttyPS0 at MMIO 0xe0001000 (irq = 26, base_baud = 3125000) is a xuartps
+    printk: legacy console [ttyPS0] enabled
+    SCSI subsystem initialized
+    debugfs: Directory 'fixed-supply' with parent 'regulator' already present!
+    usbcore: registered new interface driver usbfs
+    debugfs: Directory 'fixed-supply' with parent 'regulator' already present!
+    usbcore: registered new interface driver hub
+    usbcore: registered new device driver usb
+    mc: Linux media interface: v0.10
+    videodev: Linux video capture interface: v2.00
+    pps_core: LinuxPPS API ver. 1 registered
+    pps_core: Software ver. 5.3.6 - Copyright 2005-2007 Rodolfo Giometti <giometti@linux.it>
+    PTP clock support registered
+    jesd204: found 0 devices and 0 topologies
+    FPGA manager framework
+    Advanced Linux Sound Architecture Driver Initialized.
+    clocksource: Switched to clocksource arm_global_timer
+    NET: Registered PF_INET protocol family
+    IP idents hash table entries: 8192 (order: 4, 65536 bytes, linear)
+    tcp_listen_portaddr_hash hash table entries: 512 (order: 0, 4096 bytes, linear)
+    Table-perturb hash table entries: 65536 (order: 6, 262144 bytes, linear)
+    TCP established hash table entries: 4096 (order: 2, 16384 bytes, linear)
+    TCP bind hash table entries: 4096 (order: 4, 65536 bytes, linear)
+    TCP: Hash tables configured (established 4096 bind 4096)
+    UDP hash table entries: 256 (order: 1, 8192 bytes, linear)
+    UDP-Lite hash table entries: 256 (order: 1, 8192 bytes, linear)
+    NET: Registered PF_UNIX/PF_LOCAL protocol family
+    RPC: Registered named UNIX socket transport module.
+    RPC: Registered udp transport module.
+    RPC: Registered tcp transport module.
+    RPC: Registered tcp-with-tls transport module.
+    RPC: Registered tcp NFSv4.1 backchannel transport module.
+    workingset: timestamp_bits=30 max_order=17 bucket_order=0
+    NFS: Registering the id_resolver key type
+    Key type id_resolver registered
+    Key type id_legacy registered
+    nfs4filelayout_init: NFSv4 File Layout Driver Registering...
+    nfs4flexfilelayout_init: NFSv4 Flexfile Layout Driver Registering...
+    fuse: init (API version 7.41)
+    io scheduler mq-deadline registered
+    io scheduler kyber registered
+    io scheduler bfq registered
+    zynq-pinctrl 700.pinctrl: zynq pinctrl initialized
+    ledtrig-cpu: registered to indicate activity on CPUs
+    dma-pl330 f8003000.dma-controller: Loaded driver for PL330 DMAC-241330
+    dma-pl330 f8003000.dma-controller:      DBUFF-128x8bytes Num_Chans-8 Num_Peri-4 Num_Events-16
+    brd: module loaded
+    loop: module loaded
+    Registered mathworks_ip class
+    spi-nor spi0.0: found s25fl256s1, expected n25q128a11
+    5 fixed-partitions partitions found on MTD device spi0.0
+    Creating 5 MTD partitions on "spi0.0":
+    0x000000000000-0x000000500000 : "boot"
+    0x000000500000-0x000000520000 : "bootenv"
+    0x000000520000-0x000000540000 : "config"
+    0x000000540000-0x000000fc0000 : "image"
+    0x000000fc0000-0x000002000000 : "spare"
+    MACsec IEEE 802.1AE
+    tun: Universal TUN/TAP device driver, 1.6
+    hwmon hwmon0: temp1_input not attached to any thermal zone
+    macb e000b000.ethernet eth0: Cadence GEM rev 0x00020118 at 0xe000b000 irq 40 (00:e0:22:02:be:d7)
+    usbcore: registered new interface driver asix
+    usbcore: registered new interface driver ax88179_178a
+    usbcore: registered new interface driver cdc_ether
+    usbcore: registered new interface driver net1080
+    usbcore: registered new interface driver cdc_subset
+    usbcore: registered new interface driver zaurus
+    usbcore: registered new interface driver cdc_ncm
+    usbcore: registered new interface driver r8153_ecm
+    usbcore: registered new interface driver uas
+    usbcore: registered new interface driver usb-storage
+    usbcore: registered new interface driver usbserial_generic
+    usbserial: USB Serial support registered for generic
+    usbcore: registered new interface driver ftdi_sio
+    usbserial: USB Serial support registered for FTDI USB Serial Device
+    usbcore: registered new interface driver upd78f0730
+    usbserial: USB Serial support registered for upd78f0730
+    ULPI transceiver vendor/product ID 0x0451/0x1507
+    Found TI TUSB1210 ULPI transceiver.
+    ULPI integrity check: passed.
+    ci_hdrc ci_hdrc.0: EHCI Host Controller
+    ci_hdrc ci_hdrc.0: new USB bus registered, assigned bus number 1
+    ci_hdrc ci_hdrc.0: USB 2.0 started, EHCI 1.00
+    usb usb1: New USB device found, idVendor=1d6b, idProduct=0002, bcdDevice= 6.12
+    usb usb1: New USB device strings: Mfr=3, Product=2, SerialNumber=1
+    usb usb1: Product: EHCI Host Controller
+    usb usb1: Manufacturer: Linux 6.12.0-27067-g126deeb87ea1-dirty ehci_hcd
+    usb usb1: SerialNumber: ci_hdrc.0
+    hub 1-0:1.0: USB hub found
+    hub 1-0:1.0: 1 port detected
+    i2c_dev: i2c /dev entries driver
+    platform 70e00000.lcd-controller: Fixed dependency cycle(s) with /fpga-axi@0/i2c@41600000/hdmi@39
+    i2c 0-0039: Fixed dependency cycle(s) with /fpga-axi@0/lcd-controller@70e00000
+    adv7511 0-0039: supply avdd not found, using dummy regulator
+    adv7511 0-0039: supply dvdd not found, using dummy regulator
+    adv7511 0-0039: supply pvdd not found, using dummy regulator
+    adv7511 0-0039: supply bgvdd not found, using dummy regulator
+    adv7511 0-0039: supply dvdd-3v not found, using dummy regulator
+    at24 1-0050: supply vcc not found, using dummy regulator
+    at24 1-0050: 256 byte 24c02 EEPROM, writable, 1 bytes/write
+    gspca_main: v2.14.0 registered
+    usbcore: registered new interface driver uvcvideo
+    cdns-wdt f8005000.watchdog: Xilinx Watchdog Timer with timeout 10s
+    Xilinx Zynq CpuIdle Driver started
+    failed to register cpuidle driver
+    sdhci: Secure Digital Host Controller Interface driver
+    sdhci: Copyright(c) Pierre Ossman
+    sdhci-pltfm: SDHCI platform and OF driver helper
+    clocksource: ttc_clocksource: mask: 0xffff max_cycles: 0xffff, max_idle_ns: 537538477 ns
+    timer #0 at (ptrval), irq=46
+    hid: raw HID events driver (C) Jiri Kosina
+    usbcore: registered new interface driver usbhid
+    usbhid: USB HID core driver
+    SPI driver fb_seps525 has no spi_device_id for syncoam,seps525
+    adi-axi-dac 44a70000.spi: AXI DAC IP core (9.02.b) probed
+    mmc0: SDHCI controller on e0100000.mmc [e0100000.mmc] using ADMA
+    armv7-pmu f8891000.pmu: hw perfevents: no interrupt-affinity property, guessing.
+    hw perfevents: enabled with armv7_cortex_a9 PMU driver, 7 (8000003f) counters available
+    axi_sysid 45000000.sysid: AXI System ID core version (1.01.a) found
+    axi_sysid 45000000.sysid: [ad35xxr_evb] on [zed] git branch <main> git <194cb2059da9757f3de014a479446705ec88be08> clean [2026-04-06 07:05:12] UTC
+    mmc0: new high speed SDXC card at address 5048
+    fpga_manager fpga0: Xilinx Zynq FPGA Manager registered
+    usbcore: registered new interface driver snd-usb-audio
+    mmcblk0: mmc0:5048 SD64G 58.0 GiB
+    axi-i2s 77600000.i2s: probed, capture enabled, playback enabled
+    mmcblk0: p1 p2 p3
+    NET: Registered PF_INET6 protocol family
+    Segment Routing with IPv6
+    In-situ OAM (IOAM) with IPv6
+    sit: IPv6, IPv4 and MPLS over IPv4 tunneling driver
+    NET: Registered PF_PACKET protocol family
+    NET: Registered PF_IEEE802154 protocol family
+    Key type dns_resolver registered
+    Registering SWP/SWPB emulation handler
+    of-fpga-region fpga-region: FPGA Region probed
+    [drm] Initialized axi_hdmi_drm 1.0.0 for 70e00000.lcd-controller on minor 0
+    axi-hdmi 70e00000.lcd-controller: [drm] Cannot find any crtc or sizes
+    axi-hdmi 70e00000.lcd-controller: [drm] Cannot find any crtc or sizes
+    ad3552r-hs dac@0.1.auto: Target SPI mode: 2 !
+    debugfs: File 'Capture' in directory 'dapm' already present!
+    input: gpio-keys as /devices/soc0/gpio-keys/input/input0
+    of_cfs_init
+    of_cfs_init: OK
+    clk: Not disabling unused clocks
+    ALSA device list:
+      #0: HDMI monitor
+      #1: ZED ADAU1761
+    EXT4-fs (mmcblk0p2): recovery complete
+    EXT4-fs (mmcblk0p2): mounted filesystem 61c00ade-b582-4574-a434-d56f9cb59143 r/w with ordered data mode. Quota mode: disabled.
+    VFS: Mounted root (ext4 filesystem) on device 179:2.
+    devtmpfs: mounted
+    Freeing unused kernel image (initmem) memory: 1024K
+    Run /sbin/init as init process
+    systemd[1]: System time before build time, advancing clock.
+    systemd[1]: Failed to look up module alias 'autofs4': Function not implemented
+    systemd[1]: systemd 247.3-7+rpi1+deb11u6 running in system mode. (+PAM +AUDIT +SELINUX +IMA +APPARMOR +SMACK +SYSVINIT +UTMP +LIBCRYPTSETUP +GCRYPT +GNUTLS +ACL +XZ +LZ4 +ZSTD +SECCOMP +BLKID +ELFUTILS +KMOD +IDN2 -IDN +PCRE2 default-hierarchy=unified)
+    systemd[1]: Detected architecture arm.
+
+    Welcome to Kuiper GNU/Linux 11.2 (bullseye)!
+
+    systemd[1]: Set hostname to <analog>.
+    systemd[1]: /lib/systemd/system/plymouth-start.service:16: Unit configured to use KillMode=none. This is unsafe, as it disables systemd's process lifecycle management for the service. Please update your service to use a safer KillMode=, such as 'mixed' or 'control-group'. Support for KillMode=none is deprecated and will eventually be removed.
+    systemd[1]: /lib/systemd/system/iiod.service:14: Invalid environment assignment, ignoring: $IIOD_EXTRA_OPTS=
+    systemd[1]: Queued start job for default target Graphical Interface.
+    random: crng init done
+    systemd[1]: system-getty.slice: unit configures an IP firewall, but the local system does not support BPF/cgroup firewalling.
+    systemd[1]: (This warning is only shown for the first unit using IP firewalling.)
+    systemd[1]: Created slice system-getty.slice.
+    [  OK  ] Created slice system-getty.slice.
+    systemd[1]: Created slice system-modprobe.slice.
+    [  OK  ] Created slice system-modprobe.slice.
+    systemd[1]: Created slice system-serial\x2dgetty.slice.
+    [  OK  ] Created slice system-serial\x2dgetty.slice.
+    systemd[1]: Created slice system-systemd\x2dfsck.slice.
+    [  OK  ] Created slice system-systemd\x2dfsck.slice.
+    systemd[1]: Created slice User and Session Slice.
+    [  OK  ] Created slice User and Session Slice.
+    systemd[1]: Started Forward Password Requests to Wall Directory Watch.
+    [  OK  ] Started Forward Password R…uests to Wall Directory Watch.
+    systemd[1]: Condition check resulted in Arbitrary Executable File Formats File System Automount Point being skipped.
+    systemd[1]: Reached target Slices.
+    [  OK  ] Reached target Slices.
+    systemd[1]: Reached target Swap.
+    [  OK  ] Reached target Swap.
+    systemd[1]: Listening on Syslog Socket.
+    [  OK  ] Listening on Syslog Socket.
+    systemd[1]: Listening on fsck to fsckd communication Socket.
+    [  OK  ] Listening on fsck to fsckd communication Socket.
+    systemd[1]: Listening on initctl Compatibility Named Pipe.
+    [  OK  ] Listening on initctl Compatibility Named Pipe.
+    systemd[1]: Condition check resulted in Journal Audit Socket being skipped.
+    systemd[1]: Listening on Journal Socket (/dev/log).
+    [  OK  ] Listening on Journal Socket (/dev/log).
+    systemd[1]: Listening on Journal Socket.
+    [  OK  ] Listening on Journal Socket.
+    systemd[1]: Listening on udev Control Socket.
+    [  OK  ] Listening on udev Control Socket.
+    systemd[1]: Listening on udev Kernel Socket.
+    [  OK  ] Listening on udev Kernel Socket.
+    systemd[1]: Condition check resulted in Huge Pages File System being skipped.
+    systemd[1]: Condition check resulted in POSIX Message Queue File System being skipped.
+    systemd[1]: Mounting RPC Pipe File System...
+            Mounting RPC Pipe File System...
+    systemd[1]: Mounting Kernel Debug File System...
+            Mounting Kernel Debug File System...
+    systemd[1]: Condition check resulted in Kernel Trace File System being skipped.
+    systemd[1]: Condition check resulted in Kernel Module supporting RPCSEC_GSS being skipped.
+    systemd[1]: Starting Restore / save the current clock...
+            Starting Restore / save the current clock...
+    systemd[1]: Starting Set the console keyboard layout...
+            Starting Set the console keyboard layout...
+    systemd[1]: Condition check resulted in Create list of static device nodes for the current kernel being skipped.
+    systemd[1]: Starting Load Kernel Module configfs...
+            Starting Load Kernel Module configfs...
+    systemd[1]: Starting Load Kernel Module drm...
+            Starting Load Kernel Module drm...
+    systemd[1]: Starting Load Kernel Module fuse...
+            Starting Load Kernel Module fuse...
+    systemd[1]: Condition check resulted in Set Up Additional Binary Formats being skipped.
+    systemd[1]: Condition check resulted in File System Check on Root Device being skipped.
+    systemd[1]: Starting Journal Service...
+            Starting Journal Service...
+    systemd[1]: Starting Load Kernel Modules...
+            Starting Load Kernel Modules...
+    systemd[1]: Starting Remount Root and Kernel File Systems...
+            Starting Remount Root and Kernel File Systems...
+    systemd[1]: Starting Coldplug All udev Devices...
+            Starting Coldplug All udev Devices...
+    systemd[1]: Mounted RPC Pipe File System.
+    [  OK  ] Mounted RPC Pipe File System.
+    systemd[1]: Mounted Kernel Debug File System.
+    [  OK  ] Mounted Kernel Debug File System.
+    systemd[1]: Started Journal Service.
+    [  OK  ] Started Journal Service.
+    [  OK  ] Finished Restore / save the current clock.
+    [  OK  ] Finished Load Kernel Module configfs.
+    [  OK  ] Finished Load Kernel Module drm.
+    [  OK  ] Finished Load Kernel Module fuse.
+    [FAILED] Failed to start Load Kernel Modules.
+    See 'systemctl status systemd-modules-load.service' for details.
+    [  OK  ] Finished Set the console keyboard layout.
+            Mounting FUSE Control File System...
+            Mounting Kernel Configuration File System...
+            Starting Apply Kernel Variables...
+    [  OK  ] Mounted FUSE Control File System.
+    [  OK  ] Mounted Kernel Configuration File System.
+    [  OK  ] Finished Apply Kernel Variables.
+    [  OK  ] Finished Coldplug All udev Devices.
+    [  OK  ] Finished Remount Root and Kernel File Systems.
+            Starting Helper to synchronize boot up for ifupdown...
+            Starting Flush Journal to Persistent Storage...
+            Starting Load/Save Random Seed...
+            Starting Create System Users...
+            Starting Wait for udev To …plete Device Initialization...
+    [  OK  ] Finished Helper to synchronize boot up for ifupdown.
+    [  OK  ] Finished Create System Users.
+    [  OK  ] Finished Load/Save Random Seed.
+            Starting Create Static Device Nodes in /dev...
+    [  OK  ] Finished Flush Journal to Persistent Storage.
+    [  OK  ] Finished Create Static Device Nodes in /dev.
+    [  OK  ] Reached target Local File Systems (Pre).
+            Starting Rule-based Manage…for Device Events and Files...
+    [  OK  ] Started Rule-based Manager for Device Events and Files.
+            Starting Show Plymouth Boot Screen...
+    [  OK  ] Started Show Plymouth Boot Screen.
+    [  OK  ] Started Forward Password R…s to Plymouth Directory Watch.
+    [  OK  ] Reached target Local Encrypted Volumes.
+    [  OK  ] Found device /dev/ttyPS0.
+    [  OK  ] Found device /dev/disk/by-partuuid/5c29002e-01.
+    [  OK  ] Finished Wait for udev To Complete Device Initialization.
+            Starting File System Check…isk/by-partuuid/5c29002e-01...
+            Starting Load Kernel Modules...
+    [  OK  ] Started File System Check Daemon to report status.
+    [FAILED] Failed to start Load Kernel Modules.
+    See 'systemctl status systemd-modules-load.service' for details.
+    [  OK  ] Finished File System Check…/disk/by-partuuid/5c29002e-01.
+            Mounting /boot...
+    [  OK  ] Mounted /boot.
+    [  OK  ] Reached target Local File Systems.
+            Starting Set console font and keymap...
+            Starting Raise network interfaces...
+            Starting Preprocess NFS configuration...
+            Starting Tell Plymouth To Write Out Runtime Data...
+            Starting Create Volatile Files and Directories...
+    [  OK  ] Finished Set console font and keymap.
+    [  OK  ] Finished Tell Plymouth To Write Out Runtime Data.
+    [  OK  ] Finished Preprocess NFS configuration.
+    [  OK  ] Reached target NFS client services.
+    [  OK  ] Reached target Remote File Systems (Pre).
+    [  OK  ] Reached target Remote File Systems.
+    [  OK  ] Finished Create Volatile Files and Directories.
+            Starting Network Time Synchronization...
+            Starting Update UTMP about System Boot/Shutdown...
+    [  OK  ] Finished Update UTMP about System Boot/Shutdown.
+            Starting Load Kernel Modules...
+    [  OK  ] Started Network Time Synchronization.
+    [  OK  ] Finished Raise network interfaces.
+    [  OK  ] Reached target System Time Set.
+    [  OK  ] Reached target System Time Synchronized.
+    [FAILED] Failed to start Load Kernel Modules.
+    See 'systemctl status systemd-modules-load.service' for details.
+    [  OK  ] Reached target System Initialization.
+    [  OK  ] Started CUPS Scheduler.
+    [  OK  ] Started Daily apt download activities.
+    [  OK  ] Started Daily apt upgrade and clean activities.
+    [  OK  ] Started Periodic ext4 Onli…ata Check for All Filesystems.
+    [  OK  ] Started Discard unused blocks once a week.
+    [  OK  ] Started Daily rotation of log files.
+    [  OK  ] Started Daily man-db regeneration.
+    [  OK  ] Started Daily Cleanup of Temporary Directories.
+    [  OK  ] Reached target Paths.
+    [  OK  ] Reached target Timers.
+    [  OK  ] Listening on Avahi mDNS/DNS-SD Stack Activation Socket.
+    [  OK  ] Listening on CUPS Scheduler.
+    [  OK  ] Listening on D-Bus System Message Bus Socket.
+    [  OK  ] Listening on Erlang Port Mapper Daemon Activation Socket.
+    [  OK  ] Listening on GPS (Global P…ioning System) Daemon Sockets.
+    [  OK  ] Listening on triggerhappy.socket.
+    [  OK  ] Reached target Sockets.
+    [  OK  ] Reached target Basic System.
+            Starting Analog Devices power up/down sequence...
+            Starting Save/Restore Sound Card State...
+            Starting Avahi mDNS/DNS-SD Stack...
+    [  OK  ] Started Regular background program processing daemon.
+    [  OK  ] Started D-Bus System Message Bus.
+            Starting dphys-swapfile - …unt, and delete a swap file...
+            Starting Remove Stale Onli…t4 Metadata Check Snapshots...
+    [  OK  ] Started fan-control.
+            Starting Fix DP audio and X11 for Jupiter...
+            Starting Creating IIOD Context Attributes......
+            Starting Authorization Manager...
+            Starting DHCP Client Daemon...
+            Starting LSB: Switch to on…nless shift key is pressed)...
+            Starting LSB: rng-tools (Debian variant)...
+            Starting System Logging Service...
+            Starting User Login Management...
+            Starting triggerhappy global hotkey daemon...
+            Starting Disk Manager...
+            Starting WPA supplicant...
+    [  OK  ] Finished Save/Restore Sound Card State.
+    [  OK  ] Finished Fix DP audio and X11 for Jupiter.
+    [  OK  ] Reached target Sound Card.
+    [  OK  ] Started triggerhappy global hotkey daemon.
+    [  OK  ] Started System Logging Service.
+    [  OK  ] Started DHCP Client Daemon.
+    [  OK  ] Started LSB: rng-tools (Debian variant).
+    [  OK  ] Finished dphys-swapfile - …mount, and delete a swap file.
+    [  OK  ] Started User Login Management.
+    [  OK  ] Started WPA supplicant.
+    [  OK  ] Started Avahi mDNS/DNS-SD Stack.
+    [  OK  ] Reached target Network.
+    [  OK  ] Reached target Network is Online.
+            Starting CUPS Scheduler...
+    [  OK  ] Started Erlang Port Mapper Daemon.
+            Starting HTTP based time synchronization tool...
+            Starting Internet superserver...
+            Starting /etc/rc.local Compatibility...
+            Starting OpenBSD Secure Shell server...
+            Starting Permit User Sessions...
+    [  OK  ] Started Unattended Upgrades Shutdown.
+    [  OK  ] Started Internet superserver.
+    [  OK  ] Finished Remove Stale Onli…ext4 Metadata Check Snapshots.
+    [  OK  ] Started HTTP based time synchronization tool.
+    [  OK  ] Started /etc/rc.local Compatibility.
+    [  OK  ] Finished Permit User Sessions.
+    [  OK  ] Started Authorization Manager.
+            Starting Modem Manager...
+            Starting Light Display Manager...
+            Starting Hold until boot process finishes up...
+    [  OK  ] Started LSB: Switch to ond…(unless shift key is pressed).
+    [FAILED] Failed to start VNC Server for X11.
+
+    Raspbian GNU/Linux 11 analog ttyPS0
+
+    analog login: root (automatic login)
+
+    Linux analog 6.12.0-27067-g126deeb87ea1-dirty #6 SMP PREEMPT Tue Feb 24 11:50:36 EET 2026 armv7l
+
+    The programs included with the Debian GNU/Linux system are free software;
+    the exact distribution terms for each program are described in the
+    individual files in /usr/share/doc/*/copyright.
+
+    Debian GNU/Linux comes with ABSOLUTELY NO WARRANTY, to the extent
+    permitted by applicable law.
+    Last login: Fri Nov  8 15:17:16 GMT 2024 on ttyPS0
+    root@analog:~#
+
+AD974X hardware differences
+-------------------------------------------------------------------------------
+
+The :adi:`EVAL-AD9748` board is the 8-bit output variant.
+Rest of the hardware is identical to the AD9744 board.
+
+The :adi:`EVAL-AD9740` board is the 10-bit output variant.
+Rest of the hardware is identical to the AD9744 board.
+
+The :adi:`EVAL-AD9742` board is the 12-bit output variant.
+Rest of the hardware is identical to the AD9744 board.
+
+.. figure:: ./images/ad9744-top.jpeg
+   :alt: EVAL-AD74X top view
+   :align: center
+   :width: 400
+
+   EVAL-AD974X top view.
+
+.. figure:: ./images/ad9744-bottom.jpeg
+   :alt: EVAL-AD974X bottom view
+   :align: center
+   :width: 400
+
+   EVAL-AD974X bottom view.


### PR DESCRIPTION
## Type
- [x] Documentation
- [ ] Bug fix
- [ ] New feature
- [ ] Continuous integration

## Checklist
- [x] I have performed a self-review of changes
- [x] I have followed the guidelines:
  * https://analogdevicesinc.github.io/documentation/contributing/docs_guidelines.html
  * https://analogdevicesinc.github.io/doctools/docs_guidelines/index.html
  * https://analogdevicesinc.github.io/documentation/contributing/creating_new_pages.html#documentation-structure
- [x] I have used the appropriate roles and directives:
  * https://analogdevicesinc.github.io/doctools/docs_guidelines/roles.html
  * https://analogdevicesinc.github.io/doctools/docs_guidelines/directives.html
- [x] I ensured that binary data was committed to git lfs:
  * https://analogdevicesinc.github.io/documentation/contributing/creating_new_pages.html#adding-images-and-other-binary-files
- [x] I have built the pages I edited or created, using either `make html` or `adoc serve`:
  * https://analogdevicesinc.github.io/doctools/cli.html#serve
- [x] I have signed-off my commits and believe my contribution improves the repository.
