### PR TITLE
add eMMC installer workflow

### DIFF
--- a/docs/products/adsp/setup.rst
+++ b/docs/products/adsp/setup.rst
@@ -163,12 +163,24 @@ Configure the serial terminal for 115200 baud, 8 data bits, no parity, 1 stop bi
 Booting the System
 ---------------------------
 
+A hybrid boot architecture is being used:
+
+* **SPI Flash** stores the bootloader (U-Boot SPL and U-Boot Proper)
+* **eMMC** stores the full system image (Linux kernel and root filesystem)
+
 Download Release
 ~~~~~~~~~~~~~~~~~~
 
 Navigate to the :git-br2-external:`br2-external releases page <releases+>` and
-download the appropriate ``images-*.tar.xz`` release archive that matches your
-hardware.
+download both release archives that match your hardware (``images-bootstrap-*``
+and ``images-debug-*``), then extract them into the same directory:
+
+.. code-block:: sh
+
+   $ tar -xf images-bootstrap-*.tar.xz
+   $ tar -xf images-debug-*.tar.xz
+
+Both archives extract to ``buildroot/output/images/``.
 
 Boot U-Boot Proper
 ~~~~~~~~~~~~~~~~~~
@@ -209,14 +221,14 @@ Run GDB:
 
       .. shell:: sh
 
-         $ cd images-*   # Navigate to extracted release directory
+         $ cd buildroot/output/images
          $ gdb-multiarch -x u-boot.gdb
 
    .. tab-item:: Windows/Fedora/RHEL
 
       .. shell:: sh
 
-         $ cd images-*   # Navigate to extracted release directory
+         $ cd buildroot/output/images
          $ gdb -x u-boot.gdb
 
 Boot Linux
@@ -230,14 +242,14 @@ Start a file server in a new terminal on your PC in the release directory:
 
       .. shell:: sh
 
-         $ cd images-*   # Navigate to extracted release directory
+         $ cd buildroot/output/images
          $ python3 -m http.server
 
    .. tab-item:: Windows
 
       .. shell:: sh
 
-         $ cd images-*   # Navigate to extracted release directory
+         $ cd buildroot/output/images
          $ python -m http.server
 
 Find your IP address:
@@ -288,15 +300,6 @@ the installer proceeds to write the eMMC image.
 Install eMMC Image
 ~~~~~~~~~~~~~~~~~~
 
-If ``emmc.img`` is not compressed, compress it manually:
-
-.. code-block:: sh
-
-   $ gzip -k emmc.img
-
-Ensure ``emmc.img.gz`` is in the same directory where your HTTP server is
-running.
-
 The serial console prompts for your PC's IP address:
 
 .. code-block:: console
@@ -325,7 +328,8 @@ flash and the U-Boot console appears.
 Boot Linux from eMMC
 ~~~~~~~~~~~~~~~~~~~~
 
-After reboot, U-Boot does not boot automatically. At the U-Boot prompt, type:
+After reboot from SPI flash, U-Boot does not boot automatically. At the U-Boot
+prompt, type:
 
 .. code-block:: console
 

--- a/docs/products/adsp/setup.rst
+++ b/docs/products/adsp/setup.rst
@@ -282,14 +282,66 @@ Serial console displays a prompt:
    This will erase and program SPI flash.
    Continue? [y/N]:
 
-Type ``y`` to erase the flash contents and install U-Boot. After programming completes, 
-the console instructs you to move the S1 boot mode switch to the SPI boot position.
+Type ``y`` to erase the flash contents and install U-Boot. After programming completes,
+the installer proceeds to write the eMMC image.
+
+Install eMMC Image
+~~~~~~~~~~~~~~~~~~
+
+If ``emmc.img`` is not compressed, compress it manually:
+
+.. code-block:: sh
+
+   $ gzip -k emmc.img
+
+Ensure ``emmc.img.gz`` is in the same directory where your HTTP server is
+running.
+
+The serial console prompts for your PC's IP address:
 
 .. code-block:: console
 
-   SPI install complete
+   ======== Install eMMC Image ========
+
+   This will download emmc.img.gz from your PC and write it to /dev/mmcblk0.
+
+   Enter your PC's IP address:
+
+The board configures its network interface, downloads
+``emmc.img.gz`` from your PC, decompresses it, and writes it directly to the
+eMMC. After the write completes, the console instructs you to move the S1 boot
+mode switch:
+
+.. code-block:: console
+
+   eMMC install complete.
 
    Set the switch S1 to position 1 (SPI boot).
    Waiting for switch...
 
-Once the position change is detected, the system reboots automatically from SPI flash and the U-Boot console appears.
+Once the position change is detected, the system reboots automatically from SPI
+flash and the U-Boot console appears.
+
+Boot Linux from eMMC
+~~~~~~~~~~~~~~~~~~~~
+
+After reboot, U-Boot does not boot automatically. At the U-Boot prompt, type:
+
+.. code-block:: console
+
+   => run emmcboot
+
+U-Boot loads the kernel and device tree from the eMMC boot partition and starts
+Linux with the root filesystem on eMMC.
+
+Login
+~~~~~
+
+When the boot completes, a login prompt appears:
+
+.. code-block:: console
+
+   Welcome to the ADI SC598 EZ-Kit
+   sc598-ezkit login:
+
+Log in as ``root`` with no password (press Enter).


### PR DESCRIPTION
## Summary:

Added documentation for the eMMC installer workflow: flashing the image, booting Linux from eMMC and default login credentials.


## Note:

The image is served compressed (.gz) as a temporary workaround for a suspected race condition in the SC598 MMC kernel driver that causes a crash under memory pressure when streaming the raw 7.6 GB image. This will be reverted once the driver bug is fixed.


## Type
- [x] Documentation
- [ ] Bug fix
- [ ] New feature
- [ ] Continuous integration

## Checklist
- [ ] I have performed a self-review of changes
- [ ] I have followed the guidelines:
  * https://analogdevicesinc.github.io/documentation/contributing/docs_guidelines.html
  * https://analogdevicesinc.github.io/doctools/docs_guidelines/index.html
  * https://analogdevicesinc.github.io/documentation/contributing/creating_new_pages.html#documentation-structure
- [ ] I have used the appropriate roles and directives:
  * https://analogdevicesinc.github.io/doctools/docs_guidelines/roles.html
  * https://analogdevicesinc.github.io/doctools/docs_guidelines/directives.html
- [ ] I ensured that binary data was committed to git lfs:
  * https://analogdevicesinc.github.io/documentation/contributing/creating_new_pages.html#adding-images-and-other-binary-files
- [ ] I have built the pages I edited or created, using either `make html` or `adoc serve`:
  * https://analogdevicesinc.github.io/doctools/cli.html#serve
- [ ] I have signed-off my commits and believe my contribution improves the repository.
