### PR TITLE
reference-designs/adrd3161-01z: Add production testing guide

### DIFF
--- a/docs/solutions/reference-designs/adrd3161-01z/images/production_tests/encoder_and_motor_cable_conn.png
+++ b/docs/solutions/reference-designs/adrd3161-01z/images/production_tests/encoder_and_motor_cable_conn.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ba81cad7fda46cc1977941fbd56421f700e5135b2a513d3daced7215f9bf85c1
+size 429225

--- a/docs/solutions/reference-designs/adrd3161-01z/images/production_tests/motor_connections.png
+++ b/docs/solutions/reference-designs/adrd3161-01z/images/production_tests/motor_connections.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8705e2e735974d2db303168c10223e2ccae6c9e95dbb55418d1f7b2cd8be6c19
+size 210305

--- a/docs/solutions/reference-designs/adrd3161-01z/images/production_tests/p12_jumper_position.png
+++ b/docs/solutions/reference-designs/adrd3161-01z/images/production_tests/p12_jumper_position.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:184ba4fe58daec87b73069c9c03640d2adf508328d5b5c7b9d4472d075730511
+size 410562

--- a/docs/solutions/reference-designs/adrd3161-01z/images/production_tests/p15_jumper_position.png
+++ b/docs/solutions/reference-designs/adrd3161-01z/images/production_tests/p15_jumper_position.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:14ed2334194e42a7ec9ad058836ff4cb061a7b6e03127fee71896181ddb46cb5
+size 293265

--- a/docs/solutions/reference-designs/adrd3161-01z/images/production_tests/p6_connection.png
+++ b/docs/solutions/reference-designs/adrd3161-01z/images/production_tests/p6_connection.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:655df97ee86bc1201b79d9cdc7f39625057208985ba9f0abbdea3cba712a533c
+size 351264

--- a/docs/solutions/reference-designs/adrd3161-01z/images/production_tests/p7_connection.png
+++ b/docs/solutions/reference-designs/adrd3161-01z/images/production_tests/p7_connection.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:59efac28fb179721d7910e48b056a774f4056ae1ca1c365d9f18c4873c01996f
+size 407226

--- a/docs/solutions/reference-designs/adrd3161-01z/images/production_tests/power_connections.png
+++ b/docs/solutions/reference-designs/adrd3161-01z/images/production_tests/power_connections.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6b93f05b6ce46237d4a741b565cf44994bfc92743da95345368175b795311fea
+size 202671

--- a/docs/solutions/reference-designs/adrd3161-01z/images/production_tests/reset_TMC_reset_MCU.png
+++ b/docs/solutions/reference-designs/adrd3161-01z/images/production_tests/reset_TMC_reset_MCU.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:977375e4e653a183bec778c1dd7779703188891356100acd0a366961b026ac69
+size 466672

--- a/docs/solutions/reference-designs/adrd3161-01z/images/production_tests/s2_switch_config.png
+++ b/docs/solutions/reference-designs/adrd3161-01z/images/production_tests/s2_switch_config.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1d211eab511207bc013c8012e55422946c02e988ee9dd9339b7e495baa80bc48
+size 267695

--- a/docs/solutions/reference-designs/adrd3161-01z/images/production_tests/system_connection.png
+++ b/docs/solutions/reference-designs/adrd3161-01z/images/production_tests/system_connection.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3f37cf145e43015941fe1bdc21e507edeaa365bf8026ed4f396b6542ed6f34b0
+size 351948

--- a/docs/solutions/reference-designs/adrd3161-01z/images/production_tests/test_menu_command_1.png
+++ b/docs/solutions/reference-designs/adrd3161-01z/images/production_tests/test_menu_command_1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c8300c1c996142377d350da7f34209d4dbe802b904e539d1c73b5f8f62b169cc
+size 176253

--- a/docs/solutions/reference-designs/adrd3161-01z/images/production_tests/test_menu_command_1_result.png
+++ b/docs/solutions/reference-designs/adrd3161-01z/images/production_tests/test_menu_command_1_result.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9fde62a9df1e8b647c7d547df3c50dd216285a9d012a93bfe799c24976095c89
+size 43053

--- a/docs/solutions/reference-designs/adrd3161-01z/images/production_tests/test_menu_command_2.png
+++ b/docs/solutions/reference-designs/adrd3161-01z/images/production_tests/test_menu_command_2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0acf218cc333377f3cd1a28f50cf7f943890106d1e6c1281c72826fc1ea11d36
+size 24077

--- a/docs/solutions/reference-designs/adrd3161-01z/images/production_tests/test_menu_command_2_result.png
+++ b/docs/solutions/reference-designs/adrd3161-01z/images/production_tests/test_menu_command_2_result.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fd8a48d64ca8f84930478bd5422cbfb5989e6ea7eb8ecc46c4590f2e92c9b12b
+size 114781

--- a/docs/solutions/reference-designs/adrd3161-01z/images/production_tests/test_menu_command_3.png
+++ b/docs/solutions/reference-designs/adrd3161-01z/images/production_tests/test_menu_command_3.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ee56509de7c9f6b0965c64d600600b7975f6c53a8256c1770087a45994fb2b84
+size 43209

--- a/docs/solutions/reference-designs/adrd3161-01z/images/production_tests/test_menu_command_3_failure.png
+++ b/docs/solutions/reference-designs/adrd3161-01z/images/production_tests/test_menu_command_3_failure.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ecec7b7829ff66c58b16310aa920eda1b9a920f086e2de0d13a0cfb1fc5076bc
+size 9643

--- a/docs/solutions/reference-designs/adrd3161-01z/images/production_tests/test_process_1_wifi_connection.png
+++ b/docs/solutions/reference-designs/adrd3161-01z/images/production_tests/test_process_1_wifi_connection.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:596bd2864c83b74fb0977349c661a724dee57b214cf434c403c577103aec06c5
+size 288635

--- a/docs/solutions/reference-designs/adrd3161-01z/images/production_tests/test_process_2_reboot_conn.png
+++ b/docs/solutions/reference-designs/adrd3161-01z/images/production_tests/test_process_2_reboot_conn.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2506a7ffa56096fc9f31209d3da27e95b5bbf048c351e418bb441ed2c34dcc44
+size 57895

--- a/docs/solutions/reference-designs/adrd3161-01z/images/production_tests/test_process_3_reboot_conn.png
+++ b/docs/solutions/reference-designs/adrd3161-01z/images/production_tests/test_process_3_reboot_conn.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:25afe2dc3dc26af83a4e29c5c4ed16672f6423e9227268480e69caab96fcb002
+size 35122

--- a/docs/solutions/reference-designs/adrd3161-01z/index.rst
+++ b/docs/solutions/reference-designs/adrd3161-01z/index.rst
@@ -51,7 +51,7 @@ Required Hardware
 
 * :adi:`ADRD3161-01Z`
 * Stepper / BLDC / DC motor. Documented output represents the :adi:`QSH5718-51-28-101-10k <qsh5718>` Stepper.
-* DC power supply (9 .. 70 VDC)
+* DC power supply (9 .. 70 Vdc)
 * CAN, encoder cables, described in the :doc:`hardware-guide`
 
 To debug / reprogram the device, you will need a MAXDAP compatible debug probe, such as the :adi:`MAX32625PICO`.
@@ -64,6 +64,7 @@ User Guides
    hardware-guide
    quick-start-guide
    production-guide
+   production-testing
 
 Help and Support
 ----------------

--- a/docs/solutions/reference-designs/adrd3161-01z/production-testing.rst
+++ b/docs/solutions/reference-designs/adrd3161-01z/production-testing.rst
@@ -1,0 +1,305 @@
+Production Testing
+==================
+
+Overview
+--------
+
+The purpose of the test procedure is to identify connectivity issues, poor
+soldering, and potential manufacturing defects. Some of the issues are directly
+identified by explicit part-targeted tests, others are implicit, by running
+adjacent tests.
+
+Test Duration
+-------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 70 30
+
+   * - Step Description
+     - Estimated Time (minutes)
+   * - Test bench setup
+     - 8 min
+   * - Software test
+     - 6 min
+   * - **Total time**
+     - **14 min**
+
+Test Requirements
+-----------------
+
+Required Hardware
+^^^^^^^^^^^^^^^^^
+
+* Raspberry Pi 5, power supply
+* HDMI cable, mouse, keyboard
+* 1x USB to CAN adapter
+* 1x CAN cable
+* 1x motor :adi:`QSH5718-76-28-101-10k <qsh5718>`
+* 1x encoder cable
+* 1x :adi:`MAX32650` (Daplink programmer)
+* 1x Power supply for device under test, crimped power cable
+* :adi:`ADRD3161-01Z` as device under test (D.U.T.)
+* SD card with the test image
+
+Required Software
+^^^^^^^^^^^^^^^^^
+
+The test image will be provided as a SD test card that goes into the Raspberry Pi.
+
+Required Setup
+^^^^^^^^^^^^^^
+
+.. list-table::
+   :header-rows: 1
+   :widths: 10 90
+
+   * - No.
+     - Steps
+   * - 1
+     - Insert the SD card into the Raspberry Pi
+   * - 2
+     - Connect the Raspberry Pi to a monitor and power it
+   * - 3
+     - Put jumpers on D.U.T. P12, P15 in position
+   * - 5
+     - Connect the CAN cable to P9 and the USB into the Raspberry Pi
+   * - 6
+     - Connect the encoder cable between P16 and the motor
+   * - 7
+     - Connect the motor cable to P3 header (see picture below)
+   * - 8
+     - Connect power supply to P10 on D.U.T. board
+   * - 9
+     - S2 switch in configuration shown in picture below
+   * - 10
+     - Connect the Daplink cable to P7 connector
+   * - 11
+     - Run 1) TMC bootstrapping
+   * - 12
+     - Move the Daplink to P6 connector
+   * - 13
+     - Run 2) Microcontroller Flash
+   * - 14
+     - Run 3) System test
+
+.. note::
+
+   * When running test **1) Bootstrapping TMC**, the Daplink should be connected to **P7 connector**
+   * When running test **2) Microcontroller Flash** and **3) System Test**, the Daplink should be connected to **P6 connector**
+
+Jumper Positions
+""""""""""""""""
+
+.. grid::
+   :widths: 50 50
+
+   .. figure:: images/production_tests/p12_jumper_position.png
+
+      P12 jumper connected
+
+   .. figure:: images/production_tests/p15_jumper_position.png
+
+      P15 jumper connected
+
+S2 Switch Configuration
+"""""""""""""""""""""""
+
+.. figure:: images/production_tests/s2_switch_config.png
+   :width: 45em
+
+   S2 switch configuration
+
+Motor and Encoder Connections
+"""""""""""""""""""""""""""""
+
+When connecting the motor cable to P3, ensure the correct color order:
+
+* UX1 = **black**
+* VX2 = **green**
+* WY1 = **red**
+* Y2 = **blue**
+
+.. grid::
+   :widths: 50 50
+
+   .. figure:: images/production_tests/encoder_and_motor_cable_conn.png
+
+      Encoder cable and motor cable connections
+
+   .. figure:: images/production_tests/motor_connections.png
+
+      Motor connections
+
+Daplink Connections
+"""""""""""""""""""
+
+.. grid::
+   :widths: 50 50
+
+   .. figure:: images/production_tests/p7_connection.png
+
+      Daplink on P7 for 1) TMC bootstrapping
+
+   .. figure:: images/production_tests/p6_connection.png
+
+      Daplink on P6 for 2) Microcontroller flash
+
+Power Connections
+"""""""""""""""""
+
+.. figure:: images/production_tests/power_connections.png
+   :width: 45em
+
+   Power connections
+
+Complete Test Bench
+"""""""""""""""""""
+
+.. figure:: images/production_tests/system_connection.png
+   :width: 45em
+
+   Full system connection overview
+
+Test Process
+------------
+
+Before starting the testing procedure, make sure the Raspberry Pi is connected
+to Wi-Fi.
+
+Enabling Wi-Fi
+^^^^^^^^^^^^^^
+
+#. After the RPi boots, press CONTROL+C to exit the test screen.
+#. Click on the Wi-Fi network you want to connect to.
+
+   .. figure:: images/production_tests/test_process_1_wifi_connection.png
+      :width: 45em
+
+      Wi-Fi network selection
+
+#. Type in the password. After connecting successfully, reboot the Raspberry Pi.
+
+   .. figure:: images/production_tests/test_process_2_reboot_conn.png
+      :width: 45em
+
+      Raspberry Pi menu
+
+   .. figure:: images/production_tests/test_process_3_reboot_conn.png
+      :width: 45em
+
+      Shutdown options - select Reboot
+
+Running the Tests
+^^^^^^^^^^^^^^^^^
+
+The following test menu should appear after reboot:
+
+.. code-block:: text
+
+   Please enter your choice:
+   1) TMC Bootstrapping
+   2) Firmware Flash
+   3) System Test
+   4) Power-Off Pi
+
+1) TMC Bootstrapping
+""""""""""""""""""""
+
+Type "1" and press ENTER to run **1) TMC9660 Bootstrapping**. This step may fail
+once, in which case try it again. If it fails twice then either:
+
+* The board has already been through this test (check if any LEDs light up on
+  the board)
+* The board is defective
+
+.. figure:: images/production_tests/test_menu_command_1.png
+   :width: 45em
+
+   TMC Bootstrapping process
+
+When prompted ``Proceed with OTP burn? (y/n):``, press ``y`` then ENTER.
+
+.. figure:: images/production_tests/test_menu_command_1_result.png
+   :width: 45em
+
+   TMC Bootstrapping passed
+
+.. attention::
+
+   **1) TMC Bootstrapping** test is a **one-time step**. It might fail if you run
+   it multiple times. Thus, an error may be acceptable if the step was already
+   run and passed in the past.
+
+   To diagnose whether an error in this test is an actual fault, or just a
+   result of running the step multiple times, do the following:
+
+   * Press TMC_RST -> check DS1 lights up
+   * Press MCU_RST -> check DS1 turns off
+
+   .. list-table::
+      :header-rows: 1
+      :widths: 30 30 40
+
+      * - After pressing RST_TMC
+        - After pressing RST_MCU
+        - Diagnosis
+      * - DS1 lights up
+        - DS1 turns off
+        - OK! Both TMC and MCU are functional.
+      * - DS1 lights up
+        - DS1 stays on
+        - TMC bootstrapped, MCU not functional (could be because step 2 didn't run yet)
+      * - DS1 LED does not turn on
+        - /
+        - TMC fault/TMC not bootstrapped
+
+After TMC Bootstrapping:
+
+* Press RST_TMC button
+* Press RST_MCU button
+
+.. figure:: images/production_tests/reset_TMC_reset_MCU.png
+   :width: 45em
+
+   RST_TMC and RST_MCU buttons
+
+2) Firmware Flash
+"""""""""""""""""
+
+Type "2" in order to run **2) Firmware Flash**. Connect the Daplink cable to
+**P6 connector**.
+
+.. figure:: images/production_tests/test_menu_command_2.png
+   :width: 45em
+
+   Firmware Flash process
+
+When prompted, verify that the programmer is connected to header P6, then press
+Enter.
+
+.. figure:: images/production_tests/test_menu_command_2_result.png
+   :width: 45em
+
+   Firmware Flash passed
+
+3) System Test
+""""""""""""""
+
+Type "3" to run **3) System Test**.
+
+.. warning::
+
+   THE MOTOR WILL MOVE during this test.
+
+.. figure:: images/production_tests/test_menu_command_3.png
+   :width: 45em
+
+   System Test passed
+
+If test 3) fails, it will display:
+
+.. figure:: images/production_tests/test_menu_command_3_failure.png
+   :width: 45em
+
+   System Test failed


### PR DESCRIPTION
The documentation page is deployed here: https://plescaevelyn.github.io/adi-documentation/pull/19/

## Type
- [x] Documentation
- [ ] Bug fix
- [ ] New feature
- [ ] Continuous integration

## Checklist
- [x] I have performed a self-review of changes
- [x] I have followed the guidelines:
  * https://analogdevicesinc.github.io/documentation/contributing/docs_guidelines.html
  * https://analogdevicesinc.github.io/doctools/docs_guidelines/index.html
  * https://analogdevicesinc.github.io/documentation/contributing/creating_new_pages.html#documentation-structure
- [x] I have used the appropriate roles and directives:
  * https://analogdevicesinc.github.io/doctools/docs_guidelines/roles.html
  * https://analogdevicesinc.github.io/doctools/docs_guidelines/directives.html
- [x] I ensured that binary data was committed to git lfs:
  * https://analogdevicesinc.github.io/documentation/contributing/creating_new_pages.html#adding-images-and-other-binary-files
- [x] I have built the pages I edited or created, using either `make html` or `adoc serve`:
  * https://analogdevicesinc.github.io/doctools/cli.html#serve
- [x] I have signed-off my commits and believe my contribution improves the repository.
