### PR TITLE
reference-designs/ad-apard32690-sl: add production testing procedure for Rev E

### DIFF
--- a/docs/solutions/reference-designs/ad-apard32690-sl/production_testing/images/apard_connections.png
+++ b/docs/solutions/reference-designs/ad-apard32690-sl/production_testing/images/apard_connections.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:409ad82741ad2c8aa55724c91f31067a0e482648ffead93a7a02d168a7f034d6
+size 384898

--- a/docs/solutions/reference-designs/ad-apard32690-sl/production_testing/images/firmware_and_memory_test_jumper_positions.png
+++ b/docs/solutions/reference-designs/ad-apard32690-sl/production_testing/images/firmware_and_memory_test_jumper_positions.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:655819d0aa7d0fc8a8d5f8486f3af4f08e9f828f34efacbc8ba97124482344be
+size 433976

--- a/docs/solutions/reference-designs/ad-apard32690-sl/production_testing/images/firmware_and_memory_test_passed.png
+++ b/docs/solutions/reference-designs/ad-apard32690-sl/production_testing/images/firmware_and_memory_test_passed.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b21c17f0280d320217e07de06d48cd79ccb1af1198ddf5e0f8f7678924862daf
+size 39563

--- a/docs/solutions/reference-designs/ad-apard32690-sl/production_testing/images/logout.png
+++ b/docs/solutions/reference-designs/ad-apard32690-sl/production_testing/images/logout.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:440271d8072a9440c4d7ba0a3a2115d5eb09777637ae530b2afcb439a8629ba7
+size 58167

--- a/docs/solutions/reference-designs/ad-apard32690-sl/production_testing/images/raspberry_pi_connections.png
+++ b/docs/solutions/reference-designs/ad-apard32690-sl/production_testing/images/raspberry_pi_connections.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:efdce9ecc1742906f95b533a6ea2726a918980685187dea498dddd7876dc13c2
+size 337055

--- a/docs/solutions/reference-designs/ad-apard32690-sl/production_testing/images/reboot.png
+++ b/docs/solutions/reference-designs/ad-apard32690-sl/production_testing/images/reboot.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1f1a157acb036cd2985c3af12950941fb836ac9234e5cbf3d263d8f5c17c967c
+size 27258

--- a/docs/solutions/reference-designs/ad-apard32690-sl/production_testing/images/reset_button.png
+++ b/docs/solutions/reference-designs/ad-apard32690-sl/production_testing/images/reset_button.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:53a8641b6cf9b1752e0e43c160f4bf287705809b95b005f87a776551b0c68513
+size 439690

--- a/docs/solutions/reference-designs/ad-apard32690-sl/production_testing/images/system_test_passed.png
+++ b/docs/solutions/reference-designs/ad-apard32690-sl/production_testing/images/system_test_passed.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:411c87b9bea580b1f83b50c716adcfa2665271f7d44120152f258719de444803
+size 108328

--- a/docs/solutions/reference-designs/ad-apard32690-sl/production_testing/images/test_screens.png
+++ b/docs/solutions/reference-designs/ad-apard32690-sl/production_testing/images/test_screens.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7f6b9510490a67995b8b742dfe0f75e182c7721e6fb139d0e94f3dd7d919f13c
+size 18099

--- a/docs/solutions/reference-designs/ad-apard32690-sl/production_testing/images/wifi_connection.png
+++ b/docs/solutions/reference-designs/ad-apard32690-sl/production_testing/images/wifi_connection.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:91f515b033d6bc71c0bcf81e0fbc9b11ce6e54e373844004933b4c36b1c78c21
+size 294216

--- a/docs/solutions/reference-designs/ad-apard32690-sl/production_testing/images/wifi_flash_test_jumper_position.png
+++ b/docs/solutions/reference-designs/ad-apard32690-sl/production_testing/images/wifi_flash_test_jumper_position.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:84b99026708cc121ebab5752e64ec033335a8cc2f48b3658bfa1fd97fd493ae5
+size 335480

--- a/docs/solutions/reference-designs/ad-apard32690-sl/production_testing/images/wifi_flash_test_screen_1.png
+++ b/docs/solutions/reference-designs/ad-apard32690-sl/production_testing/images/wifi_flash_test_screen_1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5bd6db093828ef6d0b5e45d33134fe94c4a26dd598459470e9121b70aabf9b43
+size 58128

--- a/docs/solutions/reference-designs/ad-apard32690-sl/production_testing/images/wifi_flash_test_screen_2.png
+++ b/docs/solutions/reference-designs/ad-apard32690-sl/production_testing/images/wifi_flash_test_screen_2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a4241a634ee0d7b023936b1050a907d305f1d61ba765d6752240a0ce2b6ff12d
+size 95383

--- a/docs/solutions/reference-designs/ad-apard32690-sl/production_testing/images/wifi_flash_test_screen_3.png
+++ b/docs/solutions/reference-designs/ad-apard32690-sl/production_testing/images/wifi_flash_test_screen_3.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4f9c19a7f145f5a3663aaf045df31b41461ec3277c2c7562263958d08647a304
+size 47849

--- a/docs/solutions/reference-designs/ad-apard32690-sl/production_testing/images/wifi_flash_test_screen_passed.png
+++ b/docs/solutions/reference-designs/ad-apard32690-sl/production_testing/images/wifi_flash_test_screen_passed.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:afb3ed1995c941796e13c2a8d56f5c3215cd798c40e2da576695b2a2dbfb1e7d
+size 15149

--- a/docs/solutions/reference-designs/ad-apard32690-sl/production_testing/index.rst
+++ b/docs/solutions/reference-designs/ad-apard32690-sl/production_testing/index.rst
@@ -1,0 +1,273 @@
+.. _ad-apard32690-sl production_testing:
+
+Production Testing
+===================
+
+.. note::
+
+   This production test procedure applies to **Rev E** of the AD-APARD32690-SL
+   board.
+
+Overview
+--------
+
+The purpose of the test procedure is to identify connectivity issues, poor
+soldering, and potential manufacturing defects. Some of the issues are directly
+identified by explicit part-targeted tests, others are implicit, by running
+adjacent tests.
+
+Test Duration
+-------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 70 30
+
+   * - Step Description
+     - Estimated Time (minutes)
+   * - Test bench setup
+     - 10 min
+   * - Software test
+     - 5 min
+   * - **Total time**
+     - **15 min**
+
+Test Requirements
+-----------------
+
+Required Hardware
+^^^^^^^^^^^^^^^^^
+
+* 1x AD-APARD32690-SL board as device under test (DUT)
+* 1x AD-T1LUSB2.0-EBZ and USB cable
+* 1x Raspberry Pi 4 + Power supply
+* 1x MAX32625PICO (Daplink) programmer
+* 1x Micro HDMI cable for Raspberry Pi
+* 1x Mouse and keyboard for Raspberry Pi
+* 1x SD test card
+
+Required Software
+^^^^^^^^^^^^^^^^^
+
+The test image is provided on a pre-configured SD card that inserts into the
+Raspberry Pi SD card slot.
+
+Required Setup
+^^^^^^^^^^^^^^
+
+.. list-table::
+   :header-rows: 1
+   :widths: 10 90
+
+   * - No.
+     - Steps
+   * - 1
+     - Insert the SD card into the Raspberry Pi and power it
+   * - 2
+     - Connect the HDMI cable between RPi and the monitor, insert mouse and
+       keyboard dongle into the RPi's USB port
+   * - 3
+     - Connect MAX32625PICO Daplink programmer to RPi and DUT
+   * - 4
+     - Connect the T1L cable to the AD-MAXARDUINO (DUT) board
+   * - 5
+     - Connect the T1L cable to the AD-T1LUSB2.0-EBZ
+   * - 6
+     - Connect the AD-T1LUSB2.0-EBZ to the RPi using a USB cable
+
+.. figure:: images/raspberry_pi_connections.png
+   :width: 40em
+
+   Raspberry Pi connections
+
+.. figure:: images/apard_connections.png
+   :width: 40em
+
+   DUT connections
+
+Test Process
+------------
+
+Enabling Wi-Fi
+^^^^^^^^^^^^^^
+
+Before starting the testing procedure, make sure the Raspberry Pi is connected
+to Wi-Fi.
+
+#. After the RPi boots the OS, press **CONTROL+C** to exit the test screen
+#. Click on the Wi-Fi network you want to connect to
+#. Type in the password
+
+.. figure:: images/wifi_connection.png
+   :width: 40em
+
+   Wi-Fi connection
+
+After successfully connecting, reboot the Raspberry Pi:
+
+.. figure:: images/reboot.png
+   :width: 40em
+
+   Reboot Raspberry Pi
+
+.. figure:: images/logout.png
+   :width: 40em
+
+   Logout screen
+
+Running the Test Software
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+After the Raspberry Pi reboots, the test screen will appear on the monitor as
+shown below.
+
+.. figure:: images/test_screens.png
+   :width: 40em
+
+   Test menu screen
+
+The following test menu should appear:
+
+.. code-block:: text
+
+   Please enter your choice:
+   1) Firmware and memory test
+   2) System Test
+   3) WI-FI Flash Test
+   4) Power-Off Pi
+
+1) Firmware and Memory Test
+"""""""""""""""""""""""""""
+
+Type "1" into the terminal then press **ENTER** to start
+**1) Firmware and memory test**.
+
+During this step, make sure the jumpers are in the correct position:
+
+* **P38** and **P56** jumpers are inserted
+* **P50** and **P55** are on position 2-3
+
+.. figure:: images/firmware_and_memory_test_jumper_positions.png
+   :width: 40em
+
+   Jumper positions for firmware and memory test
+
+If the firmware is successfully written, you should see the message:
+"no fail.txt found. SUCCESS"
+
+Press the reset button on the board when prompted:
+
+.. figure:: images/reset_button.png
+   :width: 40em
+
+   Reset button location
+
+.. note::
+
+   In case a failure occurred, a "FAILED" message will be displayed and you
+   will be prompted to enter a new command.
+
+   If at any point a test fails, you can retry the test suite up to 3 times.
+
+After the first test is passed, a green "PASSED" message will appear on the
+screen.
+
+.. figure:: images/firmware_and_memory_test_passed.png
+   :width: 40em
+
+   Firmware and memory test passed
+
+2) System Test
+""""""""""""""
+
+Type "2" into the terminal and press **ENTER** to start **2) System Test**.
+
+.. note::
+
+   In case a failure occurred, a "FAILED" message will be displayed.
+
+After the test is passed, a green "PASSED" message will appear on the screen.
+
+.. figure:: images/system_test_passed.png
+   :width: 40em
+
+   System test passed
+
+3) Wi-Fi Flash Test
+"""""""""""""""""""
+
+Type "3" and press **ENTER** to start **3) Wi-Fi Flash Test**.
+
+Make sure the jumpers are in the correct position:
+
+* **P50** and **P55** jumpers are on position 1-2
+* **P38** and **P56** jumpers are removed
+* **P57** jumper is ON
+
+.. figure:: images/wifi_flash_test_jumper_position.png
+   :width: 40em
+
+   Jumper positions for Wi-Fi flash test
+
+Press **ENTER** to continue.
+
+.. figure:: images/wifi_flash_test_screen_1.png
+   :width: 40em
+
+   Wi-Fi flash test screen 1
+
+Press the reset button on the board and press **ENTER** to write the Wi-Fi chip
+firmware.
+
+.. figure:: images/wifi_flash_test_screen_2.png
+   :width: 40em
+
+   Wi-Fi flash test screen 2
+
+Disconnect the jumper previously connected to P57.
+
+.. figure:: images/wifi_flash_test_screen_3.png
+   :width: 40em
+
+   Wi-Fi flash test screen 3
+
+Press the **RESET** button on the board then press **ENTER**.
+
+After successful completion:
+
+.. figure:: images/wifi_flash_test_screen_passed.png
+   :width: 40em
+
+   Wi-Fi flash test passed
+
+Final Firmware Test
+"""""""""""""""""""
+
+Go back to **1) Firmware and memory test** and run it one more time. Make sure
+jumpers are in the correct position as stated earlier in this document:
+
+* **P38** and **P56** jumpers are inserted
+* **P50** and **P55** are on position 2-3
+
+.. note::
+
+   If at any point a test fails, you should retry the test suite for up to
+   3 times.
+
+Pass Criteria
+^^^^^^^^^^^^^
+
+After tests **1) Firmware and memory test**, **2) System Test**,
+**3) Wi-Fi Flash Test**, and the final **1) Firmware and memory test** have
+successfully passed, you can consider the DUT as being functional.
+
+Place the jumpers in their final position:
+
+* **P38**, **P56** installed
+* **P55**, **P50** on position 2-3
+
+4) Power-Off Pi
+^^^^^^^^^^^^^^^
+
+When you are done testing, press "4" and press **ENTER** to power-off the
+Raspberry Pi.


### PR DESCRIPTION
The documentation page is deployed here: https://plescaevelyn.github.io/adi-documentation/pull/22/

## Type
- [x] Documentation
- [ ] Bug fix
- [ ] New feature
- [ ] Continuous integration

## Checklist
- [x] I have performed a self-review of changes
- [x] I have followed the guidelines:
  * https://analogdevicesinc.github.io/documentation/contributing/docs_guidelines.html
  * https://analogdevicesinc.github.io/doctools/docs_guidelines/index.html
  * https://analogdevicesinc.github.io/documentation/contributing/creating_new_pages.html#documentation-structure
- [x] I have used the appropriate roles and directives:
  * https://analogdevicesinc.github.io/doctools/docs_guidelines/roles.html
  * https://analogdevicesinc.github.io/doctools/docs_guidelines/directives.html
- [x] I ensured that binary data was committed to git lfs:
  * https://analogdevicesinc.github.io/documentation/contributing/creating_new_pages.html#adding-images-and-other-binary-files
- [x] I have built the pages I edited or created, using either `make html` or `adoc serve`:
  * https://analogdevicesinc.github.io/doctools/cli.html#serve
- [x] I have signed-off my commits and believe my contribution improves the repository.
