### PR TITLE
reference-designs: eval-adrv904x: Fix bin files location in iio captu…

### DIFF
--- a/docs/solutions/reference-designs/eval-adrv904x/adrv904x_osc_main.rst
+++ b/docs/solutions/reference-designs/eval-adrv904x/adrv904x_osc_main.rst
@@ -93,6 +93,6 @@ appears as an additional device:
 
 To use the NLS profile, copy ``system.dtb`` built from
 ``zynqmp-zcu102-rev10-adrv904x-nls.dts`` and ``DeviceProfileTest_NLS.bin``
-renamed to ``DeviceProfileTest.bin`` to the SD card boot partition.
+renamed to ``DeviceProfileTest.bin`` to /lib/firmware on the board.
 
 .. include-template:: ../common/using-scopy.rst.jinja


### PR DESCRIPTION
Fix binary files location in iio capture window section for Korror.


## Type
- [ ] Documentation
- [x] Bug fix
- [ ] New feature
- [ ] Continuous integration

## Checklist
- [x] I have performed a self-review of changes
- [x] I have followed the guidelines:
  * https://analogdevicesinc.github.io/documentation/contributing/docs_guidelines.html
  * https://analogdevicesinc.github.io/doctools/docs_guidelines/index.html
  * https://analogdevicesinc.github.io/documentation/contributing/creating_new_pages.html#documentation-structure
- [x] I have used the appropriate roles and directives:
  * https://analogdevicesinc.github.io/doctools/docs_guidelines/roles.html
  * https://analogdevicesinc.github.io/doctools/docs_guidelines/directives.html
- [x] I ensured that binary data was committed to git lfs:
  * https://analogdevicesinc.github.io/documentation/contributing/creating_new_pages.html#adding-images-and-other-binary-files
- [x] I have built the pages I edited or created, using either `make html` or `adoc serve`:
  * https://analogdevicesinc.github.io/doctools/cli.html#serve
- [x] I have signed-off my commits and believe my contribution improves the repository.
