### PR TITLE
libmk2: updated API refrence link with the right one

### DIFF
--- a/docs/software/libm2k/index.rst
+++ b/docs/software/libm2k/index.rst
@@ -433,7 +433,7 @@ API reference
 ~~~~~~~~~~~~~
 
 An automatically generated documentation of the API can be found
-`here <https://analogdevicesinc.github.io/libm2k/annotated.html>`__.
+`here <https://analogdevicesinc.github.io/libm2k/>`__.
 
 calibration
 ~~~~~~~~~~~


### PR DESCRIPTION
The link used for the libm2k API documentation  was outdated I updated it to the current link